### PR TITLE
fix(ui): hide billing when Cloud billing is disabled

### DIFF
--- a/ui/changelog.d/enterprise-billing-navigation.fixed.md
+++ b/ui/changelog.d/enterprise-billing-navigation.fixed.md
@@ -1,0 +1,1 @@
+Billing navigation is hidden when Cloud billing is disabled, including Enterprise deployments

--- a/ui/components/layout/app-sidebar/app-sidebar-content.tsx
+++ b/ui/components/layout/app-sidebar/app-sidebar-content.tsx
@@ -24,10 +24,15 @@ interface AppSidebarContentProps {
 export function AppSidebarContent({ onSelect }: AppSidebarContentProps) {
   const pathname = usePathname();
   const { permissions } = useAuth();
-  const { apiDocsUrl } = useRuntimeConfig();
+  const { apiDocsUrl, cloudBillingEnabled } = useRuntimeConfig();
   const mode = useAppSidebarMode((state) => state.mode);
   const isCloudEnvironment = isCloud();
-  const sections = getNavigationConfig({ pathname, apiDocsUrl, permissions });
+  const sections = getNavigationConfig({
+    pathname,
+    apiDocsUrl,
+    cloudBillingEnabled,
+    permissions,
+  });
   const showChat = isCloudEnvironment && mode === APP_SIDEBAR_MODE.CHAT;
 
   return (

--- a/ui/components/layout/app-sidebar/navigation-config.test.ts
+++ b/ui/components/layout/app-sidebar/navigation-config.test.ts
@@ -157,6 +157,7 @@ describe("getNavigationConfig", () => {
     const billing = getNavigationConfig({
       pathname: "/billing",
       apiDocsUrl: null,
+      cloudBillingEnabled: true,
       permissions,
     })
       .flatMap((section) => section.items)
@@ -183,17 +184,28 @@ describe("getNavigationConfig", () => {
     const cloudItems = getNavigationConfig({
       pathname: "/",
       apiDocsUrl: null,
+      cloudBillingEnabled: true,
       permissions,
+    }).flatMap((section) => section.items);
+    const enterpriseItems = getNavigationConfig({
+      pathname: "/",
+      apiDocsUrl: null,
+      cloudBillingEnabled: false,
+      permissions: { ...permissions, manage_billing: true },
     }).flatMap((section) => section.items);
     vi.stubEnv("NEXT_PUBLIC_IS_CLOUD_ENV", "false");
     const localItems = getNavigationConfig({
       pathname: "/",
       apiDocsUrl: null,
+      cloudBillingEnabled: true,
       permissions: { ...permissions, manage_billing: true },
     }).flatMap((section) => section.items);
 
     // Then
     expect(cloudItems.find((item) => item.label === "Billing")).toBeUndefined();
+    expect(
+      enterpriseItems.find((item) => item.label === "Billing"),
+    ).toBeUndefined();
     expect(localItems.find((item) => item.label === "Billing")).toBeUndefined();
   });
 

--- a/ui/components/layout/app-sidebar/navigation-config.ts
+++ b/ui/components/layout/app-sidebar/navigation-config.ts
@@ -31,6 +31,7 @@ import {
 interface NavigationConfigOptions {
   pathname: string;
   apiDocsUrl?: string | null;
+  cloudBillingEnabled?: boolean;
   permissions?: RolePermissionAttributes;
 }
 
@@ -106,6 +107,7 @@ export function filterNavigationByPermissions(
 export function getNavigationConfig({
   pathname,
   apiDocsUrl = null,
+  cloudBillingEnabled = false,
   permissions,
 }: NavigationConfigOptions): NavigationSection[] {
   const isCloudEnvironment = isCloud();
@@ -265,7 +267,7 @@ export function getNavigationConfig({
             },
           ],
         },
-        ...(isCloudEnvironment
+        ...(isCloudEnvironment && cloudBillingEnabled
           ? [
               {
                 kind: NAVIGATION_ITEM_KIND.LINK,

--- a/ui/proxy.ts
+++ b/ui/proxy.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextAuthRequest } from "next-auth";
 
 import { auth } from "@/auth.config";
+import { readEnv } from "@/lib/runtime-env";
 
 const publicRoutes = [
   "/sign-in",
@@ -23,6 +24,8 @@ export default auth((req: NextAuthRequest) => {
 
   const user = req.auth?.user;
   const sessionError = req.auth?.error;
+  const cloudBillingEnabled =
+    (readEnv("CLOUD_BILLING_ENABLED") ?? "false") !== "false";
 
   // If there's a session error (e.g., RefreshAccessTokenError), redirect to login with error info
   if (sessionError && !isPublicRoute(pathname)) {
@@ -38,12 +41,15 @@ export default auth((req: NextAuthRequest) => {
     return NextResponse.redirect(signInUrl);
   }
 
+  if (
+    pathname.startsWith("/billing") &&
+    (!cloudBillingEnabled || user?.permissions?.manage_billing !== true)
+  ) {
+    return NextResponse.redirect(new URL("/profile", req.url));
+  }
+
   if (user?.permissions) {
     const permissions = user.permissions;
-
-    if (pathname.startsWith("/billing") && !permissions.manage_billing) {
-      return NextResponse.redirect(new URL("/profile", req.url));
-    }
 
     if (
       pathname.startsWith("/integrations") &&


### PR DESCRIPTION
### Context

The sidebar redesign in #11994 made the Billing item depend on the Cloud environment and `manage_billing` permission, but not on the install-level `CLOUD_BILLING_ENABLED` capability. Enterprise administrators therefore saw Billing even though billing is disabled for their deployment.

### Description

- Pass `cloudBillingEnabled` from runtime config into the sidebar navigation config
- Render Billing only when the environment is Cloud, Cloud billing is enabled, and the user has `manage_billing`
- Apply the same install-level capability check to direct `/billing` requests in `proxy.ts`
- Add regression coverage for Enterprise deployments and a UI changelog fragment

No dependencies added.

### Steps to review

1. Run `pnpm vitest run components/layout/app-sidebar/navigation-config.test.ts components/layout/app-sidebar/app-sidebar-content.test.tsx` from `ui/`.
2. With `NEXT_PUBLIC_IS_CLOUD_ENV=true`, `CLOUD_BILLING_ENABLED=false`, and `manage_billing=true`, verify Billing is absent from the sidebar and `/billing` redirects to `/profile`.
3. With Cloud billing enabled and `manage_billing=true`, verify Billing remains available.
4. Run `pnpm run healthcheck` and `pnpm run test:unit` from `ui/`.

Local verification: healthcheck passed; 328 unit test files and 2,142 tests passed.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings — not applicable, no Python changes
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) — no README change needed
- [x] Ensure a changelog fragment is added under the applicable component changelog directory

#### SDK/CLI

No SDK/CLI changes. No new checks.

#### UI

- [x] All issue/task requirements work as expected on the UI
- [x] No npm dependencies added or updated
- [x] Screenshots/Video — not applicable; conditional navigation behavior is covered by unit tests
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d/)

#### API

No API changes.

#### MCP Server

No MCP Server changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Billing navigation is now hidden when Cloud billing is disabled, including in Enterprise deployments.
  * Billing pages now require both enabled Cloud billing and the appropriate billing permission.
  * Users without billing access are redirected away from billing pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->