### PR TITLE
fix(sdk): validate scan configuration exclusions

### DIFF
--- a/prowler/changelog.d/scan-config-exclusion-identifiers.fixed.md
+++ b/prowler/changelog.d/scan-config-exclusion-identifiers.fixed.md
@@ -1,0 +1,1 @@
+`excluded_checks` and `excluded_services` in scan configurations now reject identifiers that are not in the provider catalogs

--- a/prowler/changelog.d/scan-config-exclusion-identifiers.fixed.md
+++ b/prowler/changelog.d/scan-config-exclusion-identifiers.fixed.md
@@ -1,1 +1,0 @@
-`excluded_checks` and `excluded_services` in scan configurations now reject identifiers that are not in the provider catalogs

--- a/prowler/config/scan_config_schema.py
+++ b/prowler/config/scan_config_schema.py
@@ -32,6 +32,8 @@ from typing import Any
 from pydantic import ValidationError
 
 from prowler.config.schema.registry import SCHEMAS
+from prowler.lib.check.check import list_services
+from prowler.lib.check.models import CheckMetadata
 
 # Pydantic v2 prefixes messages emitted from a ``field_validator`` that
 # raises ``ValueError`` with this string. Strip it so the message that
@@ -79,9 +81,9 @@ def validate_and_normalize_scan_config(
       sections and unknown keys inside registered sections are preserved
       untouched for forward compatibility with plugin-provided keys.
     - ``errors`` is a list of ``{"path": <dotted-path>, "message": <str>}``
-      entries — one per Pydantic violation. When any error is present the
-      normalized dictionary is returned empty so the caller never
-      persists a partially validated configuration.
+      entries, one per schema or exclusion-catalog violation. When any error
+      is present the normalized dictionary is returned empty so the caller
+      never persists a partially validated configuration.
 
     The input payload is never mutated.
     """
@@ -156,6 +158,35 @@ def validate_and_normalize_scan_config(
                     message = message[len(_PYDANTIC_VALUE_ERROR_PREFIX) :]
                 errors.append({"path": path, "message": message})
             continue
+
+        if model.excluded_checks:
+            available_checks = set(CheckMetadata.get_bulk(provider_key))
+            for index, check in enumerate(model.excluded_checks):
+                if check not in available_checks:
+                    errors.append(
+                        {
+                            "path": f"{provider_key}.excluded_checks[{index}]",
+                            "message": (
+                                f"Unknown check '{check}' for provider "
+                                f"'{provider_key}'."
+                            ),
+                        }
+                    )
+
+        if model.excluded_services:
+            available_services = set(list_services(provider_key))
+            for index, service in enumerate(model.excluded_services):
+                if service not in available_services:
+                    errors.append(
+                        {
+                            "path": f"{provider_key}.excluded_services[{index}]",
+                            "message": (
+                                f"Unknown service '{service}' for provider "
+                                f"'{provider_key}'."
+                            ),
+                        }
+                    )
+
         normalized[provider_key] = model.model_dump(mode="json", exclude_unset=True)
 
     if errors:

--- a/prowler/config/scan_config_schema.py
+++ b/prowler/config/scan_config_schema.py
@@ -27,6 +27,7 @@ the UI can validate live with `ajv`. This module provides:
 """
 
 import json
+from functools import lru_cache
 from typing import Any
 
 from pydantic import ValidationError
@@ -39,6 +40,18 @@ from prowler.lib.check.models import CheckMetadata
 # raises ``ValueError`` with this string. Strip it so the message that
 # reaches the UI is the one the validator actually wrote.
 _PYDANTIC_VALUE_ERROR_PREFIX = "Value error, "
+
+
+@lru_cache(maxsize=None)
+def _get_provider_check_ids(provider: str) -> frozenset[str]:
+    """Return cached check identifiers for a provider."""
+    return frozenset(CheckMetadata.get_bulk(provider))
+
+
+@lru_cache(maxsize=None)
+def _get_provider_services(provider: str) -> frozenset[str]:
+    """Return cached service identifiers for a provider."""
+    return frozenset(list_services(provider))
 
 
 def _format_loc(loc: tuple) -> str:
@@ -160,7 +173,7 @@ def validate_and_normalize_scan_config(
             continue
 
         if model.excluded_checks:
-            available_checks = set(CheckMetadata.get_bulk(provider_key))
+            available_checks = _get_provider_check_ids(provider_key)
             for index, check in enumerate(model.excluded_checks):
                 if check not in available_checks:
                     errors.append(
@@ -174,7 +187,7 @@ def validate_and_normalize_scan_config(
                     )
 
         if model.excluded_services:
-            available_services = set(list_services(provider_key))
+            available_services = _get_provider_services(provider_key)
             for index, service in enumerate(model.excluded_services):
                 if service not in available_services:
                     errors.append(

--- a/tests/config/schema/scan_config_schema_test.py
+++ b/tests/config/schema/scan_config_schema_test.py
@@ -8,14 +8,26 @@ the backend can persist verbatim in a Django ``JSONField``.
 """
 
 import json
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
 from prowler.config.scan_config_schema import (
+    _get_provider_check_ids,
+    _get_provider_services,
     validate_and_normalize_scan_config,
     validate_scan_config,
 )
+
+
+@pytest.fixture(autouse=True)
+def clear_provider_catalog_caches():
+    """Keep provider catalog cache state isolated between tests."""
+    _get_provider_check_ids.cache_clear()
+    _get_provider_services.cache_clear()
+    yield
+    _get_provider_check_ids.cache_clear()
+    _get_provider_services.cache_clear()
 
 
 class Test_Non_Dict_Root:
@@ -63,7 +75,13 @@ class Test_Success_Path:
         assert errors == []
         assert normalized == {"aws": {"plugin_option": "preserved", "another": 42}}
 
-    def test_plugin_catalog_identifiers_are_accepted(self):
+    def test_plugin_catalog_identifiers_are_accepted_and_catalogs_are_cached(self):
+        payload = {
+            "aws": {
+                "excluded_checks": ["plugin_check"],
+                "excluded_services": ["plugin_service"],
+            }
+        }
         with (
             patch(
                 "prowler.config.scan_config_schema.CheckMetadata.get_bulk",
@@ -74,15 +92,10 @@ class Test_Success_Path:
                 return_value=["plugin_service"],
             ) as service_catalog,
         ):
-            normalized, errors = validate_and_normalize_scan_config(
-                {
-                    "aws": {
-                        "excluded_checks": ["plugin_check"],
-                        "excluded_services": ["plugin_service"],
-                    }
-                }
-            )
+            first_result = validate_and_normalize_scan_config(payload)
+            second_result = validate_and_normalize_scan_config(payload)
 
+        normalized, errors = first_result
         assert errors == []
         assert normalized == {
             "aws": {
@@ -90,8 +103,38 @@ class Test_Success_Path:
                 "excluded_services": ["plugin_service"],
             }
         }
+        assert second_result == first_result
         check_catalog.assert_called_once_with("aws")
         service_catalog.assert_called_once_with("aws")
+
+    def test_catalog_caches_are_keyed_by_provider(self):
+        with (
+            patch(
+                "prowler.config.scan_config_schema.CheckMetadata.get_bulk",
+                side_effect=lambda provider: {f"{provider}_plugin_check": object()},
+            ) as check_catalog,
+            patch(
+                "prowler.config.scan_config_schema.list_services",
+                side_effect=lambda provider: [f"{provider}_plugin_service"],
+            ) as service_catalog,
+        ):
+            payload = {
+                "aws": {
+                    "excluded_checks": ["aws_plugin_check"],
+                    "excluded_services": ["aws_plugin_service"],
+                },
+                "azure": {
+                    "excluded_checks": ["azure_plugin_check"],
+                    "excluded_services": ["azure_plugin_service"],
+                },
+            }
+            first_result = validate_and_normalize_scan_config(payload)
+            second_result = validate_and_normalize_scan_config(payload)
+
+        assert first_result[1] == []
+        assert second_result == first_result
+        assert check_catalog.call_args_list == [call("aws"), call("azure")]
+        assert service_catalog.call_args_list == [call("aws"), call("azure")]
 
     def test_omitted_defaults_are_not_injected(self):
         normalized, errors = validate_and_normalize_scan_config(

--- a/tests/config/schema/scan_config_schema_test.py
+++ b/tests/config/schema/scan_config_schema_test.py
@@ -8,6 +8,7 @@ the backend can persist verbatim in a Django ``JSONField``.
 """
 
 import json
+from unittest.mock import patch
 
 import pytest
 
@@ -39,7 +40,7 @@ class Test_Success_Path:
         normalized, errors = validate_and_normalize_scan_config(
             {
                 "aws": {
-                    "excluded_checks": [" s3_bucket_public_access "],
+                    "excluded_checks": [" s3_bucket_default_encryption "],
                     "excluded_services": [" s3 "],
                 }
             }
@@ -47,7 +48,7 @@ class Test_Success_Path:
         assert errors == []
         assert normalized == {
             "aws": {
-                "excluded_checks": ["s3_bucket_public_access"],
+                "excluded_checks": ["s3_bucket_default_encryption"],
                 "excluded_services": ["s3"],
             }
         }
@@ -61,6 +62,36 @@ class Test_Success_Path:
         )
         assert errors == []
         assert normalized == {"aws": {"plugin_option": "preserved", "another": 42}}
+
+    def test_plugin_catalog_identifiers_are_accepted(self):
+        with (
+            patch(
+                "prowler.config.scan_config_schema.CheckMetadata.get_bulk",
+                return_value={"plugin_check": object()},
+            ) as check_catalog,
+            patch(
+                "prowler.config.scan_config_schema.list_services",
+                return_value=["plugin_service"],
+            ) as service_catalog,
+        ):
+            normalized, errors = validate_and_normalize_scan_config(
+                {
+                    "aws": {
+                        "excluded_checks": ["plugin_check"],
+                        "excluded_services": ["plugin_service"],
+                    }
+                }
+            )
+
+        assert errors == []
+        assert normalized == {
+            "aws": {
+                "excluded_checks": ["plugin_check"],
+                "excluded_services": ["plugin_service"],
+            }
+        }
+        check_catalog.assert_called_once_with("aws")
+        service_catalog.assert_called_once_with("aws")
 
     def test_omitted_defaults_are_not_injected(self):
         normalized, errors = validate_and_normalize_scan_config(
@@ -103,6 +134,89 @@ class Test_Success_Path:
 
 
 class Test_Error_Path:
+    def test_unknown_excluded_check_is_rejected(self):
+        normalized, errors = validate_and_normalize_scan_config(
+            {"aws": {"excluded_checks": ["aws_check_that_does_not_exist"]}}
+        )
+        assert normalized == {}
+        assert errors == [
+            {
+                "path": "aws.excluded_checks[0]",
+                "message": (
+                    "Unknown check 'aws_check_that_does_not_exist' for provider "
+                    "'aws'."
+                ),
+            }
+        ]
+
+    def test_unknown_excluded_service_is_rejected(self):
+        normalized, errors = validate_and_normalize_scan_config(
+            {"aws": {"excluded_services": ["not_a_real_aws_service"]}}
+        )
+        assert normalized == {}
+        assert errors == [
+            {
+                "path": "aws.excluded_services[0]",
+                "message": (
+                    "Unknown service 'not_a_real_aws_service' for provider 'aws'."
+                ),
+            }
+        ]
+
+    def test_multiple_unknown_exclusions_return_deterministic_errors(self):
+        normalized, errors = validate_and_normalize_scan_config(
+            {
+                "aws": {
+                    "excluded_checks": [
+                        "unknown_check_one",
+                        "s3_bucket_default_encryption",
+                        "unknown_check_two",
+                    ],
+                    "excluded_services": [
+                        "unknown_service_one",
+                        "s3",
+                        "unknown_service_two",
+                    ],
+                }
+            }
+        )
+        assert normalized == {}
+        assert errors == [
+            {
+                "path": "aws.excluded_checks[0]",
+                "message": "Unknown check 'unknown_check_one' for provider 'aws'.",
+            },
+            {
+                "path": "aws.excluded_checks[2]",
+                "message": "Unknown check 'unknown_check_two' for provider 'aws'.",
+            },
+            {
+                "path": "aws.excluded_services[0]",
+                "message": (
+                    "Unknown service 'unknown_service_one' for provider 'aws'."
+                ),
+            },
+            {
+                "path": "aws.excluded_services[2]",
+                "message": (
+                    "Unknown service 'unknown_service_two' for provider 'aws'."
+                ),
+            },
+        ]
+
+    def test_check_from_another_provider_is_rejected(self):
+        azure_check = "postgresql_flexible_server_allow_access_services_disabled"
+        normalized, errors = validate_and_normalize_scan_config(
+            {"aws": {"excluded_checks": [azure_check]}}
+        )
+        assert normalized == {}
+        assert errors == [
+            {
+                "path": "aws.excluded_checks[0]",
+                "message": f"Unknown check '{azure_check}' for provider 'aws'.",
+            }
+        ]
+
     def test_invalid_input_returns_empty_normalized_and_errors(self):
         normalized, errors = validate_and_normalize_scan_config(
             {"aws": {"excluded_services": ["s3", " s3 "]}}
@@ -214,6 +328,18 @@ class Test_Backward_Compatible_Wrapper:
         errors = validate_scan_config({"aws": {"excluded_checks": ["", ""]}})
         assert errors
         assert all(set(err) == {"path", "message"} for err in errors)
+
+    def test_unknown_exclusion_yields_the_semantic_error(self):
+        assert validate_scan_config(
+            {"aws": {"excluded_services": ["not_a_real_aws_service"]}}
+        ) == [
+            {
+                "path": "aws.excluded_services[0]",
+                "message": (
+                    "Unknown service 'not_a_real_aws_service' for provider 'aws'."
+                ),
+            }
+        ]
 
     def test_non_mapping_root_matches_new_contract(self):
         assert validate_scan_config(None) == [


### PR DESCRIPTION
### Context

Scan configurations validated exclusion field structure and duplicate values, but they accepted check and service identifiers that were not available for the selected provider. Invalid identifiers could therefore be persisted and discovered only when a scan started.

### Description

- Validate `excluded_checks` against the provider check metadata catalog
- Validate `excluded_services` against the provider service catalog
- Return deterministic indexed errors while preserving plugin-provided catalog identifiers
- Cache provider catalogs per process and provider to avoid repeated filesystem discovery
- Add regression coverage for valid, invalid, cross-provider, multiple-error, wrapper, and plugin scenarios
- Complete the unreleased exclusion behavior introduced in #12028 without a separate changelog entry

No API, UI, MCP Server, or configuration baseline files are changed.

### Steps to review

1. Run:

   ```bash
   uv run pytest tests/config/schema/scan_config_schema_test.py tests/config/schema/exclusions_test.py tests/lib/scan/scan_exclusions_test.py -q
   ```

2. Validate a configuration with `aws.excluded_checks` containing `aws_check_that_does_not_exist` and confirm the error path is `aws.excluded_checks[0]`.
3. Validate a configuration with `aws.excluded_services` containing `not_a_real_aws_service` and confirm the error path is `aws.excluded_services[0]`.
4. Confirm known identifiers such as `s3_bucket_default_encryption` and `s3` remain valid.
5. Confirm identifiers supplied by plugin catalogs remain valid.

Integration evidence from Prowler Cloud:

- Both invalid configurations returned HTTP `400` from `POST /api/v1/scan-configurations`
- The UI rendered the exact indexed validation errors for checks and services
- Neither invalid configuration was persisted
- No scan task was dispatched to the worker

Local verification:

- Strict validation module: `33 passed`
- Configuration test suite: `577 passed`
- Runtime exclusion suite: `14 passed`
- Changed-file hooks: autoflake, isort, Black, Flake8, Pylint, markdownlint, TruffleHog, Bandit, and Vulture passed

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] A new changelog fragment is not required because this completes unreleased functionality from #12028; the PR is labeled `no-changelog`.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Not applicable

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] No npm dependencies are added or updated
- [x] Screenshots or videos are not applicable because this PR does not change the UI
- [x] A UI changelog fragment is not applicable because this PR does not change the UI

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output is described in the integration evidence above
- [x] EXPLAIN ANALYZE is not applicable because no queries or indexes are changed
- [x] Performance testing is not applicable because no API query path is changed
- [x] No API specification or version update is required
- [x] An API changelog fragment is not applicable because this PR does not change the API

#### MCP Server
- [x] MCP Server verification is not applicable because this PR does not change the MCP Server
- [x] An MCP Server changelog fragment is not applicable because this PR does not change the MCP Server

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scan configuration exclusions are now validated against the selected provider’s available checks and services.
  * Unknown or cross-provider exclusions now produce clear, structured validation errors.
  * Exclusion names continue to be normalized consistently, including whitespace trimming.

* **Performance**
  * Provider check and service catalogs are cached during validation to avoid repeated lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->