### PR TITLE
feat(providers/huaweicloud): add dcs_instance_not_public check

### DIFF
--- a/prowler/changelog.d/dcs-instance-not-public.added.md
+++ b/prowler/changelog.d/dcs-instance-not-public.added.md
@@ -1,0 +1,1 @@
+`dcs_instance_not_public` check for Huawei Cloud provider, detecting DCS (Distributed Cache Service) instances with public network accessibility

--- a/prowler/providers/huaweicloud/services/dcs/dcs_client.py
+++ b/prowler/providers/huaweicloud/services/dcs/dcs_client.py
@@ -1,0 +1,4 @@
+from prowler.providers.huaweicloud.services.dcs.dcs_service import DCS
+from prowler.providers.common.provider import Provider
+
+dcs_client = DCS(Provider.get_global_provider())

--- a/prowler/providers/huaweicloud/services/dcs/dcs_instance_not_public/dcs_instance_not_public.metadata.json
+++ b/prowler/providers/huaweicloud/services/dcs/dcs_instance_not_public/dcs_instance_not_public.metadata.json
@@ -1,0 +1,36 @@
+{
+  "Provider": "huaweicloud",
+  "CheckID": "dcs_instance_not_public",
+  "CheckTitle": "DCS Redis instances are not publicly accessible",
+  "CheckType": [],
+  "ServiceName": "dcs",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "critical",
+  "ResourceType": "HUAWEICLOUD::DCS::Instance",
+  "ResourceGroup": "database",
+  "Description": "Ensure that DCS Redis instances do not have public access enabled.",
+  "Risk": "Redis instances with public access are exposed to the internet, allowing unauthorized access to cached data and potential data exfiltration.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://support.huaweicloud.com/intl/en-us/usermanual-dcs/dcs-ug-0312016.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "1. Log on to the Huawei Cloud console.\n2. Navigate to Distributed Cache Service.\n3. Select the instance.\n4. Disable public access and use VPC-only access.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Disable public access for DCS Redis instances. Access only via VPC.",
+      "Url": "https://hub.prowler.com/check/dcs_instance_not_public"
+    }
+  },
+  "Categories": [
+    "internet-exposed"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "Checks if DCS Redis instances have a public IP address assigned (publicip_address is not null)."
+}

--- a/prowler/providers/huaweicloud/services/dcs/dcs_instance_not_public/dcs_instance_not_public.py
+++ b/prowler/providers/huaweicloud/services/dcs/dcs_instance_not_public/dcs_instance_not_public.py
@@ -1,0 +1,28 @@
+from prowler.lib.check.models import Check, CheckReportHuaweiCloud
+from prowler.providers.huaweicloud.services.dcs.dcs_client import dcs_client
+
+
+class dcs_instance_not_public(Check):
+    """Check if DCS Redis instances are not publicly accessible."""
+
+    def execute(self) -> list[CheckReportHuaweiCloud]:
+        findings = []
+        for instance in dcs_client.instances:
+            report = CheckReportHuaweiCloud(
+                metadata=self.metadata(),
+                resource=instance,
+            )
+            report.region = instance.region
+            report.resource_id = instance.instance_id
+            report.resource_arn = f"huaweicloud:dcs:{instance.region}:{dcs_client.audited_account}:instance/{instance.instance_id}"
+
+            if instance.publicip_address:
+                report.status = "FAIL"
+                report.status_extended = f"DCS instance '{instance.name}' ({instance.instance_id}) has public access enabled with IP {instance.publicip_address}."
+            else:
+                report.status = "PASS"
+                report.status_extended = f"DCS instance '{instance.name}' ({instance.instance_id}) is not publicly accessible."
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/huaweicloud/services/dcs/dcs_service.py
+++ b/prowler/providers/huaweicloud/services/dcs/dcs_service.py
@@ -1,0 +1,103 @@
+from typing import List, Optional
+
+from pydantic.v1 import BaseModel
+
+from prowler.lib.logger import logger
+from prowler.providers.huaweicloud.lib.service.service import HuaweiCloudService
+
+
+class DCS(HuaweiCloudService):
+    """
+    DCS (Distributed Cache Service) service class for Huawei Cloud.
+
+    This class provides methods to interact with Huawei Cloud DCS service
+    to retrieve Redis instances and their security configuration.
+    """
+
+    def __init__(self, provider):
+        super().__init__(__class__.__name__, provider)
+
+        self.instances: List[DCSInstance] = []
+
+        if self.session.is_mock:
+            self._load_mock_data()
+            return
+
+        self._list_instances()
+
+    def _load_mock_data(self):
+        """Load mock data for testing."""
+        region = "la-south-2"
+        self.instances = [
+            DCSInstance(
+                instance_id="dcs-mock-001",
+                name="redis-secure",
+                status="RUNNING",
+                engine="Redis",
+                no_password_access="false",
+                publicip_address=None,
+                enable_ssl=True,
+                region=region,
+            ),
+            DCSInstance(
+                instance_id="dcs-mock-002",
+                name="redis-insecure",
+                status="RUNNING",
+                engine="Redis",
+                no_password_access="true",
+                publicip_address="1.2.3.4",
+                enable_ssl=False,
+                region=region,
+            ),
+        ]
+
+    def _list_instances(self):
+        """List all DCS instances across regions."""
+        if not self.regional_clients:
+            return
+
+        for region, client in self.regional_clients.items():
+            logger.info(f"DCS - Listing Instances in {region}...")
+
+            try:
+                from huaweicloudsdkdcs.v2 import ListInstancesRequest
+
+                request = ListInstancesRequest()
+                response = self._call_with_retries(client.list_instances, request)
+
+                if response and response.instances:
+                    for inst in response.instances:
+                        self.instances.append(
+                            DCSInstance(
+                                instance_id=getattr(inst, "instance_id", ""),
+                                name=getattr(inst, "name", ""),
+                                status=getattr(inst, "status", ""),
+                                engine=getattr(inst, "engine", ""),
+                                no_password_access=getattr(
+                                    inst, "no_password_access", None
+                                ),
+                                publicip_address=getattr(
+                                    inst, "publicip_address", None
+                                ),
+                                enable_ssl=getattr(inst, "enable_ssl", None),
+                                region=region,
+                            )
+                        )
+
+            except Exception as error:
+                logger.error(
+                    f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
+
+
+class DCSInstance(BaseModel):
+    """DCS instance model."""
+
+    instance_id: str
+    name: str = ""
+    status: str = ""
+    engine: str = ""
+    no_password_access: Optional[str] = None
+    publicip_address: Optional[str] = None
+    enable_ssl: Optional[bool] = None
+    region: str = ""

--- a/tests/providers/huaweicloud/services/dcs/dcs_instance_not_public/dcs_instance_not_public_test.py
+++ b/tests/providers/huaweicloud/services/dcs/dcs_instance_not_public/dcs_instance_not_public_test.py
@@ -1,0 +1,159 @@
+from unittest import mock
+
+from tests.providers.huaweicloud.huaweicloud_fixtures import (
+    set_mocked_huaweicloud_provider,
+)
+
+
+class Test_dcs_instance_not_public:
+    def test_dcs_not_public(self):
+        dcs_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.dcs.dcs_instance_not_public.dcs_instance_not_public.dcs_client",
+                new=dcs_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.dcs.dcs_service import (
+                DCSInstance,
+            )
+            from prowler.providers.huaweicloud.services.dcs.dcs_instance_not_public.dcs_instance_not_public import (
+                dcs_instance_not_public,
+            )
+
+            dcs_client.instances = [
+                DCSInstance(
+                    instance_id="dcs-001",
+                    name="redis-private",
+                    status="RUNNING",
+                    engine="Redis",
+                    publicip_address=None,
+                    region="la-south-2",
+                ),
+            ]
+            dcs_client.audited_account = "123456789012"
+
+            check = dcs_instance_not_public()
+            results = check.execute()
+
+            assert len(results) == 1
+            assert results[0].status == "PASS"
+            assert results[0].resource_id == "dcs-001"
+            assert "not publicly accessible" in results[0].status_extended
+
+    def test_dcs_public(self):
+        dcs_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.dcs.dcs_instance_not_public.dcs_instance_not_public.dcs_client",
+                new=dcs_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.dcs.dcs_service import (
+                DCSInstance,
+            )
+            from prowler.providers.huaweicloud.services.dcs.dcs_instance_not_public.dcs_instance_not_public import (
+                dcs_instance_not_public,
+            )
+
+            dcs_client.instances = [
+                DCSInstance(
+                    instance_id="dcs-002",
+                    name="redis-public",
+                    status="RUNNING",
+                    engine="Redis",
+                    publicip_address="1.2.3.4",
+                    region="la-south-2",
+                ),
+            ]
+            dcs_client.audited_account = "123456789012"
+
+            check = dcs_instance_not_public()
+            results = check.execute()
+
+            assert len(results) == 1
+            assert results[0].status == "FAIL"
+            assert results[0].resource_id == "dcs-002"
+            assert "public access" in results[0].status_extended
+
+    def test_dcs_public_mixed(self):
+        dcs_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.dcs.dcs_instance_not_public.dcs_instance_not_public.dcs_client",
+                new=dcs_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.dcs.dcs_service import (
+                DCSInstance,
+            )
+            from prowler.providers.huaweicloud.services.dcs.dcs_instance_not_public.dcs_instance_not_public import (
+                dcs_instance_not_public,
+            )
+
+            dcs_client.instances = [
+                DCSInstance(
+                    instance_id="dcs-001",
+                    name="redis-private",
+                    status="RUNNING",
+                    engine="Redis",
+                    publicip_address=None,
+                    region="la-south-2",
+                ),
+                DCSInstance(
+                    instance_id="dcs-002",
+                    name="redis-public",
+                    status="RUNNING",
+                    engine="Redis",
+                    publicip_address="1.2.3.4",
+                    region="la-south-2",
+                ),
+            ]
+            dcs_client.audited_account = "123456789012"
+
+            check = dcs_instance_not_public()
+            results = check.execute()
+
+            assert len(results) == 2
+            assert results[0].status == "PASS"
+            assert results[1].status == "FAIL"
+
+    def test_dcs_public_empty(self):
+        dcs_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.dcs.dcs_instance_not_public.dcs_instance_not_public.dcs_client",
+                new=dcs_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.dcs.dcs_instance_not_public.dcs_instance_not_public import (
+                dcs_instance_not_public,
+            )
+
+            dcs_client.instances = []
+            dcs_client.audited_account = "123456789012"
+
+            check = dcs_instance_not_public()
+            results = check.execute()
+
+            assert len(results) == 0


### PR DESCRIPTION
## New Check: dcs_instance_not_public

**Service:** DCS (Distributed Cache Service)  
**Severity:** critical  
**Categories:** internet-exposed

### Description

Ensure that DCS Redis instances do not have public access enabled.

### Risk

Redis instances with public access are exposed to the internet, allowing unauthorized access to cached data and potential data exfiltration.

### Remediation

Disable public access for DCS Redis instances. Access only via VPC.

### Implementation Details

- Checks if DCS Redis instances have a public IP address assigned (`publicip_address` is not null)
- Includes DCS service infrastructure (`dcs_client.py`, `dcs_service.py`)
- Includes unit tests

### Related Documentation

https://support.huaweicloud.com/intl/en-us/usermanual-dcs/dcs-ug-0312016.html

This is part of the Huawei Cloud provider expansion. See #11950 for the initial provider PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Huawei Cloud DCS support for discovering Redis instances and their security settings.
  * Added a security check to identify publicly accessible DCS Redis instances.
  * Findings include instance details, region, public IP status, severity, and remediation guidance.
  * Added internet-exposure categorization and guidance to disable public access.

* **Tests**
  * Added coverage for private, public, mixed, and empty DCS instance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->