### PR TITLE
feat(ui): register Stripe publishable keys in runtime config island

### DIFF
--- a/ui/lib/get-runtime-config.client.test.ts
+++ b/ui/lib/get-runtime-config.client.test.ts
@@ -105,6 +105,8 @@ describe("getRuntimeConfigClient", () => {
         "reoDevClientId",
         "sentryDsn",
         "sentryEnvironment",
+        "stripePublishableKey",
+        "stripePublishableKeyV2",
       ].sort(),
     );
     expect(config.apiBaseUrl).toBe("https://api.example.com/api/v1");

--- a/ui/lib/get-runtime-config.client.ts
+++ b/ui/lib/get-runtime-config.client.ts
@@ -21,6 +21,8 @@ const pickConfig = (
   posthogHost: parsed.posthogHost ?? null,
   reoDevClientId: parsed.reoDevClientId ?? null,
   cloudBillingEnabled: parsed.cloudBillingEnabled ?? false,
+  stripePublishableKey: parsed.stripePublishableKey ?? null,
+  stripePublishableKeyV2: parsed.stripePublishableKeyV2 ?? null,
 });
 
 // Reads the <head> island once (memoized); all-null during SSR or if it's

--- a/ui/lib/runtime-config.shared.ts
+++ b/ui/lib/runtime-config.shared.ts
@@ -10,6 +10,8 @@ export interface RuntimePublicConfig {
   posthogHost: string | null; // reserved
   reoDevClientId: string | null; // reserved
   cloudBillingEnabled: boolean;
+  stripePublishableKey: string | null; // reserved
+  stripePublishableKeyV2: string | null; // reserved
 }
 
 export const RUNTIME_CONFIG_SCRIPT_ID = "__PROWLER_RUNTIME_CONFIG__";
@@ -25,4 +27,6 @@ export const EMPTY_RUNTIME_PUBLIC_CONFIG: RuntimePublicConfig = {
   posthogHost: null,
   reoDevClientId: null,
   cloudBillingEnabled: false,
+  stripePublishableKey: null,
+  stripePublishableKeyV2: null,
 };

--- a/ui/lib/runtime-config.ts
+++ b/ui/lib/runtime-config.ts
@@ -50,11 +50,11 @@ export async function getRuntimePublicConfig(): Promise<RuntimePublicConfig> {
     cloudBillingEnabled:
       (readEnv("CLOUD_BILLING_ENABLED") ?? "false") !== "false",
     stripePublishableKey: readEnv(
-      "CLOUD_STRIPE_PUBLISHABLE_KEY",
+      "UI_CLOUD_STRIPE_PUBLISHABLE_KEY",
       "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
     ),
     stripePublishableKeyV2: readEnv(
-      "CLOUD_STRIPE_PUBLISHABLE_KEY_V2",
+      "UI_CLOUD_STRIPE_PUBLISHABLE_KEY_V2",
       "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_V2",
     ),
   };

--- a/ui/lib/runtime-config.ts
+++ b/ui/lib/runtime-config.ts
@@ -49,5 +49,13 @@ export async function getRuntimePublicConfig(): Promise<RuntimePublicConfig> {
     // server-side for V1/V2 routing). Default (unset) is off.
     cloudBillingEnabled:
       (readEnv("CLOUD_BILLING_ENABLED") ?? "false") !== "false",
+    stripePublishableKey: readEnv(
+      "CLOUD_STRIPE_PUBLISHABLE_KEY",
+      "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
+    ),
+    stripePublishableKeyV2: readEnv(
+      "CLOUD_STRIPE_PUBLISHABLE_KEY_V2",
+      "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_V2",
+    ),
   };
 }

--- a/ui/tests/runtime-config/runtime-config-page.ts
+++ b/ui/tests/runtime-config/runtime-config-page.ts
@@ -20,6 +20,8 @@ export const RUNTIME_CONFIG_KEYS = [
   "posthogHost",
   "reoDevClientId",
   "cloudBillingEnabled",
+  "stripePublishableKey",
+  "stripePublishableKeyV2",
 ] as const satisfies ReadonlyArray<keyof RuntimePublicConfig>;
 
 /**

--- a/ui/types/env.d.ts
+++ b/ui/types/env.d.ts
@@ -30,6 +30,15 @@ declare global {
 
       CLOUD_BILLING_ENABLED?: "legacy" | "metronome" | "false";
 
+      // Cloud-only Stripe publishable keys (public; shipped to the browser).
+      // V1 = legacy billing, V2 = metronome.
+      /** @deprecated use CLOUD_STRIPE_PUBLISHABLE_KEY */
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY?: string;
+      CLOUD_STRIPE_PUBLISHABLE_KEY?: string;
+      /** @deprecated use CLOUD_STRIPE_PUBLISHABLE_KEY_V2 */
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_V2?: string;
+      CLOUD_STRIPE_PUBLISHABLE_KEY_V2?: string;
+
       // Build-time public config
       NEXT_PUBLIC_IS_CLOUD_ENV?: "true" | "false";
       NEXT_PUBLIC_PROWLER_RELEASE_VERSION?: string;

--- a/ui/types/env.d.ts
+++ b/ui/types/env.d.ts
@@ -32,12 +32,12 @@ declare global {
 
       // Cloud-only Stripe publishable keys (public; shipped to the browser).
       // V1 = legacy billing, V2 = metronome.
-      /** @deprecated use CLOUD_STRIPE_PUBLISHABLE_KEY */
+      /** @deprecated use UI_CLOUD_STRIPE_PUBLISHABLE_KEY */
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY?: string;
-      CLOUD_STRIPE_PUBLISHABLE_KEY?: string;
-      /** @deprecated use CLOUD_STRIPE_PUBLISHABLE_KEY_V2 */
+      UI_CLOUD_STRIPE_PUBLISHABLE_KEY?: string;
+      /** @deprecated use UI_CLOUD_STRIPE_PUBLISHABLE_KEY_V2 */
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_V2?: string;
-      CLOUD_STRIPE_PUBLISHABLE_KEY_V2?: string;
+      UI_CLOUD_STRIPE_PUBLISHABLE_KEY_V2?: string;
 
       // Build-time public config
       NEXT_PUBLIC_IS_CLOUD_ENV?: "true" | "false";


### PR DESCRIPTION
### Context

Prowler Cloud needs to read Stripe publishable keys (legacy and Metronome/V2 billing) at runtime, and the runtime public-config island is the established mechanism for exposing cloud-only, reserved fields to the browser without an OSS consumer.

### Description

Registers `stripePublishableKey` and `stripePublishableKeyV2` as reserved fields in `RuntimePublicConfig`, following the same pattern already used for `posthogKey` and `reoDevClientId`:

- `ui/lib/runtime-config.shared.ts`: adds both fields to the `RuntimePublicConfig` interface and `EMPTY_RUNTIME_PUBLIC_CONFIG`.
- `ui/lib/runtime-config.ts`: reads them from `CLOUD_STRIPE_PUBLISHABLE_KEY` / `CLOUD_STRIPE_PUBLISHABLE_KEY_V2`, falling back to the deprecated `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` / `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_V2` names.
- `ui/lib/get-runtime-config.client.ts` (+ test): passes both fields through the client-side config parser.
- `ui/types/env.d.ts`: declares the four env var names (two current, two deprecated).

OSS has no consumer for these fields; they are reserved, matching the existing `posthogKey`/`reoDevClientId` precedent. Prowler Cloud reads them. Keeping the shared island shape upstream keeps cloud's Stripe fields in sync and avoids them being reverted on the next OSS-to-cloud sync.

### Steps to review

1. Confirm `RuntimePublicConfig` in `ui/lib/runtime-config.shared.ts` gains the two new reserved fields, defaulted to `null`.
2. Confirm `getRuntimePublicConfig()` in `ui/lib/runtime-config.ts` reads the new `CLOUD_STRIPE_PUBLISHABLE_KEY[_V2]` vars with the deprecated `NEXT_PUBLIC_*` names as fallback.
3. Confirm the client-side parser/test in `ui/lib/get-runtime-config.client.ts` / `.test.ts` pass the fields through unchanged.
4. Confirm `ui/types/env.d.ts` documents both current and deprecated env var names.
5. No OSS UI surface consumes these fields in this PR — they are reserved for Prowler Cloud, same as `posthogKey`/`reoDevClientId`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable. (Not added: these fields are reserved with no OSS-facing consumer, no OSS-visible user impact to log.)

#### API
- Not applicable, no API changes.

#### MCP Server
- Not applicable, no MCP Server changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended runtime configuration to expose Stripe publishable keys to the client: `stripePublishableKey` and `stripePublishableKeyV2`.
  * Supports both legacy (V1) and V2 Stripe publishable key values.
  * When keys are not provided, the client-facing config now safely defaults both values to `null` (and the runtime config page expectations were updated accordingly).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->