### PR TITLE
feat(providers/huaweicloud): add ecs_instance_enterprise_project check

### DIFF
--- a/prowler/changelog.d/ecs-instance-enterprise-project.added.md
+++ b/prowler/changelog.d/ecs-instance-enterprise-project.added.md
@@ -1,0 +1,1 @@
+`ecs_instance_enterprise_project` check for Huawei Cloud provider: ECS instances should be assigned to an enterprise project

--- a/prowler/providers/huaweicloud/services/ecs/ecs_instance_enterprise_project/ecs_instance_enterprise_project.metadata.json
+++ b/prowler/providers/huaweicloud/services/ecs/ecs_instance_enterprise_project/ecs_instance_enterprise_project.metadata.json
@@ -1,0 +1,36 @@
+{
+  "Provider": "huaweicloud",
+  "CheckID": "ecs_instance_enterprise_project",
+  "CheckTitle": "ECS instances should be assigned to an enterprise project",
+  "CheckType": [],
+  "ServiceName": "ecs",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "low",
+  "ResourceType": "HUAWEICLOUD::ECS::Instance",
+  "ResourceGroup": "compute",
+  "Description": "Ensure that ECS instances are assigned to an enterprise project for resource isolation, cost management, and access control.",
+  "Risk": "ECS instances without an enterprise project cannot be isolated by project-level permissions, making it harder to enforce fine-grained access control and cost allocation.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://support.huaweicloud.com/intl/en-us/usermanual-eps/eps_01_0001.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "hcloud ECS ChangeEnterpriseProject --server_id <instance_id> --enterprise_project_id <project_id>",
+      "NativeIaC": "",
+      "Other": "1. Log on to the Huawei Cloud console\n2. Navigate to Elastic Cloud Server\n3. Select the instance\n4. Click More > Manage Enterprise Project\n5. Select the target enterprise project\n6. Click OK",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Assign all ECS instances to an appropriate enterprise project.",
+      "Url": "https://hub.prowler.com/check/ecs_instance_enterprise_project"
+    }
+  },
+  "Categories": [
+    "identity-access"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/huaweicloud/services/ecs/ecs_instance_enterprise_project/ecs_instance_enterprise_project.py
+++ b/prowler/providers/huaweicloud/services/ecs/ecs_instance_enterprise_project/ecs_instance_enterprise_project.py
@@ -1,0 +1,26 @@
+from prowler.lib.check.models import Check, CheckReportHuaweiCloud
+from prowler.providers.huaweicloud.services.ecs.ecs_client import ecs_client
+
+
+class ecs_instance_enterprise_project(Check):
+    """Ensure ECS instances are assigned to an enterprise project."""
+
+    def execute(self) -> list[CheckReportHuaweiCloud]:
+        findings = []
+
+        for instance in ecs_client.instances.values():
+            report = CheckReportHuaweiCloud(metadata=self.metadata(), resource=instance)
+            report.region = instance.region
+            report.resource_id = instance.id
+            report.resource_arn = f"huaweicloud:ecs:{instance.region}:{ecs_client.audited_account}:instance/{instance.id}"
+
+            if instance.enterprise_project_id:
+                report.status = "PASS"
+                report.status_extended = f"ECS instance {instance.name} ({instance.id}) is assigned to enterprise project '{instance.enterprise_project_id}'."
+            else:
+                report.status = "FAIL"
+                report.status_extended = f"ECS instance {instance.name} ({instance.id}) is not assigned to an enterprise project."
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/huaweicloud/services/ecs/ecs_instance_enterprise_project/ecs_instance_enterprise_project_test.py
+++ b/tests/providers/huaweicloud/services/ecs/ecs_instance_enterprise_project/ecs_instance_enterprise_project_test.py
@@ -1,0 +1,102 @@
+from unittest import mock
+
+from tests.providers.huaweicloud.huaweicloud_fixtures import (
+    set_mocked_huaweicloud_provider,
+)
+
+
+class TestEcsInstanceEnterpriseProject:
+    def test_instance_with_enterprise_project_passes(self):
+        ecs_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.ecs.ecs_instance_enterprise_project.ecs_instance_enterprise_project.ecs_client",
+                new=ecs_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.ecs.ecs_instance_enterprise_project.ecs_instance_enterprise_project import (
+                ecs_instance_enterprise_project,
+            )
+            from prowler.providers.huaweicloud.services.ecs.ecs_service import Instance
+
+            instance = Instance(
+                id="inst-1",
+                name="web-server",
+                region="la-south-2",
+                status="ACTIVE",
+                enterprise_project_id="eps-123456",
+            )
+            ecs_client.instances = {instance.id: instance}
+            ecs_client.audited_account = "123456789012"
+
+            check = ecs_instance_enterprise_project()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert "eps-123456" in result[0].status_extended
+
+    def test_instance_without_enterprise_project_fails(self):
+        ecs_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.ecs.ecs_instance_enterprise_project.ecs_instance_enterprise_project.ecs_client",
+                new=ecs_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.ecs.ecs_instance_enterprise_project.ecs_instance_enterprise_project import (
+                ecs_instance_enterprise_project,
+            )
+            from prowler.providers.huaweicloud.services.ecs.ecs_service import Instance
+
+            instance = Instance(
+                id="inst-1",
+                name="web-server",
+                region="la-south-2",
+                status="ACTIVE",
+                enterprise_project_id="",
+            )
+            ecs_client.instances = {instance.id: instance}
+            ecs_client.audited_account = "123456789012"
+
+            check = ecs_instance_enterprise_project()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "not assigned to an enterprise project" in result[0].status_extended
+
+    def test_no_instances(self):
+        ecs_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.ecs.ecs_instance_enterprise_project.ecs_instance_enterprise_project.ecs_client",
+                new=ecs_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.ecs.ecs_instance_enterprise_project.ecs_instance_enterprise_project import (
+                ecs_instance_enterprise_project,
+            )
+
+            ecs_client.instances = {}
+            ecs_client.audited_account = "123456789012"
+
+            check = ecs_instance_enterprise_project()
+            result = check.execute()
+
+            assert len(result) == 0


### PR DESCRIPTION
## New Check: `ecs_instance_enterprise_project`

**Service:** ecs
**Severity:** low
**Categories:** identity-access

### Description

Ensure that ECS instances are assigned to an enterprise project for resource isolation, cost management, and access control.

### Risk

ECS instances without an enterprise project cannot be isolated by project-level permissions, making it harder to enforce fine-grained access control and cost allocation.

### Remediation

Assign all ECS instances to an appropriate enterprise project.

### Implementation Details



This is part of the Huawei Cloud provider expansion. See #11950 for the initial provider PR.
