### PR TITLE
fix(api): disable social account connection notifications

### DIFF
--- a/api/changelog.d/social-account-linking.security.md
+++ b/api/changelog.d/social-account-linking.security.md
@@ -1,1 +1,1 @@
-Social account linking now requires a verified matching email from both the identity provider and the existing user account
+Social account linking requires a verified matching email from both the identity provider and the existing user account without sending account connection notifications

--- a/api/src/backend/api/adapters.py
+++ b/api/src/backend/api/adapters.py
@@ -1,5 +1,3 @@
-import logging
-
 from allauth.account.models import EmailAddress
 from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
@@ -16,8 +14,6 @@ from api.models import (
 from api.utils import accept_invitation_for_user
 from django.db import transaction
 from django.http import HttpResponseForbidden
-
-logger = logging.getLogger(__name__)
 
 
 class ProwlerSocialAccountAdapter(DefaultSocialAccountAdapter):
@@ -104,12 +100,6 @@ class ProwlerSocialAccountAdapter(DefaultSocialAccountAdapter):
                 if not email_is_verified or not provider_verified_email:
                     raise ImmediateHttpResponse(HttpResponseForbidden())
                 sociallogin.connect(request, existing_user)
-
-    def send_notification_mail(self, *args, **kwargs):
-        try:
-            return super().send_notification_mail(*args, **kwargs)
-        except OSError:
-            logger.exception("Failed to send social account connection notification")
 
     def save_user(self, request, sociallogin, form=None):
         """

--- a/api/src/backend/api/tests/test_adapters.py
+++ b/api/src/backend/api/tests/test_adapters.py
@@ -302,7 +302,9 @@ class TestProwlerSocialAccountAdapter:
 
         sociallogin.connect.assert_called_once_with(request, create_test_user)
 
-    def test_verified_social_account_link_notifies_owner(self, create_test_user, rf):
+    def test_verified_social_account_link_does_not_send_notification(
+        self, create_test_user, rf
+    ):
         _verify_local_email(create_test_user)
         sociallogin = _real_oauth_sociallogin(
             create_test_user,
@@ -318,34 +320,7 @@ class TestProwlerSocialAccountAdapter:
             uid="verified-google-account",
             user=create_test_user,
         ).exists()
-        assert len(mail.outbox) == 1
-        assert mail.outbox[0].to == [create_test_user.email]
-
-    def test_notification_delivery_failure_does_not_break_verified_link(
-        self, create_test_user, rf
-    ):
-        _verify_local_email(create_test_user)
-        sociallogin = _real_oauth_sociallogin(
-            create_test_user,
-            uid="verified-google-account-without-smtp",
-        )
-        request = rf.get("/")
-
-        with (
-            context.request_context(request),
-            patch(
-                "allauth.socialaccount.adapter."
-                "DefaultSocialAccountAdapter.send_notification_mail",
-                side_effect=ConnectionRefusedError,
-            ),
-        ):
-            ProwlerSocialAccountAdapter().pre_social_login(request, sociallogin)
-
-        assert SocialAccount.objects.filter(
-            provider="google",
-            uid="verified-google-account-without-smtp",
-            user=create_test_user,
-        ).exists()
+        assert mail.outbox == []
 
     def test_pre_social_login_uses_verified_email_missing_from_extra_data(
         self, create_test_user, rf
@@ -367,7 +342,7 @@ class TestProwlerSocialAccountAdapter:
     def test_social_account_linking_settings_are_fail_closed(self):
         assert not socialaccount_app_settings.EMAIL_AUTHENTICATION
         assert not socialaccount_app_settings.EMAIL_AUTHENTICATION_AUTO_CONNECT
-        assert account_app_settings.EMAIL_NOTIFICATIONS
+        assert not account_app_settings.EMAIL_NOTIFICATIONS
 
     def test_save_user_social_with_invitation_joins_invited_tenant(
         self, rf, create_test_user, tenants_fixture

--- a/api/src/backend/config/settings/social_login.py
+++ b/api/src/backend/config/settings/social_login.py
@@ -13,7 +13,7 @@ GITHUB_OAUTH_CALLBACK_URL = env("SOCIAL_GITHUB_OAUTH_CALLBACK_URL", default="")
 ACCOUNT_LOGIN_METHODS = {"email"}  # Use Email / Password authentication
 ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*", "password2*"]
 ACCOUNT_EMAIL_VERIFICATION = "none"  # Do not require email confirmation
-ACCOUNT_EMAIL_NOTIFICATIONS = True
+ACCOUNT_EMAIL_NOTIFICATIONS = False
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 REST_AUTH = {
     "TOKEN_MODEL": None,


### PR DESCRIPTION
### Context

Social account linking currently enables allauth account connection email notifications. These notifications run synchronously in the API process and can fail in deployments where outbound email delivery is isolated to dedicated workers, even though account linking succeeds.

### Description

- Disable account connection notification emails during social account linking
- Remove obsolete notification delivery error handling
- Keep verified email requirements and existing account reuse unchanged
- Update regression coverage and the pending security changelog entry

### Steps to review

1. Run `cd api && uv run pytest src/backend/api/tests/test_adapters.py -q`
2. Run `cd api && uv run ruff check src/backend/api/adapters.py src/backend/api/tests/test_adapters.py src/backend/config/settings/social_login.py`
3. Verify an unverified existing account remains blocked from social linking
4. Verify a verified existing account is reused and linked without sending an account connection email

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure a changelog fragment is added under <component>/changelog.d/, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No

#### UI (if applicable)
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under ui/changelog.d/

#### API (if applicable)
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required.
- [x] Ensure a changelog fragment is added under api/changelog.d/

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Social account linking now requires verified, matching email addresses from both accounts.
  * Verified social account links no longer send account connection notification emails.
  * Email notifications are disabled by default for social account linking.
* **Documentation**
  * Updated the security guidance to clarify verification requirements and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->