### PR TITLE
ci(api): scan the SDK pin that ships, not the committed lock

### DIFF
--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -113,6 +113,15 @@ jobs:
             api/changelog.d/**
             api/AGENTS.md
 
+      # api-container-build-push.yml resolves the SDK pin to the branch tip
+      # before building, so match it here and scan what ships. Push only: PRs
+      # stay deterministic against the committed lock.
+      - name: Refresh prowler SDK pin to current branch tip
+        if: steps.check-changes.outputs.any_changed == 'true' && github.event_name == 'push'
+        run: |
+          pip install --no-cache-dir "uv==0.11.14"
+          (cd api && uv lock --upgrade-package prowler)
+
       - name: Set up Docker Buildx
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0


### PR DESCRIPTION
### Context

`api-container-build-push.yml` already refreshes the `prowler` SDK pin to the current branch tip (`uv lock --upgrade-package prowler`) before building the image it ships. `api-container-checks.yml`, the workflow that runs the Trivy scan gate, does not — it scans the container built from the committed `api/uv.lock`. That means the released image can contain a `prowler` SDK commit that was never scanned.

### Description

Adds a step, "Refresh prowler SDK pin to current branch tip", immediately before "Set up Docker Buildx" in `api-container-checks.yml`. It mirrors the resolution already performed in `api-container-build-push.yml`:

```yaml
pip install --no-cache-dir "uv==0.11.14"
(cd api && uv lock --upgrade-package prowler)
```

Gated on `steps.check-changes.outputs.any_changed == 'true' && github.event_name == 'push'`. Deliberately **not** applied on `pull_request` events, so PR builds stay deterministic against the committed lock and a PR is never failed by an unrelated SDK commit landing mid-review.

The job's harden-runner egress allowlist already permits `pypi.org`, `files.pythonhosted.org`, and `github.com`, so no allowlist change is needed.

Validated locally: YAML parses, `actionlint` clean, `zizmor` clean.

The equivalent fix was already merged in `prowler-cloud/prowler-cloud` as PR #5186; this ports it to the OSS repo.

### Steps to review

1. Confirm the new step sits directly before "Set up Docker Buildx" and after the changed-files check.
2. Confirm the `if` condition restricts it to `push` events only (PR events are untouched).
3. Compare against the equivalent step in `api-container-build-push.yml` to confirm the resolution logic matches.
4. Optionally trigger a push-triggered run on a branch with API changes and confirm the scan step now reflects the resolved lock.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### API
- [x] All issue/task requirements work as expected on the API — CI-only change, validated with `actionlint` and `zizmor` locally.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API container checks to refresh the API SDK version when API changes are detected on push.
  * Ensured container builds and security scans use dependencies resolved from the latest API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->