### PR TITLE
feat(providers/huaweicloud): add iam_password_policy_max_consecutive_identical_chars check

### DIFF
--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           # zizmor: ignore[artipacked]
           persist-credentials: true # Required by tj-actions/changed-files to fetch PR branch
+          fetch-depth: 0 # Fetch all history to allow changed-files to work with PRs
 
       - name: Check for SDK changes
         id: check-changes

--- a/prowler/changelog.d/iam-password-policy-max-consecutive-identical-chars.added.md
+++ b/prowler/changelog.d/iam-password-policy-max-consecutive-identical-chars.added.md
@@ -1,0 +1,1 @@
+`iam_password_policy_max_consecutive_identical_chars` check for Huawei Cloud provider: IAM password policy limits consecutive identical characters

--- a/prowler/providers/huaweicloud/services/iam/iam_password_policy_max_consecutive_identical_chars/iam_password_policy_max_consecutive_identical_chars.metadata.json
+++ b/prowler/providers/huaweicloud/services/iam/iam_password_policy_max_consecutive_identical_chars/iam_password_policy_max_consecutive_identical_chars.metadata.json
@@ -1,0 +1,36 @@
+{
+  "Provider": "huaweicloud",
+  "CheckID": "iam_password_policy_max_consecutive_identical_chars",
+  "CheckTitle": "IAM password policy limits consecutive identical characters",
+  "CheckType": [],
+  "ServiceName": "iam",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "low",
+  "ResourceType": "HUAWEICLOUD::IAM::PasswordPolicy",
+  "ResourceGroup": "IAM",
+  "Description": "Huawei Cloud IAM password policies can limit the number of consecutive identical characters allowed in passwords. It is recommended that this limit be set to reduce predictable patterns.",
+  "Risk": "Without a limit on consecutive identical characters, users can create passwords like 'aaaaaa' or '111111' that are significantly easier to crack via brute force and dictionary attacks.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://support.huaweicloud.com/intl/en-us/usermanual-iam/iam_01_0605.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "hcloud IAM SetDomainPasswordPolicy --maximum_consecutive_identical_chars 3",
+      "NativeIaC": "",
+      "Other": "1. Log on to the Huawei Cloud console.\n2. Choose IAM & Security.\n3. Click the Password Policy tab.\n4. Set 'Maximum consecutive identical characters' to 3 or lower.\n5. Click OK.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Configure the IAM password policy to limit consecutive identical characters in passwords.",
+      "Url": "https://hub.prowler.com/check/iam_password_policy_max_consecutive_identical_chars"
+    }
+  },
+  "Categories": [
+    "secrets"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/huaweicloud/services/iam/iam_password_policy_max_consecutive_identical_chars/iam_password_policy_max_consecutive_identical_chars.py
+++ b/prowler/providers/huaweicloud/services/iam/iam_password_policy_max_consecutive_identical_chars/iam_password_policy_max_consecutive_identical_chars.py
@@ -1,0 +1,31 @@
+from prowler.lib.check.models import Check, CheckReportHuaweiCloud
+from prowler.providers.huaweicloud.services.iam.iam_client import iam_client
+
+
+class iam_password_policy_max_consecutive_identical_chars(Check):
+    """Check if Huawei Cloud IAM password policy limits consecutive identical characters."""
+
+    def execute(self) -> list[CheckReportHuaweiCloud]:
+        findings = []
+
+        if iam_client.password_policy:
+            report = CheckReportHuaweiCloud(
+                metadata=self.metadata(), resource=iam_client.password_policy
+            )
+            report.region = iam_client.region
+            report.resource_id = f"{iam_client.audited_account}-password-policy"
+            report.resource_name = "password-policy"
+            report.resource_arn = (
+                f"HUAWEICLOUD::IAM::{iam_client.audited_account}:password-policy"
+            )
+
+            if iam_client.password_policy.maximum_consecutive_identical_chars > 0:
+                report.status = "PASS"
+                report.status_extended = f"IAM password policy limits consecutive identical characters to {iam_client.password_policy.maximum_consecutive_identical_chars}."
+            else:
+                report.status = "FAIL"
+                report.status_extended = "IAM password policy does not limit consecutive identical characters, allowing passwords like 'aaaaaa' which are easier to crack."
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/huaweicloud/services/iam/iam_password_policy_max_consecutive_identical_chars/iam_password_policy_max_consecutive_identical_chars_test.py
+++ b/tests/providers/huaweicloud/services/iam/iam_password_policy_max_consecutive_identical_chars/iam_password_policy_max_consecutive_identical_chars_test.py
@@ -1,0 +1,101 @@
+from unittest import mock
+
+from tests.providers.huaweicloud.huaweicloud_fixtures import (
+    set_mocked_huaweicloud_provider,
+)
+
+
+class TestIamPasswordPolicyMaxConsecutiveIdenticalChars:
+    def test_max_consecutive_3_passes(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_password_policy_max_consecutive_identical_chars.iam_password_policy_max_consecutive_identical_chars.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_password_policy_max_consecutive_identical_chars.iam_password_policy_max_consecutive_identical_chars import (
+                iam_password_policy_max_consecutive_identical_chars,
+            )
+            from prowler.providers.huaweicloud.services.iam.iam_service import (
+                PasswordPolicy,
+            )
+
+            iam_client.password_policy = PasswordPolicy(
+                maximum_consecutive_identical_chars=3,
+            )
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_password_policy_max_consecutive_identical_chars()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                "limits consecutive identical characters" in result[0].status_extended
+            )
+
+    def test_max_consecutive_0_fails(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_password_policy_max_consecutive_identical_chars.iam_password_policy_max_consecutive_identical_chars.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_password_policy_max_consecutive_identical_chars.iam_password_policy_max_consecutive_identical_chars import (
+                iam_password_policy_max_consecutive_identical_chars,
+            )
+            from prowler.providers.huaweicloud.services.iam.iam_service import (
+                PasswordPolicy,
+            )
+
+            iam_client.password_policy = PasswordPolicy(
+                maximum_consecutive_identical_chars=0,
+            )
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_password_policy_max_consecutive_identical_chars()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "does not limit" in result[0].status_extended
+
+    def test_no_password_policy(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_password_policy_max_consecutive_identical_chars.iam_password_policy_max_consecutive_identical_chars.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_password_policy_max_consecutive_identical_chars.iam_password_policy_max_consecutive_identical_chars import (
+                iam_password_policy_max_consecutive_identical_chars,
+            )
+
+            iam_client.password_policy = None
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_password_policy_max_consecutive_identical_chars()
+            result = check.execute()
+
+            assert len(result) == 0


### PR DESCRIPTION
## New Check: `iam_password_policy_max_consecutive_identical_chars`

**Service:** iam
**Severity:** low
**Categories:** secrets

### Description

Huawei Cloud IAM password policies can limit the number of consecutive identical characters allowed in passwords. It is recommended that this limit be set to reduce predictable patterns.

### Risk

Without a limit on consecutive identical characters, users can create passwords like 'aaaaaa' or '111111' that are significantly easier to crack via brute force and dictionary attacks.

### Remediation

Configure the IAM password policy to limit consecutive identical characters in passwords.

### Implementation Details



This is part of the Huawei Cloud provider expansion. See #11950 for the initial provider PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Huawei Cloud IAM security check to verify that password policies limit consecutive identical characters.
  - Reports compliant configurations, flags policies without this restriction, and skips accounts without a password policy.

- **Documentation**
  - Added guidance, severity details, remediation steps, and references for the new check.

- **Tests**
  - Added coverage for compliant, non-compliant, and missing-policy scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->