### PR TITLE
fix(ui): adjust sidebar logo top spacing

### DIFF
--- a/ui/changelog.d/sidebar-logo-top-padding.fixed.md
+++ b/ui/changelog.d/sidebar-logo-top-padding.fixed.md
@@ -1,0 +1,1 @@
+Sidebar logo top spacing in the main app sidebar

--- a/ui/components/layout/app-sidebar/app-sidebar-content.tsx
+++ b/ui/components/layout/app-sidebar/app-sidebar-content.tsx
@@ -37,7 +37,7 @@ export function AppSidebarContent({ onSelect }: AppSidebarContentProps) {
 
   return (
     <div className="relative flex h-full min-h-0 w-full flex-col overflow-hidden">
-      <div className="shrink-0 px-5 pt-6 pb-7">
+      <div className="shrink-0 px-5 pt-8 pb-7">
         <Link
           href="/"
           aria-label="Prowler home"


### PR DESCRIPTION
### Context

The Prowler Cloud sidebar logo needed a little more top breathing room so it does not look vertically compressed against the top of the sidebar.

### Description

This PR adjusts only the top padding around the main app sidebar logo and adds the corresponding UI changelog fragment.

| File | Change |
|------|--------|
| `ui/components/layout/app-sidebar/app-sidebar-content.tsx` | Increased the sidebar brand wrapper top padding from `pt-6` to `pt-8` |
| `ui/changelog.d/sidebar-logo-top-padding.fixed.md` | Added UI changelog fragment |

### Steps to review

1. Open the app sidebar in the desktop layout.
2. Verify the Prowler logo has slightly more top spacing.
3. Confirm the rest of the sidebar layout remains unchanged.

Verification run:

- [x] `git diff --check`
- [x] `./node_modules/.bin/prettier --check components/layout/app-sidebar/app-sidebar-content.tsx changelog.d/sidebar-logo-top-padding.fixed.md`
- [x] Pre-commit hooks: UI Prettier, ESLint, TypeScript Check, and Unit Tests passed
- [x] Local dev sign-in route verified at `http://localhost:3002/sign-in`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. N/A, UI changelog added instead.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API. N/A, no API changes.
- [x] Endpoint response output (if applicable). N/A, no API changes.
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable). N/A, no API changes.
- [x] Performance test results (if applicable). N/A, no API changes.
- [x] Any other relevant evidence of the implementation (if applicable). N/A, no API changes.
- [x] Verify if API specs need to be regenerated. N/A, no API changes.
- [x] Check if version updates are required (e.g., specs, uv, etc.). N/A, no API changes.
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable. N/A, no API changes.

#### MCP Server
- [x] All issue/task requirements work as expected on the MCP Server. N/A, no MCP changes.
- [x] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable. N/A, no MCP changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the top spacing above the logo in the main app sidebar for improved visual alignment.

* **Documentation**
  * Added a changelog entry documenting the sidebar logo spacing adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->