### PR TITLE
fix(api): apply long task limits to Attack Paths scans

### DIFF
--- a/api/changelog.d/attack-paths-scan-time-limit.fixed.md
+++ b/api/changelog.d/attack-paths-scan-time-limit.fixed.md
@@ -1,0 +1,1 @@
+`attack-paths-scan-perform` Celery tasks now use the configurable long-task time limits instead of the six-hour defaults

--- a/api/src/backend/config/celery.py
+++ b/api/src/backend/config/celery.py
@@ -74,6 +74,7 @@ celery_app.conf.task_annotations = {
         for name in (
             "scan-perform",
             "scan-perform-scheduled",
+            "attack-paths-scan-perform",
             "provider-deletion",
             "tenant-deletion",
         )

--- a/api/src/backend/tasks/tests/test_tasks.py
+++ b/api/src/backend/tasks/tests/test_tasks.py
@@ -3304,6 +3304,7 @@ class TestTaskTimeLimits:
         for name in (
             "scan-perform",
             "scan-perform-scheduled",
+            "attack-paths-scan-perform",
             "provider-deletion",
             "tenant-deletion",
         ):


### PR DESCRIPTION
### Context

Attack Paths scans currently inherit the default six-hour Celery task limit. Large scans can exceed this limit and terminate before completion, while regular scans already use the configurable long-task limits.

### Description

- Applies the configurable long-task soft and hard limits to `attack-paths-scan-perform`
- Extends the task-limit regression test to cover Attack Paths scans

This change has no new dependencies.

### Steps to review

1. Confirm `attack-paths-scan-perform` is included in the long-running task annotations in `config/celery.py`.
2. Run API test suite.
3. Confirm the Attack Paths task limit exceeds the default task limit and matches the limits applied to regular scan tasks.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### API

- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Attack path scans now use the configured long-running task time limits instead of the previous six-hour default.
  - This helps prevent longer scans from being stopped prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->