### PR TITLE
fix(gcp): detect SSH/RDP exposure when the port is not first in a multi-port firewall rule

### DIFF
--- a/prowler/changelog.d/gcp-firewall-multiport.fixed.md
+++ b/prowler/changelog.d/gcp-firewall-multiport.fixed.md
@@ -1,0 +1,1 @@
+GCP firewall SSH and RDP checks now detect exposed target ports in any position within multi-port rules

--- a/prowler/providers/gcp/services/compute/compute_firewall_rdp_access_from_the_internet_allowed/compute_firewall_rdp_access_from_the_internet_allowed.py
+++ b/prowler/providers/gcp/services/compute/compute_firewall_rdp_access_from_the_internet_allowed/compute_firewall_rdp_access_from_the_internet_allowed.py
@@ -31,7 +31,7 @@ class compute_firewall_rdp_access_from_the_internet_allowed(Check):
                                     break
                             elif int(port) == 3389:
                                 opened_port = True
-                            break
+                                break
             if (
                 "0.0.0.0/0" in firewall.source_ranges
                 and firewall.direction == "INGRESS"

--- a/prowler/providers/gcp/services/compute/compute_firewall_ssh_access_from_the_internet_allowed/compute_firewall_ssh_access_from_the_internet_allowed.py
+++ b/prowler/providers/gcp/services/compute/compute_firewall_ssh_access_from_the_internet_allowed/compute_firewall_ssh_access_from_the_internet_allowed.py
@@ -31,7 +31,7 @@ class compute_firewall_ssh_access_from_the_internet_allowed(Check):
                                     break
                             elif int(port) == 22:
                                 opened_port = True
-                            break
+                                break
             if (
                 "0.0.0.0/0" in firewall.source_ranges
                 and firewall.direction == "INGRESS"

--- a/tests/providers/gcp/services/compute/compute_firewall_rdp_access_from_the_internet_allowed/compute_firewall_rdp_access_from_the_internet_allowed_test.py
+++ b/tests/providers/gcp/services/compute/compute_firewall_rdp_access_from_the_internet_allowed/compute_firewall_rdp_access_from_the_internet_allowed_test.py
@@ -279,6 +279,48 @@ class Test_compute_firewall_rdp_access_from_the_internet_allowed:
             )
             assert result[0].resource_id == firewall.id
 
+    def test_one_non_compliant_rule_with_multiple_ports(self):
+        from prowler.providers.gcp.services.compute.compute_service import Firewall
+
+        firewall = Firewall(
+            name="test",
+            id="1234567890",
+            source_ranges=["0.0.0.0/0"],
+            direction="INGRESS",
+            allowed_rules=[{"IPProtocol": "tcp", "ports": ["80", "3389"]}],
+            project_id=GCP_PROJECT_ID,
+        )
+
+        compute_client = mock.MagicMock()
+        compute_client.project_ids = [GCP_PROJECT_ID]
+        compute_client.firewalls = [firewall]
+        compute_client.region = "global"
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_gcp_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.gcp.services.compute.compute_firewall_rdp_access_from_the_internet_allowed.compute_firewall_rdp_access_from_the_internet_allowed.compute_client",
+                new=compute_client,
+            ),
+        ):
+            from prowler.providers.gcp.services.compute.compute_firewall_rdp_access_from_the_internet_allowed.compute_firewall_rdp_access_from_the_internet_allowed import (
+                compute_firewall_rdp_access_from_the_internet_allowed,
+            )
+
+            check = compute_firewall_rdp_access_from_the_internet_allowed()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert search(
+                f"Firewall {firewall.name} does exposes port 3389",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == firewall.id
+
     def test_one_non_compliant_rule_with_port_range(self):
         from prowler.providers.gcp.services.compute.compute_service import Firewall
 

--- a/tests/providers/gcp/services/compute/compute_firewall_ssh_access_from_the_internet_allowed/compute_firewall_ssh_access_from_the_internet_allowed_test.py
+++ b/tests/providers/gcp/services/compute/compute_firewall_ssh_access_from_the_internet_allowed/compute_firewall_ssh_access_from_the_internet_allowed_test.py
@@ -279,6 +279,48 @@ class Test_compute_firewall_ssh_access_from_the_internet_allowed:
             )
             assert result[0].resource_id == firewall.id
 
+    def test_one_non_compliant_rule_with_multiple_ports(self):
+        from prowler.providers.gcp.services.compute.compute_service import Firewall
+
+        firewall = Firewall(
+            name="test",
+            id="1234567890",
+            source_ranges=["0.0.0.0/0"],
+            direction="INGRESS",
+            allowed_rules=[{"IPProtocol": "tcp", "ports": ["80", "22"]}],
+            project_id=GCP_PROJECT_ID,
+        )
+
+        compute_client = mock.MagicMock()
+        compute_client.project_ids = [GCP_PROJECT_ID]
+        compute_client.firewalls = [firewall]
+        compute_client.region = "global"
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_gcp_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.gcp.services.compute.compute_firewall_ssh_access_from_the_internet_allowed.compute_firewall_ssh_access_from_the_internet_allowed.compute_client",
+                new=compute_client,
+            ),
+        ):
+            from prowler.providers.gcp.services.compute.compute_firewall_ssh_access_from_the_internet_allowed.compute_firewall_ssh_access_from_the_internet_allowed import (
+                compute_firewall_ssh_access_from_the_internet_allowed,
+            )
+
+            check = compute_firewall_ssh_access_from_the_internet_allowed()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert search(
+                f"Firewall {firewall.name} does exposes port 22",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == firewall.id
+
     def test_one_non_compliant_rule_with_port_range(self):
         from prowler.providers.gcp.services.compute.compute_service import Firewall
 


### PR DESCRIPTION
## Description

`compute_firewall_ssh_access_from_the_internet_allowed` and `compute_firewall_rdp_access_from_the_internet_allowed` iterate a rule's ports to decide whether 22/3389 is exposed:

```python
for port in rule["ports"]:
    if port.find("-") != -1:
        lower, higher = port.split("-")
        if int(lower) <= 22 and int(higher) >= 22:
            opened_port = True
            break
    elif int(port) == 22:
        opened_port = True
    break   # <-- indented at loop-body level
```

The final `break` is aligned with the `if`/`elif`, so it runs **unconditionally after the first port**. Any firewall rule that bundles several ports and lists 22 (or 3389) in a non-first position is silently missed and reported as **PASS**, i.e. a false negative on an internet-exposed SSH/RDP port.

Verified for both checks:

| `ports` | before | after (correct) |
|---|---|---|
| `["22"]` | FAIL | FAIL |
| `["80", "22"]` | **PASS (bug)** | FAIL |
| `["443", "3389", "22"]` | **PASS (bug)** | FAIL |
| `["80", "1-100"]` | **PASS (bug)** | FAIL |
| `["80", "443"]` | PASS | PASS |

## Fix

Move the `break` into the matching `elif` branch, so the loop stops only once a match is found and otherwise keeps scanning the remaining ports (the range branch already had its own `break`). Behavior is unchanged for every previously-correct case.

## Tests

Added `test_one_non_compliant_rule_with_multiple_ports` to both checks (`["80", "22"]` / `["80", "3389"]`, asserting FAIL). Verified they **fail on the current code** and pass after the fix; the full test files stay green (26 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of internet-exposed RDP (port 3389) firewall rules, including multi-port entries.
  * Improved detection of internet-exposed SSH (port 22) firewall rules, including multi-port entries.
  * Firewall checks now stop scanning ports for a rule immediately after finding the relevant exposed port.

* **Tests**
  * Added unit coverage for firewall rules that contain multiple allowed ports to ensure correct FAIL reporting for RDP and SSH.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->