### PR TITLE
fix(ui): show AWS Organizations deployment hint in error color

### DIFF
--- a/ui/changelog.d/aws-organizations-ou-hint-error-color.fixed.md
+++ b/ui/changelog.d/aws-organizations-ou-hint-error-color.fixed.md
@@ -1,0 +1,1 @@
+AWS Organizations setup modal now shows the "Enter a valid Organizational Unit or Root ID" hint in the error color, clarifying why the deployment button is disabled

--- a/ui/components/providers/organizations/org-setup-form.tsx
+++ b/ui/components/providers/organizations/org-setup-form.tsx
@@ -486,7 +486,7 @@ export function OrgSetupForm({
                 </Button>
               )}
               {!isOrgUnitIdValid && (
-                <p className="text-text-neutral-tertiary text-xs leading-5">
+                <p className="text-text-error-primary text-xs leading-5">
                   Enter a valid Organizational Unit or Root ID above to enable
                   deployment.
                 </p>


### PR DESCRIPTION
### Description

In the AWS Organizations provider setup modal, the helper message "Enter a valid Organizational Unit or Root ID above to enable deployment." was rendered in gray (text-text-neutral-tertiary), so users missed it and assumed the disabled "Create Stack" button was broken.

This PR changes the message to use the design system error token (text-text-error-primary) so it stands out as an error. The button behavior (disabled until a valid OU/Root ID is entered) is unchanged.

<img width="1911" height="982" alt="image" src="https://github.com/user-attachments/assets/9319fe82-49b2-4a81-88a5-0ea4c53e81ab" />

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the AWS Organizations setup form to display invalid Organizational Unit or Root ID guidance in the error color, making it clearer why deployment is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->