### PR TITLE
fix(gcp): make gen2 Cloud Functions IAM policy query thread-safe

### DIFF
--- a/prowler/changelog.d/gcp-cloudfunction-gen2-iam-thread-safety.fixed.md
+++ b/prowler/changelog.d/gcp-cloudfunction-gen2-iam-thread-safety.fixed.md
@@ -1,0 +1,1 @@
+GCP Cloud Functions gen2 IAM policy retrieval now uses a per-request HTTP client, preventing a process crash from concurrent thread-unsafe `httplib2` access when a project has several gen2 functions

--- a/prowler/providers/gcp/services/cloudfunction/cloudfunction_service.py
+++ b/prowler/providers/gcp/services/cloudfunction/cloudfunction_service.py
@@ -108,7 +108,10 @@ class CloudFunction(GCPService):
                     .locations()
                     .services()
                     .getIamPolicy(resource=function.service)
-                    .execute(num_retries=DEFAULT_RETRY_ATTEMPTS)
+                    .execute(
+                        http=self.__get_AuthorizedHttp_client__(),
+                        num_retries=DEFAULT_RETRY_ATTEMPTS,
+                    )
                 )
             else:
                 response = (

--- a/tests/providers/gcp/services/cloudfunction/cloudfunction_service_test.py
+++ b/tests/providers/gcp/services/cloudfunction/cloudfunction_service_test.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+from prowler.providers.gcp.lib.service.service import GCPService
 from prowler.providers.gcp.services.cloudfunction.cloudfunction_service import (
     CloudFunction,
 )
@@ -147,6 +148,63 @@ class TestCloudFunctionService:
             assert fn.name == "no-vpc-func"
             assert fn.vpc_connector is None
             assert fn.publicly_accessible is False
+
+    def test_get_functions_iam_policy_gen2_uses_per_request_http(self):
+        """Regression: the gen2 IAM lookup must pass a per-request HTTP client.
+
+        _get_function_iam_policy runs once per function across a thread pool
+        (GCPService.__threading_call__), and httplib2 is not thread-safe. The
+        gen1 branch isolates each thread with its own AuthorizedHttp via
+        __get_AuthorizedHttp_client__; the gen2 branch must do the same. Sharing
+        the single self._run_client transport across threads corrupts the
+        process heap and aborts the scan (SIGABRT/SIGSEGV).
+        """
+        sentinel_http = object()
+
+        request = MagicMock()
+        request.execute.return_value = {"bindings": []}
+        run_client = MagicMock()
+        run_client.projects().locations().services().getIamPolicy.return_value = (
+            request
+        )
+
+        def mock_api_client(*args, **kwargs):
+            return _make_cloudfunction_client(
+                functions_list=[
+                    {
+                        "name": _FUNCTION_ID,
+                        "state": "ACTIVE",
+                        "environment": "GEN_2",
+                        "serviceConfig": {"service": _RUN_SERVICE},
+                    }
+                ]
+            )
+
+        with (
+            patch(
+                "prowler.providers.gcp.lib.service.service.GCPService.__is_api_active__",
+                new=mock_is_api_active,
+            ),
+            patch(
+                "prowler.providers.gcp.lib.service.service.GCPService.__generate_client__",
+                new=mock_api_client,
+            ),
+            patch(
+                "prowler.providers.gcp.services.cloudfunction.cloudfunction_service.discovery.build",
+                return_value=run_client,
+            ),
+            patch.object(
+                GCPService,
+                "__get_AuthorizedHttp_client__",
+                return_value=sentinel_http,
+            ),
+        ):
+            CloudFunction(set_mocked_gcp_provider(project_ids=[GCP_PROJECT_ID]))
+
+        # gen2 IAM policy must be fetched with a per-request http (not the shared
+        # self._run_client transport), mirroring the gen1 branch.
+        request.execute.assert_called_once()
+        assert request.execute.call_args.kwargs.get("http") is sentinel_http
 
     def test_get_functions_iam_policy_gen2_all_users(self):
         """Gen2 functions: allUsers binding lives on the Cloud Run service."""

--- a/tests/providers/gcp/services/cloudfunction/cloudfunction_service_test.py
+++ b/tests/providers/gcp/services/cloudfunction/cloudfunction_service_test.py
@@ -1,5 +1,6 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
+from prowler.providers.gcp.config import DEFAULT_RETRY_ATTEMPTS
 from prowler.providers.gcp.lib.service.service import GCPService
 from prowler.providers.gcp.services.cloudfunction.cloudfunction_service import (
     CloudFunction,
@@ -149,7 +150,7 @@ class TestCloudFunctionService:
             assert fn.vpc_connector is None
             assert fn.publicly_accessible is False
 
-    def test_get_functions_iam_policy_gen2_uses_per_request_http(self):
+    def test_get_functions_iam_policy_gen2_uses_distinct_per_request_http(self):
         """Regression: the gen2 IAM lookup must pass a per-request HTTP client.
 
         _get_function_iam_policy runs once per function across a thread pool
@@ -159,14 +160,23 @@ class TestCloudFunctionService:
         the single self._run_client transport across threads corrupts the
         process heap and aborts the scan (SIGABRT/SIGSEGV).
         """
-        sentinel_http = object()
+        second_function_name = "second-function"
+        second_function_id = f"projects/{GCP_PROJECT_ID}/locations/{_LOCATION_ID}/functions/{second_function_name}"
+        second_run_service = f"projects/{GCP_PROJECT_ID}/locations/{_LOCATION_ID}/services/{second_function_name}"
+        first_http = object()
+        second_http = object()
 
-        request = MagicMock()
-        request.execute.return_value = {"bindings": []}
+        first_request = MagicMock()
+        first_request.execute.return_value = {"bindings": []}
+        second_request = MagicMock()
+        second_request.execute.return_value = {"bindings": []}
         run_client = MagicMock()
-        run_client.projects().locations().services().getIamPolicy.return_value = (
-            request
-        )
+        get_iam_policy = run_client.projects().locations().services().getIamPolicy
+        get_iam_policy.side_effect = [first_request, second_request]
+
+        def run_sequentially(self, callback, iterator):
+            for value in iterator:
+                callback(value)
 
         def mock_api_client(*args, **kwargs):
             return _make_cloudfunction_client(
@@ -176,7 +186,13 @@ class TestCloudFunctionService:
                         "state": "ACTIVE",
                         "environment": "GEN_2",
                         "serviceConfig": {"service": _RUN_SERVICE},
-                    }
+                    },
+                    {
+                        "name": second_function_id,
+                        "state": "ACTIVE",
+                        "environment": "GEN_2",
+                        "serviceConfig": {"service": second_run_service},
+                    },
                 ]
             )
 
@@ -196,15 +212,27 @@ class TestCloudFunctionService:
             patch.object(
                 GCPService,
                 "__get_AuthorizedHttp_client__",
-                return_value=sentinel_http,
+                side_effect=[first_http, second_http],
+            ),
+            patch.object(
+                GCPService,
+                "__threading_call__",
+                new=run_sequentially,
             ),
         ):
             CloudFunction(set_mocked_gcp_provider(project_ids=[GCP_PROJECT_ID]))
 
-        # gen2 IAM policy must be fetched with a per-request http (not the shared
-        # self._run_client transport), mirroring the gen1 branch.
-        request.execute.assert_called_once()
-        assert request.execute.call_args.kwargs.get("http") is sentinel_http
+        get_iam_policy.assert_has_calls(
+            [call(resource=_RUN_SERVICE), call(resource=second_run_service)]
+        )
+        first_request.execute.assert_called_once_with(
+            http=first_http,
+            num_retries=DEFAULT_RETRY_ATTEMPTS,
+        )
+        second_request.execute.assert_called_once_with(
+            http=second_http,
+            num_retries=DEFAULT_RETRY_ATTEMPTS,
+        )
 
     def test_get_functions_iam_policy_gen2_all_users(self):
         """Gen2 functions: allUsers binding lives on the Cloud Run service."""


### PR DESCRIPTION
### Context

Fix #12106

`CloudFunction._get_function_iam_policy` is fanned out one thread per function by
`GCPService.__threading_call__` (`prowler/providers/gcp/lib/service/service.py:44`,
which starts a raw `threading.Thread` per item). `httplib2` is not thread-safe.

Every other threaded GCP call isolates each thread by passing a fresh transport to
`.execute(http=self.__get_AuthorizedHttp_client__(), ...)` — including the **gen1**
branch of this very method. The **gen2** branch does not: it calls `.execute()` on
the shared `self._run_client` discovery client
(`prowler/providers/gcp/services/cloudfunction/cloudfunction_service.py`). When a
project has several gen2 Cloud Functions, the threads issue concurrent requests
through that one shared client and corrupt the process heap, aborting the whole
scan. It reproduces reliably in containerized, multi-vCPU environments (e.g. Cloud
Run). Captured with `PYTHONFAULTHANDLER=1` — every crashing thread shares the same
frame, the classic non-thread-safe-`httplib2` signature:

```
Fatal Python error: Aborted
  # also observed as SIGSEGV / "malloc(): unsorted double linked list corrupted"

Current thread (most recent call first):
  File ".../httplib2/__init__.py", line 1399 in _conn_request
  File ".../google_auth_httplib2.py", line 218 in request
  File ".../googleapiclient/http.py", line 923 in execute
  File ".../gcp/services/cloudfunction/cloudfunction_service.py", line 111 in _get_function_iam_policy
  File ".../threading.py", line 1012 in run
```

An audit of every `__threading_call__` target in the GCP provider confirms this is
the only threaded call that shares a client instead of passing a per-request `http`.

### Description

`prowler/providers/gcp/services/cloudfunction/cloudfunction_service.py` — pass a
per-request HTTP client to the gen2 `getIamPolicy().execute()` call, exactly as the
gen1 branch immediately below already does:

```python
.execute(
    http=self.__get_AuthorizedHttp_client__(),
    num_retries=DEFAULT_RETRY_ATTEMPTS,
)
```

This gives each thread its own `httplib2` transport, removing the shared-client data
race. Parallelism is unchanged (no serialization) and findings are unaffected.

### Steps to review

1. `cloudfunction_service.py` — the gen2 `.execute()` now receives
   `http=self.__get_AuthorizedHttp_client__()`, matching the gen1 branch a few lines
   below.
2. New regression test asserts the gen2 IAM lookup is executed with a per-request
   `http` (a shared-client call would omit it):

   ```
   uv run pytest tests/providers/gcp/services/cloudfunction/cloudfunction_service_test.py -q
   ```
   (7 passed)
3. Optional real-world repro: scan a GCP project with several **gen2** Cloud
   Functions from a multi-vCPU container. Before: intermittent heap-corruption abort
   during the cloudfunction service. After: the scan completes and reports Cloud
   Function IAM findings.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the README.md
- [x] Ensure a changelog fragment is added under prowler/changelog.d/, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - No new permissions required for the provider.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and stability when retrieving IAM policies for second-generation Cloud Functions.
  * Prevented potential crashes caused by unsafe shared HTTP handling when processing multiple functions concurrently.
* **Tests**
  * Added a regression test to confirm second-generation IAM policy retrieval uses a separate per-request HTTP client for each function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->