### PR TITLE
docs(security): document the US region

### DIFF
--- a/docs/security/data-regions.mdx
+++ b/docs/security/data-regions.mdx
@@ -9,7 +9,9 @@ Prowler Cloud runs on AWS with high availability built in.
 | Region | URL | Location |
 |--------|-----|----------|
 | **EU** | [cloud.prowler.com](https://cloud.prowler.com) | Ireland (`eu-west-1`) |
-| **US** | On-Demand | On-Demand |
+| **US** | [cloud.us.prowler.com](https://cloud.us.prowler.com) | N. Virginia (`us-east-1`) |
+
+Each region is fully isolated: data stays in the region where the account was created and is never replicated to the other.
 
 
 ## Business Continuity

--- a/docs/security/networking.mdx
+++ b/docs/security/networking.mdx
@@ -6,18 +6,22 @@ title: 'Networking'
 
 Prowler Cloud makes outbound API calls to scan cloud provider accounts and connect to integrations. Allowlist these IPs in firewalls or security groups to restrict access to Prowler Cloud only.
 
-| Region | IP Address |
-|--------|------------|
-| EU (Ireland) | `52.48.254.174` |
+Allowlist only the region hosting the account. Each region egresses from its own IP address.
+
+| Region | IP Address | DNS |
+|--------|------------|-----|
+| EU (Ireland) | `52.48.254.174` | `egress.prowler.com` |
+| US (N. Virginia) | `18.213.69.80` | `egress.us.prowler.com` |
 
 Resolve the egress IP via DNS:
 
 ```bash
-dig egress.prowler.com +short
+dig egress.prowler.com +short      # EU
+dig egress.us.prowler.com +short   # US
 ```
 
 <Note>
-The egress IP address is stable, but it is recommended to periodically verify it remains current by querying `egress.prowler.com`.
+The egress IP addresses are stable, but it is recommended to periodically verify they remain current by querying the DNS names above.
 </Note>
 
 ## Use Cases


### PR DESCRIPTION
> **DO NOT MERGE YET — blocked on two things:**
> 1. `cloud.us.prowler.com` is not yet publicly reachable — it must be serving before this publishes, otherwise the docs point readers at a URL that does not answer.
> 2. `egress.us.prowler.com` does not exist yet; the DNS record is a separate platform PR that must be applied first.

### Context

The US region is live but the docs still listed it as "On-Demand" placeholder and the networking page only documented the EU egress IP.

### Description

- `docs/security/data-regions.mdx`: replaces the US row placeholder with the actual URL (`cloud.us.prowler.com`) and location (N. Virginia, `us-east-1`), and adds a sentence clarifying that each region is fully isolated (data is never replicated across regions).
- `docs/security/networking.mdx`: adds a DNS column to the egress IP table, adds the US row (`18.213.69.80` / `egress.us.prowler.com`), adds a note to allowlist only the region hosting the account, extends the `dig` example to cover both regions, and rewords the stability note to plural.


### Steps to review

- Read through both files and confirm the US region info (URL, region, egress IP, DNS name) is accurate before this merges.
- Do not merge until the two blockers above are resolved (ALB repoint, `egress.us.prowler.com` DNS record).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated regional documentation with the US hosting location in N. Virginia (`us-east-1`) and its regional access URL.
  * Clarified networking allowlisting requirements for region-specific egress IPs.
  * Added EU and US egress IP addresses, DNS names, and lookup examples.
  * Recommended periodically verifying egress IPs through the provided regional DNS names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
