### PR TITLE
feat(m365): add CIS M365 v7.0.0 teams external access check

### DIFF
--- a/prowler/changelog.d/m365-cis7-teams.added.md
+++ b/prowler/changelog.d/m365-cis7-teams.added.md
@@ -1,1 +1,1 @@
-1 M365 teams check covering CIS Microsoft 365 Foundations Benchmark v7.0.0 control 8.2.4
+`teams_external_access_trial_tenants_blocked` check for M365 provider, verifying that Teams external access with trial-only tenants is blocked, covering CIS Microsoft 365 Foundations Benchmark v7.0.0 control 8.2.4

--- a/prowler/changelog.d/m365-cis7-teams.added.md
+++ b/prowler/changelog.d/m365-cis7-teams.added.md
@@ -1,0 +1,1 @@
+1 M365 teams check covering CIS Microsoft 365 Foundations Benchmark v7.0.0 control 8.2.4

--- a/prowler/compliance/m365/cis_7.0_m365.json
+++ b/prowler/compliance/m365/cis_7.0_m365.json
@@ -3088,7 +3088,9 @@
     {
       "Id": "8.2.4",
       "Description": "This setting controls the organization's external access with Teams \"trial-only\" tenants. These are tenants that don't have any purchased seats. When set to Blocked, users from these trial-only tenants aren't able to search and contact your users via chats, Teams calls, and meetings (using the users' authenticated identities) and your users aren't able to reach users in these trial-only tenants. Users from the trial-only tenant are also removed from existing chats. The recommended state for People in my organization can communicate with accounts in trial Teams tenant is Off.",
-      "Checks": [],
+      "Checks": [
+        "teams_external_access_trial_tenants_blocked"
+      ],
       "Attributes": [
         {
           "Section": "8 Microsoft Teams admin center",

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -325,7 +325,9 @@ class M365PowerShell(PowerShellSession):
         """
         Get Teams User Settings.
 
-        Retrieves the current Microsoft Teams user settings.
+        Retrieves the current Microsoft Teams user settings. Enum-typed properties
+        (e.g. ExternalAccessWithTrialTenants) are serialized as their string names
+        rather than numeric values.
 
         Returns:
             dict: Teams user settings in JSON format.
@@ -337,7 +339,7 @@ class M365PowerShell(PowerShellSession):
             }
         """
         return self.execute(
-            "Get-CsTenantFederationConfiguration | ConvertTo-Json -Depth 10",
+            "Get-CsTenantFederationConfiguration | ConvertTo-Json -Depth 10 -EnumsAsStrings",
             json_parse=True,
         )
 

--- a/prowler/providers/m365/services/teams/teams_external_access_trial_tenants_blocked/teams_external_access_trial_tenants_blocked.metadata.json
+++ b/prowler/providers/m365/services/teams/teams_external_access_trial_tenants_blocked/teams_external_access_trial_tenants_blocked.metadata.json
@@ -1,0 +1,37 @@
+{
+  "Provider": "m365",
+  "CheckID": "teams_external_access_trial_tenants_blocked",
+  "CheckTitle": "External access with Teams trial-only tenants is blocked",
+  "CheckType": [],
+  "ServiceName": "teams",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "NotDefined",
+  "ResourceGroup": "collaboration",
+  "Description": "The Teams external access configuration should **block** communication with **trial-only** tenants (tenants that don't have any purchased seats). When blocked, users from these trial-only tenants cannot search for, contact, call, or meet with the organization's users via Teams external access.",
+  "Risk": "Trial-only tenants can be created quickly and anonymously, making them a common vector for social engineering and **phishing**. Allowing external access with them lets untrusted actors reach employees through Teams chats, calls, and meetings.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/microsoftteams/manage-external-access"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "Set-CsTenantFederationConfiguration -ExternalAccessWithTrialTenants Blocked",
+      "NativeIaC": "",
+      "Other": "1. Navigate to the Microsoft Teams admin center at https://admin.teams.microsoft.com/\n2. Go to **External collaboration** > **External access** > **Organization settings**\n3. Set **People in my organization can communicate with accounts in trial Teams tenants** to **Off**\n4. Click **Save**",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Block external access with Teams trial-only tenants so that users from tenants without purchased seats cannot contact your organization through Teams.",
+      "Url": "https://hub.prowler.com/check/teams_external_access_trial_tenants_blocked"
+    }
+  },
+  "Categories": [
+    "trust-boundaries",
+    "e3"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/m365/services/teams/teams_external_access_trial_tenants_blocked/teams_external_access_trial_tenants_blocked.metadata.json
+++ b/prowler/providers/m365/services/teams/teams_external_access_trial_tenants_blocked/teams_external_access_trial_tenants_blocked.metadata.json
@@ -6,7 +6,7 @@
   "ServiceName": "teams",
   "SubServiceName": "",
   "ResourceIdTemplate": "",
-  "Severity": "medium",
+  "Severity": "high",
   "ResourceType": "NotDefined",
   "ResourceGroup": "collaboration",
   "Description": "The Teams external access configuration should **block** communication with **trial-only** tenants (tenants that don't have any purchased seats). When blocked, users from these trial-only tenants cannot search for, contact, call, or meet with the organization's users via Teams external access.",
@@ -33,5 +33,5 @@
   ],
   "DependsOn": [],
   "RelatedTo": [],
-  "Notes": ""
+  "Notes": "The check evaluates the ExternalAccessWithTrialTenants property from Get-CsTenantFederationConfiguration. Microsoft's service default for this setting is Blocked, so if the property is absent from the cmdlet output the check assumes the default (secure) state and passes."
 }

--- a/prowler/providers/m365/services/teams/teams_external_access_trial_tenants_blocked/teams_external_access_trial_tenants_blocked.py
+++ b/prowler/providers/m365/services/teams/teams_external_access_trial_tenants_blocked/teams_external_access_trial_tenants_blocked.py
@@ -1,0 +1,46 @@
+from typing import List
+
+from prowler.lib.check.models import Check, CheckReportM365
+from prowler.providers.m365.services.teams.teams_client import teams_client
+
+
+class teams_external_access_trial_tenants_blocked(Check):
+    """Check if external access with Teams trial-only tenants is blocked.
+
+    This setting controls external access with Teams "trial-only" tenants (tenants
+    that don't have any purchased seats). When blocked, users from those tenants
+    cannot search for, chat, call, or meet with the organization's users.
+
+    - PASS: External access with trial-only tenants is blocked.
+    - FAIL: External access with trial-only tenants is allowed.
+    """
+
+    def execute(self) -> List[CheckReportM365]:
+        """Execute the check for external access with trial-only Teams tenants.
+
+        Returns:
+            List[CheckReportM365]: A list of reports containing the result of the check.
+        """
+        findings = []
+        user_settings = teams_client.user_settings
+        if user_settings:
+            report = CheckReportM365(
+                metadata=self.metadata(),
+                resource=user_settings,
+                resource_name="Teams User Settings",
+                resource_id="userSettings",
+            )
+            report.status = "FAIL"
+            report.status_extended = (
+                "External access with Teams trial-only tenants is allowed."
+            )
+
+            if user_settings.external_access_with_trial_tenants == "Blocked":
+                report.status = "PASS"
+                report.status_extended = (
+                    "External access with Teams trial-only tenants is blocked."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/m365/services/teams/teams_service.py
+++ b/prowler/providers/m365/services/teams/teams_service.py
@@ -119,6 +119,9 @@ class Teams(M365Service):
                     allow_teams_consumer_inbound=settings.get(
                         "AllowTeamsConsumerInbound", True
                     ),
+                    external_access_with_trial_tenants=settings.get(
+                        "ExternalAccessWithTrialTenants", "Allowed"
+                    ),
                 )
         except Exception as error:
             logger.error(
@@ -160,3 +163,4 @@ class UserSettings(BaseModel):
     allow_external_access: bool = True
     allow_teams_consumer: bool = True
     allow_teams_consumer_inbound: bool = True
+    external_access_with_trial_tenants: str = "Allowed"

--- a/prowler/providers/m365/services/teams/teams_service.py
+++ b/prowler/providers/m365/services/teams/teams_service.py
@@ -120,7 +120,7 @@ class Teams(M365Service):
                         "AllowTeamsConsumerInbound", True
                     ),
                     external_access_with_trial_tenants=settings.get(
-                        "ExternalAccessWithTrialTenants", "Allowed"
+                        "ExternalAccessWithTrialTenants", "Blocked"
                     ),
                 )
         except Exception as error:
@@ -163,4 +163,6 @@ class UserSettings(BaseModel):
     allow_external_access: bool = True
     allow_teams_consumer: bool = True
     allow_teams_consumer_inbound: bool = True
-    external_access_with_trial_tenants: str = "Allowed"
+    # Microsoft's service default for ExternalAccessWithTrialTenants is Blocked,
+    # so an absent property is assumed to be in the default (secure) state.
+    external_access_with_trial_tenants: str = "Blocked"

--- a/tests/providers/m365/services/teams/teams_external_access_trial_tenants_blocked/teams_external_access_trial_tenants_blocked_test.py
+++ b/tests/providers/m365/services/teams/teams_external_access_trial_tenants_blocked/teams_external_access_trial_tenants_blocked_test.py
@@ -1,0 +1,45 @@
+from unittest import mock
+
+from prowler.providers.m365.services.teams.teams_service import UserSettings
+from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
+
+CHECK_MODULE_PATH = "prowler.providers.m365.services.teams.teams_external_access_trial_tenants_blocked.teams_external_access_trial_tenants_blocked"
+
+
+class Test_teams_external_access_trial_tenants_blocked:
+    def _run(self, user_settings):
+        teams_client = mock.MagicMock()
+        teams_client.audited_domain = DOMAIN
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_microsoft_teams"
+            ),
+            mock.patch(f"{CHECK_MODULE_PATH}.teams_client", new=teams_client),
+        ):
+            from prowler.providers.m365.services.teams.teams_external_access_trial_tenants_blocked.teams_external_access_trial_tenants_blocked import (
+                teams_external_access_trial_tenants_blocked,
+            )
+
+            teams_client.user_settings = user_settings
+            return teams_external_access_trial_tenants_blocked().execute()
+
+    def test_no_user_settings(self):
+        assert self._run(None) == []
+
+    def test_trial_tenants_blocked(self):
+        result = self._run(UserSettings(external_access_with_trial_tenants="Blocked"))
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert (
+            result[0].status_extended
+            == "External access with Teams trial-only tenants is blocked."
+        )
+
+    def test_trial_tenants_allowed(self):
+        result = self._run(UserSettings(external_access_with_trial_tenants="Allowed"))
+        assert len(result) == 1
+        assert result[0].status == "FAIL"

--- a/tests/providers/m365/services/teams/teams_external_access_trial_tenants_blocked/teams_external_access_trial_tenants_blocked_test.py
+++ b/tests/providers/m365/services/teams/teams_external_access_trial_tenants_blocked/teams_external_access_trial_tenants_blocked_test.py
@@ -38,8 +38,23 @@ class Test_teams_external_access_trial_tenants_blocked:
             result[0].status_extended
             == "External access with Teams trial-only tenants is blocked."
         )
+        assert result[0].resource_name == "Teams User Settings"
+        assert result[0].resource_id == "userSettings"
 
     def test_trial_tenants_allowed(self):
         result = self._run(UserSettings(external_access_with_trial_tenants="Allowed"))
         assert len(result) == 1
         assert result[0].status == "FAIL"
+        assert (
+            result[0].status_extended
+            == "External access with Teams trial-only tenants is allowed."
+        )
+        assert result[0].resource_name == "Teams User Settings"
+        assert result[0].resource_id == "userSettings"
+
+    def test_trial_tenants_default(self):
+        # ExternalAccessWithTrialTenants absent from the cmdlet output: the model
+        # falls back to Microsoft's service default (Blocked), so the check passes.
+        result = self._run(UserSettings())
+        assert len(result) == 1
+        assert result[0].status == "PASS"

--- a/tests/providers/m365/services/teams/teams_service_test.py
+++ b/tests/providers/m365/services/teams/teams_service_test.py
@@ -48,6 +48,7 @@ def mock_get_user_settings(_):
         allow_external_access=False,
         allow_teams_consumer=False,
         allow_teams_consumer_inbound=False,
+        external_access_with_trial_tenants="Blocked",
     )
 
 
@@ -113,8 +114,32 @@ class Test_Teams_Service:
                 allow_external_access=False,
                 allow_teams_consumer=False,
                 allow_teams_consumer_inbound=False,
+                external_access_with_trial_tenants="Blocked",
             )
             teams_client.powershell.close()
+
+    def test_get_user_settings_parses_external_access_with_trial_tenants(self):
+        service = Teams.__new__(Teams)
+        service.powershell = mock.MagicMock()
+        service.powershell.get_user_settings.return_value = {
+            "AllowFederatedUsers": True,
+            "AllowTeamsConsumer": True,
+            "AllowTeamsConsumerInbound": True,
+            "ExternalAccessWithTrialTenants": "Allowed",
+        }
+        user_settings = Teams._get_user_settings(service)
+        assert user_settings.external_access_with_trial_tenants == "Allowed"
+
+    def test_get_user_settings_trial_tenants_defaults_to_blocked_when_absent(self):
+        # Older MicrosoftTeams module versions do not return the property; the
+        # parser assumes Microsoft's service default (Blocked).
+        service = Teams.__new__(Teams)
+        service.powershell = mock.MagicMock()
+        service.powershell.get_user_settings.return_value = {
+            "AllowFederatedUsers": True,
+        }
+        user_settings = Teams._get_user_settings(service)
+        assert user_settings.external_access_with_trial_tenants == "Blocked"
 
     @patch(
         "prowler.providers.m365.services.teams.teams_service.Teams._get_global_meeting_policy",


### PR DESCRIPTION
### Context

Part of the split of #12102, which added 37 M365 checks in a single pull request. It was broken up per service so each piece can be reviewed on its own; this one covers **teams**.

The CIS Microsoft 365 Foundations Benchmark v7.0.0 framework (`cis_7.0_m365`) defines 160 controls, and 64 of its "Automated" controls had no Prowler check.

### Description

Adds **1 M365 `teams` check** mapped to `cis_7.0_m365.json`:

| CIS control | Check |
|---|---|
| 8.2.4 | `teams_external_access_trial_tenants_blocked` |

**Data collection.** No new getter: one new field (`ExternalAccessWithTrialTenants`) on the existing user settings model.

Each check ships with its implementation, `metadata.json` and unit tests (PASS / FAIL / edge cases).

### Steps to review

1. **Discovery:** `uv run python prowler-cli.py m365 --list-checks | grep -E "teams_external_access_trial_tenants_blocked"`
2. **Tests:** `uv run pytest tests/providers/m365/services/teams/`
3. **Compliance mapping:** review the 1 requirement(s) touched in `prowler/compliance/m365/cis_7.0_m365.json`.
5. Spot-check the check logic against the CIS audit procedures (fail-closed defaults; Conditional Access report-only treated as FAIL).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

#### SDK/CLI
- Are there new checks included in this PR? **Yes** (1 M365 check)
    - No new permissions: reuses the Exchange Online / Teams sessions the provider already establishes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Microsoft Teams security check to verify that external access with trial-only tenants is blocked.
  * Reports a passing status when trial-tenant access is blocked and a failing status when it is allowed.
  * Treats missing configuration as blocked by default.
  * Added remediation guidance and CIS Microsoft 365 Foundations Benchmark v7.0.0 control mapping.

* **Tests**
  * Added coverage for blocked, allowed, missing, and default Teams settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->