### PR TITLE
chore(ui): drop the unused deployment-mode variable

### DIFF
--- a/ui/changelog.d/drop-unused-deployment-mode-env.removed.md
+++ b/ui/changelog.d/drop-unused-deployment-mode-env.removed.md
@@ -1,0 +1,1 @@
+Removed the unused `NEXT_PUBLIC_PROWLER_DEPLOYMENT_MODE` variable and its `getDeploymentMode` helper; no build ever set it and nothing read the result, so Cloud versus self-hosted behavior is decided solely by the runtime `UI_CLOUD_ENABLED` flag

--- a/ui/lib/deployment.ts
+++ b/ui/lib/deployment.ts
@@ -1,23 +1,5 @@
 import { isCloud } from "./shared/env";
 
-export const DEPLOYMENT_MODE = {
-  CLOUD: "cloud",
-  ON_PREMISE: "onpremise",
-} as const;
-
 export const PROWLER_CLOUD_ONLY_TOOLTIP = "Available only in Prowler Cloud";
-
-export type DeploymentMode =
-  (typeof DEPLOYMENT_MODE)[keyof typeof DEPLOYMENT_MODE];
-
-export const getDeploymentMode = (): DeploymentMode | undefined => {
-  const mode = process.env.NEXT_PUBLIC_PROWLER_DEPLOYMENT_MODE;
-
-  if (mode === DEPLOYMENT_MODE.CLOUD || mode === DEPLOYMENT_MODE.ON_PREMISE) {
-    return mode;
-  }
-
-  return undefined;
-};
 
 export const isGroupedJiraDispatchEnabled = (): boolean => isCloud();


### PR DESCRIPTION
### Context

Cleanup of a dead environment variable found while auditing ui/lib/deployment.ts.

### Description

Removes `DEPLOYMENT_MODE`, the `DeploymentMode` type, and `getDeploymentMode()` from
ui/lib/deployment.ts. A whole-repo grep shows the only references to
`NEXT_PUBLIC_PROWLER_DEPLOYMENT_MODE` and `getDeploymentMode` were inside this module
itself — no component, test, doc, `.env` file, or workflow referenced them. Upstream's
`ui/Dockerfile` never declared the build arg either, so the value was never set at
build time. `getDeploymentMode()` therefore always returned `undefined`.

Cloud versus self-hosted behavior is decided elsewhere, by the runtime
`UI_CLOUD_ENABLED` flag — this variable played no role in that decision.

`PROWLER_CLOUD_ONLY_TOOLTIP` and `isGroupedJiraDispatchEnabled` in the same file are
untouched.

Because this was a public, documented env var, the change is filed as a `removed`
changelog fragment rather than a silent cleanup, in case a self-hosted user had set it
expecting some effect.

### Steps to review

- Confirm a repo-wide search for `DEPLOYMENT_MODE` or `getDeploymentMode` returns
  nothing outside this diff.
- `ui/lib/deployment.test.ts` is unaffected since it only covers
  `isGroupedJiraDispatchEnabled`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient. — N/A, no dependency changes.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px) — N/A, no visual change, pure dead-code removal.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px) — N/A, no visual change.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px) — N/A, no visual change.
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
N/A — no API changes.

#### MCP Server
N/A — no MCP Server changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

**Note on `skip-sync`:** the equivalent cleanup already landed downstream in
`prowler-cloud/prowler-cloud` PR #4686, so a downstream sync PR for this change would
either conflict or be a no-op.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the unused deployment-mode environment variable and related configuration.
  - Cloud and self-hosted behavior is now determined solely by the `UI_CLOUD_ENABLED` runtime setting.

- **Documentation**
  - Updated the changelog to clarify the deployment behavior and removed configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->