### PR TITLE
fix(app): correct the worker KEDA PostgreSQL scaler

### DIFF
--- a/contrib/k8s/helm/prowler-app/templates/worker/scaled-object.yaml
+++ b/contrib/k8s/helm/prowler-app/templates/worker/scaled-object.yaml
@@ -18,15 +18,12 @@ spec:
   triggers:
     - type: {{ .Values.worker.keda.triggerType }}
       metadata:
-        userName: "postgres"
-        passwordFromEnv: POSTGRES_ADMIN_PASSWORD
-        host: {{ .Release.Name }}-postgresql
-        port: {{ .Values.postgresql.port | quote }}
-        dbName: {{ .Values.postgresql.auth.database | quote }}
-        sslmode: disable
-        # Query for KEDA to count the number of scans that are in executing, available, or scheduled states,
-        # where the scheduled time is within the last 2 hours and is before NOW(). Used for scaling workers.
-        query: >-
-          SELECT COUNT(*) FROM scans WHERE ((state='executing' OR state='available' OR state='scheduled') and scheduled_at < NOW() and scheduled_at > NOW() - INTERVAL '2 hours')
-        targetQueryValue: "1"
+        userName: {{ .Values.worker.keda.postgresql.userName | quote }}
+        passwordFromEnv: {{ .Values.worker.keda.postgresql.passwordFromEnv | quote }}
+        host: {{ .Values.worker.keda.postgresql.host | default (printf "%s-postgresql" .Release.Name) | quote }}
+        port: {{ .Values.worker.keda.postgresql.port | quote }}
+        dbName: {{ .Values.worker.keda.postgresql.database | default .Values.postgresql.auth.database | quote }}
+        sslmode: {{ .Values.worker.keda.postgresql.sslmode | quote }}
+        query: {{ .Values.worker.keda.query | quote }}
+        targetQueryValue: {{ .Values.worker.keda.targetQueryValue | quote }}
 {{- end }}

--- a/contrib/k8s/helm/prowler-app/templates/worker/scaled-object.yaml
+++ b/contrib/k8s/helm/prowler-app/templates/worker/scaled-object.yaml
@@ -20,7 +20,7 @@ spec:
       metadata:
         userName: {{ .Values.worker.keda.postgresql.userName | quote }}
         passwordFromEnv: {{ .Values.worker.keda.postgresql.passwordFromEnv | quote }}
-        host: {{ .Values.worker.keda.postgresql.host | default (printf "%s-postgresql" .Release.Name) | quote }}
+        host: {{ .Values.worker.keda.postgresql.host | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) | quote }}
         port: {{ .Values.worker.keda.postgresql.port | quote }}
         dbName: {{ .Values.worker.keda.postgresql.database | default .Values.postgresql.auth.database | quote }}
         sslmode: {{ .Values.worker.keda.postgresql.sslmode | quote }}

--- a/contrib/k8s/helm/prowler-app/values.yaml
+++ b/contrib/k8s/helm/prowler-app/values.yaml
@@ -422,10 +422,37 @@ worker:
     pollingInterval: 30
     # -- The cooldown period in seconds for scaling
     cooldownPeriod: 120
-    # -- The trigger type for scaling (cpu or memory)
+    # -- The KEDA scaler type. Only `postgresql` is supported by the default query below.
     triggerType: "postgresql"
-    # -- The target utilization percentage for the worker pods
-    value: "50"
+    # PostgreSQL connection used by the scaler query. The KEDA operator opens this
+    # connection from its own namespace, so `host` must resolve from there. The
+    # defaults target the bundled postgresql subchart; set them explicitly when
+    # using an external database (postgresql.enabled: false).
+    postgresql:
+      # -- Scaler database host. Defaults to the bundled "<release>-postgresql" service.
+      host: ""
+      # -- Scaler database port.
+      port: "5432"
+      # -- Scaler database name. Defaults to `postgresql.auth.database`.
+      database: ""
+      # -- User the scaler authenticates as.
+      userName: "postgres"
+      # -- Name of an env var on the worker container holding the password.
+      passwordFromEnv: "POSTGRES_ADMIN_PASSWORD"
+      # -- sslmode for the scaler connection.
+      sslmode: "disable"
+    # -- The scaler divides the query result by this value to get the desired replica count.
+    targetQueryValue: "1"
+    # -- Query the scaler runs to measure pending work. The default counts scans that
+    # represent real work: those executing or available (bounded to rows updated in the
+    # last 24h so orphaned rows do not pin the worker up), plus scheduled scans that are
+    # due (no lower bound, so an overdue backlog still scales up). This replaces the
+    # previous 2-hour scheduled-only window, which missed manual scans, older backlogs,
+    # and in-progress scans. Override to tune scaling for your workload.
+    query: >-
+      SELECT COUNT(*) FROM scans
+      WHERE (state IN ('executing', 'available') AND updated_at > NOW() - INTERVAL '24 hours')
+      OR (state = 'scheduled' AND scheduled_at < NOW())
 
 worker_beat:
   # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/

--- a/contrib/k8s/helm/prowler-app/values.yaml
+++ b/contrib/k8s/helm/prowler-app/values.yaml
@@ -429,7 +429,7 @@ worker:
     # defaults target the bundled postgresql subchart; set them explicitly when
     # using an external database (postgresql.enabled: false).
     postgresql:
-      # -- Scaler database host. Defaults to the bundled "<release>-postgresql" service.
+      # -- Scaler database host. Defaults to the bundled "<release>-postgresql.<namespace>.svc.cluster.local" service.
       host: ""
       # -- Scaler database port.
       port: "5432"

--- a/contrib/k8s/helm/prowler-app/values.yaml
+++ b/contrib/k8s/helm/prowler-app/values.yaml
@@ -443,16 +443,39 @@ worker:
       sslmode: "disable"
     # -- The scaler divides the query result by this value to get the desired replica count.
     targetQueryValue: "1"
-    # -- Query the scaler runs to measure pending work. The default counts scans that
-    # represent real work: those executing or available (bounded to rows updated in the
-    # last 24h so orphaned rows do not pin the worker up), plus scheduled scans that are
-    # due (no lower bound, so an overdue backlog still scales up). This replaces the
-    # previous 2-hour scheduled-only window, which missed manual scans, older backlogs,
-    # and in-progress scans. Override to tune scaling for your workload.
+    # -- Query the scaler runs to measure pending work. It replaces the previous
+    # 2-hour scheduled-only window, which missed manual scans, older backlogs and
+    # in-progress scans. Override to tune scaling for your workload.
+    #
+    # The default sums three signals:
+    #   1. Scans executing or available, bounded to rows updated in the last 24h so
+    #      orphaned rows do not pin the worker up, plus scheduled scans that are due
+    #      (no lower bound, so an overdue backlog still scales up).
+    #   2. Scan tasks published in the last 48h that no worker has finished. A PENDING
+    #      TaskResult is written at publish time (before_task_publish in api/signals.py),
+    #      so Beat's daily publishes are visible even with zero workers. Signal 1 alone
+    #      deadlocks with minReplicas 0: every scan row after the first is created by
+    #      the worker, so once the initial row ages out of the 24h bound there is
+    #      nothing to count and nothing to create more.
+    #   3. Non-scan tasks pending in the last hour. Provider connection checks,
+    #      deletions, reports and backfills never touch the scans table, so without
+    #      this they are never picked up while the worker is scaled to zero.
+    #      reconcile-orphan-tasks is excluded: it is a watchdog that runs every two
+    #      minutes and only recovers orphans left behind by a worker, so counting it
+    #      would wake the worker continuously and defeat scale-to-zero.
     query: >-
-      SELECT COUNT(*) FROM scans
+      SELECT
+      (SELECT COUNT(*) FROM scans
       WHERE (state IN ('executing', 'available') AND updated_at > NOW() - INTERVAL '24 hours')
-      OR (state = 'scheduled' AND scheduled_at < NOW())
+      OR (state = 'scheduled' AND scheduled_at < NOW()))
+      + (SELECT COUNT(*) FROM django_celery_results_taskresult
+      WHERE task_name IN ('scan-perform', 'scan-perform-scheduled')
+      AND status IN ('PENDING', 'RECEIVED', 'STARTED')
+      AND date_created > NOW() - INTERVAL '48 hours')
+      + (SELECT COUNT(*) FROM django_celery_results_taskresult
+      WHERE task_name NOT IN ('scan-perform', 'scan-perform-scheduled', 'reconcile-orphan-tasks')
+      AND status IN ('PENDING', 'RECEIVED', 'STARTED')
+      AND date_created > NOW() - INTERVAL '1 hour')
 
 worker_beat:
   # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/

--- a/contrib/k8s/helm/prowler-app/values.yaml
+++ b/contrib/k8s/helm/prowler-app/values.yaml
@@ -460,9 +460,10 @@ worker:
     #   3. Non-scan tasks pending in the last hour. Provider connection checks,
     #      deletions, reports and backfills never touch the scans table, so without
     #      this they are never picked up while the worker is scaled to zero.
-    #      reconcile-orphan-tasks is excluded: it is a watchdog that runs every two
-    #      minutes and only recovers orphans left behind by a worker, so counting it
-    #      would wake the worker continuously and defeat scale-to-zero.
+    #      This includes reconcile-orphan-tasks, a Beat watchdog that runs every two
+    #      minutes, so with minReplicas 0 the worker is woken about that often. Add
+    #      it to the excluded task names below, or raise cooldownPeriod, if you would
+    #      rather trade watchdog latency for longer idle periods.
     query: >-
       SELECT
       (SELECT COUNT(*) FROM scans
@@ -473,7 +474,7 @@ worker:
       AND status IN ('PENDING', 'RECEIVED', 'STARTED')
       AND date_created > NOW() - INTERVAL '48 hours')
       + (SELECT COUNT(*) FROM django_celery_results_taskresult
-      WHERE task_name NOT IN ('scan-perform', 'scan-perform-scheduled', 'reconcile-orphan-tasks')
+      WHERE task_name NOT IN ('scan-perform', 'scan-perform-scheduled')
       AND status IN ('PENDING', 'RECEIVED', 'STARTED')
       AND date_created > NOW() - INTERVAL '1 hour')
 


### PR DESCRIPTION
### Context

The worker KEDA `ScaledObject` (`contrib/k8s/helm/prowler-app/templates/worker/scaled-object.yaml`) has two problems that make autoscaling unusable in common setups.

**1. The connection can't be configured (and is broken by default).**
The host is hardcoded to `{{ .Release.Name }}-postgresql` and the port is read from `.Values.postgresql.port`, which the chart never defines. So the port renders empty and KEDA rejects the trigger with:

> error parsing postgresql metadata: no port given

This happens even with the bundled database, and there is no way to point the scaler at an external PostgreSQL (`postgresql.enabled: false`).

**2. The query misses most real work.**
The default query only counts scans whose `scheduled_at` is within the last 2 hours:

```sql
SELECT COUNT(*) FROM scans WHERE ((state='executing' OR state='available' OR state='scheduled') and scheduled_at < NOW() and scheduled_at > NOW() - INTERVAL '2 hours')
```

That ignores manual scans (`scheduled_at IS NULL`), any backlog older than 2 hours, and scans already executing. This can cause the trigger go inactive mid-scan, KEDA scale the worker to zero, and scans get stuck in `executing` indefinitely.

### Description

- Expose the scaler's PostgreSQL connection under `worker.keda.postgresql` (`host`, `port`, `database`, `userName`, `passwordFromEnv`, `sslmode`), with defaults that preserve the current bundled-database behaviour (`host` → `<release>-postgresql`, `database` → `postgresql.auth.database`). Setting `worker.keda.postgresql.host`/`database` now supports an external DB.
- Fix the default `port` (was empty → now `5432`).
- Make `query` and `targetQueryValue` overridable.
- Replace the default query with one that counts real pending work: scans `executing`/`available` (bounded to `updated_at` within 24h so orphaned rows don't pin the worker up forever), plus `scheduled` scans that are due (no lower bound, so an overdue backlog still scales up).
- Drop the unused `keda.value` key — the template never referenced it and its "cpu or memory" comment never matched the `postgresql` trigger.

`state`, `scheduled_at` and `updated_at` all exist on the `scans` table (`api/src/backend/api/models.py`).

### Steps to review

1. Bundled DB:
    ```
    helm template prowler contrib/k8s/helm/prowler-app \
      --set worker.keda.enabled=true \
      --show-only templates/worker/scaled-object.yaml
    ```
    → `host: "prowler-postgresql"`, `port: "5432"`, `dbName: "prowler_db"`.
2. External DB — add:
    ```
    --set postgresql.enabled=false \
    --set worker.keda.postgresql.host=my-db.ns.svc.cluster.local \
    --set worker.keda.postgresql.database=prowler
    ```
    → `host`/`dbName` reflect the overrides.
3. `helm lint` passes.

### Checklist

- [x] `helm lint` passes; renders correctly for bundled and external Postgres.
- [x] Backwards compatible for the bundled DB (net effect unchanged, except the port which was previously broken).
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced worker autoscaling with configurable PostgreSQL connection and trigger settings.
  * Added support for custom SQL queries and target values to determine scaling.
  * Updated default scaling logic to account for active, overdue, and recently pending scan work, as well as other pending tasks.
  * Added configurable database port, SSL mode, credentials, query, and target settings through chart values.
  * Improved deployment flexibility by allowing scaling behavior to be tailored without modifying chart templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->