### PR TITLE
fix(ui): enable grouped Jira dispatch for Cloud users

### DIFF
--- a/ui/lib/deployment.test.ts
+++ b/ui/lib/deployment.test.ts
@@ -10,7 +10,7 @@ describe("enterprise feature flags", () => {
     vi.unstubAllEnvs();
   });
 
-  it("should keep grouped Jira dispatch disabled by default", async () => {
+  it("should keep grouped Jira dispatch disabled outside cloud", async () => {
     // Given
     vi.stubEnv("UI_CLOUD_ENABLED", "false");
 
@@ -30,16 +30,5 @@ describe("enterprise feature flags", () => {
 
     // Then
     expect(isGroupedJiraDispatchEnabled()).toBe(true);
-  });
-
-  it("should keep grouped Jira dispatch disabled outside cloud", async () => {
-    // Given
-    vi.stubEnv("UI_CLOUD_ENABLED", "false");
-
-    // When
-    const { isGroupedJiraDispatchEnabled } = await importFresh();
-
-    // Then
-    expect(isGroupedJiraDispatchEnabled()).toBe(false);
   });
 });

--- a/ui/lib/deployment.test.ts
+++ b/ui/lib/deployment.test.ts
@@ -11,20 +11,19 @@ describe("enterprise feature flags", () => {
   });
 
   it("should keep grouped Jira dispatch disabled by default", async () => {
-    // Given / When
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+
+    // When
     const { isGroupedJiraDispatchEnabled } = await importFresh();
 
     // Then
     expect(isGroupedJiraDispatchEnabled()).toBe(false);
   });
 
-  it("should enable grouped Jira dispatch from the enterprise env flag in cloud", async () => {
+  it("should enable grouped Jira dispatch in cloud without an enterprise flag", async () => {
     // Given
-    vi.stubEnv("NEXT_PUBLIC_PROWLER_DEPLOYMENT_MODE", "cloud");
-    vi.stubEnv(
-      "NEXT_PUBLIC_PROWLER_ENTERPRISE_GROUPED_JIRA_DISPATCH_ENABLED",
-      "true",
-    );
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
 
     // When
     const { isGroupedJiraDispatchEnabled } = await importFresh();
@@ -35,11 +34,7 @@ describe("enterprise feature flags", () => {
 
   it("should keep grouped Jira dispatch disabled outside cloud", async () => {
     // Given
-    vi.stubEnv("NEXT_PUBLIC_PROWLER_DEPLOYMENT_MODE", "onpremise");
-    vi.stubEnv(
-      "NEXT_PUBLIC_PROWLER_ENTERPRISE_GROUPED_JIRA_DISPATCH_ENABLED",
-      "true",
-    );
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
 
     // When
     const { isGroupedJiraDispatchEnabled } = await importFresh();

--- a/ui/lib/deployment.ts
+++ b/ui/lib/deployment.ts
@@ -1,44 +1,14 @@
+import { isCloud } from "./shared/env";
+
 export const DEPLOYMENT_MODE = {
   CLOUD: "cloud",
   ON_PREMISE: "onpremise",
-} as const;
-
-export const ENTERPRISE_FEATURE_ENV = {
-  GROUPED_JIRA_DISPATCH_ENABLED:
-    "NEXT_PUBLIC_PROWLER_ENTERPRISE_GROUPED_JIRA_DISPATCH_ENABLED",
 } as const;
 
 export const PROWLER_CLOUD_ONLY_TOOLTIP = "Available only in Prowler Cloud";
 
 export type DeploymentMode =
   (typeof DEPLOYMENT_MODE)[keyof typeof DEPLOYMENT_MODE];
-
-type EnterpriseFeatureEnv =
-  (typeof ENTERPRISE_FEATURE_ENV)[keyof typeof ENTERPRISE_FEATURE_ENV];
-
-const getEnterpriseFeatureValue = (
-  envName: EnterpriseFeatureEnv,
-): string | undefined => {
-  if (envName === ENTERPRISE_FEATURE_ENV.GROUPED_JIRA_DISPATCH_ENABLED) {
-    return process.env
-      .NEXT_PUBLIC_PROWLER_ENTERPRISE_GROUPED_JIRA_DISPATCH_ENABLED;
-  }
-
-  return undefined;
-};
-
-const getBooleanEnv = (
-  envName: EnterpriseFeatureEnv,
-  defaultValue: boolean,
-): boolean => {
-  const value = getEnterpriseFeatureValue(envName);
-
-  if (value === undefined || value === "") {
-    return defaultValue;
-  }
-
-  return value === "true";
-};
 
 export const getDeploymentMode = (): DeploymentMode | undefined => {
   const mode = process.env.NEXT_PUBLIC_PROWLER_DEPLOYMENT_MODE;
@@ -50,6 +20,4 @@ export const getDeploymentMode = (): DeploymentMode | undefined => {
   return undefined;
 };
 
-export const isGroupedJiraDispatchEnabled = (): boolean =>
-  getDeploymentMode() === DEPLOYMENT_MODE.CLOUD &&
-  getBooleanEnv(ENTERPRISE_FEATURE_ENV.GROUPED_JIRA_DISPATCH_ENABLED, false);
+export const isGroupedJiraDispatchEnabled = (): boolean => isCloud();


### PR DESCRIPTION
### Context

Grouped Jira dispatch was gated behind the `NEXT_PUBLIC_PROWLER_ENTERPRISE_GROUPED_JIRA_DISPATCH_ENABLED` env var on top of the deployment mode. Cloud availability is already expressed by the runtime cloud flag, so the extra enterprise flag was redundant.

### Description

- `isGroupedJiraDispatchEnabled()` now returns `isCloud()` (runtime cloud flag island / `UI_CLOUD_ENABLED`), so the feature is always available in Prowler Cloud and disabled elsewhere, with no additional feature flag.
- Removed the now-unused enterprise env-flag machinery (`ENTERPRISE_FEATURE_ENV`, `getEnterpriseFeatureValue`, `getBooleanEnv`) from `ui/lib/deployment.ts`.
- Updated `ui/lib/deployment.test.ts` to stub `UI_CLOUD_ENABLED`.

### Checks

- `pnpm vitest run lib/deployment.test.ts` — 3 passed
- Consumer tests (`jira-dispatch-action-item`, `jira-dispatch-modal-host`) — 5 passed
- `tsc --noEmit` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grouped Jira dispatch is now automatically enabled in cloud deployments.

* **Bug Fixes**
  * Grouped Jira dispatch now remains disabled in non-cloud deployments with more consistent environment-based behavior.
  * Removed reliance on separate enterprise feature configuration for this capability.

* **Tests**
  * Updated feature-flag coverage to assert dispatch enablement using cloud detection only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->