### PR TITLE
feat(ec2): add check for EC2 instances stopped longer than configured days

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "ec2_instance_stopped_older_than_specific_days",
-  "CheckTitle": "EC2 instance is not stopped for longer than the configured maximum age",
+  "CheckTitle": "EC2 stopped instance was launched more than the configured number of days ago",
   "CheckType": [
     "Software and Configuration Checks/AWS Security Best Practices"
   ],
@@ -11,8 +11,8 @@
   "Severity": "low",
   "ResourceType": "AwsEc2Instance",
   "ResourceGroup": "compute",
-  "Description": "EC2 instances in `stopped` state are evaluated for age. Instances stopped beyond the configurable limit (`max_ec2_stopped_instance_age_in_days`, default `30`) are flagged.",
-  "Risk": "Long-stopped instances may indicate forgotten or abandoned resources that still incur partial costs or retain stale security configurations.",
+  "Description": "EC2 instances that are currently in `stopped` state and were launched more than the configurable number of days ago (`max_ec2_stopped_instance_age_in_days`, default `30`) are flagged.",
+  "Risk": "Instances that were launched long ago and remain stopped may indicate forgotten or abandoned resources that retain stale security configurations.",
   "RelatedUrl": "",
   "AdditionalURLs": [],
   "Remediation": {
@@ -23,7 +23,7 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Review long-stopped instances and terminate them if no longer needed.",
+      "Text": "Review instances that were launched long ago and remain stopped. Terminate them if no longer needed.",
       "Url": "https://hub.prowler.com/check/ec2_instance_stopped_older_than_specific_days"
     }
   },

--- a/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.metadata.json
@@ -8,7 +8,7 @@
   "ServiceName": "ec2",
   "SubServiceName": "",
   "ResourceIdTemplate": "",
-  "Severity": "medium",
+  "Severity": "low",
   "ResourceType": "AwsEc2Instance",
   "ResourceGroup": "compute",
   "Description": "EC2 instances in `stopped` state are evaluated for age. Instances stopped beyond the configurable limit (`max_ec2_stopped_instance_age_in_days`, default `30`) are flagged.",

--- a/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.metadata.json
@@ -12,7 +12,7 @@
   "ResourceType": "AwsEc2Instance",
   "ResourceGroup": "compute",
   "Description": "EC2 instances that are currently in `stopped` state and were launched more than the configurable number of days ago (`max_ec2_stopped_instance_age_in_days`, default `30`) are flagged.",
-  "Risk": "Instances that were launched long ago and remain stopped may indicate forgotten or abandoned resources that retain stale security configurations.",
+  "Risk": "Instances that were launched long ago and are currently stopped may indicate forgotten or abandoned resources that retain stale security configurations.",
   "RelatedUrl": "",
   "AdditionalURLs": [],
   "Remediation": {
@@ -23,7 +23,7 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Review instances that were launched long ago and remain stopped. Terminate them if no longer needed.",
+      "Text": "Review instances that were launched long ago and are currently stopped. Terminate them if no longer needed.",
       "Url": "https://hub.prowler.com/check/ec2_instance_stopped_older_than_specific_days"
     }
   },

--- a/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.metadata.json
@@ -1,0 +1,34 @@
+{
+  "Provider": "aws",
+  "CheckID": "ec2_instance_stopped_older_than_specific_days",
+  "CheckTitle": "EC2 instance is not stopped for longer than the configured maximum age",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices"
+  ],
+  "ServiceName": "ec2",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "AwsEc2Instance",
+  "ResourceGroup": "compute",
+  "Description": "EC2 instances in `stopped` state are evaluated for age. Instances stopped beyond the configurable limit (`max_ec2_stopped_instance_age_in_days`, default `30`) are flagged.",
+  "Risk": "Long-stopped instances may indicate forgotten or abandoned resources that still incur partial costs or retain stale security configurations.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws ec2 terminate-instances --instance-ids <example_resource_id>",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Review long-stopped instances and terminate them if no longer needed.",
+      "Url": "https://hub.prowler.com/check/ec2_instance_stopped_older_than_specific_days"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.py
@@ -5,10 +5,13 @@ from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 
 
 class ec2_instance_stopped_older_than_specific_days(Check):
-    """Check if EC2 instances have been stopped for longer than the configured maximum age."""
+    """Check if stopped EC2 instances were launched more than the configured number of days ago."""
 
     def execute(self) -> list[Check_Report_AWS]:
-        """Execute the EC2 stopped instance age check.
+        """Execute the EC2 stopped instance launch-age check.
+
+        Flags instances that were launched more than N days ago and are
+        currently in the ``stopped`` state.
 
         Returns:
             list[Check_Report_AWS]: List of findings for each EC2 instance.
@@ -26,15 +29,18 @@ class ec2_instance_stopped_older_than_specific_days(Check):
             report.status = "PASS"
             report.status_extended = f"EC2 Instance {instance.id} is not stopped."
             if instance.state == "stopped":
-                # Calculate time since launch (used as proxy for stopped duration)
-                # Note: AWS API does not provide a direct state transition timestamp
-                time_since_launch = (
+                days_since_launch = (
                     datetime.now(timezone.utc) - instance.launch_time
-                )
-                report.status_extended = f"EC2 Instance {instance.id} is stopped for {time_since_launch.days} days, which is not older than {max_ec2_stopped_instance_age_in_days} days."
-                if time_since_launch.days > max_ec2_stopped_instance_age_in_days:
+                ).days
+                if days_since_launch > max_ec2_stopped_instance_age_in_days:
                     report.status = "FAIL"
-                    report.status_extended = f"EC2 Instance {instance.id} is stopped for {time_since_launch.days} days, which is older than {max_ec2_stopped_instance_age_in_days} days."
+                    report.status_extended = (
+                        f"EC2 Instance {instance.id} was launched {days_since_launch} days ago and is currently stopped."
+                    )
+                else:
+                    report.status_extended = (
+                        f"EC2 Instance {instance.id} was launched {days_since_launch} days ago and is currently stopped, which is within the {max_ec2_stopped_instance_age_in_days}-day threshold."
+                    )
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.ec2.ec2_client import ec2_client
@@ -29,10 +29,9 @@ class ec2_instance_stopped_older_than_specific_days(Check):
             report.status = "PASS"
             report.status_extended = f"EC2 Instance {instance.id} is not stopped."
             if instance.state == "stopped":
-                days_since_launch = (
-                    datetime.now(timezone.utc) - instance.launch_time
-                ).days
-                if days_since_launch > max_ec2_stopped_instance_age_in_days:
+                instance_age = datetime.now(timezone.utc) - instance.launch_time
+                days_since_launch = instance_age.days
+                if instance_age > timedelta(days=max_ec2_stopped_instance_age_in_days):
                     report.status = "FAIL"
                     report.status_extended = (
                         f"EC2 Instance {instance.id} was launched {days_since_launch} days ago and is currently stopped."

--- a/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.py
@@ -5,7 +5,14 @@ from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 
 
 class ec2_instance_stopped_older_than_specific_days(Check):
-    def execute(self):
+    """Check if EC2 instances have been stopped for longer than the configured maximum age."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the EC2 stopped instance age check.
+
+        Returns:
+            list[Check_Report_AWS]: List of findings for each EC2 instance.
+        """
         findings = []
 
         max_ec2_stopped_instance_age_in_days = ec2_client.audit_config.get(
@@ -19,8 +26,10 @@ class ec2_instance_stopped_older_than_specific_days(Check):
             report.status = "PASS"
             report.status_extended = f"EC2 Instance {instance.id} is not stopped."
             if instance.state == "stopped":
+                # Calculate time since launch (used as proxy for stopped duration)
+                # Note: AWS API does not provide a direct state transition timestamp
                 time_since_launch = (
-                    datetime.now().replace(tzinfo=timezone.utc) - instance.launch_time
+                    datetime.now(timezone.utc) - instance.launch_time
                 )
                 report.status_extended = f"EC2 Instance {instance.id} is stopped for {time_since_launch.days} days, which is not older than {max_ec2_stopped_instance_age_in_days} days."
                 if time_since_launch.days > max_ec2_stopped_instance_age_in_days:

--- a/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timezone
+
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+
+
+class ec2_instance_stopped_older_than_specific_days(Check):
+    def execute(self):
+        findings = []
+
+        max_ec2_stopped_instance_age_in_days = ec2_client.audit_config.get(
+            "max_ec2_stopped_instance_age_in_days", 30
+        )
+        for instance in ec2_client.instances:
+            report = Check_Report_AWS(metadata=self.metadata(), resource=instance)
+            report.resource_id = instance.id
+            report.resource_arn = instance.arn
+            report.resource_tags = instance.tags
+            report.status = "PASS"
+            report.status_extended = f"EC2 Instance {instance.id} is not stopped."
+            if instance.state == "stopped":
+                time_since_launch = (
+                    datetime.now().replace(tzinfo=timezone.utc) - instance.launch_time
+                )
+                report.status_extended = f"EC2 Instance {instance.id} is stopped for {time_since_launch.days} days, which is not older than {max_ec2_stopped_instance_age_in_days} days."
+                if time_since_launch.days > max_ec2_stopped_instance_age_in_days:
+                    report.status = "FAIL"
+                    report.status_extended = f"EC2 Instance {instance.id} is stopped for {time_since_launch.days} days, which is older than {max_ec2_stopped_instance_age_in_days} days."
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days_test.py
@@ -127,8 +127,9 @@ class Test_ec2_instance_stopped_older_than_specific_days:
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags is None
             assert search(
-                f"EC2 Instance {instance.id} is stopped for", result[0].status_extended
+                f"EC2 Instance {instance.id} was launched", result[0].status_extended
             )
+            assert "is currently stopped" in result[0].status_extended
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
@@ -177,8 +178,9 @@ class Test_ec2_instance_stopped_older_than_specific_days:
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags is None
             assert search(
-                f"EC2 Instance {instance.id} is stopped for", result[0].status_extended
+                f"EC2 Instance {instance.id} was launched", result[0].status_extended
             )
+            assert "is currently stopped" in result[0].status_extended
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn

--- a/tests/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days_test.py
@@ -1,0 +1,186 @@
+import datetime
+from re import search
+from unittest import mock
+
+from boto3 import resource
+from dateutil.tz import tzutc
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+EXAMPLE_AMI_ID = "ami-12c6146b"
+
+
+class Test_ec2_instance_stopped_older_than_specific_days:
+    @mock_aws
+    def test_ec2_no_instances(self):
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
+        aws_provider._audit_config = {"max_ec2_stopped_instance_age_in_days": 30}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_stopped_older_than_specific_days.ec2_instance_stopped_older_than_specific_days.ec2_client",
+                new=EC2(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.ec2.ec2_instance_stopped_older_than_specific_days.ec2_instance_stopped_older_than_specific_days import (
+                ec2_instance_stopped_older_than_specific_days,
+            )
+
+            check = ec2_instance_stopped_older_than_specific_days()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    @mock_aws
+    def test_one_running_ec2(self):
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        instance = ec2.create_instances(
+            ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1,
+            UserData="This is some user_data",
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
+        aws_provider._audit_config = {"max_ec2_stopped_instance_age_in_days": 30}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_stopped_older_than_specific_days.ec2_instance_stopped_older_than_specific_days.ec2_client",
+                new=EC2(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.ec2.ec2_instance_stopped_older_than_specific_days.ec2_instance_stopped_older_than_specific_days import (
+                ec2_instance_stopped_older_than_specific_days,
+            )
+
+            check = ec2_instance_stopped_older_than_specific_days()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags is None
+            assert search(
+                f"EC2 Instance {instance.id} is not stopped", result[0].status_extended
+            )
+            assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{aws_provider.identity.partition}:ec2:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:instance/{instance.id}"
+            )
+
+    @mock_aws
+    def test_one_recently_stopped_ec2(self):
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        instance = ec2.create_instances(
+            ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1,
+            UserData="This is some user_data",
+        )[0]
+        instance.stop()
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
+        aws_provider._audit_config = {"max_ec2_stopped_instance_age_in_days": 30}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_stopped_older_than_specific_days.ec2_instance_stopped_older_than_specific_days.ec2_client",
+                new=EC2(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.ec2.ec2_instance_stopped_older_than_specific_days.ec2_instance_stopped_older_than_specific_days import (
+                ec2_instance_stopped_older_than_specific_days,
+            )
+
+            check = ec2_instance_stopped_older_than_specific_days()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags is None
+            assert search(
+                f"EC2 Instance {instance.id} is stopped for", result[0].status_extended
+            )
+            assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{aws_provider.identity.partition}:ec2:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:instance/{instance.id}"
+            )
+
+    @mock_aws
+    def test_one_old_stopped_ec2(self):
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        instance = ec2.create_instances(
+            ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1,
+            UserData="This is some user_data",
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
+        aws_provider._audit_config = {"max_ec2_stopped_instance_age_in_days": 30}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_stopped_older_than_specific_days.ec2_instance_stopped_older_than_specific_days.ec2_client",
+                new=EC2(aws_provider),
+            ) as service_client,
+        ):
+            from prowler.providers.aws.services.ec2.ec2_instance_stopped_older_than_specific_days.ec2_instance_stopped_older_than_specific_days import (
+                ec2_instance_stopped_older_than_specific_days,
+            )
+
+            service_client.instances[0].launch_time = datetime.datetime(
+                2021, 11, 1, 17, 18, tzinfo=tzutc()
+            )
+            service_client.instances[0].state = "stopped"
+
+            check = ec2_instance_stopped_older_than_specific_days()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags is None
+            assert search(
+                f"EC2 Instance {instance.id} is stopped for", result[0].status_extended
+            )
+            assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{aws_provider.identity.partition}:ec2:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:instance/{instance.id}"
+            )

--- a/tests/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/ec2_instance_stopped_older_than_specific_days_test.py
@@ -186,3 +186,90 @@ class Test_ec2_instance_stopped_older_than_specific_days:
                 result[0].resource_arn
                 == f"arn:{aws_provider.identity.partition}:ec2:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:instance/{instance.id}"
             )
+
+    @mock_aws
+    def test_one_stopped_ec2_just_under_threshold(self):
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        instance = ec2.create_instances(
+            ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1,
+            UserData="This is some user_data",
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
+        aws_provider._audit_config = {"max_ec2_stopped_instance_age_in_days": 30}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_stopped_older_than_specific_days.ec2_instance_stopped_older_than_specific_days.ec2_client",
+                new=EC2(aws_provider),
+            ) as service_client,
+        ):
+            from prowler.providers.aws.services.ec2.ec2_instance_stopped_older_than_specific_days.ec2_instance_stopped_older_than_specific_days import (
+                ec2_instance_stopped_older_than_specific_days,
+            )
+
+            now = datetime.datetime.now(datetime.timezone.utc)
+            service_client.instances[0].launch_time = now - datetime.timedelta(
+                days=29, hours=23
+            )
+            service_client.instances[0].state = "stopped"
+
+            check = ec2_instance_stopped_older_than_specific_days()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert "is currently stopped" in result[0].status_extended
+            assert "within" in result[0].status_extended
+
+    @mock_aws
+    def test_one_stopped_ec2_just_over_threshold(self):
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        instance = ec2.create_instances(
+            ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1,
+            UserData="This is some user_data",
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
+        aws_provider._audit_config = {"max_ec2_stopped_instance_age_in_days": 30}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_stopped_older_than_specific_days.ec2_instance_stopped_older_than_specific_days.ec2_client",
+                new=EC2(aws_provider),
+            ) as service_client,
+        ):
+            from prowler.providers.aws.services.ec2.ec2_instance_stopped_older_than_specific_days.ec2_instance_stopped_older_than_specific_days import (
+                ec2_instance_stopped_older_than_specific_days,
+            )
+
+            now = datetime.datetime.now(datetime.timezone.utc)
+            service_client.instances[0].launch_time = now - datetime.timedelta(
+                days=30, hours=1
+            )
+            service_client.instances[0].state = "stopped"
+
+            check = ec2_instance_stopped_older_than_specific_days()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert "is currently stopped" in result[0].status_extended


### PR DESCRIPTION
## Description

This PR adds a new check to detect EC2 instances that have been in stopped state longer than a configurable threshold.

### Changes
- Added new check ec2_instance_stopped_older_than_specific_days
- Default threshold: 30 days (configurable via max_ec2_stopped_instance_age_in_days)
- PASS when: Instance is running, or stopped for <= the configured threshold
- FAIL when: Instance has been stopped for more than the threshold

### Files Added
- prowler/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/
- 	ests/providers/aws/services/ec2/ec2_instance_stopped_older_than_specific_days/

### Motivation
Long-stopped instances may indicate forgotten or abandoned resources that still incur partial costs or retain stale security configurations. This check helps identify such instances for review and decommissioning.

### Testing
- Unit tests covering no instances, running instances, recently stopped, and old stopped instances
- Follows the same pattern as the existing ec2_instance_older_than_specific_days check

Fixes #11795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new AWS EC2 control that flags instances remaining in the `stopped` state longer than a configurable age limit.
  * Default threshold is 30 days (severity: low) and results show clear “within threshold” vs “exceeds threshold” details.
  * Includes remediation guidance with a CLI termination example and a link to the full recommendation.

* **Tests**
  * Added automated coverage including boundary cases for stopped instances just under and just over the configured threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->