### PR TITLE
feat(providers/huaweicloud): add iam_password_policy_maximum_length check

### DIFF
--- a/prowler/changelog.d/iam-password-policy-maximum-length.added.md
+++ b/prowler/changelog.d/iam-password-policy-maximum-length.added.md
@@ -1,0 +1,1 @@
+`iam_password_policy_maximum_length` check for Huawei Cloud provider: IAM password policy maximum length is 32 or greater

--- a/prowler/providers/huaweicloud/services/iam/iam_password_policy_maximum_length/iam_password_policy_maximum_length.metadata.json
+++ b/prowler/providers/huaweicloud/services/iam/iam_password_policy_maximum_length/iam_password_policy_maximum_length.metadata.json
@@ -1,0 +1,36 @@
+{
+  "Provider": "huaweicloud",
+  "CheckID": "iam_password_policy_maximum_length",
+  "CheckTitle": "IAM password policy maximum length is 32 or greater",
+  "CheckType": [],
+  "ServiceName": "iam",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "low",
+  "ResourceType": "HUAWEICLOUD::IAM::PasswordPolicy",
+  "ResourceGroup": "IAM",
+  "Description": "Huawei Cloud IAM password policies can set a maximum password length. It is recommended that the maximum password length be set to 32 or greater to allow users to create longer, more secure passwords.",
+  "Risk": "A low maximum password length restricts users from creating longer, more secure passwords, potentially weakening the overall security posture of the account.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://support.huaweicloud.com/intl/en-us/usermanual-iam/iam_01_0605.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "hcloud IAM SetDomainPasswordPolicy --maximum_password_length 32",
+      "NativeIaC": "",
+      "Other": "1. Log on to the Huawei Cloud console.\n2. Choose IAM & Security.\n3. Click the Password Policy tab.\n4. Set Maximum Password Length to 32 or greater.\n5. Click OK.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Configure the IAM password policy to allow a maximum password length of at least 32 characters.",
+      "Url": "https://hub.prowler.com/check/iam_password_policy_maximum_length"
+    }
+  },
+  "Categories": [
+    "secrets"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/huaweicloud/services/iam/iam_password_policy_maximum_length/iam_password_policy_maximum_length.py
+++ b/prowler/providers/huaweicloud/services/iam/iam_password_policy_maximum_length/iam_password_policy_maximum_length.py
@@ -1,0 +1,38 @@
+from prowler.lib.check.models import Check, CheckReportHuaweiCloud
+from prowler.providers.huaweicloud.services.iam.iam_client import iam_client
+
+
+class iam_password_policy_maximum_length(Check):
+    """Check if Huawei Cloud IAM password policy maximum length is set to 32 or greater."""
+
+    def execute(self) -> list[CheckReportHuaweiCloud]:
+        findings = []
+
+        if iam_client.password_policy:
+            report = CheckReportHuaweiCloud(
+                metadata=self.metadata(), resource=iam_client.password_policy
+            )
+            report.region = iam_client.region
+            report.resource_id = f"{iam_client.audited_account}-password-policy"
+            report.resource_name = "password-policy"
+            report.resource_arn = (
+                f"HUAWEICLOUD::IAM::{iam_client.audited_account}:password-policy"
+            )
+
+            if iam_client.password_policy.maximum_password_length >= 32:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"IAM password policy allows maximum password length of "
+                    f"{iam_client.password_policy.maximum_password_length} characters."
+                )
+            else:
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"IAM password policy allows maximum password length of "
+                    f"{iam_client.password_policy.maximum_password_length} characters, "
+                    f"which is less than the recommended 32 characters."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/huaweicloud/services/iam/iam_password_policy_maximum_length/iam_password_policy_maximum_length_test.py
+++ b/tests/providers/huaweicloud/services/iam/iam_password_policy_maximum_length/iam_password_policy_maximum_length_test.py
@@ -1,0 +1,99 @@
+from unittest import mock
+
+from tests.providers.huaweicloud.huaweicloud_fixtures import (
+    set_mocked_huaweicloud_provider,
+)
+
+
+class TestIamPasswordPolicyMaximumLength:
+    def test_maximum_length_32_passes(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_password_policy_maximum_length.iam_password_policy_maximum_length.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_password_policy_maximum_length.iam_password_policy_maximum_length import (
+                iam_password_policy_maximum_length,
+            )
+            from prowler.providers.huaweicloud.services.iam.iam_service import (
+                PasswordPolicy,
+            )
+
+            iam_client.password_policy = PasswordPolicy(
+                maximum_password_length=32,
+            )
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_password_policy_maximum_length()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert "32 characters" in result[0].status_extended
+
+    def test_maximum_length_below_32_fails(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_password_policy_maximum_length.iam_password_policy_maximum_length.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_password_policy_maximum_length.iam_password_policy_maximum_length import (
+                iam_password_policy_maximum_length,
+            )
+            from prowler.providers.huaweicloud.services.iam.iam_service import (
+                PasswordPolicy,
+            )
+
+            iam_client.password_policy = PasswordPolicy(
+                maximum_password_length=16,
+            )
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_password_policy_maximum_length()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "less than the recommended 32" in result[0].status_extended
+
+    def test_no_password_policy(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_password_policy_maximum_length.iam_password_policy_maximum_length.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_password_policy_maximum_length.iam_password_policy_maximum_length import (
+                iam_password_policy_maximum_length,
+            )
+
+            iam_client.password_policy = None
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_password_policy_maximum_length()
+            result = check.execute()
+
+            assert len(result) == 0


### PR DESCRIPTION
## New Check: `iam_password_policy_maximum_length`

**Service:** iam
**Severity:** low
**Categories:** secrets

### Description

Huawei Cloud IAM password policies can set a maximum password length. It is recommended that the maximum password length be set to 32 or greater to allow users to create longer, more secure passwords.

### Risk

A low maximum password length restricts users from creating longer, more secure passwords, potentially weakening the overall security posture of the account.

### Remediation

Configure the IAM password policy to allow a maximum password length of at least 32 characters.

### Implementation Details



This is part of the Huawei Cloud provider expansion. See #11950 for the initial provider PR.
