### PR TITLE
fix(ui): refresh permissions after tenant switch

### DIFF
--- a/ui/auth.config.test.ts
+++ b/ui/auth.config.test.ts
@@ -72,6 +72,8 @@ describe("authConfig JWT callback", () => {
         tenant_id: "tenant-1",
         user: {
           name: "Tenant User",
+          email: "tenant@example.com",
+          dateJoined: "2026-01-01",
           permissions: RESTRICTED_PERMISSIONS,
         },
       },
@@ -80,7 +82,6 @@ describe("authConfig JWT callback", () => {
       session: {
         accessToken,
         refreshToken: "elevated-refresh-token",
-        user: { permissions: RESTRICTED_PERMISSIONS },
       },
     });
 
@@ -117,6 +118,8 @@ describe("authConfig JWT callback", () => {
         tenant_id: "tenant-2",
         user: {
           name: "Tenant User",
+          email: "tenant@example.com",
+          dateJoined: "2026-01-01",
           permissions: ELEVATED_PERMISSIONS,
         },
       },
@@ -125,7 +128,6 @@ describe("authConfig JWT callback", () => {
       session: {
         accessToken,
         refreshToken: "restricted-refresh-token",
-        user: { permissions: ELEVATED_PERMISSIONS },
       },
     });
 
@@ -139,18 +141,22 @@ describe("authConfig JWT callback", () => {
     });
   });
 
-  it("should preserve the current session when the switched tenant user cannot be loaded", async () => {
+  it("should report a tenant switch failure while preserving the current session", async () => {
     // Given
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
     getUserByMeMock.mockRejectedValue(new Error("Temporary API failure"));
     const jwtCallback = authConfig.callbacks?.jwt;
     if (!jwtCallback) throw new Error("JWT callback is not configured");
+    const sessionCallback = authConfig.callbacks?.session;
+    if (!sessionCallback) throw new Error("Session callback is not configured");
     const currentToken = {
       accessToken: "current-access-token",
       refreshToken: "current-refresh-token",
       tenant_id: "tenant-1",
       user: {
         name: "Tenant User",
+        email: "tenant@example.com",
+        dateJoined: "2026-01-01",
         permissions: RESTRICTED_PERMISSIONS,
       },
     };
@@ -164,20 +170,28 @@ describe("authConfig JWT callback", () => {
         accessToken:
           "header.eyJzdWIiOiJ1c2VyLTEiLCJ0ZW5hbnRfaWQiOiJ0ZW5hbnQtMiJ9.signature",
         refreshToken: "switched-refresh-token",
-        user: { permissions: ELEVATED_PERMISSIONS },
       },
     });
+    if (!result) throw new Error("JWT callback cleared the current token");
+
+    const session = await sessionCallback({
+      session: {
+        expires: "2026-12-31T23:59:59.999Z",
+        user: { name: "Tenant User" },
+      },
+      token: result,
+    } as Parameters<typeof sessionCallback>[0]);
 
     // Then
-    expect(result).toBe(currentToken);
-    expect(result).toMatchObject({
+    expect(session).toMatchObject({
+      error: "TenantSwitchError",
       accessToken: "current-access-token",
       refreshToken: "current-refresh-token",
-      tenant_id: "tenant-1",
+      tenantId: "tenant-1",
       user: {
         permissions: RESTRICTED_PERMISSIONS,
       },
     });
-    expect(result.error).not.toBe("RefreshAccessTokenError");
+    expect(result.error).toBeUndefined();
   });
 });

--- a/ui/auth.config.test.ts
+++ b/ui/auth.config.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { authConfig } from "./auth.config";
+import type { RolePermissionAttributes } from "./types/users";
+
+const { getUserByMeMock } = vi.hoisted(() => ({
+  getUserByMeMock: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  default: vi.fn(() => ({
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    auth: vi.fn(),
+    handlers: {},
+  })),
+}));
+
+vi.mock("next-auth/providers/credentials", () => ({
+  default: vi.fn((config) => config),
+}));
+
+vi.mock("./actions/auth", () => ({
+  getToken: vi.fn(),
+  getUserByMe: getUserByMeMock,
+}));
+
+vi.mock("./lib", () => ({
+  apiBaseUrl: "https://api.example.com/api/v1",
+}));
+
+const RESTRICTED_PERMISSIONS: RolePermissionAttributes = {
+  manage_users: false,
+  manage_account: false,
+  manage_providers: false,
+  manage_scans: false,
+  manage_integrations: false,
+  manage_alerts: false,
+  unlimited_visibility: false,
+};
+
+const ELEVATED_PERMISSIONS: RolePermissionAttributes = {
+  ...RESTRICTED_PERMISSIONS,
+  manage_users: true,
+  manage_scans: true,
+};
+
+describe("authConfig JWT callback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should load elevated tenant permissions after switching from a restricted tenant", async () => {
+    // Given
+    const accessToken =
+      "header.eyJzdWIiOiJ1c2VyLTEiLCJ0ZW5hbnRfaWQiOiJ0ZW5hbnQtMiJ9.signature";
+    getUserByMeMock.mockResolvedValue({
+      name: "Tenant User",
+      email: "tenant@example.com",
+      company: "Tenant Company",
+      dateJoined: "2026-01-01",
+      permissions: ELEVATED_PERMISSIONS,
+    });
+    const jwtCallback = authConfig.callbacks?.jwt;
+    if (!jwtCallback) throw new Error("JWT callback is not configured");
+
+    // When
+    const result = await jwtCallback({
+      token: {
+        accessToken: "restricted-access-token",
+        refreshToken: "restricted-refresh-token",
+        tenant_id: "tenant-1",
+        user: {
+          name: "Tenant User",
+          permissions: RESTRICTED_PERMISSIONS,
+        },
+      },
+      user: {} as Parameters<typeof jwtCallback>[0]["user"],
+      trigger: "update",
+      session: {
+        accessToken,
+        refreshToken: "elevated-refresh-token",
+        user: { permissions: RESTRICTED_PERMISSIONS },
+      },
+    });
+
+    // Then
+    expect(getUserByMeMock).toHaveBeenCalledWith(accessToken);
+    expect(result.user).toEqual({
+      name: "Tenant User",
+      email: "tenant@example.com",
+      companyName: "Tenant Company",
+      dateJoined: "2026-01-01",
+      permissions: ELEVATED_PERMISSIONS,
+    });
+  });
+
+  it("should load restricted tenant permissions after switching from an elevated tenant", async () => {
+    // Given
+    const accessToken =
+      "header.eyJzdWIiOiJ1c2VyLTEiLCJ0ZW5hbnRfaWQiOiJ0ZW5hbnQtMSJ9.signature";
+    getUserByMeMock.mockResolvedValue({
+      name: "Tenant User",
+      email: "tenant@example.com",
+      company: "Tenant Company",
+      dateJoined: "2026-01-01",
+      permissions: RESTRICTED_PERMISSIONS,
+    });
+    const jwtCallback = authConfig.callbacks?.jwt;
+    if (!jwtCallback) throw new Error("JWT callback is not configured");
+
+    // When
+    const result = await jwtCallback({
+      token: {
+        accessToken: "elevated-access-token",
+        refreshToken: "elevated-refresh-token",
+        tenant_id: "tenant-2",
+        user: {
+          name: "Tenant User",
+          permissions: ELEVATED_PERMISSIONS,
+        },
+      },
+      user: {} as Parameters<typeof jwtCallback>[0]["user"],
+      trigger: "update",
+      session: {
+        accessToken,
+        refreshToken: "restricted-refresh-token",
+        user: { permissions: ELEVATED_PERMISSIONS },
+      },
+    });
+
+    // Then
+    expect(getUserByMeMock).toHaveBeenCalledWith(accessToken);
+    expect(result.accessToken).toBe(accessToken);
+    expect(result.refreshToken).toBe("restricted-refresh-token");
+    expect(result.tenant_id).toBe("tenant-1");
+    expect(result.user).toMatchObject({
+      permissions: RESTRICTED_PERMISSIONS,
+    });
+  });
+
+  it("should preserve the current session when the switched tenant user cannot be loaded", async () => {
+    // Given
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    getUserByMeMock.mockRejectedValue(new Error("Temporary API failure"));
+    const jwtCallback = authConfig.callbacks?.jwt;
+    if (!jwtCallback) throw new Error("JWT callback is not configured");
+    const currentToken = {
+      accessToken: "current-access-token",
+      refreshToken: "current-refresh-token",
+      tenant_id: "tenant-1",
+      user: {
+        name: "Tenant User",
+        permissions: RESTRICTED_PERMISSIONS,
+      },
+    };
+
+    // When
+    const result = await jwtCallback({
+      token: currentToken,
+      user: {} as Parameters<typeof jwtCallback>[0]["user"],
+      trigger: "update",
+      session: {
+        accessToken:
+          "header.eyJzdWIiOiJ1c2VyLTEiLCJ0ZW5hbnRfaWQiOiJ0ZW5hbnQtMiJ9.signature",
+        refreshToken: "switched-refresh-token",
+        user: { permissions: ELEVATED_PERMISSIONS },
+      },
+    });
+
+    // Then
+    expect(result).toBe(currentToken);
+    expect(result).toMatchObject({
+      accessToken: "current-access-token",
+      refreshToken: "current-refresh-token",
+      tenant_id: "tenant-1",
+      user: {
+        permissions: RESTRICTED_PERMISSIONS,
+      },
+    });
+    expect(result.error).not.toBe("RefreshAccessTokenError");
+  });
+});

--- a/ui/auth.config.ts
+++ b/ui/auth.config.ts
@@ -4,7 +4,6 @@ import NextAuth, {
   type DefaultSession,
   type NextAuthConfig,
   type Session,
-  User,
 } from "next-auth";
 import type { JWT } from "next-auth/jwt";
 import Credentials from "next-auth/providers/credentials";
@@ -58,7 +57,28 @@ const DEFAULT_PERMISSIONS: RolePermissionAttributes = {
   unlimited_visibility: false,
 };
 
+const TENANT_SWITCH_ERROR = "TenantSwitchError";
+
 type TokenUserInput = Partial<TokenUser> & { company?: string };
+
+type JwtCallback = NonNullable<NonNullable<NextAuthConfig["callbacks"]>["jwt"]>;
+type JwtCallbackParams = Parameters<JwtCallback>[0];
+
+interface JwtCallbackCredentials {
+  accessToken?: string;
+  refreshToken?: string;
+}
+
+type AuthJwtUser = JwtCallbackParams["user"] &
+  TokenUserInput &
+  JwtCallbackCredentials;
+
+interface AuthJwtCallbackParams
+  extends Omit<JwtCallbackParams, "session" | "token" | "user"> {
+  session?: Partial<ExtendedSession>;
+  token: AuthToken;
+  user: AuthJwtUser;
+}
 
 const toTokenUser = (user?: TokenUserInput): TokenUser =>
   ({
@@ -308,9 +328,13 @@ export const authConfig = {
       return true;
     },
 
-    jwt: async ({ token, account, user, trigger, session }) => {
-      const authToken = token as AuthToken;
-
+    jwt: async ({
+      token: authToken,
+      account,
+      user,
+      trigger,
+      session,
+    }: AuthJwtCallbackParams): Promise<AuthToken> => {
       // Handle tenant switch: update tokens from client-side useSession().update()
       if (trigger === "update" && session?.accessToken) {
         const newAccessToken = session.accessToken;
@@ -331,30 +355,27 @@ export const authConfig = {
         } catch (error) {
           // eslint-disable-next-line no-console
           console.warn("Error refreshing user after tenant switch:", error);
-          return authToken;
+          return {
+            ...authToken,
+            error: TENANT_SWITCH_ERROR,
+          };
         }
       }
 
       applyDecodedClaims(authToken, authToken.accessToken);
 
-      if (account && user) {
-        const signedInUser = user as User &
-          TokenUserInput & {
-            accessToken: string;
-            refreshToken: string;
-          };
-
+      if (account && user?.accessToken && user.refreshToken) {
         const nextAuthToken: AuthToken = {
           ...authToken,
-          accessToken: signedInUser.accessToken,
-          refreshToken: signedInUser.refreshToken,
-          user: toTokenUser(signedInUser),
+          accessToken: user.accessToken,
+          refreshToken: user.refreshToken,
+          user: toTokenUser(user),
           error: undefined,
         };
 
         applyDecodedClaims(
           nextAuthToken,
-          signedInUser.accessToken,
+          user.accessToken,
           "access token on sign-in",
         );
 
@@ -375,7 +396,7 @@ export const authConfig = {
       const authToken = token as AuthToken;
       const nextSession = { ...session } as ExtendedSession;
 
-      if (authToken?.error) {
+      if (authToken.error && authToken.error !== TENANT_SWITCH_ERROR) {
         nextSession.error = authToken.error;
         nextSession.user = undefined;
         nextSession.userId = undefined;
@@ -385,7 +406,8 @@ export const authConfig = {
         return nextSession;
       }
 
-      nextSession.error = undefined;
+      nextSession.error = authToken.error;
+      authToken.error = undefined;
       nextSession.userId = authToken.user_id ?? nextSession.userId;
       nextSession.tenantId = authToken.tenant_id ?? nextSession.tenantId;
       nextSession.accessToken =

--- a/ui/auth.config.ts
+++ b/ui/auth.config.ts
@@ -313,10 +313,26 @@ export const authConfig = {
 
       // Handle tenant switch: update tokens from client-side useSession().update()
       if (trigger === "update" && session?.accessToken) {
-        authToken.accessToken = session.accessToken;
-        authToken.refreshToken = session.refreshToken;
-        applyDecodedClaims(authToken, authToken.accessToken, "tenant switch");
-        return authToken;
+        const newAccessToken = session.accessToken;
+
+        try {
+          const userMeResponse = await getUserByMe(newAccessToken);
+          const nextAuthToken: AuthToken = {
+            ...authToken,
+            accessToken: newAccessToken,
+            refreshToken: session.refreshToken,
+            user: tokenUserFromApi(userMeResponse),
+            error: undefined,
+          };
+
+          applyDecodedClaims(nextAuthToken, newAccessToken, "tenant switch");
+
+          return nextAuthToken;
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.warn("Error refreshing user after tenant switch:", error);
+          return authToken;
+        }
       }
 
       applyDecodedClaims(authToken, authToken.accessToken);

--- a/ui/changelog.d/tenant-switch-permissions.fixed.md
+++ b/ui/changelog.d/tenant-switch-permissions.fixed.md
@@ -1,0 +1,1 @@
+Tenant switches now refresh session user permissions for the selected tenant

--- a/ui/components/users/forms/switch-tenant-form.test.tsx
+++ b/ui/components/users/forms/switch-tenant-form.test.tsx
@@ -1,26 +1,41 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SwitchTenantForm } from "./switch-tenant-form";
 
-const mockUpdate = vi.fn();
+const { mockReloadPage, mockSwitchTenant, mockToast, mockUpdate } = vi.hoisted(
+  () => ({
+    mockReloadPage: vi.fn(),
+    mockSwitchTenant: vi.fn(),
+    mockToast: vi.fn(),
+    mockUpdate: vi.fn(),
+  }),
+);
+
 vi.mock("next-auth/react", () => ({
   useSession: () => ({ update: mockUpdate }),
 }));
 
 vi.mock("@/actions/users/tenants", () => ({
-  switchTenant: vi.fn(),
+  switchTenant: mockSwitchTenant,
 }));
 
-const mockToast = vi.fn();
 vi.mock("@/components/shadcn", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   useToast: () => ({ toast: mockToast }),
 }));
 
+vi.mock("@/lib/navigation", () => ({
+  reloadPage: mockReloadPage,
+}));
+
 describe("SwitchTenantForm", () => {
   const setIsOpen = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("renders confirm and cancel buttons", () => {
     render(<SwitchTenantForm tenantId="test-uuid" setIsOpen={setIsOpen} />);
@@ -47,5 +62,56 @@ describe("SwitchTenantForm", () => {
 
     await user.click(screen.getByRole("button", { name: /cancel/i }));
     expect(setIsOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("shows an error when the session cannot apply the tenant switch", async () => {
+    // Given
+    const user = userEvent.setup();
+    mockSwitchTenant.mockResolvedValue({
+      success: true,
+      accessToken: "switched-access-token",
+      refreshToken: "switched-refresh-token",
+    });
+    mockUpdate.mockResolvedValue({ error: "TenantSwitchError" });
+    render(<SwitchTenantForm tenantId="test-uuid" setIsOpen={setIsOpen} />);
+
+    // When
+    await user.click(screen.getByRole("button", { name: /confirm/i }));
+
+    // Then
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith({
+        variant: "destructive",
+        title: "Oops! Something went wrong",
+        description: "Unable to switch organization. Please try again.",
+      }),
+    );
+    expect(mockReloadPage).not.toHaveBeenCalled();
+  });
+
+  it("reloads after the session applies the tenant switch", async () => {
+    // Given
+    const user = userEvent.setup();
+    mockSwitchTenant.mockResolvedValue({
+      success: true,
+      accessToken: "switched-access-token",
+      refreshToken: "switched-refresh-token",
+    });
+    mockUpdate.mockResolvedValue({
+      expires: "2026-12-31T23:59:59.999Z",
+    });
+    render(<SwitchTenantForm tenantId="test-uuid" setIsOpen={setIsOpen} />);
+
+    // When
+    await user.click(screen.getByRole("button", { name: /confirm/i }));
+
+    // Then
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith({
+        title: "Organization switched",
+        description: "The page will reload to apply the change.",
+      }),
+    );
+    expect(mockReloadPage).toHaveBeenCalledOnce();
   });
 });

--- a/ui/components/users/forms/switch-tenant-form.tsx
+++ b/ui/components/users/forms/switch-tenant-form.tsx
@@ -23,15 +23,32 @@ export const SwitchTenantForm = ({
 
     const handleSwitch = async () => {
       if ("success" in state) {
-        await update({
-          accessToken: state.accessToken,
-          refreshToken: state.refreshToken,
-        });
-        toast({
-          title: "Organization switched",
-          description: "The page will reload to apply the change.",
-        });
-        reloadPage();
+        try {
+          const updatedSession = await update({
+            accessToken: state.accessToken,
+            refreshToken: state.refreshToken,
+          });
+
+          if (
+            !updatedSession ||
+            ("error" in updatedSession && updatedSession.error)
+          ) {
+            throw new Error("Session update failed");
+          }
+
+          toast({
+            title: "Organization switched",
+            description: "The page will reload to apply the change.",
+          });
+          reloadPage();
+        } catch {
+          toast({
+            variant: "destructive",
+            title: "Oops! Something went wrong",
+            description: "Unable to switch organization. Please try again.",
+          });
+          setIsOpen(false);
+        }
       } else {
         toast({
           variant: "destructive",


### PR DESCRIPTION
### Context

Switching tenants refreshed the access and refresh tokens but kept the previous tenant's user permissions in the session. This could leave the UI with stale authorization state until the next full session refresh.

Fixes #12083

### Description

- Refresh the current user with the switched access token before committing the new JWT state.
- Derive tenant-scoped permissions from the server response instead of client session data.
- Preserve the previous valid session atomically when the user refresh fails.
- Add regression coverage for permission elevation, restriction, and transient refresh failures.
- Add the required UI changelog fragment.

No dependencies were added.

### Steps to review

1. Run `cd ui`.
2. Run `pnpm exec eslint auth.config.test.ts`.
3. Run `pnpm exec prettier --check auth.config.ts auth.config.test.ts`.
4. Run `pnpm test:unit auth.config.test.ts`.
5. Review the tenant-switch branch in `auth.config.ts` and confirm the new token is only returned after `/users/me` succeeds.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. Not needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md). Not needed.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. Not applicable to this UI-only change.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient. No dependencies added.
- [x] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px). Not applicable; this changes server-side session refresh behavior.
- [x] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px). Not applicable; this changes server-side session refresh behavior.
- [x] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px). Not applicable; this changes server-side session refresh behavior.
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tenant switching now refreshes the session user’s permissions for the selected tenant.
  * Improved tenant-switch error handling: session errors are surfaced once, and session user/tokens are cleared when the switch fails for non-tenant-switch reasons.
  * Tenant switch UI now shows clearer failure/success toasts and closes the modal on errors.
* **Tests**
  * Added unit tests for tenant-switch JWT behavior (permission updates, token preservation, and failure handling).
  * Extended `SwitchTenantForm` test coverage for success and error toast flows.  
* **Documentation**
  * Added a changelog entry for the tenant-switch permissions fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->