### PR TITLE
fix(ui): bump next-auth to 5.0.0-beta.32 to patch critical advisories

### DIFF
--- a/ui/changelog.d/next-auth-critical-advisories.security.md
+++ b/ui/changelog.d/next-auth-critical-advisories.security.md
@@ -1,0 +1,1 @@
+next-auth from 5.0.0-beta.30 to 5.0.0-beta.32, patching 2 critical Auth.js advisories (GHSA-8fpg-xm3f-6cx3 fail-open auth checks, GHSA-7rqj-j65f-68wh email homoglyph bypass)

--- a/ui/dependency-log.json
+++ b/ui/dependency-log.json
@@ -498,18 +498,18 @@
   {
     "section": "dependencies",
     "name": "next",
-    "from": "16.2.6",
-    "to": "16.2.9",
+    "from": "16.2.9",
+    "to": "16.2.11",
     "strategy": "installed",
-    "generatedAt": "2026-06-15T07:49:41.143Z"
+    "generatedAt": "2026-07-24T08:32:45.227Z"
   },
   {
     "section": "dependencies",
     "name": "next-auth",
-    "from": "5.0.0-beta.29",
-    "to": "5.0.0-beta.30",
+    "from": "5.0.0-beta.30",
+    "to": "5.0.0-beta.32",
     "strategy": "installed",
-    "generatedAt": "2025-12-15T11:18:25.093Z"
+    "generatedAt": "2026-07-24T08:32:45.227Z"
   },
   {
     "section": "dependencies",
@@ -770,26 +770,26 @@
   {
     "section": "devDependencies",
     "name": "@vitest/browser",
-    "from": "4.0.18",
-    "to": "4.1.8",
+    "from": "4.1.8",
+    "to": "4.1.10",
     "strategy": "installed",
-    "generatedAt": "2026-06-02T11:34:46.264Z"
+    "generatedAt": "2026-07-24T08:32:45.227Z"
   },
   {
     "section": "devDependencies",
     "name": "@vitest/browser-playwright",
-    "from": "4.0.18",
-    "to": "4.1.8",
+    "from": "4.1.8",
+    "to": "4.1.10",
     "strategy": "installed",
-    "generatedAt": "2026-06-02T11:34:46.264Z"
+    "generatedAt": "2026-07-24T08:32:45.227Z"
   },
   {
     "section": "devDependencies",
     "name": "@vitest/coverage-v8",
-    "from": "4.0.18",
-    "to": "4.1.8",
+    "from": "4.1.8",
+    "to": "4.1.10",
     "strategy": "installed",
-    "generatedAt": "2026-06-02T11:34:46.264Z"
+    "generatedAt": "2026-07-24T08:32:45.227Z"
   },
   {
     "section": "devDependencies",
@@ -978,10 +978,10 @@
   {
     "section": "devDependencies",
     "name": "vitest",
-    "from": "4.0.18",
-    "to": "4.1.8",
+    "from": "4.1.8",
+    "to": "4.1.10",
     "strategy": "installed",
-    "generatedAt": "2026-06-02T11:34:46.264Z"
+    "generatedAt": "2026-07-24T08:32:45.227Z"
   },
   {
     "section": "devDependencies",

--- a/ui/package.json
+++ b/ui/package.json
@@ -98,7 +98,7 @@
     "modern-screenshot": "4.7.0",
     "nanoid": "5.1.6",
     "next": "16.2.11",
-    "next-auth": "5.0.0-beta.30",
+    "next-auth": "5.0.0-beta.32",
     "next-themes": "0.2.1",
     "react": "19.2.7",
     "react-day-picker": "9.13.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -232,8 +232,8 @@ importers:
         specifier: 16.2.11
         version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-auth:
-        specifier: 5.0.0-beta.30
-        version: 5.0.0-beta.30(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        specifier: 5.0.0-beta.32
+        version: 5.0.0-beta.32(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       next-themes:
         specifier: 0.2.1
         version: 0.2.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -473,12 +473,12 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@auth/core@0.41.0':
-    resolution: {integrity: sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==}
+  '@auth/core@0.41.3':
+    resolution: {integrity: sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
-      nodemailer: ^6.8.0
+      nodemailer: ^7.0.7 || ^8.0.5
     peerDependenciesMeta:
       '@simplewebauthn/browser':
         optional: true
@@ -5861,13 +5861,13 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  next-auth@5.0.0-beta.30:
-    resolution: {integrity: sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==}
+  next-auth@5.0.0-beta.32:
+    resolution: {integrity: sha512-CGlChIEWZ6LltNVxrE5yiySMID+Idpmry47JYA5lLwgD8Sx02a8M65VL0TWVz9nbnOioS/tCW/rP/0+mE7Qp4Q==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
       next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
-      nodemailer: ^7.0.7
+      nodemailer: ^7.0.7 || ^8.0.5
       react: ^18.2.0 || ^19.0.0
     peerDependenciesMeta:
       '@simplewebauthn/browser':
@@ -7410,7 +7410,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@auth/core@0.41.0':
+  '@auth/core@0.41.3':
     dependencies:
       '@panva/hkdf': 1.2.1
       jose: 6.1.3
@@ -13524,9 +13524,9 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@5.0.0-beta.30(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  next-auth@5.0.0-beta.32(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@auth/core': 0.41.0
+      '@auth/core': 0.41.3
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -109,7 +109,7 @@ trustPolicy: no-downgrade
 trustPolicyExclude:
   # next-auth: only one one-off manual test release (`0.0.0-manual.2824fa11`) has
   # provenance; real beta/stable releases don't. Scoped to current beta line.
-  - "next-auth@5.0.0-beta.30"
+  - "next-auth@5.0.0-beta.32"
   # semver: legacy major 6.x never had provenance (added in 7.5.1+). Pinned
   # to the exact 6.x version pulled transitively (via @babel/helper-compilation-targets).
   - "semver@6.3.1"


### PR DESCRIPTION
### Context

On 2026-07-23 GitHub published two critical advisories against `next-auth <= 5.0.0-beta.31` / `@auth/core < 0.41.3`:

- [GHSA-8fpg-xm3f-6cx3](https://github.com/advisories/GHSA-8fpg-xm3f-6cx3) — configuration errors can cause existence-based auth checks to fail open (the `auth` object gets populated with an error instead of staying empty).
- [GHSA-7rqj-j65f-68wh](https://github.com/advisories/GHSA-7rqj-j65f-68wh) — the email normalizer validates the address before Unicode normalization, allowing a homoglyph `@` bypass. Affects both `next-auth` and its transitive `@auth/core`.

Since then, the `pnpm audit --audit-level critical` gate in `UI: Tests` fails on every PR that touches `ui/**`. The `UI: Tests` push run for 0b782fcb8 on master already failed with this error; later master runs look green only because the changed-files gate skips the job for non-UI pushes.

### Description

Bumps `next-auth` from `5.0.0-beta.30` to `5.0.0-beta.32`, the first patched version per both advisories, which pins the patched `@auth/core@0.41.3` transitively. `pnpm audit` goes from 3 critical findings to 0.

Also included, following repo conventions:

- `pnpm-workspace.yaml`: the exact-version `trustPolicyExclude` pin moves to `next-auth@5.0.0-beta.32` (real next-auth releases publish without provenance, so pnpm 11's `trustPolicy: no-downgrade` blocks the install without it).
- `dependency-log.json` regenerated via `pnpm run deps:log`.
- Changelog fragment under `ui/changelog.d/`.

The `pnpm-lock.yaml` diff is scoped to `next-auth`, `@auth/core`, and their `nodemailer` peer-range metadata — no other resolutions change.

**Package-health evidence for the bump:**

- Patched version confirmed by the official advisories (`first_patched_version: 5.0.0-beta.32`), published by the nextauthjs org.
- Published 2026-07-20 as part of a coordinated security release across the Auth.js monorepo (`next-auth@4.24.15` and all `@auth/*` adapters went out in the same window).
- Publisher is `gustavo@better-auth.com`, consistent with Auth.js maintenance moving under Better Auth; beta.31 had the same publisher.
- Two-beta hop (beta.30 → beta.32), both betas being the security fixes; typecheck and the auth-related unit test suite pass locally.
- License unchanged (ISC). No install scripts.
- Release age: published 2026-07-20, so it sits inside StepSecurity's 7-day npm cooldown until 2026-07-27.

### Steps to review

1. `cd ui && pnpm install --frozen-lockfile` — passes the supply-chain policy checks.
2. `pnpm run audit` — exits 0 with no critical findings (previously 3).
3. `pnpm run typecheck` — clean.
4. `pnpm exec vitest related auth.config.ts --run --project unit` — 835 tests pass.
5. Confirm the lockfile diff only touches `next-auth`/`@auth/core`.

### Checklist

- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Addressed two critical authentication vulnerabilities, including fail-open authorization checks and email homoglyph bypasses.

* **Maintenance**
  * Updated Next.js and authentication components.
  * Updated testing and browser tooling for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->