### PR TITLE
fix(ui): remove unused npm from container to drop tar CVE-2026-59873

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -4,7 +4,9 @@ FROM node:24.13.0-alpine@sha256:cd6fb7efa6490f039f3471a189214d5f548c11df1ff9e5b1
 LABEL maintainer="https://github.com/prowler-cloud"
 
 # Patch Alpine OpenSSL runtime packages before all stages inherit the base image.
-RUN apk upgrade --no-cache libcrypto3 libssl3 && corepack enable
+# The build uses pnpm via corepack, so npm is unused — remove it (and npx) to drop
+# the bundled-npm CVE surface (node-tar CVE-2026-59873) from every stage, incl. prod.
+RUN apk upgrade --no-cache libcrypto3 libssl3 && corepack enable && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/ui/changelog.d/ui-trivy-cve-2026-59873-npm-tar.security.md
+++ b/ui/changelog.d/ui-trivy-cve-2026-59873-npm-tar.security.md
@@ -1,0 +1,1 @@
+Removed the unused `npm` CLI from the UI container image, eliminating the bundled `node-tar` `CVE-2026-59873` (and future bundled-npm CVEs); the image builds with `pnpm` via `corepack` and does not use `npm`


### PR DESCRIPTION
### Context

The `ui-container-build-and-scan` Trivy step (`fail-on-critical: true`) currently fails on every UI build with a CRITICAL finding: `CVE-2026-59873`, a `node-tar` DoS via a crafted gzip bomb. This was surfaced on PR #12061 but is unrelated to that PR's changes — it affects any current build off `master`.

### Description

The vulnerable `tar` package (`7.5.1`) is not a Prowler dependency — it doesn't appear in `pnpm-lock.yaml`. It's bundled inside the **global npm CLI** shipped with the pinned base image `node:24.13.0-alpine`, at `usr/local/lib/node_modules/npm/node_modules/tar/`.

The UI image never actually uses that npm: dependencies are installed with `pnpm` via `corepack`, and the `prod` stage runs `node server.js` directly. npm is dead weight — and, as this CVE shows, a recurring source of CVE noise for a tool the image doesn't need.

Rather than pinning a patched npm version (which would need to be bumped again for the next bundled-npm CVE), this PR removes npm (and `npx`) entirely from the `base` stage of `ui/Dockerfile`, so every stage that inherits from `base` — including `prod`, the one that gets scanned — is clear of it for good.

```diff
 # Patch Alpine OpenSSL runtime packages before all stages inherit the base image.
-RUN apk upgrade --no-cache libcrypto3 libssl3 && corepack enable
+# The build uses pnpm via corepack, so npm is unused — remove it (and npx) to drop
+# the bundled-npm CVE surface (node-tar CVE-2026-59873) from every stage, incl. prod.
+RUN apk upgrade --no-cache libcrypto3 libssl3 && corepack enable && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
```

Single `RUN` line changed in `ui/Dockerfile`, plus the required `ui/changelog.d/` fragment.

### Steps to review

1. Rebuild the UI image (`docker build -f ui/Dockerfile .` or via the `ui-container-build-and-scan` workflow) and confirm it still builds successfully.
2. Confirm the Trivy scan step reports 0 CRITICAL findings (specifically, that `CVE-2026-59873` no longer appears).
3. Spot-check that `pnpm-lock.yaml` is untouched — this does not change any Prowler UI dependency, only removes the base image's unused global npm CLI.
4. Confirm `corepack` (used to activate `pnpm`) still works as expected post-removal — it does not depend on `npm` being present.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests. — N/A, single-line base-image change, no application code path affected.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings — N/A, no documentable code; inline comment added explaining the removal.
- [x] Review if backport is needed. — Likely yes, since the published self-hosted UI image is affected; flagging for maintainer confirmation.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. — N/A for SDK; UI fragment added below.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI — N/A functional change; base image only. `corepack`/`pnpm` build path does not depend on `npm`.
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient. — N/A, no Prowler dependency changed (`pnpm-lock.yaml` untouched); this removes an unused tool, it doesn't add one.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px) — N/A, no UI/visual change.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px) — N/A, no UI/visual change.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px) — N/A, no UI/visual change.
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable. — Updated `ui/changelog.d/ui-trivy-cve-2026-59873-npm-tar.security.md` to reflect the removal.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the UI container image to remove unused bundled npm and npx tools.
  * Addressed the bundled `node-tar` vulnerability (CVE-2026-59873) in the image.

* **Security**
  * Continued using pnpm through Corepack for package management without relying on npm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->