### PR TITLE
fix(ui): center auth logo

### DIFF
--- a/ui/changelog.d/auth-logo-alignment.fixed.md
+++ b/ui/changelog.d/auth-logo-alignment.fixed.md
@@ -1,0 +1,1 @@
+OSS auth logo alignment on the sign-in page

--- a/ui/components/auth/oss/auth-layout.test.tsx
+++ b/ui/components/auth/oss/auth-layout.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthLayout } from "./auth-layout";
+
+vi.mock("@/components/ThemeSwitch", () => ({
+  ThemeSwitch: () => <button type="button">Auth card theme toggle</button>,
+}));
+
+describe("AuthLayout", () => {
+  it("renders the auth card title and content without the theme toggle", () => {
+    // Given
+    const title = "Sign in to Prowler";
+
+    // When
+    render(
+      <AuthLayout title={title}>
+        <form aria-label="Sign in form">Form content</form>
+      </AuthLayout>,
+    );
+
+    // Then
+    expect(screen.getByText(title)).toBeVisible();
+    expect(screen.getByRole("form", { name: "Sign in form" })).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Auth card theme toggle" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/ui/components/auth/oss/auth-layout.test.tsx
+++ b/ui/components/auth/oss/auth-layout.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { AuthLayout } from "./auth-layout";
+import { PublicAuthShell } from "./public-auth-shell";
 
 vi.mock("@/components/ThemeSwitch", () => ({
   ThemeSwitch: () => <button type="button">Auth card theme toggle</button>,
@@ -25,5 +26,46 @@ describe("AuthLayout", () => {
     expect(
       screen.queryByRole("button", { name: "Auth card theme toggle" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders the brand in the centered auth layout flow above the card", () => {
+    // Given
+    const title = "Sign in to Prowler";
+
+    // When
+    render(
+      <AuthLayout title={title}>
+        <form aria-label="Sign in form">Form content</form>
+      </AuthLayout>,
+    );
+
+    // Then
+    const brand = screen.getByRole("img", { name: /prowler/i });
+    const brandWrapper = brand.parentElement;
+    const cardTitle = screen.getByText(title);
+
+    expect(brand).toBeVisible();
+    expect(brandWrapper).toHaveClass("relative", "z-10", "mb-8", "w-[200px]");
+    expect(brandWrapper).not.toHaveClass("absolute", "top-8");
+    expect(brand.compareDocumentPosition(cardTitle)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+});
+
+describe("PublicAuthShell", () => {
+  it("does not render a shell-level absolute brand", () => {
+    // Given / When
+    render(
+      <PublicAuthShell>
+        <main>Auth page</main>
+      </PublicAuthShell>,
+    );
+
+    // Then
+    expect(
+      screen.queryByRole("img", { name: /prowler/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Auth page")).toBeVisible();
   });
 });

--- a/ui/components/auth/oss/auth-layout.test.tsx
+++ b/ui/components/auth/oss/auth-layout.test.tsx
@@ -5,11 +5,13 @@ import { AuthLayout } from "./auth-layout";
 import { PublicAuthShell } from "./public-auth-shell";
 
 vi.mock("@/components/ThemeSwitch", () => ({
-  ThemeSwitch: () => <button type="button">Auth card theme toggle</button>,
+  ThemeSwitch: ({ "aria-label": ariaLabel }: { "aria-label"?: string }) => (
+    <button type="button" aria-label={ariaLabel} />
+  ),
 }));
 
 describe("AuthLayout", () => {
-  it("renders the auth card title and content without the theme toggle", () => {
+  it("renders the auth card title and content", () => {
     // Given
     const title = "Sign in to Prowler";
 
@@ -23,9 +25,6 @@ describe("AuthLayout", () => {
     // Then
     expect(screen.getByText(title)).toBeVisible();
     expect(screen.getByRole("form", { name: "Sign in form" })).toBeVisible();
-    expect(
-      screen.queryByRole("button", { name: "Auth card theme toggle" }),
-    ).not.toBeInTheDocument();
   });
 
   it("renders the brand in the centered auth layout flow above the card", () => {

--- a/ui/components/auth/oss/auth-layout.tsx
+++ b/ui/components/auth/oss/auth-layout.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from "react";
 
+import { ProwlerBrand } from "@/components/icons";
+
 interface AuthLayoutProps {
   title: string;
   children: ReactNode;
@@ -17,6 +19,10 @@ export const AuthLayout = ({ title, children }: AuthLayoutProps) => {
               "radial-gradient(var(--bg-button-primary) 1px, transparent 1px)",
           }}
         ></div>
+
+        <div className="relative z-10 mb-8 w-[200px]">
+          <ProwlerBrand className="w-full" />
+        </div>
 
         {/* Auth Form Container */}
         <div className="border-border-neutral-secondary dark:bg-bg-neutral-primary/85 relative z-10 flex w-full max-w-sm flex-col gap-4 rounded-[14px] border bg-white/90 px-8 py-10 shadow-sm md:max-w-md">

--- a/ui/components/auth/oss/auth-layout.tsx
+++ b/ui/components/auth/oss/auth-layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 
 import { ProwlerBrand } from "@/components/icons";
+import { ThemeSwitch } from "@/components/ThemeSwitch";
 
 interface AuthLayoutProps {
   title: string;
@@ -26,8 +27,11 @@ export const AuthLayout = ({ title, children }: AuthLayoutProps) => {
 
         {/* Auth Form Container */}
         <div className="border-border-neutral-secondary dark:bg-bg-neutral-primary/85 relative z-10 flex w-full max-w-sm flex-col gap-4 rounded-[14px] border bg-white/90 px-8 py-10 shadow-sm md:max-w-md">
-          {/* Header */}
-          <p className="pb-2 text-xl font-medium">{title}</p>
+          {/* Header with Title and Theme Toggle */}
+          <div className="flex items-center justify-between">
+            <p className="pb-2 text-xl font-medium">{title}</p>
+            <ThemeSwitch aria-label="Toggle theme" />
+          </div>
 
           {/* Content */}
           {children}

--- a/ui/components/auth/oss/auth-layout.tsx
+++ b/ui/components/auth/oss/auth-layout.tsx
@@ -1,7 +1,5 @@
 import { ReactNode } from "react";
 
-import { ThemeSwitch } from "@/components/ThemeSwitch";
-
 interface AuthLayoutProps {
   title: string;
   children: ReactNode;
@@ -22,11 +20,8 @@ export const AuthLayout = ({ title, children }: AuthLayoutProps) => {
 
         {/* Auth Form Container */}
         <div className="border-border-neutral-secondary dark:bg-bg-neutral-primary/85 relative z-10 flex w-full max-w-sm flex-col gap-4 rounded-[14px] border bg-white/90 px-8 py-10 shadow-sm md:max-w-md">
-          {/* Header with Title and Theme Toggle */}
-          <div className="flex items-center justify-between">
-            <p className="pb-2 text-xl font-medium">{title}</p>
-            <ThemeSwitch aria-label="Toggle theme" />
-          </div>
+          {/* Header */}
+          <p className="pb-2 text-xl font-medium">{title}</p>
 
           {/* Content */}
           {children}

--- a/ui/components/auth/oss/public-auth-shell.tsx
+++ b/ui/components/auth/oss/public-auth-shell.tsx
@@ -1,18 +1,9 @@
 import type { ReactNode } from "react";
 
-import { ProwlerBrand } from "@/components/icons";
-
 interface PublicAuthShellProps {
   children: ReactNode;
 }
 
 export const PublicAuthShell = ({ children }: PublicAuthShellProps) => {
-  return (
-    <div className="relative min-h-screen">
-      <div className="pointer-events-none absolute top-8 left-1/2 z-20 w-[200px] -translate-x-1/2">
-        <ProwlerBrand className="w-full" />
-      </div>
-      {children}
-    </div>
-  );
+  return <div className="relative min-h-screen">{children}</div>;
 };


### PR DESCRIPTION
### Context

Fixes the OSS auth page regression where the new brand logo was positioned too close to the top of the viewport after the auth shell started rendering it with absolute positioning.

### Description

- Move the new `ProwlerBrand` logo back into the centered auth layout flow above the auth card
- Remove the shell-level absolute logo from `PublicAuthShell`
- Keep the existing auth card header and theme switch behavior unchanged
- Add focused unit coverage for the auth layout content, centered logo placement, and absence of a shell-level logo

### Steps to review

1. Open the sign-in page and verify the logo is centered above the auth card instead of pinned near the top of the viewport.
2. Verify the auth card title, form content, and existing card theme toggle still render correctly.
3. Run `cd ui && pnpm test:unit components/auth/oss/auth-layout.test.tsx`.
4. Run `cd ui && pnpm exec eslint components/auth/oss/auth-layout.tsx components/auth/oss/public-auth-shell.tsx components/auth/oss/auth-layout.test.tsx --max-warnings 0`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Not applicable.

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [x] Ensure new entries are added to ui/CHANGELOG.md, if applicable.

#### API (if applicable)
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required.
- [ ] Ensure new entries are added to api/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the OSS sign-in page layout by aligning the Prowler brand logo above the authentication form.
  * Simplified the public authentication shell to prevent duplicate or misplaced branding.
* **Tests**
  * Added coverage for authentication layout rendering, logo placement, and public shell behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->