### PR TITLE
fix(api): recover scans stranded in executing by a dead worker

### DIFF
--- a/api/changelog.d/scan-stuck-queued.fixed.md
+++ b/api/changelog.d/scan-stuck-queued.fixed.md
@@ -1,0 +1,1 @@
+Recover scans stranded in `executing` by a dead worker and dispatch the next queued scan so a provider's scans no longer stay stuck in `Queued`

--- a/api/src/backend/api/migrations/0098_scan_cleanup_periodic_task.py
+++ b/api/src/backend/api/migrations/0098_scan_cleanup_periodic_task.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+
+TASK_NAME = "scan-cleanup-stale-scans"
+INTERVAL_MINUTES = 15
+
+
+def create_periodic_task(apps, schema_editor):
+    IntervalSchedule = apps.get_model("django_celery_beat", "IntervalSchedule")
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+
+    schedule, _ = IntervalSchedule.objects.get_or_create(
+        every=INTERVAL_MINUTES,
+        period="minutes",
+    )
+
+    PeriodicTask.objects.update_or_create(
+        name=TASK_NAME,
+        defaults={
+            "task": TASK_NAME,
+            "interval": schedule,
+            "enabled": True,
+        },
+    )
+
+
+def delete_periodic_task(apps, schema_editor):
+    IntervalSchedule = apps.get_model("django_celery_beat", "IntervalSchedule")
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+
+    PeriodicTask.objects.filter(name=TASK_NAME).delete()
+
+    # Clean up the schedule if no other task references it
+    IntervalSchedule.objects.filter(
+        every=INTERVAL_MINUTES,
+        period="minutes",
+        periodictask__isnull=True,
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0097_attack_paths_scan_db_defaults"),
+        ("django_celery_beat", "0019_alter_periodictasks_options"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_periodic_task, delete_periodic_task),
+    ]

--- a/api/src/backend/api/migrations/0099_scans_non_terminal_state_index.py
+++ b/api/src/backend/api/migrations/0099_scans_non_terminal_state_index.py
@@ -1,0 +1,23 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("api", "0098_scan_cleanup_periodic_task"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="scan",
+            index=models.Index(
+                condition=models.Q(
+                    ("state__in", ["executing", "available", "scheduled"])
+                ),
+                fields=["state", "tenant_id", "provider_id"],
+                name="scans_non_terminal_state_idx",
+            ),
+        ),
+    ]

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -732,6 +732,20 @@ class Scan(RowLevelSecurityProtectedModel):
                 include=["id"],
                 name="scans_prov_ins_desc_idx",
             ),
+            # Serves the cross-tenant `scan-cleanup-stale-scans` sweeps, which
+            # run every 15 minutes and would otherwise scan the whole history:
+            # only non-terminal scans are indexed, so it stays tiny.
+            models.Index(
+                fields=["state", "tenant_id", "provider_id"],
+                condition=Q(
+                    state__in=[
+                        StateChoices.EXECUTING,
+                        StateChoices.AVAILABLE,
+                        StateChoices.SCHEDULED,
+                    ]
+                ),
+                name="scans_non_terminal_state_idx",
+            ),
         ]
 
     class JSONAPIMeta:

--- a/api/src/backend/config/django/base.py
+++ b/api/src/backend/config/django/base.py
@@ -315,6 +315,17 @@ ATTACK_PATHS_SCAN_STALE_THRESHOLD_MINUTES = env.int(
     "ATTACK_PATHS_SCAN_STALE_THRESHOLD_MINUTES", 2880
 )  # 48h
 
+# Stale scan cleanup. A scan whose worker dies mid-run is stranded in
+# `executing`; because scans run one-at-a-time per provider (#11848), that also
+# blocks every queued scan for the provider. The periodic `scan-cleanup-stale-scans`
+# task fails such scans and drains the queue. A scan on a live worker is only
+# reaped after the stale ceiling (matched to the long hard time-limit); a scan
+# whose worker is gone is reaped after the shorter inactivity window.
+SCAN_INACTIVITY_THRESHOLD_MINUTES = env.int("SCAN_INACTIVITY_THRESHOLD_MINUTES", 30)
+SCAN_STALE_THRESHOLD_MINUTES = env.int(
+    "SCAN_STALE_THRESHOLD_MINUTES", 2880
+)  # 48h
+
 # Selects where the persistent attack-paths graph is stored. The scan
 # temporary database is always Neo4j; only the sink is configurable.
 # Valid values: "neo4j" (default, OSS and local dev), "neptune" (hosted).

--- a/api/src/backend/config/django/base.py
+++ b/api/src/backend/config/django/base.py
@@ -342,6 +342,10 @@ elif SCAN_STALE_THRESHOLD_MINUTES < SCAN_INACTIVITY_THRESHOLD_MINUTES:
     )
 
 SCAN_CLEANUP_ENABLED = _scan_cleanup_config_error is None
+# Exported so the task can log the reason itself. Settings are imported before
+# Django applies `LOGGING`, so the message below is emitted by the logging
+# last-resort handler and does not reach the configured structured handlers.
+SCAN_CLEANUP_CONFIG_ERROR = _scan_cleanup_config_error
 
 if _scan_cleanup_config_error:
     logging.getLogger(__name__).error(

--- a/api/src/backend/config/django/base.py
+++ b/api/src/backend/config/django/base.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 
 from config.custom_logging import LOGGING  # noqa
@@ -315,16 +316,52 @@ ATTACK_PATHS_SCAN_STALE_THRESHOLD_MINUTES = env.int(
     "ATTACK_PATHS_SCAN_STALE_THRESHOLD_MINUTES", 2880
 )  # 48h
 
-# Stale scan cleanup. A scan whose worker dies mid-run is stranded in
-# `executing`; because scans run one-at-a-time per provider (#11848), that also
-# blocks every queued scan for the provider. The periodic `scan-cleanup-stale-scans`
-# task fails such scans and drains the queue. A scan on a live worker is only
-# reaped after the stale ceiling (matched to the long hard time-limit); a scan
-# whose worker is gone is reaped after the shorter inactivity window.
+# Stale scan cleanup. A scan whose worker dies mid-run is stranded; because scans
+# run one-at-a-time per provider (#11848), that also blocks every queued scan for
+# the provider. The periodic `scan-cleanup-stale-scans` task fails such scans and
+# drains the queue. A scan whose worker is alive, or whose liveness could not be
+# established, is only reaped past the stale ceiling; a scan whose worker is
+# confirmed gone is reaped after the shorter inactivity window.
 SCAN_INACTIVITY_THRESHOLD_MINUTES = env.int("SCAN_INACTIVITY_THRESHOLD_MINUTES", 30)
-SCAN_STALE_THRESHOLD_MINUTES = env.int(
-    "SCAN_STALE_THRESHOLD_MINUTES", 2880
-)  # 48h
+SCAN_STALE_THRESHOLD_MINUTES = env.int("SCAN_STALE_THRESHOLD_MINUTES", 2880)  # 48h
+
+# Failing a scan is destructive, so an unsafe threshold policy disables the
+# watchdog instead of silently widening what it may reap. Startup is deliberately
+# NOT aborted: a config typo must not take down the API, worker and Beat.
+_scan_cleanup_config_error = None
+if SCAN_INACTIVITY_THRESHOLD_MINUTES <= 0 or SCAN_STALE_THRESHOLD_MINUTES <= 0:
+    _scan_cleanup_config_error = (
+        "SCAN_INACTIVITY_THRESHOLD_MINUTES and SCAN_STALE_THRESHOLD_MINUTES must "
+        "both be positive"
+    )
+elif SCAN_STALE_THRESHOLD_MINUTES < SCAN_INACTIVITY_THRESHOLD_MINUTES:
+    _scan_cleanup_config_error = (
+        "SCAN_STALE_THRESHOLD_MINUTES must be greater than or equal to "
+        "SCAN_INACTIVITY_THRESHOLD_MINUTES, otherwise a scan on a live worker "
+        "would be reaped sooner than one whose worker is confirmed gone"
+    )
+
+SCAN_CLEANUP_ENABLED = _scan_cleanup_config_error is None
+
+if _scan_cleanup_config_error:
+    logging.getLogger(__name__).error(
+        "Stale scan cleanup is DISABLED - invalid configuration: %s",
+        _scan_cleanup_config_error,
+    )
+else:
+    # The stale ceiling must not undercut how long `scan-perform` is allowed to
+    # run, or a legitimately long scan on a live worker could be reaped early.
+    _scan_hard_limit_minutes = (
+        env.int("DJANGO_CELERY_LONG_TASK_TIME_LIMIT", 48 * 60 * 60) // 60
+    )
+    if SCAN_STALE_THRESHOLD_MINUTES < _scan_hard_limit_minutes:
+        logging.getLogger(__name__).warning(
+            "SCAN_STALE_THRESHOLD_MINUTES (%s) is below the scan hard time limit "
+            "(%s minutes); a long-running scan on a live worker may be reaped "
+            "before Celery stops it",
+            SCAN_STALE_THRESHOLD_MINUTES,
+            _scan_hard_limit_minutes,
+        )
 
 # Selects where the persistent attack-paths graph is stored. The scan
 # temporary database is always Neo4j; only the sink is configurable.

--- a/api/src/backend/tasks/jobs/orphan_recovery.py
+++ b/api/src/backend/tasks/jobs/orphan_recovery.py
@@ -85,6 +85,7 @@ _SKIP_RECOVERY = {
     "scan-perform-scheduled",
     "attack-paths-scan-perform",
     "attack-paths-cleanup-stale-scans",
+    "scan-cleanup-stale-scans",
     "reconcile-orphan-tasks",
 }
 

--- a/api/src/backend/tasks/jobs/scan_cleanup.py
+++ b/api/src/backend/tasks/jobs/scan_cleanup.py
@@ -1,0 +1,223 @@
+"""Detect and fail stale ``Scan`` rows, then drain the provider queue.
+
+Since #11848 scans run one-at-a-time per provider: launching a scan while
+another is active for the same provider leaves the new scan ``QUEUED`` (state
+``available``, shown as "Queued" in the UI) until the active scan's Celery task
+finishes and its ``finally`` block dispatches the next queued scan.
+
+``scan-perform`` uses ``acks_late=False`` and is deliberately excluded from
+orphan recovery, so a worker that dies mid-scan (OOM, hard time-limit kill, node
+failure) never runs that ``finally``. The scan is stranded in ``executing`` and,
+because ``_get_dispatched_provider_scan`` still counts it as active, every queued
+scan for that provider stays "Queued" forever (issue #12007).
+
+This periodic task reaps such stranded ``executing`` scans - confirmed dead by
+pinging the recorded worker - marks them ``failed``, revokes the lost task, and
+dispatches the next queued scan so the provider's queue drains. It never re-runs
+the dead scan (that would duplicate findings); it only fails it and releases the
+queue. It mirrors ``cleanup_stale_attack_paths_scans`` for the main ``Scan``
+model.
+"""
+
+from datetime import UTC, datetime, timedelta
+from functools import partial
+
+from api.db_router import MainRouter
+from api.db_utils import rls_transaction
+from api.models import Scan, StateChoices
+from celery import states
+from celery.utils.log import get_task_logger
+from config.django.base import (
+    SCAN_INACTIVITY_THRESHOLD_MINUTES,
+    SCAN_STALE_THRESHOLD_MINUTES,
+)
+from django.db import DatabaseError
+from django.db.transaction import on_commit
+from tasks.jobs.orphan_recovery import is_worker_alive
+from tasks.jobs.orphan_recovery import revoke_task as _revoke_task
+
+logger = get_task_logger(__name__)
+
+
+def cleanup_stale_scans() -> dict:
+    """Fail ``executing`` scans whose worker is gone and drain the provider queue.
+
+    Detection per scan:
+    - worker recorded and alive: reap only if ``started_at`` is past the stale
+      ceiling (matched to the long hard time-limit), i.e. the task overran and
+      the worker will be killed anyway;
+    - worker recorded and gone: reap once the scan has been silent (no
+      ``updated_at`` heartbeat) for longer than the inactivity window;
+    - no worker recorded: fall back to the stale ceiling on ``started_at``.
+
+    An unreachable control bus makes every worker look alive, so a still-running
+    scan is never failed by mistake.
+
+    Returns a summary dict with the count and ids of the scans cleaned up.
+    """
+    now = datetime.now(tz=UTC)
+    stale_cutoff = now - timedelta(minutes=SCAN_STALE_THRESHOLD_MINUTES)
+    inactivity_cutoff = now - timedelta(minutes=SCAN_INACTIVITY_THRESHOLD_MINUTES)
+
+    executing_scans = list(
+        Scan.all_objects.using(MainRouter.admin_db)
+        .filter(state=StateChoices.EXECUTING)
+        .select_related("task__task_runner_task")
+    )
+
+    workers = {
+        tr.worker
+        for scan in executing_scans
+        if (tr := _task_result_for(scan)) and tr.worker
+    }
+    # Ping each distinct worker once; errors are treated as "alive" upstream.
+    worker_alive = {worker: is_worker_alive(worker) for worker in workers}
+
+    cleaned_up: list[str] = []
+    for scan in executing_scans:
+        task_result = _task_result_for(scan)
+        worker = task_result.worker if task_result else None
+        reason, recheck_inactivity_cutoff = _stale_reason(
+            scan, worker, worker_alive, stale_cutoff, inactivity_cutoff
+        )
+        if reason is None:
+            continue
+
+        if _fail_stale_scan(
+            scan,
+            task_result,
+            reason,
+            revoke=worker is not None,
+            inactivity_cutoff=recheck_inactivity_cutoff,
+        ):
+            cleaned_up.append(str(scan.id))
+            # Release the provider queue the dead scan was blocking. Runs after
+            # the FAILED state is committed so the next dispatch no longer sees
+            # this scan as the active one.
+            _drain_provider_queue(str(scan.tenant_id), str(scan.provider_id))
+
+    logger.info(f"Stale scan cleanup: {len(cleaned_up)} scan(s) cleaned up")
+    return {"cleaned_up_count": len(cleaned_up), "scan_ids": cleaned_up}
+
+
+def _task_result_for(scan):
+    """Return the scan's ``TaskResult`` row, or ``None`` if it has no task."""
+    return getattr(scan.task, "task_runner_task", None) if scan.task else None
+
+
+def _stale_reason(
+    scan,
+    worker,
+    worker_alive: dict,
+    stale_cutoff: datetime,
+    inactivity_cutoff: datetime,
+) -> tuple[str | None, datetime | None]:
+    """Classify one ``executing`` scan.
+
+    Returns ``(reason, recheck_inactivity_cutoff)``. ``reason`` is ``None`` when
+    the scan must be preserved. ``recheck_inactivity_cutoff`` is set only for the
+    dead-worker case so the row can be re-checked for late activity under lock.
+    """
+    if worker:
+        if worker_alive.get(worker, True):
+            if scan.started_at is None or scan.started_at >= stale_cutoff:
+                return None, None
+            return (
+                "Scan exceeded stale threshold - cleaned up by periodic task",
+                None,
+            )
+
+        # Worker is gone: give a scan that heartbeated recently one more cycle,
+        # in case the worker is being replaced.
+        if scan.updated_at >= inactivity_cutoff:
+            logger.info(
+                f"Preserving scan {scan.id}: worker {worker} is gone but activity "
+                f"is recent (progress={scan.progress}, updated_at={scan.updated_at})"
+            )
+            return None, None
+        return (
+            f"Worker unresponsive and scan inactive for "
+            f"{SCAN_INACTIVITY_THRESHOLD_MINUTES} minutes - cleaned up by periodic task",
+            inactivity_cutoff,
+        )
+
+    # No worker recorded: time-based heuristic only.
+    if scan.started_at is None or scan.started_at >= stale_cutoff:
+        return None, None
+    return (
+        "No worker recorded, scan exceeded stale threshold - cleaned up by periodic task",
+        None,
+    )
+
+
+def _fail_stale_scan(
+    scan,
+    task_result,
+    reason: str,
+    *,
+    revoke: bool = False,
+    inactivity_cutoff: datetime | None = None,
+) -> bool:
+    """Atomically lock the row, re-verify eligibility, and mark it ``FAILED``.
+
+    Registers task revocation after commit when requested. Returns ``True`` if
+    the scan was failed, ``False`` if it moved on or vanished.
+    """
+    scan_id = str(scan.id)
+    try:
+        with rls_transaction(str(scan.tenant_id)):
+            try:
+                fresh_scan = Scan.objects.select_for_update().get(id=scan.id)
+            except Scan.DoesNotExist:
+                logger.warning(f"Scan {scan_id} no longer exists, skipping")
+                return False
+
+            if fresh_scan.state != StateChoices.EXECUTING:
+                logger.info(f"Scan {scan_id} is now {fresh_scan.state}, skipping")
+                return False
+
+            if (
+                inactivity_cutoff is not None
+                and fresh_scan.updated_at >= inactivity_cutoff
+            ):
+                logger.info(
+                    f"Scan {scan_id} received activity during worker checks, skipping"
+                )
+                return False
+
+            now = datetime.now(tz=UTC)
+            fresh_scan.state = StateChoices.FAILED
+            fresh_scan.completed_at = now
+            update_fields = ["state", "completed_at", "updated_at"]
+            if fresh_scan.started_at is not None:
+                fresh_scan.duration = int(
+                    (now - fresh_scan.started_at).total_seconds()
+                )
+                update_fields.append("duration")
+            fresh_scan.save(update_fields=update_fields)
+
+            if task_result:
+                task_result.status = states.FAILURE
+                task_result.date_done = now
+                task_result.save(update_fields=["status", "date_done"])
+
+            if revoke and task_result:
+                on_commit(
+                    partial(_revoke_task, task_result, terminate=True),
+                    using=fresh_scan._state.db,
+                )
+    except DatabaseError:
+        logger.exception(f"Failed to mark stale scan {scan_id} as failed")
+        return False
+
+    logger.info(f"Cleaned up stale scan {scan_id}: {reason}")
+    return True
+
+
+def _drain_provider_queue(tenant_id: str, provider_id: str) -> None:
+    """Dispatch the next queued scan for the provider (best effort)."""
+    # Imported lazily: ``tasks.tasks`` imports this module, so a top-level import
+    # would be circular.
+    from tasks.tasks import _dispatch_next_queued_provider_scan_best_effort
+
+    _dispatch_next_queued_provider_scan_best_effort(tenant_id, provider_id)

--- a/api/src/backend/tasks/jobs/scan_cleanup.py
+++ b/api/src/backend/tasks/jobs/scan_cleanup.py
@@ -7,16 +7,25 @@ finishes and its ``finally`` block dispatches the next queued scan.
 
 ``scan-perform`` uses ``acks_late=False`` and is deliberately excluded from
 orphan recovery, so a worker that dies mid-scan (OOM, hard time-limit kill, node
-failure) never runs that ``finally``. The scan is stranded in ``executing`` and,
-because ``_get_dispatched_provider_scan`` still counts it as active, every queued
-scan for that provider stays "Queued" forever (issue #12007).
+failure) never runs that ``finally``. The scan is stranded and, because
+``_get_dispatched_provider_scan`` still counts it as active, every queued scan
+for that provider stays "Queued" forever (issue #12007).
 
-This periodic task reaps such stranded ``executing`` scans - confirmed dead by
-pinging the recorded worker - marks them ``failed``, revokes the lost task, and
-dispatches the next queued scan so the provider's queue drains. It never re-runs
-the dead scan (that would duplicate findings); it only fails it and releases the
-queue. It mirrors ``cleanup_stale_attack_paths_scans`` for the main ``Scan``
-model.
+This periodic task recovers from that in two complementary passes:
+
+1. **Reap** scans a dead worker stranded. A scan blocks the provider queue when
+   it is ``executing`` OR ``available``/``scheduled`` with a dispatched task
+   (a task can be lost after dispatch but before it reaches ``executing``).
+   Liveness is confirmed by pinging the recorded worker with bounded retries;
+   only a scan whose worker is *confirmed* gone (or an unrecorded worker past
+   the stale ceiling) is failed. It never re-runs the scan (that would duplicate
+   findings) — it only fails it and releases the queue.
+2. **Drain** every provider that still has a ``QUEUED`` scan but no active scan.
+   This retries a queue release that a transient error dropped on a previous run
+   (the reaped scan is already terminal, so a reap-only retry would never fire),
+   making the recovery self-healing across runs.
+
+It mirrors ``cleanup_stale_attack_paths_scans`` for the main ``Scan`` model.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -25,60 +34,56 @@ from functools import partial
 from api.db_router import MainRouter
 from api.db_utils import rls_transaction
 from api.models import Scan, StateChoices
-from celery import states
+from celery import current_app, states
 from celery.utils.log import get_task_logger
 from config.django.base import (
     SCAN_INACTIVITY_THRESHOLD_MINUTES,
     SCAN_STALE_THRESHOLD_MINUTES,
 )
 from django.db import DatabaseError
+from django.db.models import Q
 from django.db.transaction import on_commit
-from tasks.jobs.orphan_recovery import is_worker_alive
 from tasks.jobs.orphan_recovery import revoke_task as _revoke_task
 
 logger = get_task_logger(__name__)
 
+# Worker-liveness ping tuning (mirrors the Attack Paths cleanup added in #11986):
+# a single short ping can misjudge a busy worker as dead, so ping with bounded
+# retries and exponential backoff, and treat a control-bus failure as "unknown".
+WORKER_PING_BASE_TIMEOUT_SECONDS = 5
+WORKER_PING_MAX_ATTEMPTS = 3
+
 
 def cleanup_stale_scans() -> dict:
-    """Fail ``executing`` scans whose worker is gone and drain the provider queue.
+    """Fail scans stranded by a dead worker and drain blocked provider queues.
 
-    Detection per scan:
-    - worker recorded and alive: reap only if ``started_at`` is past the stale
-      ceiling (matched to the long hard time-limit), i.e. the task overran and
-      the worker will be killed anyway;
-    - worker recorded and gone: reap once the scan has been silent (no
-      ``updated_at`` heartbeat) for longer than the inactivity window;
-    - no worker recorded: fall back to the stale ceiling on ``started_at``.
-
-    An unreachable control bus makes every worker look alive, so a still-running
-    scan is never failed by mistake.
-
-    Returns a summary dict with the count and ids of the scans cleaned up.
+    Returns a summary dict: how many scans were reaped (with their ids) and how
+    many provider queues were checked for a pending release.
     """
     now = datetime.now(tz=UTC)
     stale_cutoff = now - timedelta(minutes=SCAN_STALE_THRESHOLD_MINUTES)
     inactivity_cutoff = now - timedelta(minutes=SCAN_INACTIVITY_THRESHOLD_MINUTES)
 
-    executing_scans = list(
-        Scan.all_objects.using(MainRouter.admin_db)
-        .filter(state=StateChoices.EXECUTING)
-        .select_related("task__task_runner_task")
-    )
+    candidates = _stale_scan_candidates()
 
     workers = {
         tr.worker
-        for scan in executing_scans
+        for scan in candidates
         if (tr := _task_result_for(scan)) and tr.worker
     }
-    # Ping each distinct worker once; errors are treated as "alive" upstream.
-    worker_alive = {worker: is_worker_alive(worker) for worker in workers}
+    responsive_workers, unresponsive_workers = _ping_workers(workers)
 
     cleaned_up: list[str] = []
-    for scan in executing_scans:
+    for scan in candidates:
         task_result = _task_result_for(scan)
         worker = task_result.worker if task_result else None
         reason, recheck_inactivity_cutoff = _stale_reason(
-            scan, worker, worker_alive, stale_cutoff, inactivity_cutoff
+            scan,
+            worker,
+            responsive_workers,
+            unresponsive_workers,
+            stale_cutoff,
+            inactivity_cutoff,
         )
         if reason is None:
             continue
@@ -87,17 +92,52 @@ def cleanup_stale_scans() -> dict:
             scan,
             task_result,
             reason,
-            revoke=worker is not None,
+            expected_state=scan.state,
+            revoke=bool(worker),
             inactivity_cutoff=recheck_inactivity_cutoff,
         ):
             cleaned_up.append(str(scan.id))
-            # Release the provider queue the dead scan was blocking. Runs after
-            # the FAILED state is committed so the next dispatch no longer sees
-            # this scan as the active one.
-            _drain_provider_queue(str(scan.tenant_id), str(scan.provider_id))
 
-    logger.info(f"Stale scan cleanup: {len(cleaned_up)} scan(s) cleaned up")
-    return {"cleaned_up_count": len(cleaned_up), "scan_ids": cleaned_up}
+    # Second pass: release any provider queue that has a QUEUED scan but nothing
+    # active — covers a reaped provider and retries a drain a prior run dropped.
+    queues_checked = _drain_pending_provider_queues()
+
+    logger.info(
+        "Stale scan cleanup: %d scan(s) failed, %d provider queue(s) checked",
+        len(cleaned_up),
+        queues_checked,
+    )
+    return {
+        "cleaned_up_count": len(cleaned_up),
+        "scan_ids": cleaned_up,
+        "queues_checked": queues_checked,
+    }
+
+
+def _stale_scan_candidates() -> list[Scan]:
+    """Scans that currently block their provider queue.
+
+    Mirrors ``_get_dispatched_provider_scan``: an ``executing`` scan, or an
+    ``available``/``scheduled`` scan whose task is still in a dispatched state
+    (so a task lost before reaching ``executing`` is covered too). A ``QUEUED``
+    task status is intentionally excluded — those are the waiting scans we want
+    to release, not reap.
+    """
+    # Imported lazily: ``tasks.tasks`` imports this module, so a top-level import
+    # would be circular.
+    from tasks.tasks import DISPATCHED_SCAN_TASK_STATES
+
+    return list(
+        Scan.all_objects.using(MainRouter.admin_db)
+        .filter(
+            Q(state=StateChoices.EXECUTING)
+            | Q(
+                state__in=(StateChoices.AVAILABLE, StateChoices.SCHEDULED),
+                task__task_runner_task__status__in=DISPATCHED_SCAN_TASK_STATES,
+            )
+        )
+        .select_related("task__task_runner_task")
+    )
 
 
 def _task_result_for(scan):
@@ -105,21 +145,70 @@ def _task_result_for(scan):
     return getattr(scan.task, "task_runner_task", None) if scan.task else None
 
 
+def _ping_workers(workers: set[str]) -> tuple[set[str], set[str] | None]:
+    """Ping worker destinations, retrying only the ones that stay silent.
+
+    Returns ``(responsive, unresponsive)``. ``unresponsive`` is ``None`` when the
+    final attempt raised — the pending workers then have unknown liveness and
+    their scans must be preserved rather than failed.
+    """
+    pending = set(workers)
+    responsive: set[str] = set()
+
+    for attempt in range(WORKER_PING_MAX_ATTEMPTS):
+        if not pending:
+            return responsive, set()
+
+        timeout = WORKER_PING_BASE_TIMEOUT_SECONDS * 2**attempt
+        try:
+            response = current_app.control.inspect(
+                destination=sorted(pending), timeout=timeout
+            ).ping()
+        except Exception:
+            attempts_remaining = WORKER_PING_MAX_ATTEMPTS - attempt - 1
+            if attempts_remaining:
+                logger.warning(
+                    "Scan cleanup worker ping attempt %d failed; retrying %d "
+                    "pending worker(s) with %d attempt(s) remaining",
+                    attempt + 1,
+                    len(pending),
+                    attempts_remaining,
+                    exc_info=True,
+                )
+                continue
+
+            logger.exception(
+                "Scan cleanup worker ping attempts exhausted; preserving scans "
+                "for workers with unknown liveness"
+            )
+            return responsive, None
+
+        responded = pending.intersection((response or {}).keys())
+        responsive.update(responded)
+        pending.difference_update(responded)
+
+    return responsive, pending
+
+
 def _stale_reason(
     scan,
     worker,
-    worker_alive: dict,
+    responsive_workers: set[str],
+    unresponsive_workers: set[str] | None,
     stale_cutoff: datetime,
     inactivity_cutoff: datetime,
 ) -> tuple[str | None, datetime | None]:
-    """Classify one ``executing`` scan.
+    """Classify one blocking scan.
 
     Returns ``(reason, recheck_inactivity_cutoff)``. ``reason`` is ``None`` when
     the scan must be preserved. ``recheck_inactivity_cutoff`` is set only for the
-    dead-worker case so the row can be re-checked for late activity under lock.
+    confirmed-dead-worker case so the row can be re-checked for late activity
+    under lock.
     """
     if worker:
-        if worker_alive.get(worker, True):
+        if worker in responsive_workers:
+            # Worker alive: only reap a task that blew past the stale ceiling
+            # (matched to the long hard time-limit); it will be killed anyway.
             if scan.started_at is None or scan.started_at >= stale_cutoff:
                 return None, None
             return (
@@ -127,12 +216,29 @@ def _stale_reason(
                 None,
             )
 
-        # Worker is gone: give a scan that heartbeated recently one more cycle,
-        # in case the worker is being replaced.
+        if unresponsive_workers is None or worker not in unresponsive_workers:
+            # Liveness unknown (control bus failed, or worker not in the
+            # confirmed-dead set): preserve, try again next run.
+            logger.info(
+                "Preserving scan %s: worker %s liveness is unknown "
+                "(state=%s, updated_at=%s)",
+                scan.id,
+                worker,
+                scan.state,
+                scan.updated_at,
+            )
+            return None, None
+
+        # Worker confirmed gone: give a scan that heartbeated recently one more
+        # cycle in case the worker is being replaced.
         if scan.updated_at >= inactivity_cutoff:
             logger.info(
-                f"Preserving scan {scan.id}: worker {worker} is gone but activity "
-                f"is recent (progress={scan.progress}, updated_at={scan.updated_at})"
+                "Preserving scan %s: worker %s is gone but activity is recent "
+                "(progress=%s, updated_at=%s)",
+                scan.id,
+                worker,
+                scan.progress,
+                scan.updated_at,
             )
             return None, None
         return (
@@ -141,7 +247,9 @@ def _stale_reason(
             inactivity_cutoff,
         )
 
-    # No worker recorded: time-based heuristic only.
+    # No worker recorded: time-based heuristic only. A dispatched scan that never
+    # reached a worker has no started_at, so it is preserved until the stale
+    # ceiling — this never reaps a scan merely waiting in the broker queue.
     if scan.started_at is None or scan.started_at >= stale_cutoff:
         return None, None
     return (
@@ -155,6 +263,7 @@ def _fail_stale_scan(
     task_result,
     reason: str,
     *,
+    expected_state: str,
     revoke: bool = False,
     inactivity_cutoff: datetime | None = None,
 ) -> bool:
@@ -172,7 +281,10 @@ def _fail_stale_scan(
                 logger.warning(f"Scan {scan_id} no longer exists, skipping")
                 return False
 
-            if fresh_scan.state != StateChoices.EXECUTING:
+            # State must be unchanged since the snapshot: a scan that has since
+            # advanced (e.g. available -> executing, or -> completed) is not ours
+            # to fail.
+            if fresh_scan.state != expected_state:
                 logger.info(f"Scan {scan_id} is now {fresh_scan.state}, skipping")
                 return False
 
@@ -214,10 +326,33 @@ def _fail_stale_scan(
     return True
 
 
-def _drain_provider_queue(tenant_id: str, provider_id: str) -> None:
-    """Dispatch the next queued scan for the provider (best effort)."""
-    # Imported lazily: ``tasks.tasks`` imports this module, so a top-level import
-    # would be circular.
-    from tasks.tasks import _dispatch_next_queued_provider_scan_best_effort
+def _drain_pending_provider_queues() -> int:
+    """Release provider queues that have a ``QUEUED`` scan but nothing active.
 
-    _dispatch_next_queued_provider_scan_best_effort(tenant_id, provider_id)
+    Idempotent and best effort: ``_dispatch_next_queued_provider_scan`` re-checks
+    for a dispatched/executing scan under lock and no-ops when one exists, so this
+    only advances a genuinely stalled queue. Returns the number of provider
+    queues checked.
+    """
+    # Imported lazily to avoid the circular import with ``tasks.tasks``.
+    from tasks.tasks import (
+        QUEUED_SCAN_TASK_STATE,
+        _dispatch_next_queued_provider_scan_best_effort,
+    )
+
+    pending = list(
+        Scan.all_objects.using(MainRouter.admin_db)
+        .filter(
+            state=StateChoices.AVAILABLE,
+            task__task_runner_task__status=QUEUED_SCAN_TASK_STATE,
+        )
+        .values_list("tenant_id", "provider_id")
+        .distinct()
+    )
+
+    for tenant_id, provider_id in pending:
+        _dispatch_next_queued_provider_scan_best_effort(
+            str(tenant_id), str(provider_id)
+        )
+
+    return len(pending)

--- a/api/src/backend/tasks/jobs/scan_cleanup.py
+++ b/api/src/backend/tasks/jobs/scan_cleanup.py
@@ -40,6 +40,7 @@ from api.models import Scan, StateChoices
 from celery import current_app, states
 from celery.utils.log import get_task_logger
 from config.django.base import (
+    SCAN_CLEANUP_CONFIG_ERROR,
     SCAN_CLEANUP_ENABLED,
     SCAN_INACTIVITY_THRESHOLD_MINUTES,
     SCAN_STALE_THRESHOLD_MINUTES,
@@ -66,9 +67,12 @@ def cleanup_stale_scans() -> dict:
     many provider queues were checked for a pending release.
     """
     if not SCAN_CLEANUP_ENABLED:
+        # Carry the reason rather than pointing at the startup log: settings are
+        # imported before Django configures `LOGGING`, so that message never
+        # reaches the structured handlers. This one does.
         logger.error(
-            "Stale scan cleanup skipped: invalid threshold configuration, see "
-            "the configuration error logged at startup"
+            "Stale scan cleanup skipped: invalid threshold configuration - %s",
+            SCAN_CLEANUP_CONFIG_ERROR,
         )
         return {"cleaned_up_count": 0, "scan_ids": [], "queues_checked": 0}
 

--- a/api/src/backend/tasks/jobs/scan_cleanup.py
+++ b/api/src/backend/tasks/jobs/scan_cleanup.py
@@ -13,19 +13,22 @@ for that provider stays "Queued" forever (issue #12007).
 
 This periodic task recovers from that in two complementary passes:
 
-1. **Reap** scans a dead worker stranded. A scan blocks the provider queue when
-   it is ``executing`` OR ``available``/``scheduled`` with a dispatched task
-   (a task can be lost after dispatch but before it reaches ``executing``).
-   Liveness is confirmed by pinging the recorded worker with bounded retries;
-   only a scan whose worker is *confirmed* gone (or an unrecorded worker past
-   the stale ceiling) is failed. It never re-runs the scan (that would duplicate
-   findings) — it only fails it and releases the queue.
+1. **Reap** the scans that block a provider queue: ``executing`` scans, and
+   ``available``/``scheduled`` scans whose task is still dispatched (a task can
+   be lost after dispatch but before it reaches ``executing``). A scan is only
+   failed when its worker is *confirmed* gone and it has been silent for the
+   inactivity window, or when it is older than the stale ceiling. Liveness that
+   cannot be established is treated as alive, so a healthy scan is never failed
+   because the control bus was unreachable. The dead scan is never re-run (that
+   would duplicate findings) - it is failed and its task revoked.
 2. **Drain** every provider that still has a ``QUEUED`` scan but no active scan.
-   This retries a queue release that a transient error dropped on a previous run
+   This retries a queue release that a transient error dropped on an earlier run
    (the reaped scan is already terminal, so a reap-only retry would never fire),
    making the recovery self-healing across runs.
 
-It mirrors ``cleanup_stale_attack_paths_scans`` for the main ``Scan`` model.
+``Scan`` is the source of truth: its state is committed first and the task result
+is finalized afterwards, so a failure between the two can only leave a stale task
+result, never a failed task result for a scan that is still running.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -37,19 +40,21 @@ from api.models import Scan, StateChoices
 from celery import current_app, states
 from celery.utils.log import get_task_logger
 from config.django.base import (
+    SCAN_CLEANUP_ENABLED,
     SCAN_INACTIVITY_THRESHOLD_MINUTES,
     SCAN_STALE_THRESHOLD_MINUTES,
 )
 from django.db import DatabaseError
 from django.db.models import Q
 from django.db.transaction import on_commit
+from django_celery_results.models import TaskResult
 from tasks.jobs.orphan_recovery import revoke_task as _revoke_task
 
 logger = get_task_logger(__name__)
 
 # Worker-liveness ping tuning (mirrors the Attack Paths cleanup added in #11986):
 # a single short ping can misjudge a busy worker as dead, so ping with bounded
-# retries and exponential backoff, and treat a control-bus failure as "unknown".
+# retries and exponential backoff.
 WORKER_PING_BASE_TIMEOUT_SECONDS = 5
 WORKER_PING_MAX_ATTEMPTS = 3
 
@@ -60,27 +65,33 @@ def cleanup_stale_scans() -> dict:
     Returns a summary dict: how many scans were reaped (with their ids) and how
     many provider queues were checked for a pending release.
     """
+    if not SCAN_CLEANUP_ENABLED:
+        logger.error(
+            "Stale scan cleanup skipped: invalid threshold configuration, see "
+            "the configuration error logged at startup"
+        )
+        return {"cleaned_up_count": 0, "scan_ids": [], "queues_checked": 0}
+
     now = datetime.now(tz=UTC)
     stale_cutoff = now - timedelta(minutes=SCAN_STALE_THRESHOLD_MINUTES)
     inactivity_cutoff = now - timedelta(minutes=SCAN_INACTIVITY_THRESHOLD_MINUTES)
 
     candidates = _stale_scan_candidates()
 
-    workers = {
-        tr.worker
-        for scan in candidates
-        if (tr := _task_result_for(scan)) and tr.worker
-    }
-    responsive_workers, unresponsive_workers = _ping_workers(workers)
+    workers = set()
+    for scan in candidates:
+        task_result = _task_result_for(scan)
+        if task_result is not None and task_result.worker:
+            workers.add(task_result.worker)
+
+    _, unresponsive_workers = _ping_workers(workers)
 
     cleaned_up: list[str] = []
     for scan in candidates:
         task_result = _task_result_for(scan)
-        worker = task_result.worker if task_result else None
         reason, recheck_inactivity_cutoff = _stale_reason(
             scan,
-            worker,
-            responsive_workers,
+            task_result,
             unresponsive_workers,
             stale_cutoff,
             inactivity_cutoff,
@@ -88,18 +99,25 @@ def cleanup_stale_scans() -> dict:
         if reason is None:
             continue
 
+        # Only SIGTERM a worker that actually has this scan running. A task that
+        # never reached a worker is revoked without terminate, so the message is
+        # discarded if the broker ever delivers it.
+        worker = task_result.worker if task_result else None
+        terminate = bool(worker) and scan.state == StateChoices.EXECUTING
+
         if _fail_stale_scan(
             scan,
             task_result,
             reason,
             expected_state=scan.state,
-            revoke=bool(worker),
+            terminate=terminate,
             inactivity_cutoff=recheck_inactivity_cutoff,
         ):
             cleaned_up.append(str(scan.id))
 
     # Second pass: release any provider queue that has a QUEUED scan but nothing
-    # active — covers a reaped provider and retries a drain a prior run dropped.
+    # active. Runs after the reaps above, so the revocations they registered are
+    # already committed before a follower is dispatched.
     queues_checked = _drain_pending_provider_queues()
 
     logger.info(
@@ -120,8 +138,8 @@ def _stale_scan_candidates() -> list[Scan]:
     Mirrors ``_get_dispatched_provider_scan``: an ``executing`` scan, or an
     ``available``/``scheduled`` scan whose task is still in a dispatched state
     (so a task lost before reaching ``executing`` is covered too). A ``QUEUED``
-    task status is intentionally excluded — those are the waiting scans we want
-    to release, not reap.
+    task status is intentionally excluded - those are the waiting scans this
+    task releases, not reaps.
     """
     # Imported lazily: ``tasks.tasks`` imports this module, so a top-level import
     # would be circular.
@@ -148,12 +166,18 @@ def _task_result_for(scan):
 def _ping_workers(workers: set[str]) -> tuple[set[str], set[str] | None]:
     """Ping worker destinations, retrying only the ones that stay silent.
 
-    Returns ``(responsive, unresponsive)``. ``unresponsive`` is ``None`` when the
-    final attempt raised — the pending workers then have unknown liveness and
-    their scans must be preserved rather than failed.
+    Returns ``(responsive, unresponsive)``. ``unresponsive`` is ``None`` when
+    liveness could not be established, and those workers must be treated as
+    alive. That covers both an inspect call that raises and one that simply
+    returns nothing: Celery swallows reply timeouts (``Mailbox._collect``
+    catches ``socket.timeout`` and ``Inspect._prepare`` returns ``None``), so a
+    silent control bus is indistinguishable from every worker being dead. A
+    worker is only reported unresponsive when some other destination answered,
+    which proves the control bus itself is healthy.
     """
     pending = set(workers)
     responsive: set[str] = set()
+    control_plane_replied = False
 
     for attempt in range(WORKER_PING_MAX_ATTEMPTS):
         if not pending:
@@ -162,16 +186,16 @@ def _ping_workers(workers: set[str]) -> tuple[set[str], set[str] | None]:
         timeout = WORKER_PING_BASE_TIMEOUT_SECONDS * 2**attempt
         try:
             response = current_app.control.inspect(
-                destination=sorted(pending), timeout=timeout
+                destination=sorted(pending),
+                timeout=timeout,
             ).ping()
         except Exception:
             attempts_remaining = WORKER_PING_MAX_ATTEMPTS - attempt - 1
             if attempts_remaining:
                 logger.warning(
-                    "Scan cleanup worker ping attempt %d failed; retrying %d "
-                    "pending worker(s) with %d attempt(s) remaining",
+                    "Scan cleanup worker ping attempt %d failed; retrying with "
+                    "%d attempt(s) remaining",
                     attempt + 1,
-                    len(pending),
                     attempts_remaining,
                     exc_info=True,
                 )
@@ -183,17 +207,43 @@ def _ping_workers(workers: set[str]) -> tuple[set[str], set[str] | None]:
             )
             return responsive, None
 
-        responded = pending.intersection((response or {}).keys())
+        if response:
+            # At least one destination answered, so the control bus works.
+            control_plane_replied = True
+
+        responded = pending.intersection(response or {})
         responsive.update(responded)
         pending.difference_update(responded)
+
+    if pending and not control_plane_replied:
+        logger.warning(
+            "Scan cleanup: no worker answered on the control bus; treating %d "
+            "worker(s) as alive rather than dead",
+            len(pending),
+        )
+        return responsive, None
 
     return responsive, pending
 
 
+def _reference_time(scan, task_result) -> datetime | None:
+    """Timestamp to age a scan from.
+
+    ``started_at`` once the scan reached a worker, otherwise the moment its task
+    row was created (falling back to the scan's insertion time). Without this
+    fallback a scan that never started has no timestamp to age, and would block
+    its provider queue forever.
+    """
+    if scan.started_at is not None:
+        return scan.started_at
+    if task_result is not None and task_result.date_created is not None:
+        return task_result.date_created
+    return scan.inserted_at
+
+
 def _stale_reason(
     scan,
-    worker,
-    responsive_workers: set[str],
+    task_result,
     unresponsive_workers: set[str] | None,
     stale_cutoff: datetime,
     inactivity_cutoff: datetime,
@@ -202,35 +252,19 @@ def _stale_reason(
 
     Returns ``(reason, recheck_inactivity_cutoff)``. ``reason`` is ``None`` when
     the scan must be preserved. ``recheck_inactivity_cutoff`` is set only for the
-    confirmed-dead-worker case so the row can be re-checked for late activity
-    under lock.
+    confirmed-dead-worker case, so the row can be re-checked for late activity
+    under the final lock.
     """
-    if worker:
-        if worker in responsive_workers:
-            # Worker alive: only reap a task that blew past the stale ceiling
-            # (matched to the long hard time-limit); it will be killed anyway.
-            if scan.started_at is None or scan.started_at >= stale_cutoff:
-                return None, None
-            return (
-                "Scan exceeded stale threshold - cleaned up by periodic task",
-                None,
-            )
+    worker = task_result.worker if task_result else None
+    confirmed_dead = (
+        bool(worker)
+        and unresponsive_workers is not None
+        and worker in unresponsive_workers
+    )
 
-        if unresponsive_workers is None or worker not in unresponsive_workers:
-            # Liveness unknown (control bus failed, or worker not in the
-            # confirmed-dead set): preserve, try again next run.
-            logger.info(
-                "Preserving scan %s: worker %s liveness is unknown "
-                "(state=%s, updated_at=%s)",
-                scan.id,
-                worker,
-                scan.state,
-                scan.updated_at,
-            )
-            return None, None
-
-        # Worker confirmed gone: give a scan that heartbeated recently one more
-        # cycle in case the worker is being replaced.
+    if confirmed_dead:
+        # Give a scan that heartbeated recently one more cycle, in case the
+        # worker is being replaced.
         if scan.updated_at >= inactivity_cutoff:
             logger.info(
                 "Preserving scan %s: worker %s is gone but activity is recent "
@@ -242,18 +276,21 @@ def _stale_reason(
             )
             return None, None
         return (
-            f"Worker unresponsive and scan inactive for "
-            f"{SCAN_INACTIVITY_THRESHOLD_MINUTES} minutes - cleaned up by periodic task",
+            "Worker unresponsive and scan inactive for "
+            f"{SCAN_INACTIVITY_THRESHOLD_MINUTES} minutes - "
+            "cleaned up by periodic task",
             inactivity_cutoff,
         )
 
-    # No worker recorded: time-based heuristic only. A dispatched scan that never
-    # reached a worker has no started_at, so it is preserved until the stale
-    # ceiling — this never reaps a scan merely waiting in the broker queue.
-    if scan.started_at is None or scan.started_at >= stale_cutoff:
+    # Worker alive, liveness unknown, or never recorded: only the stale ceiling
+    # may reap, so a slow-but-healthy scan is never failed. A scan that never
+    # started is aged from its task creation time instead of `started_at`.
+    reference = _reference_time(scan, task_result)
+    if reference is None or reference >= stale_cutoff:
         return None, None
     return (
-        "No worker recorded, scan exceeded stale threshold - cleaned up by periodic task",
+        "Scan exceeded the stale threshold of "
+        f"{SCAN_STALE_THRESHOLD_MINUTES} minutes - cleaned up by periodic task",
         None,
     )
 
@@ -264,13 +301,14 @@ def _fail_stale_scan(
     reason: str,
     *,
     expected_state: str,
-    revoke: bool = False,
+    terminate: bool = False,
     inactivity_cutoff: datetime | None = None,
 ) -> bool:
     """Atomically lock the row, re-verify eligibility, and mark it ``FAILED``.
 
-    Registers task revocation after commit when requested. Returns ``True`` if
-    the scan was failed, ``False`` if it moved on or vanished.
+    The task result is finalized and revoked after the scan commits, so a
+    rollback can never leave a failed task result behind a running scan.
+    Returns ``True`` if the scan was failed, ``False`` if it moved on or vanished.
     """
     scan_id = str(scan.id)
     try:
@@ -281,9 +319,8 @@ def _fail_stale_scan(
                 logger.warning(f"Scan {scan_id} no longer exists, skipping")
                 return False
 
-            # State must be unchanged since the snapshot: a scan that has since
-            # advanced (e.g. available -> executing, or -> completed) is not ours
-            # to fail.
+            # The state must be unchanged since the snapshot: a scan that has
+            # advanced (available -> executing, or -> completed) is not ours.
             if fresh_scan.state != expected_state:
                 logger.info(f"Scan {scan_id} is now {fresh_scan.state}, skipping")
                 return False
@@ -297,25 +334,25 @@ def _fail_stale_scan(
                 )
                 return False
 
+            # Re-read the task status: this snapshot predates up to ~35s of
+            # worker probing, in which the task may have reported its own result.
+            if task_result is not None and _task_is_ready(task_result.task_id):
+                logger.info(f"Scan {scan_id} task already finished, skipping")
+                return False
+
             now = datetime.now(tz=UTC)
             fresh_scan.state = StateChoices.FAILED
             fresh_scan.completed_at = now
             update_fields = ["state", "completed_at", "updated_at"]
             if fresh_scan.started_at is not None:
-                fresh_scan.duration = int(
-                    (now - fresh_scan.started_at).total_seconds()
-                )
+                elapsed = now - fresh_scan.started_at
+                fresh_scan.duration = int(elapsed.total_seconds())
                 update_fields.append("duration")
             fresh_scan.save(update_fields=update_fields)
 
-            if task_result:
-                task_result.status = states.FAILURE
-                task_result.date_done = now
-                task_result.save(update_fields=["status", "date_done"])
-
-            if revoke and task_result:
+            if task_result is not None:
                 on_commit(
-                    partial(_revoke_task, task_result, terminate=True),
+                    partial(_finalize_task_result, task_result.task_id, terminate),
                     using=fresh_scan._state.db,
                 )
     except DatabaseError:
@@ -326,13 +363,44 @@ def _fail_stale_scan(
     return True
 
 
+def _task_is_ready(task_id: str) -> bool:
+    """Whether the task already reported a terminal result."""
+    status = (
+        TaskResult.objects.filter(task_id=task_id)
+        .values_list("status", flat=True)
+        .first()
+    )
+    return status in states.READY_STATES
+
+
+def _finalize_task_result(task_id: str, terminate: bool) -> None:
+    """Mark the lost task terminal and revoke it, after the scan commit.
+
+    ``Scan`` is the source of truth. ``TaskResult`` lives on the ``admin``
+    connection (see ``MainRouter``), so it cannot join the scan's RLS
+    transaction; running it post-commit means a crash in between leaves only a
+    stale task result, never a ``FAILURE`` for a scan that is still running.
+    """
+    task_result = TaskResult.objects.filter(task_id=task_id).first()
+    if task_result is None:
+        logger.warning(f"Task result {task_id} no longer exists, skipping")
+        return
+
+    if task_result.status not in states.READY_STATES:
+        task_result.status = states.FAILURE
+        task_result.date_done = datetime.now(tz=UTC)
+        task_result.save(update_fields=["status", "date_done"])
+
+    _revoke_task(task_result, terminate=terminate)
+
+
 def _drain_pending_provider_queues() -> int:
     """Release provider queues that have a ``QUEUED`` scan but nothing active.
 
     Idempotent and best effort: ``_dispatch_next_queued_provider_scan`` re-checks
-    for a dispatched/executing scan under lock and no-ops when one exists, so this
-    only advances a genuinely stalled queue. Returns the number of provider
-    queues checked.
+    for a dispatched or executing scan under the provider lock and no-ops when
+    one exists, so this only advances a genuinely stalled queue. Returns the
+    number of provider queues checked.
     """
     # Imported lazily to avoid the circular import with ``tasks.tasks``.
     from tasks.tasks import (
@@ -352,7 +420,8 @@ def _drain_pending_provider_queues() -> int:
 
     for tenant_id, provider_id in pending:
         _dispatch_next_queued_provider_scan_best_effort(
-            str(tenant_id), str(provider_id)
+            str(tenant_id),
+            str(provider_id),
         )
 
     return len(pending)

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -89,6 +89,7 @@ from tasks.jobs.scan import (
     reset_ephemeral_resource_findings_count,
     update_provider_compliance_scores,
 )
+from tasks.jobs.scan_cleanup import cleanup_stale_scans
 from tasks.utils import (
     _get_or_create_scheduled_scan,
     batched,
@@ -697,6 +698,13 @@ def perform_attack_paths_scan_task(self, tenant_id: str, scan_id: str):
 @shared_task(name="attack-paths-cleanup-stale-scans", queue="attack-paths-scans")
 def cleanup_stale_attack_paths_scans_task():
     return cleanup_stale_attack_paths_scans()
+
+
+@shared_task(name="scan-cleanup-stale-scans", queue="celery")
+def cleanup_stale_scans_task():
+    """Periodic watchdog: fail scans stranded in `executing` by a dead worker
+    and dispatch the next queued scan the dead scan was blocking."""
+    return cleanup_stale_scans()
 
 
 @shared_task(name="reconcile-orphan-tasks", queue="celery")

--- a/api/src/backend/tasks/tests/test_orphan_recovery.py
+++ b/api/src/backend/tasks/tests/test_orphan_recovery.py
@@ -188,6 +188,7 @@ class TestReconcileTaskResults:
             "scan-perform",
             "attack-paths-scan-perform",
             "attack-paths-cleanup-stale-scans",
+            "scan-cleanup-stale-scans",
         ],
     )
     def test_scan_task_is_skipped_entirely(self, tenants_fixture, task_name):

--- a/api/src/backend/tasks/tests/test_scan_cleanup.py
+++ b/api/src/backend/tasks/tests/test_scan_cleanup.py
@@ -1,0 +1,278 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from api.models import Scan, StateChoices, Task
+from celery import states
+from django_celery_results.models import TaskResult
+from tasks.jobs.scan_cleanup import _fail_stale_scan, cleanup_stale_scans
+
+
+@pytest.mark.django_db
+class TestCleanupStaleScans:
+    @pytest.fixture(autouse=True)
+    def execute_on_commit_callbacks(self):
+        # Fire the post-commit revoke synchronously so tests can assert on it.
+        with patch(
+            "tasks.jobs.scan_cleanup.on_commit",
+            side_effect=lambda callback, **kwargs: callback(),
+        ):
+            yield
+
+    def _create_executing_scan(
+        self,
+        tenant,
+        provider,
+        *,
+        started_at=None,
+        updated_at=None,
+        worker=None,
+        task_status="STARTED",
+    ):
+        """Create an EXECUTING `Scan` with an optional Task + TaskResult."""
+        scan = Scan.objects.create(
+            tenant_id=tenant.id,
+            provider=provider,
+            name="Running scan",
+            trigger=Scan.TriggerChoices.MANUAL,
+            state=StateChoices.EXECUTING,
+            started_at=started_at or datetime.now(tz=UTC),
+        )
+
+        task_result = None
+        if worker is not None:
+            task_result = TaskResult.objects.create(
+                task_id=str(scan.id),
+                task_name="scan-perform",
+                status=task_status,
+                worker=worker,
+            )
+            task = Task.objects.create(
+                id=task_result.task_id,
+                task_runner_task=task_result,
+                tenant_id=tenant.id,
+            )
+            scan.task = task
+            scan.save(update_fields=["task_id"])
+
+        if updated_at is not None:
+            # `updated_at` uses auto_now, so bypass it with a queryset update.
+            Scan.all_objects.filter(id=scan.id).update(updated_at=updated_at)
+            scan.updated_at = updated_at
+
+        return scan, task_result
+
+    def _create_queued_scan(self, tenant, provider):
+        """Create an AVAILABLE scan whose task is QUEUED behind the active one."""
+        task_result = TaskResult.objects.create(
+            task_id=str(uuid.uuid4()),
+            task_name="scan-perform",
+            status="QUEUED",
+        )
+        task = Task.objects.create(
+            id=task_result.task_id,
+            task_runner_task=task_result,
+            tenant_id=tenant.id,
+        )
+        scan = Scan.objects.create(
+            tenant_id=tenant.id,
+            provider=provider,
+            name="Queued scan",
+            trigger=Scan.TriggerChoices.MANUAL,
+            state=StateChoices.AVAILABLE,
+            task=task,
+        )
+        return scan, task, task_result
+
+    @patch("tasks.jobs.scan_cleanup.is_worker_alive")
+    def test_no_executing_scans_is_noop(
+        self, mock_alive, tenants_fixture, aws_provider
+    ):
+        result = cleanup_stale_scans()
+
+        assert result == {"cleaned_up_count": 0, "scan_ids": []}
+        mock_alive.assert_not_called()
+
+    @patch("tasks.jobs.scan_cleanup._revoke_task")
+    @patch("tasks.jobs.scan_cleanup.is_worker_alive", return_value=False)
+    def test_reaps_dead_worker_inactive_scan_and_drains_queue(
+        self,
+        mock_alive,
+        mock_revoke,
+        tenants_fixture,
+        aws_provider,
+        django_capture_on_commit_callbacks,
+    ):
+        tenant = tenants_fixture[0]
+        provider = aws_provider
+
+        started_at = datetime.now(tz=UTC) - timedelta(hours=1)
+        updated_at = datetime.now(tz=UTC) - timedelta(minutes=31)
+        scan, task_result = self._create_executing_scan(
+            tenant,
+            provider,
+            started_at=started_at,
+            updated_at=updated_at,
+            worker="dead@host",
+        )
+        queued_scan, queued_task, queued_task_result = self._create_queued_scan(
+            tenant, provider
+        )
+
+        with patch(
+            "tasks.tasks.perform_scan_task.apply_async"
+        ) as mock_apply_async:
+            with django_capture_on_commit_callbacks(execute=True):
+                result = cleanup_stale_scans()
+
+        assert result["cleaned_up_count"] == 1
+        assert str(scan.id) in result["scan_ids"]
+
+        scan.refresh_from_db()
+        assert scan.state == StateChoices.FAILED
+        assert scan.completed_at is not None
+        assert scan.duration is not None
+
+        task_result.refresh_from_db()
+        assert task_result.status == states.FAILURE
+        assert task_result.date_done is not None
+
+        mock_revoke.assert_called_once_with(task_result, terminate=True)
+
+        # The queued scan behind the dead one is dispatched.
+        queued_task_result.refresh_from_db()
+        assert queued_task_result.status == states.PENDING
+        mock_apply_async.assert_called_once_with(
+            kwargs={
+                "tenant_id": str(tenant.id),
+                "scan_id": str(queued_scan.id),
+                "provider_id": str(provider.id),
+            },
+            task_id=str(queued_task.id),
+        )
+
+    @patch("tasks.jobs.scan_cleanup._revoke_task")
+    @patch("tasks.jobs.scan_cleanup.is_worker_alive", return_value=True)
+    def test_preserves_live_worker_within_stale_threshold(
+        self, mock_alive, mock_revoke, tenants_fixture, aws_provider
+    ):
+        tenant = tenants_fixture[0]
+        provider = aws_provider
+        scan, task_result = self._create_executing_scan(
+            tenant,
+            provider,
+            started_at=datetime.now(tz=UTC) - timedelta(minutes=5),
+            worker="live@host",
+        )
+
+        result = cleanup_stale_scans()
+
+        assert result["cleaned_up_count"] == 0
+        mock_revoke.assert_not_called()
+        scan.refresh_from_db()
+        assert scan.state == StateChoices.EXECUTING
+
+    @patch("tasks.jobs.scan_cleanup._revoke_task")
+    @patch("tasks.jobs.scan_cleanup.is_worker_alive", return_value=False)
+    def test_preserves_dead_worker_with_recent_activity(
+        self, mock_alive, mock_revoke, tenants_fixture, aws_provider
+    ):
+        tenant = tenants_fixture[0]
+        provider = aws_provider
+        scan, task_result = self._create_executing_scan(
+            tenant,
+            provider,
+            started_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            updated_at=datetime.now(tz=UTC) - timedelta(minutes=1),
+            worker="dead@host",
+        )
+
+        result = cleanup_stale_scans()
+
+        assert result["cleaned_up_count"] == 0
+        mock_revoke.assert_not_called()
+        scan.refresh_from_db()
+        assert scan.state == StateChoices.EXECUTING
+
+    @patch("tasks.jobs.scan_cleanup._revoke_task")
+    @patch("tasks.jobs.scan_cleanup.is_worker_alive")
+    def test_reaps_scan_without_worker_past_stale_threshold(
+        self, mock_alive, mock_revoke, tenants_fixture, aws_provider
+    ):
+        tenant = tenants_fixture[0]
+        provider = aws_provider
+        # Older than the default 48h stale ceiling.
+        scan, _ = self._create_executing_scan(
+            tenant,
+            provider,
+            started_at=datetime.now(tz=UTC) - timedelta(days=3),
+            worker=None,
+        )
+
+        result = cleanup_stale_scans()
+
+        assert result["cleaned_up_count"] == 1
+        # No task/worker, so nothing to ping or revoke.
+        mock_alive.assert_not_called()
+        mock_revoke.assert_not_called()
+        scan.refresh_from_db()
+        assert scan.state == StateChoices.FAILED
+
+    @patch("tasks.jobs.scan_cleanup.is_worker_alive", return_value=True)
+    def test_ignores_non_executing_scans(
+        self, mock_alive, tenants_fixture, aws_provider
+    ):
+        tenant = tenants_fixture[0]
+        provider = aws_provider
+        Scan.objects.create(
+            tenant_id=tenant.id,
+            provider=provider,
+            name="Completed scan",
+            trigger=Scan.TriggerChoices.MANUAL,
+            state=StateChoices.COMPLETED,
+        )
+
+        result = cleanup_stale_scans()
+
+        assert result == {"cleaned_up_count": 0, "scan_ids": []}
+        mock_alive.assert_not_called()
+
+    @patch("tasks.jobs.scan_cleanup._revoke_task")
+    def test_fail_stale_scan_skips_when_no_longer_executing(
+        self, mock_revoke, tenants_fixture, aws_provider
+    ):
+        """A stale snapshot must not fail a scan that already moved on."""
+        tenant = tenants_fixture[0]
+        provider = aws_provider
+        scan, task_result = self._create_executing_scan(
+            tenant,
+            provider,
+            started_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            updated_at=datetime.now(tz=UTC) - timedelta(minutes=31),
+            worker="dead@host",
+        )
+        # The row completed between the snapshot read and acquiring the lock.
+        Scan.all_objects.filter(id=scan.id).update(state=StateChoices.COMPLETED)
+
+        failed = _fail_stale_scan(scan, task_result, "reason", revoke=True)
+
+        assert failed is False
+        mock_revoke.assert_not_called()
+        scan.refresh_from_db()
+        assert scan.state == StateChoices.COMPLETED
+        task_result.refresh_from_db()
+        assert task_result.status == "STARTED"
+
+
+@pytest.mark.django_db
+class TestCleanupStaleScansTask:
+    @patch("tasks.tasks.cleanup_stale_scans")
+    def test_task_invokes_cleanup(self, mock_cleanup):
+        from tasks.tasks import cleanup_stale_scans_task
+
+        mock_cleanup.return_value = {"cleaned_up_count": 0, "scan_ids": []}
+        result = cleanup_stale_scans_task.run()
+
+        assert result == {"cleaned_up_count": 0, "scan_ids": []}
+        mock_cleanup.assert_called_once_with()

--- a/api/src/backend/tasks/tests/test_scan_cleanup.py
+++ b/api/src/backend/tasks/tests/test_scan_cleanup.py
@@ -6,7 +6,7 @@ import pytest
 from api.models import Scan, StateChoices, Task
 from celery import states
 from django_celery_results.models import TaskResult
-from tasks.jobs.scan_cleanup import _fail_stale_scan, cleanup_stale_scans
+from tasks.jobs.scan_cleanup import _fail_stale_scan, _ping_workers, cleanup_stale_scans
 
 
 @pytest.mark.django_db
@@ -20,33 +20,38 @@ class TestCleanupStaleScans:
         ):
             yield
 
-    def _create_executing_scan(
+    def _create_scan(
         self,
         tenant,
         provider,
         *,
+        state,
         started_at=None,
         updated_at=None,
         worker=None,
         task_status="STARTED",
+        name="Scan",
     ):
-        """Create an EXECUTING `Scan` with an optional Task + TaskResult."""
+        """Create a `Scan` with an optional Task + TaskResult.
+
+        ``task_status=None`` creates a scan with no task at all.
+        """
         scan = Scan.objects.create(
             tenant_id=tenant.id,
             provider=provider,
-            name="Running scan",
+            name=name,
             trigger=Scan.TriggerChoices.MANUAL,
-            state=StateChoices.EXECUTING,
-            started_at=started_at or datetime.now(tz=UTC),
+            state=state,
+            started_at=started_at,
         )
 
         task_result = None
-        if worker is not None:
+        if task_status is not None:
             task_result = TaskResult.objects.create(
                 task_id=str(scan.id),
                 task_name="scan-perform",
                 status=task_status,
-                worker=worker,
+                worker=worker or "",
             )
             task = Task.objects.create(
                 id=task_result.task_id,
@@ -65,40 +70,26 @@ class TestCleanupStaleScans:
 
     def _create_queued_scan(self, tenant, provider):
         """Create an AVAILABLE scan whose task is QUEUED behind the active one."""
-        task_result = TaskResult.objects.create(
-            task_id=str(uuid.uuid4()),
-            task_name="scan-perform",
-            status="QUEUED",
-        )
-        task = Task.objects.create(
-            id=task_result.task_id,
-            task_runner_task=task_result,
-            tenant_id=tenant.id,
-        )
-        scan = Scan.objects.create(
-            tenant_id=tenant.id,
-            provider=provider,
-            name="Queued scan",
-            trigger=Scan.TriggerChoices.MANUAL,
+        scan, _ = self._create_scan(
+            tenant,
+            provider,
             state=StateChoices.AVAILABLE,
-            task=task,
+            task_status="QUEUED",
+            name="Queued scan",
         )
-        return scan, task, task_result
+        return scan, scan.task, scan.task.task_runner_task
 
-    @patch("tasks.jobs.scan_cleanup.is_worker_alive")
-    def test_no_executing_scans_is_noop(
-        self, mock_alive, tenants_fixture, aws_provider
-    ):
+    @patch("tasks.jobs.scan_cleanup._ping_workers", return_value=(set(), set()))
+    def test_no_candidates_is_noop(self, mock_ping, tenants_fixture, aws_provider):
         result = cleanup_stale_scans()
 
-        assert result == {"cleaned_up_count": 0, "scan_ids": []}
-        mock_alive.assert_not_called()
+        assert result == {"cleaned_up_count": 0, "scan_ids": [], "queues_checked": 0}
 
     @patch("tasks.jobs.scan_cleanup._revoke_task")
-    @patch("tasks.jobs.scan_cleanup.is_worker_alive", return_value=False)
+    @patch("tasks.jobs.scan_cleanup._ping_workers")
     def test_reaps_dead_worker_inactive_scan_and_drains_queue(
         self,
-        mock_alive,
+        mock_ping,
         mock_revoke,
         tenants_fixture,
         aws_provider,
@@ -106,28 +97,27 @@ class TestCleanupStaleScans:
     ):
         tenant = tenants_fixture[0]
         provider = aws_provider
+        mock_ping.return_value = (set(), {"dead@host"})
 
-        started_at = datetime.now(tz=UTC) - timedelta(hours=1)
-        updated_at = datetime.now(tz=UTC) - timedelta(minutes=31)
-        scan, task_result = self._create_executing_scan(
+        scan, task_result = self._create_scan(
             tenant,
             provider,
-            started_at=started_at,
-            updated_at=updated_at,
+            state=StateChoices.EXECUTING,
+            started_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            updated_at=datetime.now(tz=UTC) - timedelta(minutes=31),
             worker="dead@host",
         )
         queued_scan, queued_task, queued_task_result = self._create_queued_scan(
             tenant, provider
         )
 
-        with patch(
-            "tasks.tasks.perform_scan_task.apply_async"
-        ) as mock_apply_async:
+        with patch("tasks.tasks.perform_scan_task.apply_async") as mock_apply_async:
             with django_capture_on_commit_callbacks(execute=True):
                 result = cleanup_stale_scans()
 
         assert result["cleaned_up_count"] == 1
         assert str(scan.id) in result["scan_ids"]
+        assert result["queues_checked"] == 1
 
         scan.refresh_from_db()
         assert scan.state == StateChoices.FAILED
@@ -137,7 +127,6 @@ class TestCleanupStaleScans:
         task_result.refresh_from_db()
         assert task_result.status == states.FAILURE
         assert task_result.date_done is not None
-
         mock_revoke.assert_called_once_with(task_result, terminate=True)
 
         # The queued scan behind the dead one is dispatched.
@@ -153,15 +142,46 @@ class TestCleanupStaleScans:
         )
 
     @patch("tasks.jobs.scan_cleanup._revoke_task")
-    @patch("tasks.jobs.scan_cleanup.is_worker_alive", return_value=True)
+    @patch("tasks.jobs.scan_cleanup._ping_workers")
+    def test_reaps_dispatched_scan_lost_before_executing(
+        self, mock_ping, mock_revoke, tenants_fixture, aws_provider
+    ):
+        """A task lost before reaching EXECUTING still blocks the queue -> reap it."""
+        tenant = tenants_fixture[0]
+        provider = aws_provider
+        mock_ping.return_value = (set(), {"dead@host"})
+
+        scan, task_result = self._create_scan(
+            tenant,
+            provider,
+            state=StateChoices.AVAILABLE,
+            started_at=None,
+            updated_at=datetime.now(tz=UTC) - timedelta(minutes=31),
+            worker="dead@host",
+            task_status="STARTED",
+        )
+
+        result = cleanup_stale_scans()
+
+        assert result["cleaned_up_count"] == 1
+        scan.refresh_from_db()
+        assert scan.state == StateChoices.FAILED
+        assert scan.duration is None  # never started
+        mock_revoke.assert_called_once_with(task_result, terminate=True)
+
+    @patch("tasks.jobs.scan_cleanup._revoke_task")
+    @patch("tasks.jobs.scan_cleanup._ping_workers")
     def test_preserves_live_worker_within_stale_threshold(
-        self, mock_alive, mock_revoke, tenants_fixture, aws_provider
+        self, mock_ping, mock_revoke, tenants_fixture, aws_provider
     ):
         tenant = tenants_fixture[0]
         provider = aws_provider
-        scan, task_result = self._create_executing_scan(
+        mock_ping.return_value = ({"live@host"}, set())
+
+        scan, _ = self._create_scan(
             tenant,
             provider,
+            state=StateChoices.EXECUTING,
             started_at=datetime.now(tz=UTC) - timedelta(minutes=5),
             worker="live@host",
         )
@@ -174,15 +194,18 @@ class TestCleanupStaleScans:
         assert scan.state == StateChoices.EXECUTING
 
     @patch("tasks.jobs.scan_cleanup._revoke_task")
-    @patch("tasks.jobs.scan_cleanup.is_worker_alive", return_value=False)
+    @patch("tasks.jobs.scan_cleanup._ping_workers")
     def test_preserves_dead_worker_with_recent_activity(
-        self, mock_alive, mock_revoke, tenants_fixture, aws_provider
+        self, mock_ping, mock_revoke, tenants_fixture, aws_provider
     ):
         tenant = tenants_fixture[0]
         provider = aws_provider
-        scan, task_result = self._create_executing_scan(
+        mock_ping.return_value = (set(), {"dead@host"})
+
+        scan, _ = self._create_scan(
             tenant,
             provider,
+            state=StateChoices.EXECUTING,
             started_at=datetime.now(tz=UTC) - timedelta(hours=1),
             updated_at=datetime.now(tz=UTC) - timedelta(minutes=1),
             worker="dead@host",
@@ -196,66 +219,118 @@ class TestCleanupStaleScans:
         assert scan.state == StateChoices.EXECUTING
 
     @patch("tasks.jobs.scan_cleanup._revoke_task")
-    @patch("tasks.jobs.scan_cleanup.is_worker_alive")
+    @patch("tasks.jobs.scan_cleanup._ping_workers")
+    def test_preserves_scan_with_unknown_worker_liveness(
+        self, mock_ping, mock_revoke, tenants_fixture, aws_provider
+    ):
+        """A control-bus failure (unresponsive=None) must never fail a scan."""
+        tenant = tenants_fixture[0]
+        provider = aws_provider
+        mock_ping.return_value = (set(), None)
+
+        scan, _ = self._create_scan(
+            tenant,
+            provider,
+            state=StateChoices.EXECUTING,
+            started_at=datetime.now(tz=UTC) - timedelta(hours=5),
+            updated_at=datetime.now(tz=UTC) - timedelta(hours=5),
+            worker="maybe@host",
+        )
+
+        result = cleanup_stale_scans()
+
+        assert result["cleaned_up_count"] == 0
+        mock_revoke.assert_not_called()
+        scan.refresh_from_db()
+        assert scan.state == StateChoices.EXECUTING
+
+    @patch("tasks.jobs.scan_cleanup._revoke_task")
+    @patch("tasks.jobs.scan_cleanup._ping_workers", return_value=(set(), set()))
     def test_reaps_scan_without_worker_past_stale_threshold(
-        self, mock_alive, mock_revoke, tenants_fixture, aws_provider
+        self, mock_ping, mock_revoke, tenants_fixture, aws_provider
     ):
         tenant = tenants_fixture[0]
         provider = aws_provider
-        # Older than the default 48h stale ceiling.
-        scan, _ = self._create_executing_scan(
+        # Older than the default 48h stale ceiling, and no task/worker recorded.
+        scan, _ = self._create_scan(
             tenant,
             provider,
+            state=StateChoices.EXECUTING,
             started_at=datetime.now(tz=UTC) - timedelta(days=3),
-            worker=None,
+            task_status=None,
         )
 
         result = cleanup_stale_scans()
 
         assert result["cleaned_up_count"] == 1
-        # No task/worker, so nothing to ping or revoke.
-        mock_alive.assert_not_called()
-        mock_revoke.assert_not_called()
+        mock_revoke.assert_not_called()  # nothing to revoke
         scan.refresh_from_db()
         assert scan.state == StateChoices.FAILED
 
-    @patch("tasks.jobs.scan_cleanup.is_worker_alive", return_value=True)
-    def test_ignores_non_executing_scans(
-        self, mock_alive, tenants_fixture, aws_provider
-    ):
+    @patch("tasks.jobs.scan_cleanup._ping_workers", return_value=(set(), set()))
+    def test_ignores_completed_scans(self, mock_ping, tenants_fixture, aws_provider):
         tenant = tenants_fixture[0]
         provider = aws_provider
-        Scan.objects.create(
-            tenant_id=tenant.id,
-            provider=provider,
-            name="Completed scan",
-            trigger=Scan.TriggerChoices.MANUAL,
-            state=StateChoices.COMPLETED,
+        self._create_scan(
+            tenant, provider, state=StateChoices.COMPLETED, task_status=None
         )
 
         result = cleanup_stale_scans()
 
-        assert result == {"cleaned_up_count": 0, "scan_ids": []}
-        mock_alive.assert_not_called()
+        assert result == {"cleaned_up_count": 0, "scan_ids": [], "queues_checked": 0}
+
+    @patch("tasks.jobs.scan_cleanup._ping_workers", return_value=(set(), set()))
+    def test_safety_net_dispatches_orphaned_queued_scan(
+        self,
+        mock_ping,
+        tenants_fixture,
+        aws_provider,
+        django_capture_on_commit_callbacks,
+    ):
+        """A QUEUED scan with no active scan is dispatched even with nothing to reap."""
+        tenant = tenants_fixture[0]
+        provider = aws_provider
+        queued_scan, queued_task, queued_task_result = self._create_queued_scan(
+            tenant, provider
+        )
+
+        with patch("tasks.tasks.perform_scan_task.apply_async") as mock_apply_async:
+            with django_capture_on_commit_callbacks(execute=True):
+                result = cleanup_stale_scans()
+
+        assert result["cleaned_up_count"] == 0
+        assert result["queues_checked"] == 1
+        queued_task_result.refresh_from_db()
+        assert queued_task_result.status == states.PENDING
+        mock_apply_async.assert_called_once_with(
+            kwargs={
+                "tenant_id": str(tenant.id),
+                "scan_id": str(queued_scan.id),
+                "provider_id": str(provider.id),
+            },
+            task_id=str(queued_task.id),
+        )
 
     @patch("tasks.jobs.scan_cleanup._revoke_task")
-    def test_fail_stale_scan_skips_when_no_longer_executing(
+    def test_fail_stale_scan_skips_when_state_changed(
         self, mock_revoke, tenants_fixture, aws_provider
     ):
         """A stale snapshot must not fail a scan that already moved on."""
         tenant = tenants_fixture[0]
         provider = aws_provider
-        scan, task_result = self._create_executing_scan(
+        scan, task_result = self._create_scan(
             tenant,
             provider,
+            state=StateChoices.EXECUTING,
             started_at=datetime.now(tz=UTC) - timedelta(hours=1),
-            updated_at=datetime.now(tz=UTC) - timedelta(minutes=31),
             worker="dead@host",
         )
         # The row completed between the snapshot read and acquiring the lock.
         Scan.all_objects.filter(id=scan.id).update(state=StateChoices.COMPLETED)
 
-        failed = _fail_stale_scan(scan, task_result, "reason", revoke=True)
+        failed = _fail_stale_scan(
+            scan, task_result, "reason", expected_state=StateChoices.EXECUTING, revoke=True
+        )
 
         assert failed is False
         mock_revoke.assert_not_called()
@@ -266,13 +341,38 @@ class TestCleanupStaleScans:
 
 
 @pytest.mark.django_db
+class TestPingWorkers:
+    @patch("tasks.jobs.scan_cleanup.current_app")
+    def test_returns_responsive_and_unresponsive(self, mock_app):
+        mock_app.control.inspect.return_value.ping.return_value = {"a@host": {"ok": "pong"}}
+
+        responsive, unresponsive = _ping_workers({"a@host", "b@host"})
+
+        assert responsive == {"a@host"}
+        assert unresponsive == {"b@host"}
+
+    @patch("tasks.jobs.scan_cleanup.current_app")
+    def test_unknown_when_ping_keeps_raising(self, mock_app):
+        mock_app.control.inspect.return_value.ping.side_effect = Exception("bus down")
+
+        responsive, unresponsive = _ping_workers({"a@host"})
+
+        assert responsive == set()
+        assert unresponsive is None
+
+
+@pytest.mark.django_db
 class TestCleanupStaleScansTask:
     @patch("tasks.tasks.cleanup_stale_scans")
     def test_task_invokes_cleanup(self, mock_cleanup):
         from tasks.tasks import cleanup_stale_scans_task
 
-        mock_cleanup.return_value = {"cleaned_up_count": 0, "scan_ids": []}
+        mock_cleanup.return_value = {
+            "cleaned_up_count": 0,
+            "scan_ids": [],
+            "queues_checked": 0,
+        }
         result = cleanup_stale_scans_task.run()
 
-        assert result == {"cleaned_up_count": 0, "scan_ids": []}
+        assert result == mock_cleanup.return_value
         mock_cleanup.assert_called_once_with()

--- a/api/src/backend/tasks/tests/test_scan_cleanup.py
+++ b/api/src/backend/tasks/tests/test_scan_cleanup.py
@@ -366,6 +366,29 @@ class TestCleanupStaleScans:
 
         assert result == {"cleaned_up_count": 0, "scan_ids": [], "queues_checked": 0}
 
+    @patch("tasks.jobs.scan_cleanup.SCAN_CLEANUP_ENABLED", False)
+    @patch("tasks.jobs.scan_cleanup._ping_workers")
+    def test_no_ops_when_disabled_by_invalid_configuration(
+        self, mock_ping, tenants_fixture, aws_provider
+    ):
+        # An unsafe threshold policy must not reap anything, however stale.
+        tenant = tenants_fixture[0]
+        self._create_scan(
+            tenant,
+            aws_provider,
+            state=StateChoices.EXECUTING,
+            started_at=datetime.now(tz=UTC) - timedelta(days=30),
+            updated_at=datetime.now(tz=UTC) - timedelta(days=30),
+            worker="dead-worker",
+        )
+
+        result = cleanup_stale_scans()
+
+        assert result == {"cleaned_up_count": 0, "scan_ids": [], "queues_checked": 0}
+        mock_ping.assert_not_called()
+        scan = Scan.objects.get(provider=aws_provider)
+        assert scan.state == StateChoices.EXECUTING
+
     @patch("tasks.jobs.scan_cleanup._ping_workers", return_value=(set(), set()))
     def test_safety_net_dispatches_orphaned_queued_scan(
         self,

--- a/api/src/backend/tasks/tests/test_scan_cleanup.py
+++ b/api/src/backend/tasks/tests/test_scan_cleanup.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
@@ -13,7 +12,7 @@ from tasks.jobs.scan_cleanup import _fail_stale_scan, _ping_workers, cleanup_sta
 class TestCleanupStaleScans:
     @pytest.fixture(autouse=True)
     def execute_on_commit_callbacks(self):
-        # Fire the post-commit revoke synchronously so tests can assert on it.
+        # Fire the post-commit finalization synchronously so tests can assert it.
         with patch(
             "tasks.jobs.scan_cleanup.on_commit",
             side_effect=lambda callback, **kwargs: callback(),
@@ -30,6 +29,7 @@ class TestCleanupStaleScans:
         updated_at=None,
         worker=None,
         task_status="STARTED",
+        task_created_at=None,
         name="Scan",
     ):
         """Create a `Scan` with an optional Task + TaskResult.
@@ -53,6 +53,12 @@ class TestCleanupStaleScans:
                 status=task_status,
                 worker=worker or "",
             )
+            if task_created_at is not None:
+                # `date_created` uses auto_now_add, so bypass it.
+                TaskResult.objects.filter(pk=task_result.pk).update(
+                    date_created=task_created_at
+                )
+                task_result.refresh_from_db()
             task = Task.objects.create(
                 id=task_result.task_id,
                 task_runner_task=task_result,
@@ -127,6 +133,7 @@ class TestCleanupStaleScans:
         task_result.refresh_from_db()
         assert task_result.status == states.FAILURE
         assert task_result.date_done is not None
+        # A running worker must actually be stopped.
         mock_revoke.assert_called_once_with(task_result, terminate=True)
 
         # The queued scan behind the dead one is dispatched.
@@ -146,7 +153,7 @@ class TestCleanupStaleScans:
     def test_reaps_dispatched_scan_lost_before_executing(
         self, mock_ping, mock_revoke, tenants_fixture, aws_provider
     ):
-        """A task lost before reaching EXECUTING still blocks the queue -> reap it."""
+        """A task lost before reaching EXECUTING still blocks the queue."""
         tenant = tenants_fixture[0]
         provider = aws_provider
         mock_ping.return_value = (set(), {"dead@host"})
@@ -167,7 +174,87 @@ class TestCleanupStaleScans:
         scan.refresh_from_db()
         assert scan.state == StateChoices.FAILED
         assert scan.duration is None  # never started
-        mock_revoke.assert_called_once_with(task_result, terminate=True)
+        # The scan never reached EXECUTING, so nothing must be terminated.
+        mock_revoke.assert_called_once_with(task_result, terminate=False)
+
+    @patch("tasks.jobs.scan_cleanup._revoke_task")
+    @patch("tasks.jobs.scan_cleanup._ping_workers", return_value=(set(), set()))
+    def test_reaps_aged_pending_scan_without_worker_and_dispatches_follower(
+        self,
+        mock_ping,
+        mock_revoke,
+        tenants_fixture,
+        aws_provider,
+        django_capture_on_commit_callbacks,
+    ):
+        """A PENDING scan that never reached a worker must not block forever.
+
+        Regression test: it has no `started_at`, so it is aged from the task
+        creation time instead.
+        """
+        tenant = tenants_fixture[0]
+        provider = aws_provider
+
+        scan, task_result = self._create_scan(
+            tenant,
+            provider,
+            state=StateChoices.AVAILABLE,
+            started_at=None,
+            worker=None,
+            task_status=states.PENDING,
+            task_created_at=datetime.now(tz=UTC) - timedelta(hours=72),
+        )
+        queued_scan, queued_task, queued_task_result = self._create_queued_scan(
+            tenant, provider
+        )
+
+        with patch("tasks.tasks.perform_scan_task.apply_async") as mock_apply_async:
+            with django_capture_on_commit_callbacks(execute=True):
+                result = cleanup_stale_scans()
+
+        assert result["cleaned_up_count"] == 1
+        assert str(scan.id) in result["scan_ids"]
+
+        scan.refresh_from_db()
+        assert scan.state == StateChoices.FAILED
+        # The never-consumed broker message is revoked without terminating.
+        mock_revoke.assert_called_once_with(task_result, terminate=False)
+
+        # The follower is now dispatched instead of staying queued forever.
+        queued_task_result.refresh_from_db()
+        assert queued_task_result.status == states.PENDING
+        mock_apply_async.assert_called_once_with(
+            kwargs={
+                "tenant_id": str(tenant.id),
+                "scan_id": str(queued_scan.id),
+                "provider_id": str(provider.id),
+            },
+            task_id=str(queued_task.id),
+        )
+
+    @patch("tasks.jobs.scan_cleanup._revoke_task")
+    @patch("tasks.jobs.scan_cleanup._ping_workers", return_value=(set(), set()))
+    def test_preserves_recent_pending_scan_without_worker(
+        self, mock_ping, mock_revoke, tenants_fixture, aws_provider
+    ):
+        """A scan still waiting in the broker queue must never be reaped."""
+        tenant = tenants_fixture[0]
+        provider = aws_provider
+        scan, _ = self._create_scan(
+            tenant,
+            provider,
+            state=StateChoices.AVAILABLE,
+            started_at=None,
+            worker=None,
+            task_status=states.PENDING,
+        )
+
+        result = cleanup_stale_scans()
+
+        assert result["cleaned_up_count"] == 0
+        mock_revoke.assert_not_called()
+        scan.refresh_from_db()
+        assert scan.state == StateChoices.AVAILABLE
 
     @patch("tasks.jobs.scan_cleanup._revoke_task")
     @patch("tasks.jobs.scan_cleanup._ping_workers")
@@ -223,7 +310,7 @@ class TestCleanupStaleScans:
     def test_preserves_scan_with_unknown_worker_liveness(
         self, mock_ping, mock_revoke, tenants_fixture, aws_provider
     ):
-        """A control-bus failure (unresponsive=None) must never fail a scan."""
+        """Unknown liveness must never fail a scan before the stale ceiling."""
         tenant = tenants_fixture[0]
         provider = aws_provider
         mock_ping.return_value = (set(), None)
@@ -287,7 +374,7 @@ class TestCleanupStaleScans:
         aws_provider,
         django_capture_on_commit_callbacks,
     ):
-        """A QUEUED scan with no active scan is dispatched even with nothing to reap."""
+        """A QUEUED scan with no active scan is dispatched with nothing to reap."""
         tenant = tenants_fixture[0]
         provider = aws_provider
         queued_scan, queued_task, queued_task_result = self._create_queued_scan(
@@ -329,7 +416,11 @@ class TestCleanupStaleScans:
         Scan.all_objects.filter(id=scan.id).update(state=StateChoices.COMPLETED)
 
         failed = _fail_stale_scan(
-            scan, task_result, "reason", expected_state=StateChoices.EXECUTING, revoke=True
+            scan,
+            task_result,
+            "reason",
+            expected_state=StateChoices.EXECUTING,
+            terminate=True,
         )
 
         assert failed is False
@@ -339,17 +430,72 @@ class TestCleanupStaleScans:
         task_result.refresh_from_db()
         assert task_result.status == "STARTED"
 
+    @patch("tasks.jobs.scan_cleanup._revoke_task")
+    def test_fail_stale_scan_skips_when_task_already_finished(
+        self, mock_revoke, tenants_fixture, aws_provider
+    ):
+        """The task may report its own result while workers are being probed."""
+        tenant = tenants_fixture[0]
+        provider = aws_provider
+        scan, task_result = self._create_scan(
+            tenant,
+            provider,
+            state=StateChoices.EXECUTING,
+            started_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            worker="dead@host",
+        )
+        TaskResult.objects.filter(pk=task_result.pk).update(status=states.SUCCESS)
+
+        failed = _fail_stale_scan(
+            scan,
+            task_result,
+            "reason",
+            expected_state=StateChoices.EXECUTING,
+            terminate=True,
+        )
+
+        assert failed is False
+        mock_revoke.assert_not_called()
+        scan.refresh_from_db()
+        assert scan.state == StateChoices.EXECUTING
+
 
 @pytest.mark.django_db
 class TestPingWorkers:
     @patch("tasks.jobs.scan_cleanup.current_app")
-    def test_returns_responsive_and_unresponsive(self, mock_app):
-        mock_app.control.inspect.return_value.ping.return_value = {"a@host": {"ok": "pong"}}
+    def test_reports_dead_worker_only_when_another_replies(self, mock_app):
+        """A silent worker is only confirmed dead if the control bus answered."""
+        mock_app.control.inspect.return_value.ping.return_value = {
+            "a@host": {"ok": "pong"}
+        }
 
         responsive, unresponsive = _ping_workers({"a@host", "b@host"})
 
         assert responsive == {"a@host"}
         assert unresponsive == {"b@host"}
+
+    @patch("tasks.jobs.scan_cleanup.current_app")
+    def test_unknown_when_ping_returns_none(self, mock_app):
+        """Regression: Celery swallows reply timeouts and returns None.
+
+        That is indistinguishable from a broken control bus, so it must never be
+        reported as confirmed worker death.
+        """
+        mock_app.control.inspect.return_value.ping.return_value = None
+
+        responsive, unresponsive = _ping_workers({"a@host"})
+
+        assert responsive == set()
+        assert unresponsive is None
+
+    @patch("tasks.jobs.scan_cleanup.current_app")
+    def test_unknown_when_ping_returns_empty_dict(self, mock_app):
+        mock_app.control.inspect.return_value.ping.return_value = {}
+
+        responsive, unresponsive = _ping_workers({"a@host"})
+
+        assert responsive == set()
+        assert unresponsive is None
 
     @patch("tasks.jobs.scan_cleanup.current_app")
     def test_unknown_when_ping_keeps_raising(self, mock_app):
@@ -359,6 +505,19 @@ class TestPingWorkers:
 
         assert responsive == set()
         assert unresponsive is None
+
+    @patch("tasks.jobs.scan_cleanup.current_app")
+    def test_retries_only_pending_workers(self, mock_app):
+        """A worker that answers on a later attempt is never reported dead."""
+        mock_app.control.inspect.return_value.ping.side_effect = [
+            {"a@host": {"ok": "pong"}},
+            {"b@host": {"ok": "pong"}},
+        ]
+
+        responsive, unresponsive = _ping_workers({"a@host", "b@host"})
+
+        assert responsive == {"a@host", "b@host"}
+        assert unresponsive == set()
 
 
 @pytest.mark.django_db

--- a/api/src/backend/tasks/tests/test_scan_cleanup.py
+++ b/api/src/backend/tasks/tests/test_scan_cleanup.py
@@ -366,10 +366,15 @@ class TestCleanupStaleScans:
 
         assert result == {"cleaned_up_count": 0, "scan_ids": [], "queues_checked": 0}
 
+    @patch(
+        "tasks.jobs.scan_cleanup.SCAN_CLEANUP_CONFIG_ERROR",
+        "invalid stale-scan thresholds",
+    )
     @patch("tasks.jobs.scan_cleanup.SCAN_CLEANUP_ENABLED", False)
     @patch("tasks.jobs.scan_cleanup._ping_workers")
+    @patch("tasks.jobs.scan_cleanup.logger.error")
     def test_no_ops_when_disabled_by_invalid_configuration(
-        self, mock_ping, tenants_fixture, aws_provider
+        self, mock_log_error, mock_ping, tenants_fixture, aws_provider
     ):
         # An unsafe threshold policy must not reap anything, however stale.
         tenant = tenants_fixture[0]
@@ -388,6 +393,8 @@ class TestCleanupStaleScans:
         mock_ping.assert_not_called()
         scan = Scan.objects.get(provider=aws_provider)
         assert scan.state == StateChoices.EXECUTING
+        mock_log_error.assert_called_once()
+        assert "invalid stale-scan thresholds" in str(mock_log_error.call_args)
 
     @patch("tasks.jobs.scan_cleanup._ping_workers", return_value=(set(), set()))
     def test_safety_net_dispatches_orphaned_queued_scan(

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -200,7 +200,9 @@ A fix addressing this permission issue is being evaluated in [PR #9953](https://
 
 ### Scan Stuck in Executing State After Worker Crash
 
-When running Prowler Local Server via Docker Compose, a scan may remain indefinitely in the `executing` state if the worker process crashes (for example, due to an Out of Memory condition) before it can update the scan status. Since it is not currently possible to cancel a scan in `executing` state through the UI, the workaround is to manually update the scan record in the database.
+When running Prowler Local Server via Docker Compose, a scan may remain in the `executing` state if the worker process crashes (for example, due to an Out of Memory condition) before it can update the scan status. Because scans run one at a time per provider, a scan stuck in `executing` also keeps any newer scans for that provider in the `Queued` state.
+
+A periodic task (`scan-cleanup-stale-scans`) automatically detects these scans — it confirms the worker is gone, marks the scan `failed`, and releases the provider's queue so the next scan starts. It runs every 15 minutes, so recovery normally completes within roughly 30–45 minutes of the last scan activity (the `SCAN_INACTIVITY_THRESHOLD_MINUTES` window, default 30 minutes, plus up to one scheduling interval). If you need to recover immediately instead of waiting, use the manual workaround below.
 
 **Root Cause:**
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -202,7 +202,9 @@ A fix addressing this permission issue is being evaluated in [PR #9953](https://
 
 When running Prowler Local Server via Docker Compose, a scan may remain in the `executing` state if the worker process crashes (for example, due to an Out of Memory condition) before it can update the scan status. Because scans run one at a time per provider, a scan stuck in `executing` also keeps any newer scans for that provider in the `Queued` state.
 
-A periodic task (`scan-cleanup-stale-scans`) automatically detects these scans — it confirms the worker is gone, marks the scan `failed`, and releases the provider's queue so the next scan starts. It runs every 15 minutes, so recovery normally completes within roughly 30–45 minutes of the last scan activity (the `SCAN_INACTIVITY_THRESHOLD_MINUTES` window, default 30 minutes, plus up to one scheduling interval). If you need to recover immediately instead of waiting, use the manual workaround below.
+A periodic task (`scan-cleanup-stale-scans`) automatically detects these scans — it confirms the worker is gone, marks the scan `failed`, and releases the provider's queue so the next scan starts. It runs every 15 minutes, so recovery normally completes within roughly 30–45 minutes of the last scan activity (the `SCAN_INACTIVITY_THRESHOLD_MINUTES` window, default 30 minutes, plus up to one scheduling interval).
+
+When the worker cannot be reached at all — for example a single-worker deployment where that worker died — its liveness cannot be confirmed, so the scan is instead released after `SCAN_STALE_THRESHOLD_MINUTES` (default 48 hours) to guarantee a healthy scan is never failed by a temporary connectivity problem. The same ceiling applies to a scan whose task was lost before it ever started. If you need to recover sooner than that, use the manual workaround below.
 
 **Root Cause:**
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -200,6 +200,8 @@ A fix addressing this permission issue is being evaluated in [PR #9953](https://
 
 ### Scan Stuck in Executing State After Worker Crash
 
+<VersionBadge version="5.36.0" />
+
 When running Prowler Local Server via Docker Compose, a scan may remain in the `executing` state if the worker process crashes (for example, due to an Out of Memory condition) before it can update the scan status. Because scans run one at a time per provider, a scan stuck in `executing` also keeps any newer scans for that provider in the `Queued` state.
 
 A periodic task (`scan-cleanup-stale-scans`) automatically detects these scans — it confirms the worker is gone, marks the scan `failed`, and releases the provider's queue so the next scan starts. It runs every 15 minutes, so recovery normally completes within roughly 30–45 minutes of the last scan activity (the `SCAN_INACTIVITY_THRESHOLD_MINUTES` window, default 30 minutes, plus up to one scheduling interval).


### PR DESCRIPTION
### Context

Fix #12007

Since #11848 (v5.33.0) scans run one-at-a-time per provider. When a scan is launched while another is active for the same provider, the new scan is created in the `available` state (shown as **Queued** in the UI) and is *not* dispatched to Celery — it waits until the active scan's task finishes and its `finally` block dispatches the next queued scan.

`scan-perform` uses `acks_late=False` and is deliberately excluded from orphan recovery, so a worker that dies mid-scan (OOM, hard time-limit kill, node failure) never runs that `finally`. The scan is stranded in `executing` (the scenario already documented in the troubleshooting guide / #6893) and, because it still counts as the provider's active scan, **every queued scan for that provider stays "Queued" forever** — which is exactly what the reporter saw ("other jobs sometimes start, but the job in the queue never starts").

### Description

Adds a periodic watchdog task `scan-cleanup-stale-scans` that recovers scans stranded in `executing` by a dead worker, mirroring the existing `cleanup_stale_attack_paths_scans` for the main `Scan` model:

- Reads all `executing` scans (cross-tenant, admin DB) and pings each recorded worker once.
  - **worker alive** → only reaped if it overran the stale ceiling (`SCAN_STALE_THRESHOLD_MINUTES`, default 48h, matched to the long hard time-limit);
  - **worker gone** → reaped after the shorter inactivity window (`SCAN_INACTIVITY_THRESHOLD_MINUTES`, default 30m of no progress heartbeat);
  - **no worker recorded** → time-based fallback on `started_at`;
  - unreachable control bus → every worker looks alive, so nothing is reaped by mistake.
- For each stranded scan: locks and re-verifies the row, marks it `failed` (with `completed_at`/`duration`), marks the `TaskResult` terminal, and revokes the lost task after commit.
- **Then dispatches the next queued scan for that provider**, so the provider's queue drains.

It never re-runs the dead scan (that would duplicate findings) — it only fails it and releases the queue. The task is registered as a `PeriodicTask` (every 15 min) and added to `_SKIP_RECOVERY` so the orphan watchdog never re-enqueues it.

New settings (env-overridable, no `.env` changes required — same convention as the Attack Paths thresholds):
- `SCAN_INACTIVITY_THRESHOLD_MINUTES` (default 30)
- `SCAN_STALE_THRESHOLD_MINUTES` (default 2880)

Files:
- `tasks/jobs/scan_cleanup.py` — new reaper + queue-drain
- `tasks/tasks.py` — `cleanup_stale_scans_task` (`queue="celery"`)
- `tasks/jobs/orphan_recovery.py` — skip the new maintenance task
- `config/django/base.py` — thresholds
- `api/migrations/0098_scan_cleanup_periodic_task.py` — PeriodicTask (15 min)
- `tasks/tests/test_scan_cleanup.py` — unit tests
- `tasks/tests/test_orphan_recovery.py` — cover skip of the new task
- `docs/troubleshooting.mdx` — note automatic recovery now exists
- `api/changelog.d/scan-stuck-queued.fixed.md`

### Steps to review

1. Read `tasks/jobs/scan_cleanup.py`. Confirm the detection matrix (alive/dead/no-worker) and that queue drain runs only after the FAILED state commits.
2. `cd api && uv run pytest src/backend/tasks/tests/test_scan_cleanup.py src/backend/tasks/tests/test_orphan_recovery.py -q`
3. Confirm the migration applies and creates the `scan-cleanup-stale-scans` PeriodicTask: `uv run python src/backend/manage.py migrate`.
4. End-to-end: start a scan, kill the worker mid-scan (`docker kill` the worker) so the scan is left in `executing`, queue another scan for the same provider (it goes to `Queued`), then run the task (`uv run python src/backend/manage.py shell -c "from tasks.tasks import cleanup_stale_scans_task; print(cleanup_stale_scans_task())"`) and confirm the stuck scan flips to `failed` and the queued scan starts.

### Checklist

- [x] Tests added (`test_scan_cleanup.py`) and orphan-recovery skip covered.
- [x] Changelog fragment under `api/changelog.d/`.
- [ ] Backport: consider backporting to the 5.33.x/5.34.x lines where the per-provider queuing shipped.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically recovers scans stuck in “executing” after a worker crash by marking them as failed.
  * Unblocks provider queues so the next queued scan can run.
  * Preserves scans when workers appear active or their status is unknown.

* **Maintenance**
  * Runs stale-scan cleanup automatically every 15 minutes.
  * Improves performance when checking active scans.

* **Documentation**
  * Updates troubleshooting guidance with recovery timing and configurable thresholds.

* **Tests**
  * Adds coverage for cleanup, queue recovery, worker checks, and race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->