### PR TITLE
fix(api): invoke m365 module without a hardcoded python version path

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -102,7 +102,9 @@ ENV PATH="/home/prowler/.local/bin:$PATH"
 RUN uv sync --locked --no-install-project && \
     rm -rf ~/.cache/uv
 
-RUN .venv/bin/python .venv/lib/python3.12/site-packages/prowler/providers/m365/lib/powershell/m365_powershell.py
+# Invoked as a module so the base image's Python minor version is not baked
+# into a site-packages path.
+RUN .venv/bin/python -m prowler.providers.m365.lib.powershell.m365_powershell
 
 USER root
 


### PR DESCRIPTION
### Context

The `api/Dockerfile` invokes the m365 PowerShell helper script by hardcoding its full site-packages path, including the base image's Python minor version (`python3.12`). When the base image bumps to a new minor version, that path no longer exists and the build fails:

```
.venv/bin/python: can't open file '/home/prowler/.venv/lib/python3.12/site-packages/prowler/providers/m365/lib/powershell/m365_powershell.py': [Errno 2] No such file or directory
```

This is currently breaking the open Renovate PR (`renovate/docker`), which bumps the base image to `python:3.14.6` — the build fails deterministically at this step. It accounted for 3 of the last 5 failures of the "API: Container Checks" workflow.

### Description

Invoke the m365 PowerShell helper as a module (`python -m prowler.providers...`) instead of by file path, so the Python minor version is never baked into the invocation. This removes the coupling entirely — it will not break on any future Python bump.

```diff
-RUN .venv/bin/python .venv/lib/python3.12/site-packages/prowler/providers/m365/lib/powershell/m365_powershell.py
+# Invoked as a module so the base image's Python minor version is not baked
+# into a site-packages path.
+RUN .venv/bin/python -m prowler.providers.m365.lib.powershell.m365_powershell
```

Unblocks the Renovate base-image bump PR.

### Steps to review

Verification already performed:
- Ran `.venv/bin/python -m prowler.providers.m365.lib.powershell.m365_powershell` inside the actual built API image from `WORKDIR /home/prowler` — exited 0.
- Confirmed the module uses absolute imports only and has a standard `if __name__ == "__main__": main()` guard, so `-m` invocation is equivalent to direct file invocation.
- Ran hadolint (with the workflow's DL3013 ignore) against the modified Dockerfile — passes.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable) — verified inside the built image and with hadolint, see "Steps to review"
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container build compatibility by removing dependency on a specific Python minor version.
  * Ensured the M365 PowerShell component runs reliably across supported Python environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->