### PR TITLE
fix(ci): ignore unfixed Perl Storable CVE-2026-57433

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -35,6 +35,20 @@ CVE-2026-13221 pkg:perl-base exp:2026-08-15
 CVE-2026-13221 pkg:perl-modules-5.36 exp:2026-08-15
 CVE-2026-13221 pkg:libperl5.36 exp:2026-08-15
 
+# CVE-2026-57433 — Perl Storable signed integer overflow when deserializing a
+# crafted SX_HOOK record (retrieve_hook_common passes a wrapped negative count
+# to av_extend).
+# Packages: perl, perl-base, perl-modules-5.36, libperl5.36.
+# Why ignored: perl-base is part of Debian's "Essential: yes" set; it cannot be
+# removed without breaking dpkg. Prowler does not invoke perl at runtime and
+# never calls Storable's thaw/retrieve on attacker-controlled blobs, so the
+# vulnerable deserialization path is unreachable. Fixed upstream in
+# Storable 3.41; no Debian bookworm fix is available yet.
+CVE-2026-57433 pkg:perl exp:2026-08-15
+CVE-2026-57433 pkg:perl-base exp:2026-08-15
+CVE-2026-57433 pkg:perl-modules-5.36 exp:2026-08-15
+CVE-2026-57433 pkg:libperl5.36 exp:2026-08-15
+
 # CVE-2025-7458 — SQLite integer overflow.
 # Package: libsqlite3-0.
 # Why ignored: transitive dependency of CPython's stdlib sqlite3 module. The


### PR DESCRIPTION
### Description

The Trivy scan on the API container image fails with 4 critical vulnerabilities. All 4 are the same CVE, CVE-2026-57433 (signed integer overflow in Perl's Storable when deserializing a crafted SX_HOOK record), reported once per Debian perl package: perl, perl-base, perl-modules-5.36 and libperl5.36.

There is no fix available in Debian bookworm yet (upstream fix is in Storable 3.41), and perl-base is part of Debian's Essential set, so it cannot be removed. Prowler never invokes perl at runtime nor deserializes Storable blobs, so the vulnerable path is unreachable.

This PR suppresses the CVE in .trivyignore, scoped per package and with the usual expiry date (2026-08-15), following the same pattern as previous suppressions (#11709).

Verified locally by re-filtering the failed run's report with trivy convert --ignorefile .trivyignore: criticals go from 4 to 0.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container vulnerability scanning exclusions for CVE-2026-57433.
  * Added an expiration date and documented the runtime risk assessment and upstream fix status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->