### PR TITLE
test(ui): await recent-chats render in lighthouse panel chat test

### DIFF
--- a/ui/app/(prowler)/lighthouse/_components/panel/lighthouse-panel-chat.test.tsx
+++ b/ui/app/(prowler)/lighthouse/_components/panel/lighthouse-panel-chat.test.tsx
@@ -170,11 +170,12 @@ describe("LighthousePanelChat", () => {
     // When
     render(<LighthousePanelChat />);
 
-    // Then: composer is live and the empty state lists recent chats
+    // Then: composer is live and the empty state lists recent chats.
+    // Sessions load on a later render than the composer, so await them.
     expect(
       await screen.findByRole("textbox", { name: "Message" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Recent chats")).toBeInTheDocument();
+    expect(await screen.findByText("Recent chats")).toBeInTheDocument();
     expect(
       await screen.findByText("Counting critical findings"),
     ).toBeInTheDocument();


### PR DESCRIPTION
### Context

The `lighthouse-panel-chat` unit test `renders the chat composer and recent chats once ready` flakes in CI, failing on `expect(screen.getByText("Recent chats"))`. It surfaced on the Next.js 16.2.11 upgrade PR (#12093), but it is **not** caused by the upgrade: the same test fails at the same line on `master` with the previous Next.js 16.2.9 (e.g. runs on `7f0dc9b7d` and `f587dbf41`). It is a pre-existing latent race that only manifests under CI parallel load.

### Description

The composer (`textbox "Message"`) renders from the config-load chain, while the "Recent chats" section renders from a **separate async chain** (`refreshSessions` in `PanelChatReady`'s mount effect) that resolves *after* the composer. The test awaited only the composer and then queried "Recent chats" **synchronously**, so under load the sync query raced the sessions render and failed.

Fix: await the section with `findByText` instead of `getByText`, matching the already-awaited assertion on the session title right below it. Test-only change; no component or product behavior is touched.

```diff
-    expect(screen.getByText("Recent chats")).toBeInTheDocument();
+    expect(await screen.findByText("Recent chats")).toBeInTheDocument();
```

### Steps to review

- `cd ui && pnpm vitest run --project unit "app/(prowler)/lighthouse/_components/panel/lighthouse-panel-chat.test.tsx"` → 13/13 pass.
- Root cause confirmed deterministically: deferring the sessions mock resolution reproduces the exact CI error (`Unable to find … "Recent chats"`) with the old synchronous assertion, and passes with the awaited one.

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests. (test-only change)
- [x] Review if code is being documented following the style guide.
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md (not needed)
- [x] Ensure a changelog fragment is added under `<component>/changelog.d/`, if applicable. (N/A — test-only, no user-visible change; `no-changelog`)

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI (no UI change; test-only)
- [ ] Screenshots/Video - Mobile (X < 640px) — N/A, no UI change
- [ ] Screenshots/Video - Tablet (640px > X < 1024px) — N/A, no UI change
- [ ] Screenshots/Video - Desktop (X > 1024px) — N/A, no UI change
- [x] Ensure a changelog fragment is added under `ui/changelog.d/` (N/A — test-only)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved chat interface test reliability by waiting for recent chats to load asynchronously.
  * Added clarifying comments explaining that session content refreshes on a later render than the composer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->