### PR TITLE
ci(helm): publish immutable chart versions on release

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -45,8 +45,7 @@ jobs:
           echo "Setting chart version and appVersion to ${RELEASE_TAG}"
           # Publish an immutable chart version per release instead of the static
           # 0.0.1 in source, so every release is a distinct, addressable artifact.
-          sed -i "s/^version:.*/version: ${RELEASE_TAG}/" ${{ env.CHART_PATH }}/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${RELEASE_TAG}\"/" ${{ env.CHART_PATH }}/Chart.yaml
+          yq -i ".version = \"${RELEASE_TAG}\" | .appVersion = \"${RELEASE_TAG}\"" ${{ env.CHART_PATH }}/Chart.yaml
         env:
           GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -38,10 +38,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
-      - name: Set appVersion from release tag
+      - name: Set chart version and appVersion from release tag
         run: |
-          RELEASE_TAG="${GITHUB_EVENT_RELEASE_TAG_NAME}"
-          echo "Setting appVersion to ${RELEASE_TAG}"
+          # Strip any leading "v" so the chart version is valid SemVer 2.
+          RELEASE_TAG="${GITHUB_EVENT_RELEASE_TAG_NAME#v}"
+          echo "Setting chart version and appVersion to ${RELEASE_TAG}"
+          # Publish an immutable chart version per release instead of the static
+          # 0.0.1 in source, so every release is a distinct, addressable artifact.
+          sed -i "s/^version:.*/version: ${RELEASE_TAG}/" ${{ env.CHART_PATH }}/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"${RELEASE_TAG}\"/" ${{ env.CHART_PATH }}/Chart.yaml
         env:
           GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
### Context

The Helm chart release workflow (`.github/workflows/helm-chart-release.yml`) rewrites `appVersion` from the release tag but leaves the chart `version` at the static `0.0.1` in source. Every release therefore overwrites the same OCI tag:

```
oci://ghcr.io/prowler-cloud/charts/prowler:0.0.1
```

So `0.0.1` is mutable — consumers that track it silently receive a different chart whenever a release runs, and tooling like Renovate has no version to bump. Because image tags default to `.Chart.AppVersion`, the running images also move underneath a pinned `0.0.1`. In practice consumers have to pin every image tag by hand to get reproducible deploys.

(The workflow header notes it isn't maintained by the Prowler team, so opening this as a draft for discussion.)

### Description

Set the chart `version` (not just `appVersion`) from the release tag, so each release publishes a distinct, immutable artifact (e.g. `prowler-5.35.0.tgz` → `.../charts/prowler:5.35.0`). A leading `v` is stripped so the version stays valid SemVer 2. Source `Chart.yaml` stays at `0.0.1`, matching the pattern already used for `appVersion`.

Result: consumers can pin `targetRevision: 5.35.0`, Renovate can bump the chart, and pinning the chart transitively pins the image tags (which default to `appVersion` == chart version).

**Migration note:** existing consumers tracking `0.0.1` should move to a pinned release version; `0.0.1` will stop receiving updates once releases publish real versions.

### Steps to review

1. The change adds one `sed` for `version:` next to the existing `appVersion:` one, plus a leading-`v` strip.
2. Simulated locally with `RELEASE_TAG=5.35.0`:
    - `sed` yields `version: 5.35.0` / `appVersion: "5.35.0"`,
    - `helm lint` passes,
    - `helm package` produces `prowler-5.35.0.tgz` (instead of `prowler-0.0.1.tgz`).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Helm charts are now published with immutable, release-specific versions.
  * Chart and application versions are derived consistently from the release tag.
  * Leading “v” in release tags is removed to ensure SemVer 2-compatible chart versioning.
  * Versioning behavior is streamlined to keep chart and appVersion aligned per release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->