### PR TITLE
feat(providers/huaweicloud): add obs_bucket_encryption_and_not_public check

### DIFF
--- a/prowler/changelog.d/obs-bucket-encryption-and-not-public.added.md
+++ b/prowler/changelog.d/obs-bucket-encryption-and-not-public.added.md
@@ -1,0 +1,1 @@
+`obs_bucket_encryption_and_not_public` check for Huawei Cloud provider: OBS buckets are encrypted and not publicly accessible

--- a/prowler/providers/huaweicloud/services/obs/obs_bucket_encryption_and_not_public/obs_bucket_encryption_and_not_public.metadata.json
+++ b/prowler/providers/huaweicloud/services/obs/obs_bucket_encryption_and_not_public/obs_bucket_encryption_and_not_public.metadata.json
@@ -1,0 +1,37 @@
+{
+  "Provider": "huaweicloud",
+  "CheckID": "obs_bucket_encryption_and_not_public",
+  "CheckTitle": "OBS buckets are encrypted and not publicly accessible",
+  "CheckType": [],
+  "ServiceName": "obs",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "HUAWEICLOUD::OBS::Bucket",
+  "ResourceGroup": "storage",
+  "Description": "Ensure that OBS buckets have server-side encryption enabled and are not publicly accessible, providing defense-in-depth for stored objects.",
+  "Risk": "OBS buckets that are unencrypted or publicly accessible expose sensitive data to potential compromise. Public access allows unauthorized reads, and lack of encryption leaves data unprotected at rest.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://support.huaweicloud.com/intl/en-us/usermanual-obs/obs_03_0088.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "1. Log on to the Huawei Cloud console.\n2. Navigate to Object Storage Service.\n3. Select the bucket.\n4. Click the Encryption tab and enable server-side encryption with a KMS key.\n5. Click the Permissions tab and set the bucket ACL to private.\n6. Click Save.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Enable server-side encryption and set the bucket ACL to private for all OBS buckets.",
+      "Url": "https://hub.prowler.com/check/obs_bucket_encryption_and_not_public"
+    }
+  },
+  "Categories": [
+    "encryption",
+    "internet-exposed"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/huaweicloud/services/obs/obs_bucket_encryption_and_not_public/obs_bucket_encryption_and_not_public.py
+++ b/prowler/providers/huaweicloud/services/obs/obs_bucket_encryption_and_not_public/obs_bucket_encryption_and_not_public.py
@@ -1,0 +1,39 @@
+from prowler.lib.check.models import Check, CheckReportHuaweiCloud
+from prowler.providers.huaweicloud.services.obs.obs_client import obs_client
+
+
+class obs_bucket_encryption_and_not_public(Check):
+    """Check if OBS buckets are both encrypted and not publicly accessible."""
+
+    def execute(self) -> list[CheckReportHuaweiCloud]:
+        findings = []
+
+        for bucket in obs_client.buckets:
+            report = CheckReportHuaweiCloud(metadata=self.metadata(), resource=bucket)
+            report.region = bucket.region
+            report.resource_id = bucket.name
+            report.resource_arn = (
+                f"huaweicloud:obs:{bucket.region}:"
+                f"{obs_client.audited_account}:bucket/{bucket.name}"
+            )
+
+            if bucket.is_encrypted and not bucket.is_public:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"OBS bucket {bucket.name} is encrypted"
+                    f" and not publicly accessible."
+                )
+            else:
+                report.status = "FAIL"
+                issues = []
+                if not bucket.is_encrypted:
+                    issues.append("is not encrypted")
+                if bucket.is_public:
+                    issues.append("is publicly accessible")
+                report.status_extended = (
+                    f"OBS bucket {bucket.name} " + " and ".join(issues) + "."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/huaweicloud/services/obs/obs_bucket_encryption_and_not_public/obs_bucket_encryption_and_not_public_test.py
+++ b/tests/providers/huaweicloud/services/obs/obs_bucket_encryption_and_not_public/obs_bucket_encryption_and_not_public_test.py
@@ -1,0 +1,173 @@
+from unittest import mock
+
+from tests.providers.huaweicloud.huaweicloud_fixtures import (
+    set_mocked_huaweicloud_provider,
+)
+
+
+class TestObsBucketEncryptionAndNotPublic:
+    def test_encrypted_private_bucket_passes(self):
+        obs_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.obs.obs_bucket_encryption_and_not_public.obs_bucket_encryption_and_not_public.obs_client",
+                new=obs_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.obs.obs_bucket_encryption_and_not_public.obs_bucket_encryption_and_not_public import (
+                obs_bucket_encryption_and_not_public,
+            )
+            from prowler.providers.huaweicloud.services.obs.obs_service import Bucket
+
+            bucket = Bucket(
+                name="good-bucket",
+                region="la-south-2",
+                is_encrypted=True,
+                is_public=False,
+                acl="private",
+            )
+            obs_client.buckets = [bucket]
+            obs_client.audited_account = "123456789012"
+
+            check = obs_bucket_encryption_and_not_public()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert "encrypted and not publicly accessible" in result[0].status_extended
+
+    def test_unencrypted_private_bucket_fails(self):
+        obs_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.obs.obs_bucket_encryption_and_not_public.obs_bucket_encryption_and_not_public.obs_client",
+                new=obs_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.obs.obs_bucket_encryption_and_not_public.obs_bucket_encryption_and_not_public import (
+                obs_bucket_encryption_and_not_public,
+            )
+            from prowler.providers.huaweicloud.services.obs.obs_service import Bucket
+
+            bucket = Bucket(
+                name="unencrypted-bucket",
+                region="la-south-2",
+                is_encrypted=False,
+                is_public=False,
+                acl="private",
+            )
+            obs_client.buckets = [bucket]
+            obs_client.audited_account = "123456789012"
+
+            check = obs_bucket_encryption_and_not_public()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "not encrypted" in result[0].status_extended
+
+    def test_encrypted_public_bucket_fails(self):
+        obs_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.obs.obs_bucket_encryption_and_not_public.obs_bucket_encryption_and_not_public.obs_client",
+                new=obs_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.obs.obs_bucket_encryption_and_not_public.obs_bucket_encryption_and_not_public import (
+                obs_bucket_encryption_and_not_public,
+            )
+            from prowler.providers.huaweicloud.services.obs.obs_service import Bucket
+
+            bucket = Bucket(
+                name="public-bucket",
+                region="la-south-2",
+                is_encrypted=True,
+                is_public=True,
+                acl="public-read",
+            )
+            obs_client.buckets = [bucket]
+            obs_client.audited_account = "123456789012"
+
+            check = obs_bucket_encryption_and_not_public()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "publicly accessible" in result[0].status_extended
+
+    def test_unencrypted_public_bucket_fails(self):
+        obs_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.obs.obs_bucket_encryption_and_not_public.obs_bucket_encryption_and_not_public.obs_client",
+                new=obs_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.obs.obs_bucket_encryption_and_not_public.obs_bucket_encryption_and_not_public import (
+                obs_bucket_encryption_and_not_public,
+            )
+            from prowler.providers.huaweicloud.services.obs.obs_service import Bucket
+
+            bucket = Bucket(
+                name="bad-bucket",
+                region="la-south-2",
+                is_encrypted=False,
+                is_public=True,
+                acl="public-read",
+            )
+            obs_client.buckets = [bucket]
+            obs_client.audited_account = "123456789012"
+
+            check = obs_bucket_encryption_and_not_public()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "not encrypted" in result[0].status_extended
+            assert "publicly accessible" in result[0].status_extended
+
+    def test_no_buckets(self):
+        obs_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.obs.obs_bucket_encryption_and_not_public.obs_bucket_encryption_and_not_public.obs_client",
+                new=obs_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.obs.obs_bucket_encryption_and_not_public.obs_bucket_encryption_and_not_public import (
+                obs_bucket_encryption_and_not_public,
+            )
+
+            obs_client.buckets = []
+            obs_client.audited_account = "123456789012"
+
+            check = obs_bucket_encryption_and_not_public()
+            result = check.execute()
+
+            assert len(result) == 0


### PR DESCRIPTION
## New Check: `obs_bucket_encryption_and_not_public`

**Service:** obs
**Severity:** high
**Categories:** encryption, internet-exposed

### Description

Ensure that OBS buckets have server-side encryption enabled and are not publicly accessible, providing defense-in-depth for stored objects.

### Risk

OBS buckets that are unencrypted or publicly accessible expose sensitive data to potential compromise. Public access allows unauthorized reads, and lack of encryption leaves data unprotected at rest.

### Remediation

Enable server-side encryption and set the bucket ACL to private for all OBS buckets.

### Implementation Details



This is part of the Huawei Cloud provider expansion. See #11950 for the initial provider PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Huawei Cloud OBS security check to verify buckets use encryption and remain private.
  * Reports pass or fail results with details about missing encryption and/or public accessibility.
  * Added severity, categorization, documentation, and remediation guidance for the check.

* **Tests**
  * Added coverage for encrypted/private, unencrypted, public, combined-failure, and empty-bucket scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->