### PR TITLE
feat(providers/huaweicloud): add elb_load_balancer_configured check

### DIFF
--- a/prowler/changelog.d/elb-load-balancer-configured.added.md
+++ b/prowler/changelog.d/elb-load-balancer-configured.added.md
@@ -1,0 +1,1 @@
+`elb_load_balancer_configured` check for Huawei Cloud provider: At least one ELB load balancer is configured

--- a/prowler/providers/huaweicloud/services/elb/elb_load_balancer_configured/elb_load_balancer_configured.metadata.json
+++ b/prowler/providers/huaweicloud/services/elb/elb_load_balancer_configured/elb_load_balancer_configured.metadata.json
@@ -1,0 +1,36 @@
+{
+  "Provider": "huaweicloud",
+  "CheckID": "elb_load_balancer_configured",
+  "CheckTitle": "At least one ELB load balancer is configured",
+  "CheckType": [],
+  "ServiceName": "elb",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "low",
+  "ResourceType": "HUAWEICLOUD::ELB::LoadBalancer",
+  "ResourceGroup": "network",
+  "Description": "Ensure that at least one Elastic Load Balancer (ELB) is configured to distribute traffic and provide high availability.",
+  "Risk": "Without any load balancers configured, applications may lack traffic distribution, high availability, and fault tolerance, leading to single points of failure.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://support.huaweicloud.com/intl/en-us/usermanual-elb/elb_ug_jt_0001.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "1. Log on to the Huawei Cloud console.\n2. Navigate to Elastic Load Balance.\n3. Click Create Load Balancer.\n4. Configure the load balancer with appropriate listeners and backend server groups.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Configure at least one ELB load balancer for application traffic distribution.",
+      "Url": "https://hub.prowler.com/check/elb_load_balancer_configured"
+    }
+  },
+  "Categories": [
+    "resilience"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/huaweicloud/services/elb/elb_load_balancer_configured/elb_load_balancer_configured.py
+++ b/prowler/providers/huaweicloud/services/elb/elb_load_balancer_configured/elb_load_balancer_configured.py
@@ -1,0 +1,38 @@
+from prowler.lib.check.models import Check, CheckReportHuaweiCloud
+from prowler.providers.huaweicloud.services.elb.elb_client import elb_client
+
+
+class elb_load_balancer_configured(Check):
+    """Check if at least one ELB load balancer is configured."""
+
+    def execute(self) -> list[CheckReportHuaweiCloud]:
+        findings = []
+
+        if elb_client.load_balancers:
+            for load_balancer in elb_client.load_balancers:
+                report = CheckReportHuaweiCloud(
+                    metadata=self.metadata(), resource=load_balancer
+                )
+                report.region = load_balancer.region
+                report.resource_id = load_balancer.id
+                report.resource_arn = (
+                    f"huaweicloud:elb:{load_balancer.region}:"
+                    f"{elb_client.audited_account}:loadbalancer/{load_balancer.id}"
+                )
+                report.status = "PASS"
+                report.status_extended = (
+                    f"ELB load balancer {load_balancer.name} ({load_balancer.id}) "
+                    f"is configured."
+                )
+                findings.append(report)
+        else:
+            report = CheckReportHuaweiCloud(metadata=self.metadata(), resource={})
+            report.region = elb_client.region
+            report.resource_id = "no-load-balancer"
+            report.resource_name = "load-balancer"
+            report.resource_arn = ""
+            report.status = "FAIL"
+            report.status_extended = "No ELB load balancers are configured."
+            findings.append(report)
+
+        return findings

--- a/tests/providers/huaweicloud/services/elb/elb_load_balancer_configured/elb_load_balancer_configured_test.py
+++ b/tests/providers/huaweicloud/services/elb/elb_load_balancer_configured/elb_load_balancer_configured_test.py
@@ -1,0 +1,121 @@
+from unittest import mock
+
+from tests.providers.huaweicloud.huaweicloud_fixtures import (
+    set_mocked_huaweicloud_provider,
+)
+
+
+class TestElbLoadBalancerConfigured:
+    def test_load_balancer_exists_passes(self):
+        elb_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.elb.elb_load_balancer_configured.elb_load_balancer_configured.elb_client",
+                new=elb_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.elb.elb_load_balancer_configured.elb_load_balancer_configured import (
+                elb_load_balancer_configured,
+            )
+            from prowler.providers.huaweicloud.services.elb.elb_service import (
+                LoadBalancer,
+            )
+
+            lb = LoadBalancer(
+                id="lb-1",
+                name="my-lb",
+                vip_address="192.168.1.1",
+                public_ip="",
+                is_public=False,
+                region="la-south-2",
+            )
+            elb_client.load_balancers = [lb]
+            elb_client.audited_account = "123456789012"
+            elb_client.region = "la-south-2"
+
+            check = elb_load_balancer_configured()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert "configured" in result[0].status_extended
+
+    def test_multiple_load_balancers_pass(self):
+        elb_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.elb.elb_load_balancer_configured.elb_load_balancer_configured.elb_client",
+                new=elb_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.elb.elb_load_balancer_configured.elb_load_balancer_configured import (
+                elb_load_balancer_configured,
+            )
+            from prowler.providers.huaweicloud.services.elb.elb_service import (
+                LoadBalancer,
+            )
+
+            lb1 = LoadBalancer(
+                id="lb-1",
+                name="lb-1",
+                vip_address="192.168.1.1",
+                public_ip="",
+                is_public=False,
+                region="la-south-2",
+            )
+            lb2 = LoadBalancer(
+                id="lb-2",
+                name="lb-2",
+                vip_address="192.168.1.2",
+                public_ip="",
+                is_public=False,
+                region="la-south-2",
+            )
+            elb_client.load_balancers = [lb1, lb2]
+            elb_client.audited_account = "123456789012"
+            elb_client.region = "la-south-2"
+
+            check = elb_load_balancer_configured()
+            result = check.execute()
+
+            assert len(result) == 2
+            assert result[0].status == "PASS"
+            assert result[1].status == "PASS"
+
+    def test_no_load_balancers_fails(self):
+        elb_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.elb.elb_load_balancer_configured.elb_load_balancer_configured.elb_client",
+                new=elb_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.elb.elb_load_balancer_configured.elb_load_balancer_configured import (
+                elb_load_balancer_configured,
+            )
+
+            elb_client.load_balancers = []
+            elb_client.audited_account = "123456789012"
+            elb_client.region = "la-south-2"
+
+            check = elb_load_balancer_configured()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "No ELB load balancers" in result[0].status_extended


### PR DESCRIPTION
## New Check: `elb_load_balancer_configured`

**Service:** elb
**Severity:** low
**Categories:** resilience

### Description

Ensure that at least one Elastic Load Balancer (ELB) is configured to distribute traffic and provide high availability.

### Risk

Without any load balancers configured, applications may lack traffic distribution, high availability, and fault tolerance, leading to single points of failure.

### Remediation

Configure at least one ELB load balancer for application traffic distribution.

### Implementation Details



This is part of the Huawei Cloud provider expansion. See #11950 for the initial provider PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Huawei Cloud ELB check to verify that at least one load balancer is configured.
  * Reports each configured load balancer as passing, including region, identifier, status, and descriptive details.
  * Reports a failure when no load balancers are present.

* **Documentation**
  * Added check documentation covering severity, risks, remediation, recommendations, and resilience classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->