### PR TITLE
docs: explain reduced scan scope results

### DIFF
--- a/docs/user-guide/tutorials/prowler-app-scan-configuration.mdx
+++ b/docs/user-guide/tutorials/prowler-app-scan-configuration.mdx
@@ -8,7 +8,7 @@ import { SubscriptionBanner } from "/snippets/subscription-banner.mdx"
 
 <VersionBadge version="5.32.0" />
 
-Scan Configuration lets you override, per provider, specific values in the default configuration Prowler's checks use during a scan. Each configuration modifies how specific checks behave, e.g.: thresholds, allowed values, retention windows, and you attach it to the providers that you want to use it on their next scan.
+Scan Configuration lets you override, per provider, specific values in the default configuration Prowler's checks use during a scan. Each configuration can modify how specific checks behave, such as thresholds, allowed values, and retention windows, or exclude checks and services from the scan scope. Attach it to the providers that should use it on their next scan.
 
 <SubscriptionBanner />
 
@@ -53,6 +53,24 @@ azure:
 gcp:
   storage_min_retention_days: 30
 ```
+
+### Limiting the Scan Scope
+
+<VersionBadge version="5.35.0" />
+
+Use `excluded_checks` to skip individual checks and `excluded_services` to skip every check in a service for the matching provider type:
+
+```yaml
+aws:
+  excluded_checks:
+    - s3_bucket_public_access
+  excluded_services:
+    - ec2
+```
+
+<Warning>
+When a Scan Configuration excludes checks or services, Prowler calculates overviews, aggregations, and other result-based information from the reduced scan scope. The displayed information reflects only the checks and services that ran, not a complete assessment of the provider. Consider the applied Scan Configuration when interpreting totals and security posture.
+</Warning>
 
 ## Creating a Scan Configuration
 


### PR DESCRIPTION
### Context

Scan Configuration documentation explains how to override check settings, but it does not cover the supported check and service exclusions or how a reduced scan scope affects result-based information.

Without this context, overviews and aggregations may be interpreted as a complete assessment of the provider even when the applied Scan Configuration excluded part of the scan scope. This documentation aligns with the scan configuration exclusions introduced in #12028.

### Description

- Document `excluded_checks` and `excluded_services` with a minimal YAML example.
- Mark the reduced scan scope capability as available from Prowler 5.35.0.
- Warn that overviews, aggregations, and other result-based information reflect only the checks and services that ran.
- Keep the existing subscription banner and Cloud navigation marker as the canonical indicators that Scan Configuration is available in Prowler Cloud and Prowler Private Cloud.

This PR changes OSS documentation only. It does not modify runtime behavior, dependencies, or configuration defaults.

### Steps to review

1. Open `docs/user-guide/tutorials/prowler-app-scan-configuration.mdx`.
2. Review the new "Limiting the Scan Scope" section and YAML example.
3. Confirm the warning clearly describes how exclusions affect overviews, aggregations, totals, and security posture.
4. Confirm the existing subscription banner remains visible for the page.
5. From `docs/`, run `mint broken-links` with the repository-supported Mintlify CLI version.

Local validation: `mint@4.2.689 broken-links` completed successfully with no broken links.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests. Not applicable to this documentation-only change.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. No backport is required.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md). No README change is required.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. No changelog is required for this documentation-only change.

#### SDK/CLI

- Are there new checks included in this PR? No

#### UI

- Not applicable.

#### API

- Not applicable.

#### MCP Server

- Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that scan configurations can exclude specific checks and services.
  * Added guidance for limiting scan scope with `excluded_checks` and `excluded_services`.
  * Included a YAML example and noted that compliance overviews reflect the reduced scan scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->