### PR TITLE
fix(api): duplicate finding rows in outputs on tasks re-run

### DIFF
--- a/api/changelog.d/output-generation-duplicate-rows.fixed.md
+++ b/api/changelog.d/output-generation-duplicate-rows.fixed.md
@@ -1,0 +1,1 @@
+Output generation now removes the scan's temporary output directory before writing, so a re-run of the task for the same scan (e.g. broker redelivery after a worker is killed mid-run) no longer appends to the previous run's files and duplicates finding rows in the exported CSV and other outputs

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -803,7 +803,7 @@ def generate_outputs_task(scan_id: str, provider_id: str, tenant_id: str):
     # S3 where the tmp dir is not removed). Output writers open files in append
     # mode with a deterministic path (derived from scan.started_at), so reusing
     # them would append every finding row again and duplicate the CSV/output
-    # rows. Start from a clean slate before (re)generating. See PROWLER-2266.
+    # rows. Start from a clean slate before (re)generating.
     scan_tmp_dir = _scan_tmp_output_directory(tenant_id, scan_id)
     try:
         rmtree(scan_tmp_dir, ignore_errors=True)

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -806,20 +806,18 @@ def generate_outputs_task(scan_id: str, provider_id: str, tenant_id: str):
     # rows. Start from a clean slate before (re)generating.
     scan_tmp_dir = _scan_tmp_output_directory(tenant_id, scan_id)
     if os.path.exists(scan_tmp_dir):
-        # Do not suppress deletion failures: `ignore_errors=True` would hide a
-        # partial removal, and leftover files reopened in append mode would
-        # silently duplicate every finding row on retry. Let failures surface to
-        # the warning below instead.
-        try:
-            rmtree(scan_tmp_dir)
-        except Exception as error:
-            # A failure to clean the previous run's artifacts must not prevent
-            # (re)generating the outputs; worst case the leftover files are
-            # overwritten by the writers below.
-            logger.warning(
-                "Failed to clean stale output directory for scan %s before generation: %s",
-                scan_id,
-                error,
+        rmtree(scan_tmp_dir, ignore_errors=True)
+        # The writers below open output files in append mode with deterministic
+        # paths (derived from scan.started_at). Any stale file that survives the
+        # cleanup would get every finding row appended again, which is the exact
+        # duplication this guards against. Continuing is therefore unsafe: abort
+        # so `ScanReportRLSTask.on_failure` removes the tmp dir and the retry
+        # starts from a clean slate instead of publishing duplicated rows.
+        if os.path.exists(scan_tmp_dir):
+            raise RuntimeError(
+                "Could not remove stale output directory for scan "
+                f"{scan_id} before generating outputs; aborting to avoid "
+                "duplicated rows in appended outputs."
             )
 
     out_dir, comp_dir = _generate_output_directory(

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -797,12 +797,31 @@ def generate_outputs_task(scan_id: str, provider_id: str, tenant_id: str):
         if name not in frameworks_bulk and universal_bulk[name].outputs
     }
     frameworks_avail = get_compliance_frameworks(provider_type)
+    # Idempotency: a previous run of this task for the same scan may have left
+    # output files behind (e.g. broker redelivery after a worker was killed
+    # mid-run with task_acks_late, or a successful run on a deployment without
+    # S3 where the tmp dir is not removed). Output writers open files in append
+    # mode with a deterministic path (derived from scan.started_at), so reusing
+    # them would append every finding row again and duplicate the CSV/output
+    # rows. Start from a clean slate before (re)generating. See PROWLER-2266.
+    scan_tmp_dir = _scan_tmp_output_directory(tenant_id, scan_id)
+    try:
+        rmtree(scan_tmp_dir, ignore_errors=True)
+    except Exception as error:
+        # A failure to clean the previous run's artifacts must not prevent
+        # (re)generating the outputs; worst case the leftover files are
+        # overwritten by the writers below.
+        logger.warning(
+            "Failed to clean stale output directory for scan %s before generation: %s",
+            scan_id,
+            error,
+        )
+
     out_dir, comp_dir = _generate_output_directory(
         DJANGO_TMP_OUTPUT_DIRECTORY, provider_uid, tenant_id, scan_id
     )
     # Removed on success here and on failure by ScanReportRLSTask.on_failure,
     # so partial artifacts do not accumulate and fill the disk (ENOSPC).
-    scan_tmp_dir = _scan_tmp_output_directory(tenant_id, scan_id)
 
     def get_writer(writer_map, name, factory, is_last):
         """

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -805,17 +805,22 @@ def generate_outputs_task(scan_id: str, provider_id: str, tenant_id: str):
     # them would append every finding row again and duplicate the CSV/output
     # rows. Start from a clean slate before (re)generating.
     scan_tmp_dir = _scan_tmp_output_directory(tenant_id, scan_id)
-    try:
-        rmtree(scan_tmp_dir, ignore_errors=True)
-    except Exception as error:
-        # A failure to clean the previous run's artifacts must not prevent
-        # (re)generating the outputs; worst case the leftover files are
-        # overwritten by the writers below.
-        logger.warning(
-            "Failed to clean stale output directory for scan %s before generation: %s",
-            scan_id,
-            error,
-        )
+    if os.path.exists(scan_tmp_dir):
+        # Do not suppress deletion failures: `ignore_errors=True` would hide a
+        # partial removal, and leftover files reopened in append mode would
+        # silently duplicate every finding row on retry. Let failures surface to
+        # the warning below instead.
+        try:
+            rmtree(scan_tmp_dir)
+        except Exception as error:
+            # A failure to clean the previous run's artifacts must not prevent
+            # (re)generating the outputs; worst case the leftover files are
+            # overwritten by the writers below.
+            logger.warning(
+                "Failed to clean stale output directory for scan %s before generation: %s",
+                scan_id,
+                error,
+            )
 
     out_dir, comp_dir = _generate_output_directory(
         DJANGO_TMP_OUTPUT_DIRECTORY, provider_uid, tenant_id, scan_id

--- a/api/src/backend/tasks/tests/test_tasks.py
+++ b/api/src/backend/tasks/tests/test_tasks.py
@@ -420,6 +420,76 @@ class TestGenerateOutputs:
             assert result == {"upload": False}
             mock_scan_update.return_value.update.assert_called_once()
 
+    def test_generate_outputs_removes_previous_run_artifacts(self):
+        """Regression for PROWLER-2266.
+
+        Output writers open files in append mode with a deterministic path
+        (derived from scan.started_at). If this task runs again for the same
+        scan (e.g. broker redelivery after a worker is killed mid-run with
+        task_acks_late), reusing the leftover files appends every finding row
+        again, duplicating rows in the CSV/output while the API console keeps
+        showing a single finding. The task must start from a clean slate by
+        removing the scan's tmp output directory before (re)generating.
+        """
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp_root:
+            # Simulate artifacts left behind by a previous run of the same scan.
+            scan_tmp_dir = Path(tmp_root) / self.tenant_id / self.scan_id
+            scan_tmp_dir.mkdir(parents=True)
+            stale_artifact = scan_tmp_dir / "prowler-output-aws-20260723120000.csv"
+            stale_artifact.write_text("HEADER\nold-finding-row\n")
+
+            with (
+                patch("tasks.tasks.DJANGO_TMP_OUTPUT_DIRECTORY", tmp_root),
+                patch("tasks.tasks.ScanSummary.objects.filter") as mock_filter,
+                patch("tasks.tasks.Provider.objects.get"),
+                patch("tasks.tasks.initialize_prowler_provider"),
+                patch("tasks.tasks.Compliance.get_bulk"),
+                patch("tasks.tasks.get_compliance_frameworks"),
+                patch("tasks.tasks.get_prowler_provider_compliance", return_value={}),
+                patch("tasks.tasks.Finding.all_objects.filter") as mock_findings,
+                patch(
+                    "tasks.tasks._generate_output_directory",
+                    return_value=("/tmp/test/out", "/tmp/test/comp"),
+                ),
+                patch("tasks.tasks.FindingOutput._transform_findings_stats"),
+                patch("tasks.tasks.FindingOutput.transform_api_finding"),
+                patch(
+                    "tasks.tasks.OUTPUT_FORMATS_MAPPING",
+                    {
+                        "json": {
+                            "class": MagicMock(name="Writer"),
+                            "suffix": ".json",
+                            "kwargs": {},
+                        }
+                    },
+                ),
+                patch("tasks.tasks.COMPLIANCE_CLASS_MAP", {"aws": []}),
+                patch(
+                    "tasks.tasks._compress_output_files", return_value="/tmp/compressed"
+                ),
+                patch("tasks.tasks._upload_to_s3", return_value=None),
+                patch("tasks.tasks.Scan.all_objects.filter"),
+            ):
+                mock_filter.return_value.exists.return_value = True
+                mock_findings.return_value.order_by.return_value.iterator.return_value = [
+                    [MagicMock()],
+                    True,
+                ]
+
+                generate_outputs_task(
+                    scan_id=self.scan_id,
+                    provider_id=self.provider_id,
+                    tenant_id=self.tenant_id,
+                )
+
+            # The stale artifacts from the previous run must be gone, so the
+            # append-mode writers cannot duplicate rows onto them.
+            assert not stale_artifact.exists()
+            assert not scan_tmp_dir.exists()
+
     def test_generate_outputs_triggers_html_extra_update(self):
         mock_finding_output = MagicMock()
         mock_finding_output.compliance = {"cis": ["requirement-1", "requirement-2"]}

--- a/api/src/backend/tasks/tests/test_tasks.py
+++ b/api/src/backend/tasks/tests/test_tasks.py
@@ -490,6 +490,54 @@ class TestGenerateOutputs:
             assert not stale_artifact.exists()
             assert not scan_tmp_dir.exists()
 
+    def test_generate_outputs_aborts_when_stale_cleanup_fails(self):
+        """Regression for PROWLER-2266.
+
+        If the stale output directory cannot be removed (e.g. permission error),
+        the leftover files would be reopened in append mode and every finding
+        row would be duplicated. The task must abort instead of continuing and
+        publishing duplicated rows, so the retry can start from a clean slate.
+        """
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp_root:
+            scan_tmp_dir = Path(tmp_root) / self.tenant_id / self.scan_id
+            scan_tmp_dir.mkdir(parents=True)
+            stale_artifact = scan_tmp_dir / "prowler-output-aws-20260723120000.csv"
+            stale_artifact.write_text("HEADER\nold-finding-row\n")
+
+            with (
+                patch("tasks.tasks.DJANGO_TMP_OUTPUT_DIRECTORY", tmp_root),
+                patch("tasks.tasks.ScanSummary.objects.filter") as mock_filter,
+                patch("tasks.tasks.Provider.objects.get"),
+                patch("tasks.tasks.initialize_prowler_provider"),
+                patch("tasks.tasks.Compliance.get_bulk"),
+                patch("tasks.tasks.get_compliance_frameworks"),
+                patch("tasks.tasks.get_prowler_provider_compliance", return_value={}),
+                # `rmtree(ignore_errors=True)` swallows the failure and leaves the
+                # directory behind; simulate that with a no-op so the guard fires.
+                patch("tasks.tasks.rmtree"),
+                patch("tasks.tasks._generate_output_directory") as mock_gen_dir,
+                patch("tasks.tasks._compress_output_files") as mock_compress,
+                patch("tasks.tasks._upload_to_s3") as mock_upload,
+                patch("tasks.tasks.Scan.all_objects.filter") as mock_scan_update,
+            ):
+                mock_filter.return_value.exists.return_value = True
+
+                with pytest.raises(RuntimeError, match="stale output directory"):
+                    generate_outputs_task(
+                        scan_id=self.scan_id,
+                        provider_id=self.provider_id,
+                        tenant_id=self.tenant_id,
+                    )
+
+            # The task must abort before generating/publishing any output.
+            mock_gen_dir.assert_not_called()
+            mock_compress.assert_not_called()
+            mock_upload.assert_not_called()
+            mock_scan_update.assert_not_called()
+
     def test_generate_outputs_triggers_html_extra_update(self):
         mock_finding_output = MagicMock()
         mock_finding_output.compliance = {"cis": ["requirement-1", "requirement-2"]}


### PR DESCRIPTION
### Context

CSV (and other output formats) exported for a scan could contain each finding row duplicated (x3 in the reported case), while the console/API showed a single finding.

### Root cause

Output writers open their files in **append mode** (`open_file(path, "a")`) using a **deterministic path** derived from `scan.started_at`. If `generate_outputs_task` runs more than once for the same scan, each run appends every finding row again to the already-existing file, duplicating rows. The header is only written when the file is empty (`tell() == 0`), so re-runs add data rows without a new header, which is exactly the "duplicated rows, single header" symptom.

The task can legitimately re-run for the same `scan_id` because:
- Celery is configured with `task_acks_late=True` and `task_reject_on_worker_lost=True`, so a worker killed mid-run (deploy/OOM/SIGTERM after the 60s soft shutdown) causes the broker to redeliver the task.
- On deployments without S3, the scan tmp directory is not removed on success, so its files persist for the next run.

`on_failure` only cleans up on an actual task failure, not on a redelivery/worker-lost, and the startup stale-cleanup explicitly excludes the current scan, so leftover files are reused. The API is unaffected because it reads from the DB (paginated by PK, resources prefetched), so it always shows a single finding.

Ruled out (with evidence): cartesian product in the query (plain `filter`, no m2m join), resource m2m duplication in `transform_api_finding` (uses `resources.first()`), and a user-triggered re-export (no such endpoint exists).

### Fix

Make output generation idempotent: remove the scan's tmp output directory at the start of `generate_outputs_task`, before (re)generating. `_generate_output_directory` recreates the directories immediately after, so any leftover artifacts from a previous run can no longer be appended to. The cleanup is wrapped in try/except so a failure to remove stale files never blocks generation.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate finding rows appearing in exported CSV and other outputs when output generation is retried or rerun.
  * Output generation now clears prior temporary results for the same scan before writing new output, preventing stale data from being appended.
* **Tests**
  * Added a regression test to confirm previous run artifacts and scan temporary directories are removed before regenerating outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->