### PR TITLE
fix(kubernetes): block kubeconfig command auth bypass

### DIFF
--- a/api/changelog.d/kubernetes-auth-provider-cmd-path.security.md
+++ b/api/changelog.d/kubernetes-auth-provider-cmd-path.security.md
@@ -1,0 +1,1 @@
+Kubernetes kubeconfig validation now rejects legacy `auth-provider.config.cmd-path` command authentication in Prowler Cloud/API

--- a/api/src/backend/api/tests/test_serializers.py
+++ b/api/src/backend/api/tests/test_serializers.py
@@ -309,6 +309,36 @@ current-context: test-context
         assert not serializer.is_valid()
         assert "kubeconfig_content" in serializer.errors
 
+    def test_kubeconfig_with_auth_provider_cmd_path_is_rejected(self):
+        kubeconfig_content = """
+apiVersion: v1
+kind: Config
+clusters:
+  - name: test-cluster
+    cluster:
+      server: https://kubernetes.example.test
+users:
+  - name: test-user
+    user:
+      auth-provider:
+        name: gcp
+        config:
+          cmd-path: /bin/sh
+contexts:
+  - name: test-context
+    context:
+      cluster: test-cluster
+      user: test-user
+current-context: test-context
+"""
+
+        serializer = KubernetesProviderSecret(
+            data={"kubeconfig_content": kubeconfig_content}
+        )
+
+        assert not serializer.is_valid()
+        assert "kubeconfig_content" in serializer.errors
+
     def test_malformed_kubeconfig_is_rejected(self):
         serializer = KubernetesProviderSecret(
             data={"kubeconfig_content": "apiVersion: ["}

--- a/api/src/backend/api/v1/serializer_utils/providers.py
+++ b/api/src/backend/api/v1/serializer_utils/providers.py
@@ -214,7 +214,7 @@ from rest_framework_json_api import serializers
                     "kubeconfig_content": {
                         "type": "string",
                         "description": "The content of the Kubernetes kubeconfig file, encoded as a string. "
-                        "Kubeconfig exec authentication is not supported in Prowler Cloud for security reasons.",
+                        "Kubeconfig command-based authentication is not supported in Prowler Cloud for security reasons.",
                     }
                 },
                 "required": ["kubeconfig_content"],

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -1569,14 +1569,14 @@ class FindingMetadataSerializer(BaseSerializerV1):
 
 
 # Provider secrets
-KUBERNETES_KUBECONFIG_EXEC_ERROR = (
-    "Kubernetes kubeconfig exec authentication is not supported in Prowler Cloud "
-    "for security reasons."
+KUBERNETES_KUBECONFIG_UNSUPPORTED_COMMAND_AUTH_ERROR = (
+    "Kubernetes kubeconfig command-based authentication is not supported in "
+    "Prowler Cloud for security reasons."
 )
 KUBERNETES_KUBECONFIG_INVALID_ERROR = "Invalid Kubernetes kubeconfig content."
 
 
-def kubeconfig_contains_exec_auth(kubeconfig: dict) -> bool:
+def kubeconfig_contains_unsupported_command_auth(kubeconfig: dict) -> bool:
     users = kubeconfig.get("users", [])
     if not isinstance(users, list):
         raise ValidationError(KUBERNETES_KUBECONFIG_INVALID_ERROR)
@@ -1590,6 +1590,17 @@ def kubeconfig_contains_exec_auth(kubeconfig: dict) -> bool:
             raise ValidationError(KUBERNETES_KUBECONFIG_INVALID_ERROR)
 
         if "exec" in user:
+            return True
+
+        auth_provider = user.get("auth-provider", {})
+        if not isinstance(auth_provider, dict):
+            continue
+
+        auth_provider_config = auth_provider.get("config", {})
+        if not isinstance(auth_provider_config, dict):
+            continue
+
+        if "cmd-path" in auth_provider_config:
             return True
 
     return False
@@ -1788,8 +1799,10 @@ class KubernetesProviderSecret(serializers.Serializer):
         if not isinstance(kubeconfig, dict):
             raise serializers.ValidationError(KUBERNETES_KUBECONFIG_INVALID_ERROR)
 
-        if kubeconfig_contains_exec_auth(kubeconfig):
-            raise serializers.ValidationError(KUBERNETES_KUBECONFIG_EXEC_ERROR)
+        if kubeconfig_contains_unsupported_command_auth(kubeconfig):
+            raise serializers.ValidationError(
+                KUBERNETES_KUBECONFIG_UNSUPPORTED_COMMAND_AUTH_ERROR
+            )
 
         return kubeconfig_content
 

--- a/ui/changelog.d/kubernetes-auth-provider-cmd-path.security.md
+++ b/ui/changelog.d/kubernetes-auth-provider-cmd-path.security.md
@@ -1,0 +1,1 @@
+Kubernetes credential forms now reject kubeconfig files using legacy `auth-provider.config.cmd-path` command authentication

--- a/ui/components/providers/workflow/forms/via-credentials/k8s-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/via-credentials/k8s-credentials-form.tsx
@@ -5,8 +5,8 @@ import { Control, useWatch } from "react-hook-form";
 import { WizardTextareaField } from "@/components/providers/workflow/forms/fields";
 import { KubernetesCredentials } from "@/types";
 import {
-  KUBECONFIG_EXEC_AUTHENTICATION_ERROR,
-  kubeconfigContainsExecAuthentication,
+  KUBECONFIG_UNSUPPORTED_COMMAND_AUTHENTICATION_ERROR,
+  kubeconfigContainsUnsupportedCommandAuthentication,
 } from "@/types/formSchemas";
 
 export const KubernetesCredentialsForm = ({
@@ -18,9 +18,8 @@ export const KubernetesCredentialsForm = ({
     control,
     name: "kubeconfig_content",
   });
-  const hasExecAuthentication = kubeconfigContainsExecAuthentication(
-    kubeconfigContent ?? "",
-  );
+  const hasUnsupportedCommandAuthentication =
+    kubeconfigContainsUnsupportedCommandAuthentication(kubeconfigContent ?? "");
 
   return (
     <>
@@ -42,9 +41,9 @@ export const KubernetesCredentialsForm = ({
         minRows={10}
         isRequired
       />
-      {hasExecAuthentication && (
+      {hasUnsupportedCommandAuthentication && (
         <p className="text-text-error-primary text-xs">
-          {KUBECONFIG_EXEC_AUTHENTICATION_ERROR}
+          {KUBECONFIG_UNSUPPORTED_COMMAND_AUTHENTICATION_ERROR}
         </p>
       )}
     </>

--- a/ui/types/formSchemas.test.ts
+++ b/ui/types/formSchemas.test.ts
@@ -6,6 +6,7 @@ import {
   addCredentialsFormSchema,
   addCredentialsRoleFormSchema,
   addProviderFormSchema,
+  KUBECONFIG_UNSUPPORTED_COMMAND_AUTHENTICATION_ERROR,
 } from "./formSchemas";
 
 const BASE_AWS_ROLE_VALUES = {
@@ -194,6 +195,7 @@ users:
     expect(result.error.issues).toContainEqual(
       expect.objectContaining({
         path: [ProviderCredentialFields.KUBECONFIG_CONTENT],
+        message: KUBECONFIG_UNSUPPORTED_COMMAND_AUTHENTICATION_ERROR,
       }),
     );
   });
@@ -220,8 +222,28 @@ users:
     expect(result.error.issues).toContainEqual(
       expect.objectContaining({
         path: [ProviderCredentialFields.KUBECONFIG_CONTENT],
+        message: KUBECONFIG_UNSUPPORTED_COMMAND_AUTHENTICATION_ERROR,
       }),
     );
+  });
+
+  it("accepts kubeconfig auth-provider without cmd-path", () => {
+    const schema = addCredentialsFormSchema("kubernetes");
+
+    const result = schema.safeParse({
+      ...BASE_KUBERNETES_VALUES,
+      [ProviderCredentialFields.KUBECONFIG_CONTENT]: `apiVersion: v1
+kind: Config
+users:
+  - name: test-user
+    user:
+      auth-provider:
+        name: oidc
+        config:
+          client-id: prowler`,
+    });
+
+    expect(result.success).toBe(true);
   });
 
   it("accepts malformed kubeconfig content for backend validation", () => {

--- a/ui/types/formSchemas.test.ts
+++ b/ui/types/formSchemas.test.ts
@@ -198,6 +198,32 @@ users:
     );
   });
 
+  it("reports kubeconfig auth-provider cmd-path on kubeconfig_content field", () => {
+    const schema = addCredentialsFormSchema("kubernetes");
+
+    const result = schema.safeParse({
+      ...BASE_KUBERNETES_VALUES,
+      [ProviderCredentialFields.KUBECONFIG_CONTENT]: `apiVersion: v1
+kind: Config
+users:
+  - name: test-user
+    user:
+      auth-provider:
+        name: gcp
+        config:
+          cmd-path: /bin/sh`,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        path: [ProviderCredentialFields.KUBECONFIG_CONTENT],
+      }),
+    );
+  });
+
   it("accepts malformed kubeconfig content for backend validation", () => {
     const schema = addCredentialsFormSchema("kubernetes");
 

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -6,14 +6,14 @@ import { validateMutelistYaml, validateYaml } from "@/lib/yaml";
 
 import { PROVIDER_TYPES, ProviderType } from "./providers";
 
-export const KUBECONFIG_EXEC_AUTHENTICATION_ERROR =
-  "Kubernetes kubeconfig exec authentication is not supported in Prowler Cloud for security reasons.";
+export const KUBECONFIG_UNSUPPORTED_COMMAND_AUTHENTICATION_ERROR =
+  "Kubernetes kubeconfig command-based authentication is not supported in Prowler Cloud for security reasons.";
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 };
 
-export const kubeconfigContainsExecAuthentication = (
+export const kubeconfigContainsUnsupportedCommandAuthentication = (
   value: string,
 ): boolean => {
   try {
@@ -28,7 +28,16 @@ export const kubeconfigContainsExecAuthentication = (
         return false;
       }
 
-      return "exec" in userEntry.user;
+      if ("exec" in userEntry.user) {
+        return true;
+      }
+
+      const authProvider = userEntry.user["auth-provider"];
+      if (!isRecord(authProvider) || !isRecord(authProvider.config)) {
+        return false;
+      }
+
+      return "cmd-path" in authProvider.config;
     });
   } catch {
     return false;
@@ -229,9 +238,13 @@ export const addCredentialsFormSchema = (
                     .string()
                     .min(1, "Kubeconfig Content is required")
                     .refine(
-                      (value) => !kubeconfigContainsExecAuthentication(value),
+                      (value) =>
+                        !kubeconfigContainsUnsupportedCommandAuthentication(
+                          value,
+                        ),
                       {
-                        error: KUBECONFIG_EXEC_AUTHENTICATION_ERROR,
+                        error:
+                          KUBECONFIG_UNSUPPORTED_COMMAND_AUTHENTICATION_ERROR,
                       },
                     ),
                 }


### PR DESCRIPTION
### Context

Kubernetes kubeconfigs could still define command-based authentication through `users[*].user.auth-provider.config.cmd-path`. The backend already rejected `users[*].user.exec`, but this legacy auth-provider path needed the same treatment because backend validation is the security boundary for provider secrets.

### Description

- Reject Kubernetes kubeconfigs containing `users[*].user.auth-provider.config.cmd-path` in the API serializer validation.
- Keep rejecting `users[*].user.exec` command authentication.
- Update Kubernetes provider secret schema/help text to document that command-based authentication is unsupported.
- Mirror the validation and warning in the UI as UX feedback, while keeping backend validation authoritative.
- Add API and UI tests for `exec`, `auth-provider.config.cmd-path`, valid kubeconfigs, and malformed/non-mapping cases.
- Add API/UI changelog fragments.

### Steps to review

Validated locally:

- `cd api && uv run pytest src/backend/api/tests/test_serializers.py::TestKubernetesProviderSecret -q` → `5 passed, 3 warnings`
- `cd api && uv run ruff check src/backend/api/v1/serializers.py src/backend/api/v1/serializer_utils/providers.py src/backend/api/tests/test_serializers.py` → passed
- `cd ui && ./node_modules/.bin/vitest run --project unit types/formSchemas.test.ts` → `27 passed`
- `cd ui && ./node_modules/.bin/eslint types/formSchemas.ts types/formSchemas.test.ts components/providers/workflow/forms/via-credentials/k8s-credentials-form.tsx --max-warnings 40` → passed
- `cd ui && ./node_modules/.bin/prettier --check types/formSchemas.ts types/formSchemas.test.ts components/providers/workflow/forms/via-credentials/k8s-credentials-form.tsx` → passed
- `cd ui && ./node_modules/.bin/tsc` → passed

Review receipt:

- `gentle-ai review validate --gate pre-pr --base-ref origin/master` → allowed

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in Jira as PROWLER-2250.
- [x] Is it assigned to me, if not, request it via the issue/feature.

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [x] Ensure new entries are added to ui/CHANGELOG.md

#### API (if applicable)
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required.
- [x] Ensure new entries are added to api/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Security Enhancements**
  * Kubernetes credential validation now rejects kubeconfigs using legacy command-based authentication, including `auth-provider.config.cmd-path` (not just `exec`).
  * API and UI now surface clearer “unsupported command authentication” validation messages for affected kubeconfig inputs.

* **Documentation**
  * Updated Kubernetes kubeconfig guidance to explicitly state that command-based authentication is not supported for security reasons.

* **Tests**
  * Added/extended form and serializer test coverage to confirm `cmd-path`-based kubeconfig authentication is rejected, while kubeconfigs without `cmd-path` are accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->