### PR TITLE
fix(alibabacloud): normalize security group policy case

### DIFF
--- a/prowler/changelog.d/alibabacloud-security-group-policy-case.fixed.md
+++ b/prowler/changelog.d/alibabacloud-security-group-policy-case.fixed.md
@@ -1,0 +1,1 @@
+Alibaba Cloud SSH and RDP security group checks no longer produce false negatives when allowed rules use capitalized `Policy="Accept"` values

--- a/prowler/providers/alibabacloud/services/ecs/ecs_securitygroup_restrict_rdp_internet/ecs_securitygroup_restrict_rdp_internet.py
+++ b/prowler/providers/alibabacloud/services/ecs/ecs_securitygroup_restrict_rdp_internet/ecs_securitygroup_restrict_rdp_internet.py
@@ -26,7 +26,7 @@ class ecs_securitygroup_restrict_rdp_internet(Check):
 
             for ingress_rule in security_group.ingress_rules:
                 # Check if rule allows traffic (policy == "accept")
-                if ingress_rule.get("policy", "accept") != "accept":
+                if str(ingress_rule.get("policy", "accept")).lower() != "accept":
                     continue
 
                 # Check protocol (tcp for RDP)

--- a/prowler/providers/alibabacloud/services/ecs/ecs_securitygroup_restrict_ssh_internet/ecs_securitygroup_restrict_ssh_internet.py
+++ b/prowler/providers/alibabacloud/services/ecs/ecs_securitygroup_restrict_ssh_internet/ecs_securitygroup_restrict_ssh_internet.py
@@ -26,7 +26,7 @@ class ecs_securitygroup_restrict_ssh_internet(Check):
 
             for ingress_rule in security_group.ingress_rules:
                 # Check if rule allows traffic (policy == "accept")
-                if ingress_rule.get("policy", "accept") != "accept":
+                if str(ingress_rule.get("policy", "accept")).lower() != "accept":
                     continue
 
                 # Check protocol (tcp for SSH)

--- a/tests/providers/alibabacloud/services/ecs/ecs_securitygroup_restrict_rdp_internet/ecs_securitygroup_restrict_rdp_internet_test.py
+++ b/tests/providers/alibabacloud/services/ecs/ecs_securitygroup_restrict_rdp_internet/ecs_securitygroup_restrict_rdp_internet_test.py
@@ -37,7 +37,7 @@ class TestEcsSecurityGroupRestrictRdpInternet:
                         "ip_protocol": "tcp",
                         "source_cidr_ip": "0.0.0.0/0",
                         "port_range": "3389/3389",
-                        "policy": "accept",
+                        "policy": "Accept",
                     }
                 ],
             )
@@ -80,7 +80,7 @@ class TestEcsSecurityGroupRestrictRdpInternet:
                         "ip_protocol": "tcp",
                         "source_cidr_ip": "10.0.0.0/24",
                         "port_range": "3389/3389",
-                        "policy": "accept",
+                        "policy": "Accept",
                     }
                 ],
             )

--- a/tests/providers/alibabacloud/services/ecs/ecs_securitygroup_restrict_ssh_internet/ecs_securitygroup_restrict_ssh_internet_test.py
+++ b/tests/providers/alibabacloud/services/ecs/ecs_securitygroup_restrict_ssh_internet/ecs_securitygroup_restrict_ssh_internet_test.py
@@ -37,7 +37,7 @@ class TestEcsSecurityGroupRestrictSSHInternet:
                         "ip_protocol": "tcp",
                         "source_cidr_ip": "0.0.0.0/0",
                         "port_range": "22/22",
-                        "policy": "accept",
+                        "policy": "Accept",
                     }
                 ],
             )
@@ -81,7 +81,7 @@ class TestEcsSecurityGroupRestrictSSHInternet:
                         "ip_protocol": "tcp",
                         "source_cidr_ip": "10.0.0.0/24",
                         "port_range": "22/22",
-                        "policy": "accept",
+                        "policy": "Accept",
                     }
                 ],
             )


### PR DESCRIPTION
## Summary

- normalize Alibaba Cloud security group rule policies before evaluating SSH and RDP exposure
- cover the `Policy="Accept"` capitalization returned by `DescribeSecurityGroupAttribute`
- update SSH and RDP fixtures to match the real API response

## Problem

Alibaba Cloud returns allowed security group rules with `Policy="Accept"`. Both checks compared this value case-sensitively to lowercase `"accept"`, so valid allow rules were skipped and public TCP/22 and TCP/3389 exposure could be reported as PASS.

## Testing

```text
uv run pytest -q \
  tests/providers/alibabacloud/services/ecs/ecs_securitygroup_restrict_ssh_internet/ecs_securitygroup_restrict_ssh_internet_test.py \
  tests/providers/alibabacloud/services/ecs/ecs_securitygroup_restrict_rdp_internet/ecs_securitygroup_restrict_rdp_internet_test.py

4 passed
```

Black check passes for all four changed files, and `git diff --check` is clean.

Fixes #12048

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Alibaba Cloud ECS security group checks for internet-exposed SSH and RDP so allowed rules are evaluated case-insensitively (e.g., `Policy="Accept"`).
  - Improved handling of missing or unexpected `Policy` values to avoid false negatives.

- **Tests**
  - Updated SSH and RDP security-group test cases to use capitalized `Policy` values and verify the corrected evaluation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->