### PR TITLE
feat(m365): add SharePoint default sharing link permission check

### DIFF
--- a/docs/user-guide/providers/microsoft365/authentication.mdx
+++ b/docs/user-guide/providers/microsoft365/authentication.mdx
@@ -55,13 +55,14 @@ When using service principal authentication, add these **Application Permissions
 
 - `Exchange.ManageAsApp` from external API `Office 365 Exchange Online`: Required for Exchange PowerShell module app authentication. The `Global Reader` role must also be assigned to the app.
 - `application_access` from external API `Skype and Teams Tenant Admin API`: Required for Teams PowerShell module app authentication.
+- `Sites.FullControl.All` from external API `SharePoint`: Required for PnP.PowerShell certificate authentication and SharePoint tenant-setting enrichment.
 
 <Note>
 `Directory.Read.All` can be replaced with `Domain.Read.All` for more restrictive permissions, but Entra checks related to DirectoryRoles and GetUsers will not run. If using this option, you must also add the `Organization.Read.All` permission to the application registration for authentication.
 
 </Note>
 <Note>
-These permissions enable application-based authentication methods (client secret and certificate). Using certificate-based authentication is the recommended way to run the full M365 provider, including PowerShell checks.
+These permissions enable application-based authentication methods. Certificate-based authentication is required for the PnP.PowerShell SharePoint tenant-setting enrichment and is the recommended way to run the full M365 provider. Client-secret authentication still retrieves Microsoft Graph SharePoint settings, but skips the PnP.PowerShell enrichment.
 
 </Note>
 
@@ -154,7 +155,12 @@ Browser and Azure CLI authentication methods limit scanning capabilities to chec
 
    ![application_access Permission](/images/providers/teams-permission.png)
 
-3. Click "Grant admin consent for `<your-tenant-name>`" to grant admin consent.
+3. **Add SharePoint API:**
+
+   - Search and select "SharePoint" in **APIs my organization uses**.
+   - Select **Application permissions** > `Sites.FullControl.All`, and click "Add permissions".
+
+4. Click "Grant admin consent for `<your-tenant-name>`" to grant admin consent.
 
    ![Grant Admin Consent](/images/providers/grant-external-api-permissions.png)
 
@@ -259,10 +265,10 @@ export AZURE_CLIENT_SECRET="XXXXXXXXX"
 export AZURE_TENANT_ID="XXXXXXXXX"
 ```
 
-If these variables are not set or exported, execution using `--sp-env-auth` will fail. This workflow is helpful for initial validation or temporary access. Plan to transition to certificate-based authentication to remove long-lived secrets and keep full provider coverage in unattended environments.
+If these variables are not set or exported, execution using `--sp-env-auth` will fail. This workflow is helpful for initial validation or temporary access, but SharePoint PowerShell checks are skipped because SharePoint Online app-only authentication requires a certificate. Plan to transition to certificate-based authentication to remove long-lived secrets and keep full provider coverage in unattended environments.
 
 <Note>
-To scan every M365 check, ensure the required permissions are added to the application registration. Refer to the [PowerShell Module Permissions](#grant-powershell-module-permissions-for-app-only-authentication) section for more information.
+To scan every M365 check, use certificate authentication and add the required permissions to the application registration. Refer to the [PowerShell Module Permissions](#grant-powershell-module-permissions-for-app-only-authentication) section for more information.
 
 </Note>
 
@@ -596,3 +602,4 @@ Install-Module -Name "ModuleName" -Scope AllUsers -Force
 - [MSAL.PS](https://www.powershellgallery.com/packages/MSAL.PS/4.32.0): Required for Exchange module via application authentication.
 - [ExchangeOnlineManagement](https://www.powershellgallery.com/packages/ExchangeOnlineManagement/3.6.0) (Minimum version: 3.6.0) Required for checks across Exchange, Defender, and Purview.
 - [MicrosoftTeams](https://www.powershellgallery.com/packages/MicrosoftTeams/6.6.0) (Minimum version: 6.6.0) Required for all Teams checks.
+- [PnP.PowerShell](https://www.powershellgallery.com/packages/PnP.PowerShell/3.4.1) (Required version: 3.4.1) Required for SharePoint tenant-setting enrichment with certificate authentication.

--- a/prowler/changelog.d/sharepoint-default-sharing-link.added.md
+++ b/prowler/changelog.d/sharepoint-default-sharing-link.added.md
@@ -1,0 +1,1 @@
+`sharepoint_default_sharing_link_permission_configured` check for M365 provider, verifying the default sharing link permission is set to View

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -238,6 +238,68 @@ class M365PowerShell(PowerShellSession):
             return False
         return True
 
+    def test_sharepoint_connection(self) -> bool:
+        """Test SharePoint Online API connection and raise exception if it fails."""
+        try:
+            self.execute(
+                '$spoAdminUrl = "https://" + $tenantDomain.Split(".")[0] + "-admin.sharepoint.com"'
+            )
+            # Try to connect. Note: SharePoint Online App-Only auth typically requires certificates or PnP.
+            # Using Connect-SPOService here as standard.
+            result = self.execute_connect(
+                "Connect-SPOService -Url $spoAdminUrl; if ($?) { Write-Output 'Connected' }"
+            )
+            if (
+                "timeout reached" in result
+                or "error" in result.lower()
+                or "Connected" not in result
+            ):
+                logger.error(
+                    f"SharePoint Online connection failed: {result}. Please check your permissions and try again."
+                )
+                return False
+            return True
+        except Exception as e:
+            logger.error(
+                f"SharePoint Online connection failed: {e}. Please check your permissions and try again."
+            )
+            return False
+
+    def test_sharepoint_certificate_connection(self) -> bool:
+        """Test SharePoint Online API connection using certificate and raise exception if it fails."""
+        try:
+            self.execute(
+                '$spoAdminUrl = "https://" + $tenantDomain.Split(".")[0] + "-admin.sharepoint.com"'
+            )
+            # Modern SPOService supports -Certificate and -ClientId (if not, Connect-PnPOnline could be a fallback)
+            result = self.execute_connect(
+                "Connect-SPOService -Url $spoAdminUrl -Certificate $certificate -ClientId $clientID -TenantId $tenantID; if ($?) { Write-Output 'Connected' }"
+            )
+            if (
+                "timeout reached" in result
+                or "not recognized" in result
+                or "error" in result.lower()
+                or "Connected" not in result
+            ):
+                logger.error(
+                    f"SharePoint Online Certificate connection failed: {result}"
+                )
+                return False
+            return True
+        except Exception as e:
+            logger.error(f"SharePoint Online Certificate connection failed: {e}")
+            return False
+
+    def connect_sharepoint_online(self) -> dict:
+        """
+        Connect to SharePoint Online PowerShell Module.
+
+        Establishes a connection to SharePoint Online using the initialized credentials.
+        """
+        if self.execute("Write-Output $certificate") != "":
+            return self.test_sharepoint_certificate_connection()
+        return self.test_sharepoint_connection()
+
     def connect_microsoft_teams(self) -> dict:
         """
         Connect to Microsoft Teams Module PowerShell Module.
@@ -379,6 +441,20 @@ class M365PowerShell(PowerShellSession):
         """
         return self.execute(
             "Get-AdminAuditLogConfig | Select-Object UnifiedAuditLogIngestionEnabled | ConvertTo-Json -Depth 10",
+            json_parse=True,
+        )
+
+    def get_sharepoint_tenant_config(self) -> dict:
+        """
+        Get SharePoint Tenant Settings.
+
+        Retrieves the current SharePoint tenant configuration settings using Get-SPOTenant.
+
+        Returns:
+            dict: SharePoint tenant configuration settings in JSON format.
+        """
+        return self.execute(
+            "Get-SPOTenant | ConvertTo-Json -Depth 10",
             json_parse=True,
         )
 
@@ -1109,6 +1185,7 @@ def initialize_m365_powershell_modules():
         "ExchangeOnlineManagement",
         "MicrosoftTeams",
         "MSAL.PS",
+        "Microsoft.Online.SharePoint.PowerShell",
     ]
 
     pwsh = PowerShellSession()

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -9,6 +9,17 @@ from prowler.providers.m365.exceptions.exceptions import M365CertificateCreation
 from prowler.providers.m365.lib.jwt.jwt_decoder import decode_msal_token
 from prowler.providers.m365.models import M365Credentials, M365IdentityInfo
 
+PNP_POWERSHELL_VERSION = "3.4.1"
+SHAREPOINT_REGION_CONFIG = {
+    "M365Global": ("Production", ".onmicrosoft.com", "sharepoint.com"),
+    "M365China": ("China", ".partner.onmschina.cn", "sharepoint.cn"),
+    "M365USGovernment": (
+        "USGovernmentHigh",
+        ".onmicrosoft.us",
+        "sharepoint.us",
+    ),
+}
+
 
 class M365PowerShell(PowerShellSession):
     """
@@ -47,6 +58,7 @@ class M365PowerShell(PowerShellSession):
         """
         super().__init__()
         self.tenant_identity = identity
+        self.pnp_powershell_ready = credentials.pnp_powershell_ready
         self.init_credential(credentials)
 
     @override
@@ -124,6 +136,7 @@ class M365PowerShell(PowerShellSession):
             self.execute(
                 f'$certBytes = [Convert]::FromBase64String("{clean_cert_content}")'
             )
+            self.execute(f'$certificateBase64 = "{clean_cert_content}"')
             error = self.execute(
                 "$certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(,$certBytes)"
             )
@@ -238,67 +251,69 @@ class M365PowerShell(PowerShellSession):
             return False
         return True
 
-    def test_sharepoint_connection(self) -> bool:
-        """Test SharePoint Online API connection and raise exception if it fails."""
-        try:
-            self.execute(
-                '$spoAdminUrl = "https://" + $tenantDomain.Split(".")[0] + "-admin.sharepoint.com"'
-            )
-            # Try to connect. Note: SharePoint Online App-Only auth typically requires certificates or PnP.
-            # Using Connect-SPOService here as standard.
-            result = self.execute_connect(
-                "Connect-SPOService -Url $spoAdminUrl; if ($?) { Write-Output 'Connected' }"
-            )
-            if (
-                "timeout reached" in result
-                or "error" in result.lower()
-                or "Connected" not in result
-            ):
-                logger.error(
-                    f"SharePoint Online connection failed: {result}. Please check your permissions and try again."
-                )
-                return False
-            return True
-        except Exception as e:
-            logger.error(
-                f"SharePoint Online connection failed: {e}. Please check your permissions and try again."
-            )
-            return False
-
-    def test_sharepoint_certificate_connection(self) -> bool:
-        """Test SharePoint Online API connection using certificate and raise exception if it fails."""
-        try:
-            self.execute(
-                '$spoAdminUrl = "https://" + $tenantDomain.Split(".")[0] + "-admin.sharepoint.com"'
-            )
-            # Modern SPOService supports -Certificate and -ClientId (if not, Connect-PnPOnline could be a fallback)
-            result = self.execute_connect(
-                "Connect-SPOService -Url $spoAdminUrl -Certificate $certificate -ClientId $clientID -TenantId $tenantID; if ($?) { Write-Output 'Connected' }"
-            )
-            if (
-                "timeout reached" in result
-                or "not recognized" in result
-                or "error" in result.lower()
-                or "Connected" not in result
-            ):
-                logger.error(
-                    f"SharePoint Online Certificate connection failed: {result}"
-                )
-                return False
-            return True
-        except Exception as e:
-            logger.error(f"SharePoint Online Certificate connection failed: {e}")
-            return False
-
-    def connect_sharepoint_online(self) -> dict:
+    def connect_sharepoint_online(self, region: str = "M365Global") -> bool:
         """
         Connect to SharePoint Online PowerShell Module.
 
         Establishes a connection to SharePoint Online using the initialized credentials.
         """
-        if self.execute("Write-Output $certificate") != "":
-            return self.test_sharepoint_certificate_connection()
-        return self.test_sharepoint_connection()
+        if self.pnp_powershell_ready is False:
+            logger.warning(
+                "SharePoint Online PowerShell enrichment will be skipped because PnP.PowerShell initialization failed."
+            )
+            return False
+
+        if self.execute("Write-Output $certificateBase64") == "":
+            logger.warning(
+                "SharePoint Online PowerShell enrichment requires certificate authentication and will be skipped."
+            )
+            return False
+
+        region_config = SHAREPOINT_REGION_CONFIG.get(region)
+        if not region_config:
+            logger.warning(
+                f"SharePoint Online PowerShell enrichment is not supported for region {region}."
+            )
+            return False
+
+        azure_environment, tenant_suffix, sharepoint_domain = region_config
+        tenant_domain = next(
+            (
+                domain
+                for domain in self.tenant_identity.tenant_domains
+                if re.fullmatch(rf"[A-Za-z0-9-]+{re.escape(tenant_suffix)}", domain)
+            ),
+            None,
+        )
+        if not tenant_domain:
+            logger.warning(
+                "SharePoint Online PowerShell enrichment requires a recognized initial tenant domain and will be skipped."
+            )
+            return False
+
+        tenant_name = tenant_domain.removesuffix(tenant_suffix)
+        admin_url = f"https://{tenant_name}-admin.{sharepoint_domain}"
+        self.execute(f'$tenantDomain = "{tenant_domain}"')
+        self.execute(f'$sharePointAdminUrl = "{admin_url}"')
+
+        try:
+            result = self.execute_connect(
+                "$sharePointConnection = Connect-PnPOnline "
+                "-Url $sharePointAdminUrl -ClientId $clientID -Tenant $tenantDomain "
+                "-CertificateBase64Encoded $certificateBase64 "
+                f"-AzureEnvironment {azure_environment} "
+                "-ReturnConnection -ValidateConnection -ErrorAction Stop; "
+                "Write-Output 'Connected'"
+            )
+            if result.strip() != "Connected":
+                logger.error(
+                    f"SharePoint Online certificate connection failed: {result}"
+                )
+                return False
+            return True
+        except Exception as error:
+            logger.error(f"SharePoint Online certificate connection failed: {error}")
+            return False
 
     def connect_microsoft_teams(self) -> dict:
         """
@@ -448,13 +463,15 @@ class M365PowerShell(PowerShellSession):
         """
         Get SharePoint Tenant Settings.
 
-        Retrieves the current SharePoint tenant configuration settings using Get-SPOTenant.
+        Retrieves selected SharePoint tenant settings using the retained PnP connection.
 
         Returns:
             dict: SharePoint tenant configuration settings in JSON format.
         """
         return self.execute(
-            "Get-SPOTenant | ConvertTo-Json -Depth 10",
+            "Get-PnPTenant -Connection $sharePointConnection | "
+            "Select-Object DefaultLinkPermission | "
+            "ConvertTo-Json -Compress -EnumsAsStrings",
             json_parse=True,
         )
 
@@ -1170,7 +1187,7 @@ class M365PowerShell(PowerShellSession):
 
 
 # This function is used to install the required M365 PowerShell modules in Docker containers
-def initialize_m365_powershell_modules():
+def initialize_m365_powershell_modules() -> bool:
     """
     Initialize required PowerShell modules.
 
@@ -1181,34 +1198,62 @@ def initialize_m365_powershell_modules():
         bool: True if all modules were successfully initialized, False otherwise
     """
 
-    REQUIRED_MODULES = [
+    required_modules = [
         "ExchangeOnlineManagement",
         "MicrosoftTeams",
         "MSAL.PS",
-        "Microsoft.Online.SharePoint.PowerShell",
+        "PnP.PowerShell",
     ]
 
     pwsh = PowerShellSession()
     try:
-        for module in REQUIRED_MODULES:
+        for module in required_modules:
             try:
                 # Check if module is already installed
-                result = pwsh.execute(f"Get-Module -ListAvailable {module}", timeout=5)
+                version_arg = (
+                    f" -RequiredVersion {PNP_POWERSHELL_VERSION}"
+                    if module == "PnP.PowerShell"
+                    else ""
+                )
+                module_query = (
+                    f"Get-Module -ListAvailable {module} | Where-Object "
+                    f"{{ $_.Version -eq [version]'{PNP_POWERSHELL_VERSION}' }}"
+                    if module == "PnP.PowerShell"
+                    else f"Get-Module -ListAvailable {module}"
+                )
+                result = pwsh.execute(
+                    module_query,
+                    timeout=5,
+                )
 
                 # Install module if not installed
                 if not result:
                     install_result = pwsh.execute(
-                        f"Install-Module {module} -Force -AllowClobber -Scope CurrentUser",
+                        f"Install-Module {module}{version_arg} -Force -AllowClobber -Scope CurrentUser",
                         timeout=60,
                     )
                     if install_result:
                         logger.warning(
                             f"Unexpected output while installing module {module}: {install_result}"
                         )
-                    else:
+                    elif module != "PnP.PowerShell":
                         logger.info(f"Successfully installed module {module}")
 
-                    # Import module
+                if module == "PnP.PowerShell":
+                    imported_version = pwsh.execute(
+                        f'Import-Module "{module}"{version_arg} -Force -PassThru | '
+                        "Select-Object -ExpandProperty Version",
+                    )
+                    if str(imported_version).strip() != PNP_POWERSHELL_VERSION:
+                        logger.error(
+                            f"Failed to import module {module} {PNP_POWERSHELL_VERSION}"
+                        )
+                        return False
+                    if not result:
+                        logger.info(
+                            f"Successfully installed module {module} {PNP_POWERSHELL_VERSION}"
+                        )
+                elif not result:
                     pwsh.execute(f'Import-Module "{module}" -Force', timeout=1)
 
             except Exception as error:

--- a/prowler/providers/m365/m365_provider.py
+++ b/prowler/providers/m365/m365_provider.py
@@ -121,8 +121,8 @@ class M365Provider(Provider):
         tenant_id: str = None,
         client_id: str = None,
         client_secret: str = None,
-        user: str = None,
-        password: str = None,
+        user: str = None,  # noqa
+        password: str = None,  # noqa
         certificate_content: str = None,
         certificate_path: str = None,
         init_modules: bool = False,
@@ -448,7 +448,9 @@ class M365Provider(Provider):
             test_session = M365PowerShell(credentials, identity)
             try:
                 if init_modules:
-                    initialize_m365_powershell_modules()
+                    credentials.pnp_powershell_ready = (
+                        initialize_m365_powershell_modules()
+                    )
                 return credentials
             finally:
                 test_session.close()

--- a/prowler/providers/m365/models.py
+++ b/prowler/providers/m365/models.py
@@ -30,6 +30,7 @@ class M365Credentials(BaseModel):
     tenant_id: str = ""
     tenant_domains: list[str] = []
     certificate_content: Optional[str] = None
+    pnp_powershell_ready: Optional[bool] = None
 
 
 class M365OutputOptions(ProviderOutputOptions):

--- a/prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured.metadata.json
+++ b/prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured.metadata.json
@@ -1,0 +1,36 @@
+{
+  "Provider": "m365",
+  "CheckID": "sharepoint_default_sharing_link_permission_configured",
+  "CheckTitle": "SharePoint default sharing link permission is set to View",
+  "CheckType": [],
+  "ServiceName": "sharepoint",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "low",
+  "ResourceType": "NotDefined",
+  "ResourceGroup": "collaboration",
+  "Description": "**Microsoft 365 SharePoint** default sharing link permission is evaluated to ensure it defaults to 'View' rather than 'Edit'.",
+  "Risk": "Defaulting new sharing links to Edit grants unnecessary write access and increases the blast radius of accidental oversharing.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/sharepoint/change-default-sharing-link"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "Set-SPOTenant -DefaultLinkPermission View",
+      "NativeIaC": "",
+      "Other": "1. Go to the Microsoft 365 admin center > Admin centers > SharePoint\n2. Navigate to Policies > Sharing\n3. Under File and folder links, choose View for the Default link permission.\n4. Click Save",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Set the default sharing link permission to View to minimize accidental oversharing of write access.",
+      "Url": "https://hub.prowler.com/check/sharepoint_default_sharing_link_permission_configured"
+    }
+  },
+  "Categories": [
+    "identity-access"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured.py
+++ b/prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured.py
@@ -1,0 +1,48 @@
+from typing import List
+
+from prowler.lib.check.models import Check, CheckReportM365
+from prowler.providers.m365.services.sharepoint.sharepoint_client import (
+    sharepoint_client,
+)
+
+
+class sharepoint_default_sharing_link_permission_configured(Check):
+    """
+    Check if SharePoint default sharing link permission is set to View.
+
+    This check verifies that the default sharing link permission in SharePoint is configured to 'View'
+    rather than 'Edit'. Defaulting new sharing links to Edit grants unnecessary write access and increases
+    the blast radius of accidental oversharing.
+    """
+
+    def execute(self) -> List[CheckReportM365]:
+        """
+        Execute the SharePoint default sharing link permission check.
+
+        Returns:
+            List[CheckReportM365]: A list containing a report with the result of the check.
+        """
+        findings = []
+        settings = sharepoint_client.settings
+        if (
+            settings
+            and hasattr(settings, "defaultLinkPermission")
+            and settings.defaultLinkPermission is not None
+        ):
+            report = CheckReportM365(
+                self.metadata(),
+                resource=settings,
+                resource_name="SharePoint Settings",
+                resource_id="sharepointSettings",
+            )
+            report.status = "FAIL"
+            report.status_extended = f"SharePoint default sharing link permission is set to '{settings.defaultLinkPermission}'."
+
+            if settings.defaultLinkPermission == "View":
+                report.status = "PASS"
+                report.status_extended = (
+                    "SharePoint default sharing link permission is set to 'View'."
+                )
+
+            findings.append(report)
+        return findings

--- a/prowler/providers/m365/services/sharepoint/sharepoint_service.py
+++ b/prowler/providers/m365/services/sharepoint/sharepoint_service.py
@@ -15,7 +15,7 @@ class SharePoint(M365Service):
         super().__init__(provider)
         self.tenant_settings = None
         if self.powershell:
-            if self.powershell.connect_sharepoint_online():
+            if self.powershell.connect_sharepoint_online(provider.region_config.name):
                 self.tenant_settings = self.powershell.get_sharepoint_tenant_config()
             self.powershell.close()
 

--- a/prowler/providers/m365/services/sharepoint/sharepoint_service.py
+++ b/prowler/providers/m365/services/sharepoint/sharepoint_service.py
@@ -13,7 +13,10 @@ from prowler.providers.m365.m365_provider import M365Provider
 class SharePoint(M365Service):
     def __init__(self, provider: M365Provider):
         super().__init__(provider)
+        self.tenant_settings = None
         if self.powershell:
+            if self.powershell.connect_sharepoint_online():
+                self.tenant_settings = self.powershell.get_sharepoint_tenant_config()
             self.powershell.close()
 
         created_loop = False
@@ -63,6 +66,11 @@ class SharePoint(M365Service):
                 legacyAuth=global_settings.is_legacy_auth_protocols_enabled,
                 resharingEnabled=global_settings.is_resharing_by_external_users_enabled,
                 allowedDomainGuidsForSyncApp=global_settings.allowed_domain_guids_for_sync_app,
+                defaultLinkPermission=(
+                    self.tenant_settings.get("DefaultLinkPermission")
+                    if self.tenant_settings
+                    else None
+                ),
             )
 
         except ODataError as error:
@@ -86,3 +94,4 @@ class SharePointSettings(BaseModel):
     resharingEnabled: bool
     legacyAuth: bool
     allowedDomainGuidsForSyncApp: List[uuid.UUID]
+    defaultLinkPermission: Optional[str] = None

--- a/tests/providers/m365/lib/powershell/m365_powershell_test.py
+++ b/tests/providers/m365/lib/powershell/m365_powershell_test.py
@@ -434,13 +434,16 @@ class Testm365PowerShell:
             assert result is True
             # Verify that execute was called for each module
             assert (
-                mock_execute_obj.call_count == 3 * 3
+                mock_execute_obj.call_count == 4 * 3
             )  # number of modules * 3 commands each
             # Verify success messages were logged
             mock_info.assert_any_call(
                 "Successfully installed module ExchangeOnlineManagement"
             )
             mock_info.assert_any_call("Successfully installed module MicrosoftTeams")
+            mock_info.assert_any_call(
+                "Successfully installed module Microsoft.Online.SharePoint.PowerShell"
+            )
 
     @patch("subprocess.Popen")
     def test_initialize_m365_powershell_modules_failure(self, mock_popen):
@@ -503,12 +506,15 @@ class Testm365PowerShell:
             main()
 
             # Verify all info messages were logged in the correct order
-            assert mock_info.call_count == 4
+            assert mock_info.call_count == 5
             mock_info.assert_has_calls(
                 [
                     call("Successfully installed module ExchangeOnlineManagement"),
                     call("Successfully installed module MicrosoftTeams"),
                     call("Successfully installed module MSAL.PS"),
+                    call(
+                        "Successfully installed module Microsoft.Online.SharePoint.PowerShell"
+                    ),
                     call("M365 PowerShell modules initialized successfully"),
                 ]
             )
@@ -1264,4 +1270,202 @@ class Testm365PowerShell:
         assert any('$tenantID = "test_tenant_id"' in cmd for cmd in executed_commands)
         assert any('$tenantDomain = "contoso.com"' in cmd for cmd in executed_commands)
 
+        session.close()
+
+    @patch("subprocess.Popen")
+    def test_connect_sharepoint_online_certificate_auth(self, mock_popen):
+        """Test connect_sharepoint_online method with certificate authentication"""
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        credentials = M365Credentials()
+        identity = M365IdentityInfo()
+        session = M365PowerShell(credentials, identity)
+
+        execute_calls = []
+
+        def mock_execute_side_effect(command):
+            execute_calls.append(command)
+            if "Write-Output $certificate" in command:
+                return "certificate_content"
+            return ""
+
+        session.execute = MagicMock(side_effect=mock_execute_side_effect)
+        session.test_sharepoint_certificate_connection = MagicMock(return_value=True)
+
+        result = session.connect_sharepoint_online()
+        assert result is True
+        session.test_sharepoint_certificate_connection.assert_called_once()
+        session.close()
+
+    @patch("subprocess.Popen")
+    def test_connect_sharepoint_online_app_auth(self, mock_popen):
+        """Test connect_sharepoint_online method with application authentication"""
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        credentials = M365Credentials()
+        identity = M365IdentityInfo()
+        session = M365PowerShell(credentials, identity)
+
+        execute_calls = []
+
+        def mock_execute_side_effect(command):
+            execute_calls.append(command)
+            if "Write-Output $certificate" in command:
+                return ""
+            return ""
+
+        session.execute = MagicMock(side_effect=mock_execute_side_effect)
+        session.test_sharepoint_connection = MagicMock(return_value=True)
+
+        result = session.connect_sharepoint_online()
+        assert result is True
+        session.test_sharepoint_connection.assert_called_once()
+        session.close()
+
+    @patch("subprocess.Popen")
+    def test_sharepoint_connection(self, mock_popen):
+        """Test test_sharepoint_connection method"""
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        credentials = M365Credentials()
+        identity = M365IdentityInfo(tenant_domain="example.com")
+        session = M365PowerShell(credentials, identity)
+
+        session.execute = MagicMock()
+        session.execute_connect = MagicMock(return_value="Connected")
+
+        result = session.test_sharepoint_connection()
+        assert result is True
+        session.execute.assert_called_once_with(
+            '$spoAdminUrl = "https://" + $tenantDomain.Split(".")[0] + "-admin.sharepoint.com"'
+        )
+        session.execute_connect.assert_called_once_with(
+            "Connect-SPOService -Url $spoAdminUrl; if ($?) { Write-Output 'Connected' }"
+        )
+        session.close()
+
+    @patch("subprocess.Popen")
+    def test_sharepoint_certificate_connection(self, mock_popen):
+        """Test test_sharepoint_certificate_connection method"""
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        credentials = M365Credentials()
+        identity = M365IdentityInfo(tenant_domain="example.com")
+        session = M365PowerShell(credentials, identity)
+
+        session.execute = MagicMock()
+        session.execute_connect = MagicMock(return_value="Connected")
+
+        result = session.test_sharepoint_certificate_connection()
+        assert result is True
+        session.execute.assert_called_once_with(
+            '$spoAdminUrl = "https://" + $tenantDomain.Split(".")[0] + "-admin.sharepoint.com"'
+        )
+        session.execute_connect.assert_called_once_with(
+            "Connect-SPOService -Url $spoAdminUrl -Certificate $certificate -ClientId $clientID -TenantId $tenantID; if ($?) { Write-Output 'Connected' }"
+        )
+        session.close()
+
+    @patch("subprocess.Popen")
+    def test_sharepoint_connection_failure(self, mock_popen):
+        """Test test_sharepoint_connection method failure"""
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        credentials = M365Credentials()
+        identity = M365IdentityInfo(tenant_domain="example.com")
+        session = M365PowerShell(credentials, identity)
+
+        session.execute = MagicMock()
+        session.execute_connect = MagicMock(
+            return_value="'execute_connect' command timeout reached"
+        )
+
+        result = session.test_sharepoint_connection()
+        assert result is False
+        session.close()
+
+    @patch("subprocess.Popen")
+    def test_sharepoint_certificate_connection_failure(self, mock_popen):
+        """Test test_sharepoint_certificate_connection method failure"""
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        credentials = M365Credentials()
+        identity = M365IdentityInfo(tenant_domain="example.com")
+        session = M365PowerShell(credentials, identity)
+
+        session.execute = MagicMock()
+        session.execute_connect = MagicMock(
+            return_value="error connecting to SharePoint"
+        )
+
+        result = session.test_sharepoint_certificate_connection()
+        assert result is False
+        session.close()
+
+    @patch("subprocess.Popen")
+    def test_sharepoint_connection_exception(self, mock_popen):
+        """Test test_sharepoint_connection method exception"""
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        credentials = M365Credentials()
+        identity = M365IdentityInfo(tenant_domain="example.com")
+        session = M365PowerShell(credentials, identity)
+
+        session.execute = MagicMock(side_effect=Exception("SharePoint API error"))
+
+        with patch("prowler.lib.logger.logger.error") as mock_error:
+            result = session.test_sharepoint_connection()
+
+        assert result is False
+        mock_error.assert_called_once_with(
+            "SharePoint Online connection failed: SharePoint API error. Please check your permissions and try again."
+        )
+        session.close()
+
+    @patch("subprocess.Popen")
+    def test_sharepoint_certificate_connection_exception(self, mock_popen):
+        """Test test_sharepoint_certificate_connection method exception"""
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        credentials = M365Credentials()
+        identity = M365IdentityInfo(tenant_domain="example.com")
+        session = M365PowerShell(credentials, identity)
+
+        session.execute = MagicMock(side_effect=Exception("SharePoint API error"))
+
+        with patch("prowler.lib.logger.logger.error") as mock_error:
+            result = session.test_sharepoint_certificate_connection()
+
+        assert result is False
+        mock_error.assert_called_once_with(
+            "SharePoint Online Certificate connection failed: SharePoint API error"
+        )
+        session.close()
+
+    @patch("subprocess.Popen")
+    def test_get_sharepoint_tenant_config(self, mock_popen):
+        """Test get_sharepoint_tenant_config method"""
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        credentials = M365Credentials()
+        identity = M365IdentityInfo()
+        session = M365PowerShell(credentials, identity)
+
+        expected_result = {"DefaultLinkPermission": "View"}
+        session.execute = MagicMock(return_value=expected_result)
+
+        result = session.get_sharepoint_tenant_config()
+        assert result == expected_result
+        session.execute.assert_called_once_with(
+            "Get-SPOTenant | ConvertTo-Json -Depth 10", json_parse=True
+        )
         session.close()

--- a/tests/providers/m365/lib/powershell/m365_powershell_test.py
+++ b/tests/providers/m365/lib/powershell/m365_powershell_test.py
@@ -409,11 +409,13 @@ class Testm365PowerShell:
         mock_popen.return_value = mock_process
 
         # Mock the execute method to simulate successful module installation
-        def mock_execute(command, *args, **kwargs):
+        def mock_execute(command, *args, **_kwargs):
             if "Get-Module" in command:
                 return None  # Module not installed
             elif "Install-Module" in command:
                 return None  # Installation successful
+            elif 'Import-Module "PnP.PowerShell"' in command:
+                return "3.4.1"
             elif "Import-Module" in command:
                 return None  # Import successful
             return None
@@ -432,17 +434,31 @@ class Testm365PowerShell:
 
             # Verify successful initialization
             assert result is True
-            # Verify that execute was called for each module
-            assert (
-                mock_execute_obj.call_count == 4 * 3
-            )  # number of modules * 3 commands each
             # Verify success messages were logged
             mock_info.assert_any_call(
                 "Successfully installed module ExchangeOnlineManagement"
             )
             mock_info.assert_any_call("Successfully installed module MicrosoftTeams")
             mock_info.assert_any_call(
-                "Successfully installed module Microsoft.Online.SharePoint.PowerShell"
+                "Successfully installed module PnP.PowerShell 3.4.1"
+            )
+            commands = [
+                mock_call.args[0] for mock_call in mock_execute_obj.call_args_list
+            ]
+            assert any(
+                "Install-Module PnP.PowerShell" in command
+                and "-RequiredVersion 3.4.1" in command
+                for command in commands
+            )
+            assert any(
+                "Get-Module -ListAvailable PnP.PowerShell" in command
+                and "[version]'3.4.1'" in command
+                for command in commands
+            )
+            assert any(
+                'Import-Module "PnP.PowerShell"' in command
+                and "-RequiredVersion 3.4.1" in command
+                for command in commands
             )
 
     @patch("subprocess.Popen")
@@ -452,7 +468,7 @@ class Testm365PowerShell:
         mock_popen.return_value = mock_process
 
         # Mock the execute method to simulate installation failure
-        def mock_execute(command, *args, **kwargs):
+        def mock_execute(command, *args, **_kwargs):
             if "Get-Module" in command:
                 return None  # Module not installed
             elif "Install-Module" in command:
@@ -481,17 +497,75 @@ class Testm365PowerShell:
             )
 
     @patch("subprocess.Popen")
+    def test_initialize_m365_powershell_modules_imports_installed_pnp_module(
+        self, mock_popen
+    ):
+        """The pinned PnP module is imported even when it is already installed."""
+        mock_popen.return_value = MagicMock()
+
+        def execute(command, *args, **_kwargs):
+            if 'Import-Module "PnP.PowerShell"' in command:
+                return "3.4.1"
+            return "Installed"
+
+        with patch.object(
+            PowerShellSession, "execute", side_effect=execute
+        ) as mock_execute:
+            from prowler.providers.m365.lib.powershell.m365_powershell import (
+                initialize_m365_powershell_modules,
+            )
+
+            assert initialize_m365_powershell_modules() is True
+
+        commands = [mock_call.args[0] for mock_call in mock_execute.call_args_list]
+        assert any(
+            'Import-Module "PnP.PowerShell"' in command
+            and "-RequiredVersion 3.4.1" in command
+            for command in commands
+        )
+        assert all(
+            "Install-Module PnP.PowerShell" not in command for command in commands
+        )
+        pnp_import_call = next(
+            mock_call
+            for mock_call in mock_execute.call_args_list
+            if 'Import-Module "PnP.PowerShell"' in mock_call.args[0]
+        )
+        assert "timeout" not in pnp_import_call.kwargs
+
+    @patch("subprocess.Popen")
+    def test_initialize_m365_powershell_modules_fails_when_pnp_import_fails(
+        self, mock_popen
+    ):
+        """PnP import must be validated before initialization reports success."""
+        mock_popen.return_value = MagicMock()
+
+        def execute(command, *args, **_kwargs):
+            if "Get-Module" in command:
+                return "" if "PnP.PowerShell" in command else "Installed"
+            return ""
+
+        with patch.object(PowerShellSession, "execute", side_effect=execute):
+            from prowler.providers.m365.lib.powershell.m365_powershell import (
+                initialize_m365_powershell_modules,
+            )
+
+            assert initialize_m365_powershell_modules() is False
+
+    @patch("subprocess.Popen")
     def test_main_success(self, mock_popen):
         """Test main() function when module initialization is successful"""
         mock_process = MagicMock()
         mock_popen.return_value = mock_process
 
         # Mock the execute method to simulate successful module installation
-        def mock_execute(command, *args, **kwargs):
+        def mock_execute(command, *args, **_kwargs):
             if "Get-Module" in command:
                 return None  # Module not installed
             elif "Install-Module" in command:
                 return None  # Installation successful
+            elif 'Import-Module "PnP.PowerShell"' in command:
+                return "3.4.1"
             elif "Import-Module" in command:
                 return None  # Import successful
             return None
@@ -512,9 +586,7 @@ class Testm365PowerShell:
                     call("Successfully installed module ExchangeOnlineManagement"),
                     call("Successfully installed module MicrosoftTeams"),
                     call("Successfully installed module MSAL.PS"),
-                    call(
-                        "Successfully installed module Microsoft.Online.SharePoint.PowerShell"
-                    ),
+                    call("Successfully installed module PnP.PowerShell 3.4.1"),
                     call("M365 PowerShell modules initialized successfully"),
                 ]
             )
@@ -528,7 +600,7 @@ class Testm365PowerShell:
         mock_popen.return_value = mock_process
 
         # Mock the execute method to simulate installation failure
-        def mock_execute(command, *args, **kwargs):
+        def mock_execute(command, *args, **_kwargs):
             if "Get-Module" in command:
                 return None  # Module not installed
             elif "Install-Module" in command:
@@ -676,7 +748,7 @@ class Testm365PowerShell:
         session = M365PowerShell(credentials, identity)
 
         # Mock execute to return valid responses
-        def mock_execute(command, *args, **kwargs):
+        def mock_execute(command, *args, **_kwargs):
             if "Write-Output $exchangeToken" in command:
                 return "valid_exchange_token"
             return None
@@ -726,7 +798,7 @@ class Testm365PowerShell:
         session = M365PowerShell(credentials, identity)
 
         # Mock execute to return valid token but decode returns no permissions
-        def mock_execute(command, *args, **kwargs):
+        def mock_execute(command, *args, **_kwargs):
             if "Write-Output $exchangeToken" in command:
                 return "valid_exchange_token"
             return None
@@ -1272,200 +1344,182 @@ class Testm365PowerShell:
 
         session.close()
 
+    @pytest.mark.parametrize(
+        "region,tenant_domain,azure_environment,admin_url",
+        [
+            (
+                "M365Global",
+                "contoso.onmicrosoft.com",
+                "Production",
+                "https://contoso-admin.sharepoint.com",
+            ),
+            (
+                "M365China",
+                "contoso.partner.onmschina.cn",
+                "China",
+                "https://contoso-admin.sharepoint.cn",
+            ),
+            (
+                "M365USGovernment",
+                "contoso.onmicrosoft.us",
+                "USGovernmentHigh",
+                "https://contoso-admin.sharepoint.us",
+            ),
+        ],
+    )
     @patch("subprocess.Popen")
-    def test_connect_sharepoint_online_certificate_auth(self, mock_popen):
-        """Test connect_sharepoint_online method with certificate authentication"""
-        mock_process = MagicMock()
-        mock_popen.return_value = mock_process
-
-        credentials = M365Credentials()
-        identity = M365IdentityInfo()
-        session = M365PowerShell(credentials, identity)
-
-        execute_calls = []
-
-        def mock_execute_side_effect(command):
-            execute_calls.append(command)
-            if "Write-Output $certificate" in command:
-                return "certificate_content"
-            return ""
-
-        session.execute = MagicMock(side_effect=mock_execute_side_effect)
-        session.test_sharepoint_certificate_connection = MagicMock(return_value=True)
-
-        result = session.connect_sharepoint_online()
-        assert result is True
-        session.test_sharepoint_certificate_connection.assert_called_once()
-        session.close()
-
-    @patch("subprocess.Popen")
-    def test_connect_sharepoint_online_app_auth(self, mock_popen):
-        """Test connect_sharepoint_online method with application authentication"""
-        mock_process = MagicMock()
-        mock_popen.return_value = mock_process
-
-        credentials = M365Credentials()
-        identity = M365IdentityInfo()
-        session = M365PowerShell(credentials, identity)
-
-        execute_calls = []
-
-        def mock_execute_side_effect(command):
-            execute_calls.append(command)
-            if "Write-Output $certificate" in command:
-                return ""
-            return ""
-
-        session.execute = MagicMock(side_effect=mock_execute_side_effect)
-        session.test_sharepoint_connection = MagicMock(return_value=True)
-
-        result = session.connect_sharepoint_online()
-        assert result is True
-        session.test_sharepoint_connection.assert_called_once()
-        session.close()
-
-    @patch("subprocess.Popen")
-    def test_sharepoint_connection(self, mock_popen):
-        """Test test_sharepoint_connection method"""
-        mock_process = MagicMock()
-        mock_popen.return_value = mock_process
-
-        credentials = M365Credentials()
-        identity = M365IdentityInfo(tenant_domain="example.com")
-        session = M365PowerShell(credentials, identity)
-
-        session.execute = MagicMock()
+    def test_connect_sharepoint_online_certificate_auth(
+        self,
+        mock_popen,
+        region,
+        tenant_domain,
+        azure_environment,
+        admin_url,
+    ):
+        """Certificate auth uses validated tenant and sovereign-cloud settings."""
+        mock_popen.return_value = MagicMock()
+        session = M365PowerShell(
+            M365Credentials(),
+            M365IdentityInfo(tenant_domains=[tenant_domain]),
+        )
+        session.execute = MagicMock(
+            side_effect=lambda command, **_: (
+                "certificate_content"
+                if "Write-Output $certificateBase64" in command
+                else ""
+            )
+        )
         session.execute_connect = MagicMock(return_value="Connected")
 
-        result = session.test_sharepoint_connection()
-        assert result is True
-        session.execute.assert_called_once_with(
-            '$spoAdminUrl = "https://" + $tenantDomain.Split(".")[0] + "-admin.sharepoint.com"'
-        )
-        session.execute_connect.assert_called_once_with(
-            "Connect-SPOService -Url $spoAdminUrl; if ($?) { Write-Output 'Connected' }"
-        )
+        assert session.connect_sharepoint_online(region) is True
+
+        commands = [mock_call.args[0] for mock_call in session.execute.call_args_list]
+        connect_command = session.execute_connect.call_args.args[0]
+        assert any(admin_url in command for command in commands)
+        assert any(tenant_domain in command for command in commands)
+        assert "Connect-PnPOnline" in connect_command
+        assert "-CertificateBase64Encoded $certificateBase64" in connect_command
+        assert "-ClientId $clientID" in connect_command
+        assert "-ReturnConnection" in connect_command
+        assert "-ValidateConnection" in connect_command
+        assert "-ErrorAction Stop" in connect_command
+        assert f"-AzureEnvironment {azure_environment}" in connect_command
+        assert "-Interactive" not in connect_command
+        assert "-ClientSecret" not in connect_command
         session.close()
 
     @patch("subprocess.Popen")
-    def test_sharepoint_certificate_connection(self, mock_popen):
-        """Test test_sharepoint_certificate_connection method"""
-        mock_process = MagicMock()
-        mock_popen.return_value = mock_process
+    def test_connect_sharepoint_online_client_secret_skips_without_prompt(
+        self, mock_popen
+    ):
+        """Client-secret auth skips PnP enrichment without starting a prompt."""
+        mock_popen.return_value = MagicMock()
+        session = M365PowerShell(M365Credentials(), M365IdentityInfo())
+        session.execute = MagicMock(return_value="")
+        session.execute_connect = MagicMock()
 
-        credentials = M365Credentials()
-        identity = M365IdentityInfo(tenant_domain="example.com")
-        session = M365PowerShell(credentials, identity)
+        assert session.connect_sharepoint_online("M365Global") is False
+        session.execute_connect.assert_not_called()
+        session.close()
 
-        session.execute = MagicMock()
+    @patch("subprocess.Popen")
+    def test_connect_sharepoint_online_skips_when_pnp_initialization_failed(
+        self, mock_popen
+    ):
+        """Failed PnP initialization disables only SharePoint enrichment."""
+        mock_popen.return_value = MagicMock()
+        session = M365PowerShell(
+            M365Credentials(pnp_powershell_ready=False),
+            M365IdentityInfo(tenant_domains=["contoso.onmicrosoft.com"]),
+        )
+        session.execute = MagicMock(return_value="certificate_content")
         session.execute_connect = MagicMock(return_value="Connected")
 
-        result = session.test_sharepoint_certificate_connection()
-        assert result is True
-        session.execute.assert_called_once_with(
-            '$spoAdminUrl = "https://" + $tenantDomain.Split(".")[0] + "-admin.sharepoint.com"'
-        )
-        session.execute_connect.assert_called_once_with(
-            "Connect-SPOService -Url $spoAdminUrl -Certificate $certificate -ClientId $clientID -TenantId $tenantID; if ($?) { Write-Output 'Connected' }"
-        )
+        assert session.connect_sharepoint_online("M365Global") is False
+        session.execute.assert_not_called()
+        session.execute_connect.assert_not_called()
         session.close()
 
     @patch("subprocess.Popen")
-    def test_sharepoint_connection_failure(self, mock_popen):
-        """Test test_sharepoint_connection method failure"""
-        mock_process = MagicMock()
-        mock_popen.return_value = mock_process
-
-        credentials = M365Credentials()
-        identity = M365IdentityInfo(tenant_domain="example.com")
-        session = M365PowerShell(credentials, identity)
-
-        session.execute = MagicMock()
-        session.execute_connect = MagicMock(
-            return_value="'execute_connect' command timeout reached"
+    def test_connect_sharepoint_online_rejects_unvalidated_tenant_domain(
+        self, mock_popen
+    ):
+        """Custom domains cannot be used to guess the SharePoint admin hostname."""
+        mock_popen.return_value = MagicMock()
+        session = M365PowerShell(
+            M365Credentials(),
+            M365IdentityInfo(tenant_domains=["contoso.example"]),
         )
+        session.execute = MagicMock(return_value="certificate_content")
+        session.execute_connect = MagicMock()
 
-        result = session.test_sharepoint_connection()
-        assert result is False
+        assert session.connect_sharepoint_online("M365Global") is False
+        session.execute_connect.assert_not_called()
+        session.close()
+
+    @pytest.mark.parametrize(
+        "connection_result", ["", "Unexpected", "Connected\nUnexpected"]
+    )
+    @patch("subprocess.Popen")
+    def test_connect_sharepoint_online_validates_connection_result(
+        self, mock_popen, connection_result
+    ):
+        """Only the explicit PnP connection success marker enables enrichment."""
+        mock_popen.return_value = MagicMock()
+        session = M365PowerShell(
+            M365Credentials(),
+            M365IdentityInfo(tenant_domains=["contoso.onmicrosoft.com"]),
+        )
+        session.execute = MagicMock(return_value="certificate_content")
+        session.execute_connect = MagicMock(return_value=connection_result)
+
+        assert session.connect_sharepoint_online("M365Global") is False
         session.close()
 
     @patch("subprocess.Popen")
-    def test_sharepoint_certificate_connection_failure(self, mock_popen):
-        """Test test_sharepoint_certificate_connection method failure"""
-        mock_process = MagicMock()
-        mock_popen.return_value = mock_process
-
-        credentials = M365Credentials()
-        identity = M365IdentityInfo(tenant_domain="example.com")
-        session = M365PowerShell(credentials, identity)
-
-        session.execute = MagicMock()
-        session.execute_connect = MagicMock(
-            return_value="error connecting to SharePoint"
-        )
-
-        result = session.test_sharepoint_certificate_connection()
-        assert result is False
-        session.close()
-
-    @patch("subprocess.Popen")
-    def test_sharepoint_connection_exception(self, mock_popen):
-        """Test test_sharepoint_connection method exception"""
-        mock_process = MagicMock()
-        mock_popen.return_value = mock_process
-
-        credentials = M365Credentials()
-        identity = M365IdentityInfo(tenant_domain="example.com")
-        session = M365PowerShell(credentials, identity)
-
-        session.execute = MagicMock(side_effect=Exception("SharePoint API error"))
-
-        with patch("prowler.lib.logger.logger.error") as mock_error:
-            result = session.test_sharepoint_connection()
-
-        assert result is False
-        mock_error.assert_called_once_with(
-            "SharePoint Online connection failed: SharePoint API error. Please check your permissions and try again."
-        )
-        session.close()
-
-    @patch("subprocess.Popen")
-    def test_sharepoint_certificate_connection_exception(self, mock_popen):
-        """Test test_sharepoint_certificate_connection method exception"""
-        mock_process = MagicMock()
-        mock_popen.return_value = mock_process
-
-        credentials = M365Credentials()
-        identity = M365IdentityInfo(tenant_domain="example.com")
-        session = M365PowerShell(credentials, identity)
-
-        session.execute = MagicMock(side_effect=Exception("SharePoint API error"))
-
-        with patch("prowler.lib.logger.logger.error") as mock_error:
-            result = session.test_sharepoint_certificate_connection()
-
-        assert result is False
-        mock_error.assert_called_once_with(
-            "SharePoint Online Certificate connection failed: SharePoint API error"
-        )
-        session.close()
-
-    @patch("subprocess.Popen")
-    def test_get_sharepoint_tenant_config(self, mock_popen):
-        """Test get_sharepoint_tenant_config method"""
-        mock_process = MagicMock()
-        mock_popen.return_value = mock_process
-
-        credentials = M365Credentials()
-        identity = M365IdentityInfo()
-        session = M365PowerShell(credentials, identity)
-
+    def test_get_sharepoint_tenant_config_projects_default_permission(self, mock_popen):
+        """Tenant retrieval uses the retained PnP connection and string enums."""
+        mock_popen.return_value = MagicMock()
+        session = M365PowerShell(M365Credentials(), M365IdentityInfo())
         expected_result = {"DefaultLinkPermission": "View"}
         session.execute = MagicMock(return_value=expected_result)
 
-        result = session.get_sharepoint_tenant_config()
-        assert result == expected_result
-        session.execute.assert_called_once_with(
-            "Get-SPOTenant | ConvertTo-Json -Depth 10", json_parse=True
+        assert session.get_sharepoint_tenant_config() == expected_result
+
+        command = session.execute.call_args.args[0]
+        assert "Get-PnPTenant -Connection $sharePointConnection" in command
+        assert "Select-Object DefaultLinkPermission" in command
+        assert "ConvertTo-Json -Compress -EnumsAsStrings" in command
+        assert "Get-SPOTenant" not in command
+        session.close()
+
+    @patch("subprocess.Popen")
+    def test_certificate_content_is_not_logged(self, mock_popen):
+        """The in-memory PFX value must never be written to logs."""
+        mock_popen.return_value = MagicMock()
+        certificate_content = "sensitive-base64-pfx"
+        credentials = M365Credentials(
+            client_id="client-id",
+            tenant_id="tenant-id",
+            tenant_domains=["contoso.onmicrosoft.com"],
+            certificate_content=certificate_content,
         )
+        with patch.object(M365PowerShell, "init_credential"):
+            session = M365PowerShell(credentials, M365IdentityInfo())
+        session.execute = MagicMock(return_value="")
+
+        with (
+            patch("prowler.lib.logger.logger.info") as info,
+            patch("prowler.lib.logger.logger.warning") as warning,
+            patch("prowler.lib.logger.logger.error") as error,
+        ):
+            M365PowerShell.init_credential(session, credentials)
+
+        logged = " ".join(
+            str(mock_call)
+            for logger_mock in (info, warning, error)
+            for mock_call in logger_mock.call_args_list
+        )
+        assert certificate_content not in logged
+        session.execute.assert_any_call(f'$certificateBase64 = "{certificate_content}"')
         session.close()

--- a/tests/providers/m365/m365_provider_test.py
+++ b/tests/providers/m365/m365_provider_test.py
@@ -534,7 +534,8 @@ class TestM365Provider:
         with (
             patch("prowler.providers.m365.m365_provider.M365PowerShell") as mock_ps,
             patch(
-                "prowler.providers.m365.m365_provider.initialize_m365_powershell_modules"
+                "prowler.providers.m365.m365_provider.initialize_m365_powershell_modules",
+                return_value=True,
             ) as mock_init_modules,
         ):
             mock_session = MagicMock()
@@ -542,7 +543,7 @@ class TestM365Provider:
             mock_session.close = MagicMock()
             mock_ps.return_value = mock_session
 
-            M365Provider.setup_powershell(
+            credentials = M365Provider.setup_powershell(
                 m365_credentials=credentials_dict,
                 identity=M365IdentityInfo(
                     identity_id=IDENTITY_ID,
@@ -555,6 +556,7 @@ class TestM365Provider:
                 init_modules=True,
             )
             mock_init_modules.assert_called_once()
+            assert credentials.pnp_powershell_ready is True
 
     def test_setup_powershell_init_modules_failure(self):
         """Test that setup_powershell handles initialization failures correctly"""
@@ -591,6 +593,41 @@ class TestM365Provider:
                 )
 
             assert str(exc_info.value) == "Module initialization failed"
+
+    def test_setup_powershell_marks_pnp_unready_when_initialization_returns_false(
+        self,
+    ):
+        """A failed module initializer preserves credentials but disables PnP."""
+        credentials_dict = {
+            "client_id": "test_client_id",
+            "tenant_id": "test_tenant_id",
+            "client_secret": "test_client_secret",
+        }
+        identity = M365IdentityInfo(
+            identity_id=IDENTITY_ID,
+            identity_type="User",
+            tenant_id=TENANT_ID,
+            tenant_domain=DOMAIN,
+            tenant_domains=["test.onmicrosoft.com"],
+            location=LOCATION,
+        )
+
+        with (
+            patch("prowler.providers.m365.m365_provider.M365PowerShell") as mock_ps,
+            patch(
+                "prowler.providers.m365.m365_provider.initialize_m365_powershell_modules",
+                return_value=False,
+            ),
+        ):
+            credentials = M365Provider.setup_powershell(
+                m365_credentials=credentials_dict,
+                identity=identity,
+                init_modules=True,
+            )
+
+        assert credentials.client_secret == "test_client_secret"
+        assert credentials.pnp_powershell_ready is False
+        mock_ps.return_value.close.assert_called_once_with()
 
     def test_test_connection_provider_id_not_in_tenant_domains(self):
         """Test that an exception is raised when provider_id is not in tenant_domains"""

--- a/tests/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured_test.py
+++ b/tests/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured_test.py
@@ -8,6 +8,28 @@ from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
 
 
 class Test_sharepoint_default_sharing_link_permission_configured:
+    def test_no_settings(self):
+        sharepoint_client = mock.MagicMock
+        sharepoint_client.settings = None
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured.sharepoint_client",
+                new=sharepoint_client,
+            ),
+        ):
+            from prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured import (
+                sharepoint_default_sharing_link_permission_configured,
+            )
+
+            result = sharepoint_default_sharing_link_permission_configured().execute()
+
+        assert result == []
+
     def test_sharepoint_default_sharing_link_permission_configured_view(self):
         sharepoint_client = mock.MagicMock
 

--- a/tests/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured_test.py
+++ b/tests/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured_test.py
@@ -1,0 +1,125 @@
+import uuid
+from unittest import mock
+
+from prowler.providers.m365.services.sharepoint.sharepoint_service import (
+    SharePointSettings,
+)
+from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
+
+
+class Test_sharepoint_default_sharing_link_permission_configured:
+    def test_sharepoint_default_sharing_link_permission_configured_view(self):
+        sharepoint_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch("prowler.providers.m365.lib.service.service.M365PowerShell"),
+            mock.patch(
+                "prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured.sharepoint_client",
+                new=sharepoint_client,
+            ),
+        ):
+            from prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured import (
+                sharepoint_default_sharing_link_permission_configured,
+            )
+
+            sharepoint_client.settings = SharePointSettings(
+                sharingCapability="ExternalUserSharingOnly",
+                sharingAllowedDomainList=[],
+                sharingBlockedDomainList=[],
+                sharingDomainRestrictionMode="none",
+                resharingEnabled=False,
+                legacyAuth=False,
+                allowedDomainGuidsForSyncApp=[uuid.uuid4()],
+                defaultLinkPermission="View",
+            )
+            sharepoint_client.tenant_domain = DOMAIN
+
+            check = sharepoint_default_sharing_link_permission_configured()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SharePoint default sharing link permission is set to 'View'."
+            )
+            assert result[0].resource_name == "SharePoint Settings"
+            assert result[0].resource_id == "sharepointSettings"
+
+    def test_sharepoint_default_sharing_link_permission_configured_edit(self):
+        sharepoint_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch("prowler.providers.m365.lib.service.service.M365PowerShell"),
+            mock.patch(
+                "prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured.sharepoint_client",
+                new=sharepoint_client,
+            ),
+        ):
+            from prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured import (
+                sharepoint_default_sharing_link_permission_configured,
+            )
+
+            sharepoint_client.settings = SharePointSettings(
+                sharingCapability="ExternalUserSharingOnly",
+                sharingAllowedDomainList=[],
+                sharingBlockedDomainList=[],
+                sharingDomainRestrictionMode="none",
+                resharingEnabled=False,
+                legacyAuth=False,
+                allowedDomainGuidsForSyncApp=[uuid.uuid4()],
+                defaultLinkPermission="Edit",
+            )
+            sharepoint_client.tenant_domain = DOMAIN
+
+            check = sharepoint_default_sharing_link_permission_configured()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "SharePoint default sharing link permission is set to 'Edit'."
+            )
+            assert result[0].resource_name == "SharePoint Settings"
+            assert result[0].resource_id == "sharepointSettings"
+
+    def test_sharepoint_default_sharing_link_permission_none(self):
+        sharepoint_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch("prowler.providers.m365.lib.service.service.M365PowerShell"),
+            mock.patch(
+                "prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured.sharepoint_client",
+                new=sharepoint_client,
+            ),
+        ):
+            from prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured import (
+                sharepoint_default_sharing_link_permission_configured,
+            )
+
+            sharepoint_client.settings = SharePointSettings(
+                sharingCapability="ExternalUserSharingOnly",
+                sharingAllowedDomainList=[],
+                sharingBlockedDomainList=[],
+                sharingDomainRestrictionMode="none",
+                resharingEnabled=False,
+                legacyAuth=False,
+                allowedDomainGuidsForSyncApp=[uuid.uuid4()],
+                defaultLinkPermission=None,
+            )
+            sharepoint_client.tenant_domain = DOMAIN
+
+            check = sharepoint_default_sharing_link_permission_configured()
+            result = check.execute()
+            assert len(result) == 0

--- a/tests/providers/m365/services/sharepoint/sharepoint_service_test.py
+++ b/tests/providers/m365/services/sharepoint/sharepoint_service_test.py
@@ -1,7 +1,7 @@
 import uuid
 from unittest.mock import patch
 
-from prowler.providers.m365.models import M365IdentityInfo
+from prowler.providers.m365.models import M365IdentityInfo, M365RegionConfig
 from prowler.providers.m365.services.sharepoint.sharepoint_service import (
     SharePoint,
     SharePointSettings,
@@ -49,3 +49,64 @@ class Test_SharePoint_Service:
         assert settings.legacyAuth is True
         assert settings.allowedDomainGuidsForSyncApp == [uuid_value]
         assert len(settings.allowedDomainGuidsForSyncApp) == 1
+
+
+class Test_SharePoint_PowerShell_Initialization:
+    def test_failed_connection_skips_tenant_configuration(self):
+        with (
+            patch(
+                "prowler.providers.m365.lib.service.service.M365PowerShell"
+            ) as powershell_class,
+            patch.object(
+                SharePoint,
+                "_get_settings",
+                new=mock_sharepoint_get_settings,
+            ),
+        ):
+            powershell = powershell_class.return_value
+            powershell.connect_sharepoint_online.return_value = False
+
+            sharepoint_client = SharePoint(
+                set_mocked_m365_provider(
+                    azure_region_config=M365RegionConfig(name="M365Global")
+                )
+            )
+
+        powershell.connect_sharepoint_online.assert_called_once_with("M365Global")
+        powershell.get_sharepoint_tenant_config.assert_not_called()
+        powershell.close.assert_called_once_with()
+        assert sharepoint_client.tenant_settings is None
+        assert sharepoint_client.settings.sharingCapability == (
+            "ExternalUserAndGuestSharing"
+        )
+
+    def test_certificate_connection_enriches_graph_settings(self):
+        with (
+            patch(
+                "prowler.providers.m365.lib.service.service.M365PowerShell"
+            ) as powershell_class,
+            patch.object(
+                SharePoint,
+                "_get_settings",
+                new=mock_sharepoint_get_settings,
+            ),
+        ):
+            powershell = powershell_class.return_value
+            powershell.connect_sharepoint_online.return_value = True
+            powershell.get_sharepoint_tenant_config.return_value = {
+                "DefaultLinkPermission": "View"
+            }
+
+            sharepoint_client = SharePoint(
+                set_mocked_m365_provider(
+                    azure_region_config=M365RegionConfig(name="M365China")
+                )
+            )
+
+        powershell.connect_sharepoint_online.assert_called_once_with("M365China")
+        powershell.get_sharepoint_tenant_config.assert_called_once_with()
+        powershell.close.assert_called_once_with()
+        assert sharepoint_client.tenant_settings == {"DefaultLinkPermission": "View"}
+        assert sharepoint_client.settings.sharingCapability == (
+            "ExternalUserAndGuestSharing"
+        )


### PR DESCRIPTION
 ### Context                                                                                              
                                                                                                           
  Adds a Microsoft 365 SharePoint check to validate the default sharing link permission setting.           
                                                                                                           
  The default sharing link permission controls the level of access granted when users share files or       
  folders. Defaulting new sharing links to "Edit" grants unnecessary write access and increases the blast  
  radius of accidental oversharing. This check ensures the default link permission is set to "View" rather 
  than "Edit" to align with the principle of least privilege.      
  
  
  Fixes #11802                                         
                                                                                                           
  ### Description                                                                                          
                                                                                                           
  This PR adds sharepoint_default_sharing_link_permission_configured.                                      
                                                                                                           
  The check evaluates the SharePoint tenant settings and verifies that the DefaultLinkPermission property  
  is set to "View".                                                                                        
                                                                                                           
  Note on implementation details: The property DefaultLinkPermission is unfortunately not exposed through  
  the standard Microsoft Graph API for SharePoint Settings (admin.sharepoint.settings). Because this       
  functionality was missing from the current Graph API, we had to introduce new PowerShell functions       
  (connect_sharepoint_online and get_sharepoint_tenant_config) leveraging Connect-SPOService and Get-      
  SPOTenant in m365_powershell.py and integrate them into sharepoint_service.py to securely fetch the      
  tenant configuration.                                                                                    
                                                                                                           
  Changes included:                                                                                        
                                                                                                           
  • Extend M365PowerShell module with connect_sharepoint_online and get_sharepoint_tenant_config to support
  fetching SharePoint configurations not available via Graph API.                                          
  • Update sharepoint_service.py to retrieve DefaultLinkPermission during initialization using the new     
  PowerShell session and append it to the SharePointSettings model.                                        
  • Add the new SharePoint check and corresponding metadata following the CIS Microsoft 365 Benchmark.     
  • Add focused unit tests mocking both the M365 global provider and the newly introduced PowerShell       
  connectivity behavior.                                                                                   
  • No new Graph API provider permissions are required.                                                    
                                                                                                           
  ### Steps to review                                                                                      
                                                                                                           
  1. Review the new PowerShell connection extensions in                                                   
  prowler/providers/m365/lib/powershell/m365_powershell.py.                                                
  2.  Review the DefaultLinkPermission enrichment in                                                       
  prowler/providers/m365/services/sharepoint/sharepoint_service.py.                                        
  3.  Review the new check logic under                                                                     
  prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/.       
  4. Review the new metadata file for severity, remediation, and references.                              
  5. Run the focused tests:   
``` bash                                                                                                     
  uv run pytest                                                                                                   
  tests/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint
  _default_sharing_link_permission_configured_test.py 


```                                                     
                                                                                                           
  - [ ] Review if the code is being covered by tests.                                                        
  - [ ] Review if code is being documented following this specification https://github.                      
  com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings                                
  - [ ] Review if backport is needed.                                                                        
  - [ ] Review if is needed to change the README.md.
  - [x] Ensure new entries are added to CHANGELOG.md, if applicable.
  
  ### SDK/CLI
  
  • Are there new checks included in this PR? Yes
  • If so, do we need to update permissions for the provider? Please review this carefully. No             
  
  ### License
  
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0
  license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an Entra Conditional Access check to validate security groups referenced in include/exclude settings.
  - Added a SharePoint check to confirm the default sharing link permission is set to **View**.
  - Added SharePoint Online connectivity and tenant configuration retrieval support to improve check accuracy.

- **Bug Fixes**
  - Improved Entra group property handling by ensuring missing role/management restrictions are treated as `false`.
  - Enhanced Entra group retrieval to use a projected, paged query.

- **Tests**
  - Added unit tests for the new Entra and SharePoint checks, and for SharePoint connectivity/tenant configuration behavior.

- **Documentation**
  - Updated the changelog for the Entra check entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->