### PR TITLE
fix(app): cap Celery worker concurrency in the Helm chart

### DIFF
--- a/contrib/k8s/helm/prowler-app/values.yaml
+++ b/contrib/k8s/helm/prowler-app/values.yaml
@@ -189,6 +189,11 @@ api:
     DJANGO_STALE_WHILE_REVALIDATE: "60"
     DJANGO_MANAGE_DB_PARTITIONS: "True"
     DJANGO_BROKER_VISIBILITY_TIMEOUT: "86400"
+    # Caps the Celery prefork pool size on the worker pods. Without it, Celery
+    # sizes the pool from the number of visible CPUs, so on large nodes the
+    # worker spawns one child per CPU, each loading the full Prowler SDK, and
+    # OOMKills under memory pressure. Raise it on bigger workers.
+    DJANGO_CELERY_WORKER_CONCURRENCY: "2"
 
   # Secret names to be used as env vars for api, worker, and worker_beat.
   secrets: []


### PR DESCRIPTION
### Context

The API reads `DJANGO_CELERY_WORKER_CONCURRENCY` as an opt-in override for Celery's prefork pool size (`api/src/backend/config/settings/celery.py`, added in #11075). When it is unset, Celery falls back to `os.cpu_count()`.

On Kubernetes the worker pod usually sees the node's CPU count, not its own CPU limit. On large nodes (16+ CPUs) the worker then spawns one prefork child per CPU, each loading the full Prowler SDK working set, and OOMKills under memory pressure — the exact failure #11075 was opened to prevent. Because the chart never sets the variable, a stock install still hits this.

### Description

Set a conservative default of `DJANGO_CELERY_WORKER_CONCURRENCY: "2"` in the shared `api.djangoConfig` ConfigMap, which the worker pods already consume via `envFrom`. This makes a default install independent of node size. Operators can raise it for larger workers — the chart sets no worker resource limits by default, so a low default is the safe choice, and it sits alongside the other opinionated `DJANGO_*` values already in `djangoConfig`.

This is the chart-level counterpart to #11075: that PR made the knob available; this gives the chart a safe out-of-the-box value.

Only `contrib/k8s/helm/prowler-app/values.yaml` changes (+5 lines).

### Steps to review

1. Read the 5-line addition to `contrib/k8s/helm/prowler-app/values.yaml`.
2. Render the ConfigMap:
    ```
    helm template prowler contrib/k8s/helm/prowler-app \
      --show-only templates/api/configmap.yaml | grep CONCURRENCY
    # DJANGO_CELERY_WORKER_CONCURRENCY: "2"
    ```
3. The worker Deployment already imports this ConfigMap through `envFrom`, so no template change is needed.

### Checklist

- [x] `helm lint` passes.
- [x] Rendered ConfigMap contains the setting; the worker imports it via `envFrom`.
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for limiting the number of concurrent Celery worker processes.
  * This enables more predictable resource usage for background task processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->