### PR TITLE
fix(ui): prevent cloud upgrade modal flash on close

### DIFF
--- a/ui/changelog.d/prowler-2254-cloud-upgrade-modal-flash.fixed.md
+++ b/ui/changelog.d/prowler-2254-cloud-upgrade-modal-flash.fixed.md
@@ -1,0 +1,1 @@
+Contextual Cloud upgrade modal content remains stable throughout the closing animation

--- a/ui/components/shared/cloud-upgrade-modal.test.tsx
+++ b/ui/components/shared/cloud-upgrade-modal.test.tsx
@@ -7,9 +7,40 @@ import { CLOUD_UPGRADE_FEATURE } from "@/types/cloud-upgrade";
 
 import { CloudUpgradeModal } from "./cloud-upgrade-modal";
 
+const modalTestState = vi.hoisted(() => ({
+  keepContentMounted: false,
+}));
+
+vi.mock("@/components/shadcn/modal", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/components/shadcn/modal")>();
+  const { createElement } = await import("react");
+
+  return {
+    ...actual,
+    Modal: (props: Parameters<typeof actual.Modal>[0]) => {
+      if (!modalTestState.keepContentMounted) {
+        return createElement(actual.Modal, props);
+      }
+
+      return createElement(
+        "div",
+        { "aria-label": props.title, role: "dialog" },
+        createElement(
+          "button",
+          { onClick: () => props.onOpenChange?.(false), type: "button" },
+          "Close",
+        ),
+        props.children,
+      );
+    },
+  };
+});
+
 describe("CloudUpgradeModal", () => {
   afterEach(() => {
     cleanup();
+    modalTestState.keepContentMounted = false;
     vi.unstubAllEnvs();
     useCloudUpgradeStore.getState().closeCloudUpgrade();
   });
@@ -119,6 +150,42 @@ describe("CloudUpgradeModal", () => {
     expect(trigger).toHaveFocus();
     expect(useCloudUpgradeStore.getState().activeFeature).toBeNull();
   });
+
+  it.each([
+    {
+      feature: CLOUD_UPGRADE_FEATURE.ALERTS,
+      otherTitle: "Add Your Entire AWS Organization",
+      title: "Turn Findings into Alerts",
+    },
+    {
+      feature: CLOUD_UPGRADE_FEATURE.AWS_ORGANIZATIONS,
+      otherTitle: "Turn Findings into Alerts",
+      title: "Add Your Entire AWS Organization",
+    },
+  ])(
+    "does not replace $title with another upgrade while closing",
+    async ({ feature, otherTitle, title }) => {
+      // Given
+      vi.stubEnv("NEXT_PUBLIC_IS_CLOUD_ENV", "false");
+      modalTestState.keepContentMounted = true;
+      const user = userEvent.setup();
+      useCloudUpgradeStore.getState().openCloudUpgrade(feature);
+
+      render(<CloudUpgradeModal />);
+      expect(screen.getByRole("dialog", { name: title })).toBeVisible();
+
+      // When
+      await user.click(screen.getByRole("button", { name: "Close" }));
+
+      // Then
+      expect(useCloudUpgradeStore.getState().activeFeature).toBeNull();
+      expect(screen.getByRole("dialog", { name: title })).toBeVisible();
+      expect(
+        screen.queryByText("Scale Prowler Without Operating It"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(otherTitle)).not.toBeInTheDocument();
+    },
+  );
 
   it("does not render upgrade UI in Prowler Cloud", () => {
     // Given

--- a/ui/components/shared/cloud-upgrade-modal.tsx
+++ b/ui/components/shared/cloud-upgrade-modal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Check, Cloud } from "lucide-react";
-import { useRef } from "react";
 
 import { Badge } from "@/components/shadcn/badge/badge";
 import { Button } from "@/components/shadcn/button/button";
@@ -15,29 +14,24 @@ import {
 } from "@/lib/cloud-upgrade";
 import { isCloud } from "@/lib/shared/env";
 import { useCloudUpgradeStore } from "@/store";
-import { CLOUD_UPGRADE_FEATURE } from "@/types/cloud-upgrade";
 
 const allowInitialAutoFocus = () => {};
 
 export const CloudUpgradeModal = () => {
   const activeFeature = useCloudUpgradeStore((state) => state.activeFeature);
+  const retainedFeature = useCloudUpgradeStore(
+    (state) => state.retainedFeature,
+  );
   const closeCloudUpgrade = useCloudUpgradeStore(
     (state) => state.closeCloudUpgrade,
   );
   const returnFocusElement = useCloudUpgradeStore(
     (state) => state.returnFocusElement,
   );
-  const lastActiveFeature = useRef(
-    activeFeature ?? CLOUD_UPGRADE_FEATURE.GENERAL,
-  );
 
   if (isCloud()) return null;
 
-  if (activeFeature !== null) {
-    lastActiveFeature.current = activeFeature;
-  }
-
-  const feature = lastActiveFeature.current;
+  const feature = activeFeature ?? retainedFeature;
   const content = CLOUD_UPGRADE_CONTENT[feature];
 
   return (

--- a/ui/components/shared/cloud-upgrade-modal.tsx
+++ b/ui/components/shared/cloud-upgrade-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Check, Cloud } from "lucide-react";
+import { useRef } from "react";
 
 import { Badge } from "@/components/shadcn/badge/badge";
 import { Button } from "@/components/shadcn/button/button";
@@ -26,10 +27,17 @@ export const CloudUpgradeModal = () => {
   const returnFocusElement = useCloudUpgradeStore(
     (state) => state.returnFocusElement,
   );
+  const lastActiveFeature = useRef(
+    activeFeature ?? CLOUD_UPGRADE_FEATURE.GENERAL,
+  );
 
   if (isCloud()) return null;
 
-  const feature = activeFeature ?? CLOUD_UPGRADE_FEATURE.GENERAL;
+  if (activeFeature !== null) {
+    lastActiveFeature.current = activeFeature;
+  }
+
+  const feature = lastActiveFeature.current;
   const content = CLOUD_UPGRADE_CONTENT[feature];
 
   return (

--- a/ui/store/cloud-upgrade/store.test.ts
+++ b/ui/store/cloud-upgrade/store.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { CLOUD_UPGRADE_FEATURE } from "@/types/cloud-upgrade";
+
+import { useCloudUpgradeStore } from "./store";
+
+describe("useCloudUpgradeStore", () => {
+  beforeEach(() => {
+    useCloudUpgradeStore.setState({
+      activeFeature: null,
+      retainedFeature: CLOUD_UPGRADE_FEATURE.GENERAL,
+      returnFocusElement: null,
+    });
+  });
+
+  it("retains the opened feature when the modal closes", () => {
+    // Given
+    useCloudUpgradeStore
+      .getState()
+      .openCloudUpgrade(CLOUD_UPGRADE_FEATURE.ALERTS);
+
+    // When
+    useCloudUpgradeStore.getState().closeCloudUpgrade();
+
+    // Then
+    expect(useCloudUpgradeStore.getState().activeFeature).toBeNull();
+    expect(useCloudUpgradeStore.getState().retainedFeature).toBe(
+      CLOUD_UPGRADE_FEATURE.ALERTS,
+    );
+  });
+
+  it("updates the retained feature when another upgrade opens", () => {
+    // Given
+    useCloudUpgradeStore
+      .getState()
+      .openCloudUpgrade(CLOUD_UPGRADE_FEATURE.ALERTS);
+
+    // When
+    useCloudUpgradeStore
+      .getState()
+      .openCloudUpgrade(CLOUD_UPGRADE_FEATURE.AWS_ORGANIZATIONS);
+
+    // Then
+    expect(useCloudUpgradeStore.getState().activeFeature).toBe(
+      CLOUD_UPGRADE_FEATURE.AWS_ORGANIZATIONS,
+    );
+    expect(useCloudUpgradeStore.getState().retainedFeature).toBe(
+      CLOUD_UPGRADE_FEATURE.AWS_ORGANIZATIONS,
+    );
+  });
+});

--- a/ui/store/cloud-upgrade/store.ts
+++ b/ui/store/cloud-upgrade/store.ts
@@ -1,9 +1,13 @@
 import { create } from "zustand";
 
-import type { CloudUpgradeFeature } from "@/types/cloud-upgrade";
+import {
+  CLOUD_UPGRADE_FEATURE,
+  type CloudUpgradeFeature,
+} from "@/types/cloud-upgrade";
 
 interface CloudUpgradeStoreState {
   activeFeature: CloudUpgradeFeature | null;
+  retainedFeature: CloudUpgradeFeature;
   returnFocusElement: HTMLElement | null;
   openCloudUpgrade: (
     feature: CloudUpgradeFeature,
@@ -15,10 +19,12 @@ interface CloudUpgradeStoreState {
 // Upgrade prompts are ephemeral and shared so only one modal can be open.
 export const useCloudUpgradeStore = create<CloudUpgradeStoreState>((set) => ({
   activeFeature: null,
+  retainedFeature: CLOUD_UPGRADE_FEATURE.GENERAL,
   returnFocusElement: null,
   openCloudUpgrade: (activeFeature, requestedReturnFocusElement) =>
     set({
       activeFeature,
+      retainedFeature: activeFeature,
       returnFocusElement:
         requestedReturnFocusElement ??
         (document.activeElement instanceof HTMLElement


### PR DESCRIPTION
### Context

Jira: [PROWLER-2254](https://prowlerpro.atlassian.net/browse/PROWLER-2254)

Closing a contextual Cloud upgrade modal in Prowler Local Server cleared its active feature before the Radix exit animation completed. While the content remained mounted, it briefly rendered the generic Prowler Cloud overview instead.

No GitHub issue exists for this internal Jira bug.

### Description

- Preserve the last active Cloud upgrade feature while the modal closes.
- Prevent Alerts and AWS Organizations upgrade content from being replaced during the exit animation.
- Add regression coverage for both contextual upgrade flows.
- Add the required UI changelog fragment.

No dependencies are added or updated.

### Steps to review

1. Review how `CloudUpgradeModal` retains the last non-null contextual feature during the closing animation.
2. Run `cd ui && pnpm test:unit components/shared/cloud-upgrade-modal.test.tsx`.
3. Run `cd ui && pnpm run healthcheck`.
4. In Prowler Local Server, open the Alerts upgrade modal and close it.
5. Confirm that “Turn Findings into Alerts” remains visible throughout the closing animation and “Scale Prowler Without Operating It” never flashes.
6. Repeat with the AWS Organizations upgrade modal.

### Checklist

<details>
<summary><b>Community Checklist</b></summary>

- [x] This issue is tracked internally as [PROWLER-2254](https://prowlerpro.atlassian.net/browse/PROWLER-2254).
- [x] Assignment through the public issue workflow is not applicable to this internal Jira bug.
- [x] I reviewed open pull requests and confirmed there is no existing PR implementing the same outcome.

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code documentation is needed — N/A, no public API change.
- [ ] Review if backport is needed.
- [x] Review if README changes are needed — N/A.

#### SDK/CLI
- Are there new checks included in this PR? No.

#### UI
- [x] All issue/task requirements work as expected on the UI.
- [x] No npm dependencies are added or updated.
- [ ] Screenshots/Video — Mobile.
- [ ] Screenshots/Video — Tablet.
- [ ] Screenshots/Video — Desktop.
- [x] A changelog fragment is included under `ui/changelog.d/`.

#### API
- [x] API changes, response evidence, query analysis, performance evidence, spec regeneration, version updates, and API changelog are N/A.

#### MCP Server
- [x] MCP Server changes and changelog are N/A.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


[PROWLER-2254]: https://prowlerpro.atlassian.net/browse/PROWLER-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROWLER-2254]: https://prowlerpro.atlassian.net/browse/PROWLER-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud upgrade modal content now stays stable throughout the closing animation, avoiding unexpected swaps to other upgrade details.
  * Closing the modal clears the currently active upgrade state while keeping the same title/content visible until the animation completes.

* **Tests**
  * Added coverage to ensure the modal maintains the correct title/content when the close behavior intentionally keeps content mounted, and to verify store state updates (active vs retained) behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->