### PR TITLE
feat(providers/huaweicloud): add kms_key_rotation_period check

### DIFF
--- a/prowler/changelog.d/kms-key-rotation-period.added.md
+++ b/prowler/changelog.d/kms-key-rotation-period.added.md
@@ -1,0 +1,1 @@
+`kms_key_rotation_period` check for Huawei Cloud provider: KMS keys with rotation enabled have a rotation period configured

--- a/prowler/providers/huaweicloud/services/kms/kms_key_rotation_period/kms_key_rotation_period.metadata.json
+++ b/prowler/providers/huaweicloud/services/kms/kms_key_rotation_period/kms_key_rotation_period.metadata.json
@@ -1,0 +1,36 @@
+{
+  "Provider": "huaweicloud",
+  "CheckID": "kms_key_rotation_period",
+  "CheckTitle": "KMS keys with rotation enabled have a rotation period configured",
+  "CheckType": [],
+  "ServiceName": "kms",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "low",
+  "ResourceType": "HUAWEICLOUD::KMS::Key",
+  "ResourceGroup": "security",
+  "Description": "Ensure that KMS keys with automatic rotation enabled have a rotation period explicitly configured. A missing rotation period may indicate misconfigured key rotation.",
+  "Risk": "If key rotation is enabled but no rotation period is set, the key may not rotate at the expected interval, leaving the cryptographic material in use longer than intended and increasing the risk of key compromise.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://support.huaweicloud.com/intl/en-us/usermanual-dew/dew_01_0139.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "hcloud KMS UpdateKeyRotation --key_id <key_id> --rotation_interval <period>",
+      "NativeIaC": "",
+      "Other": "1. Log on to the Huawei Cloud console.\n2. Navigate to Key Management Service.\n3. Select the key.\n4. Click the Rotation tab.\n5. Set the rotation period.\n6. Click OK.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Configure a rotation period for all KMS keys that have rotation enabled.",
+      "Url": "https://hub.prowler.com/check/kms_key_rotation_period"
+    }
+  },
+  "Categories": [
+    "encryption"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/huaweicloud/services/kms/kms_key_rotation_period/kms_key_rotation_period.py
+++ b/prowler/providers/huaweicloud/services/kms/kms_key_rotation_period/kms_key_rotation_period.py
@@ -1,0 +1,41 @@
+from prowler.lib.check.models import Check, CheckReportHuaweiCloud
+from prowler.providers.huaweicloud.services.kms.kms_client import kms_client
+
+
+class kms_key_rotation_period(Check):
+    """Check if KMS keys with rotation enabled have a rotation period configured."""
+
+    def execute(self) -> list[CheckReportHuaweiCloud]:
+        findings = []
+
+        for key in kms_client.keys:
+            report = CheckReportHuaweiCloud(metadata=self.metadata(), resource=key)
+            report.region = key.region
+            report.resource_id = key.id
+            report.resource_arn = (
+                f"huaweicloud:kms:{key.region}:"
+                f"{kms_client.audited_account}:key/{key.id}"
+            )
+
+            if not key.is_rotation_enabled:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"KMS key {key.alias} ({key.id}) does not have rotation enabled, "
+                    f"rotation period check is not applicable."
+                )
+            elif key.rotation_period:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"KMS key {key.alias} ({key.id}) has rotation enabled "
+                    f"with period {key.rotation_period}."
+                )
+            else:
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"KMS key {key.alias} ({key.id}) has rotation enabled "
+                    f"but no rotation period is configured."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/huaweicloud/services/kms/kms_key_rotation_period/kms_key_rotation_period_test.py
+++ b/tests/providers/huaweicloud/services/kms/kms_key_rotation_period/kms_key_rotation_period_test.py
@@ -1,0 +1,112 @@
+from unittest import mock
+
+from tests.providers.huaweicloud.huaweicloud_fixtures import (
+    set_mocked_huaweicloud_provider,
+)
+
+
+class TestKmsKeyRotationPeriod:
+    def test_rotation_enabled_with_period_passes(self):
+        kms_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.kms.kms_key_rotation_period.kms_key_rotation_period.kms_client",
+                new=kms_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.kms.kms_key_rotation_period.kms_key_rotation_period import (
+                kms_key_rotation_period,
+            )
+            from prowler.providers.huaweicloud.services.kms.kms_service import KMSKey
+
+            key = KMSKey(
+                id="key-1",
+                alias="alias/rotated-key",
+                is_rotation_enabled=True,
+                rotation_period="30d",
+                region="la-south-2",
+            )
+            kms_client.keys = [key]
+            kms_client.audited_account = "123456789012"
+
+            check = kms_key_rotation_period()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert "30d" in result[0].status_extended
+
+    def test_rotation_enabled_without_period_fails(self):
+        kms_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.kms.kms_key_rotation_period.kms_key_rotation_period.kms_client",
+                new=kms_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.kms.kms_key_rotation_period.kms_key_rotation_period import (
+                kms_key_rotation_period,
+            )
+            from prowler.providers.huaweicloud.services.kms.kms_service import KMSKey
+
+            key = KMSKey(
+                id="key-1",
+                alias="alias/bad-key",
+                is_rotation_enabled=True,
+                rotation_period="",
+                region="la-south-2",
+            )
+            kms_client.keys = [key]
+            kms_client.audited_account = "123456789012"
+
+            check = kms_key_rotation_period()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "no rotation period" in result[0].status_extended
+
+    def test_rotation_disabled_passes(self):
+        kms_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.kms.kms_key_rotation_period.kms_key_rotation_period.kms_client",
+                new=kms_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.kms.kms_key_rotation_period.kms_key_rotation_period import (
+                kms_key_rotation_period,
+            )
+            from prowler.providers.huaweicloud.services.kms.kms_service import KMSKey
+
+            key = KMSKey(
+                id="key-1",
+                alias="alias/static-key",
+                is_rotation_enabled=False,
+                rotation_period="",
+                region="la-south-2",
+            )
+            kms_client.keys = [key]
+            kms_client.audited_account = "123456789012"
+
+            check = kms_key_rotation_period()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert "not applicable" in result[0].status_extended


### PR DESCRIPTION
## New Check: `kms_key_rotation_period`

**Service:** kms
**Severity:** low
**Categories:** encryption

### Description

Ensure that KMS keys with automatic rotation enabled have a rotation period explicitly configured. A missing rotation period may indicate misconfigured key rotation.

### Risk

If key rotation is enabled but no rotation period is set, the key may not rotate at the expected interval, leaving the cryptographic material in use longer than intended and increasing the risk of key compromise.

### Remediation

Configure a rotation period for all KMS keys that have rotation enabled.

### Implementation Details



This is part of the Huawei Cloud provider expansion. See #11950 for the initial provider PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Huawei Cloud KMS security check for key rotation periods.
  * Reports keys with rotation enabled but no configured rotation period.
  * Includes key status, region, identifier, and remediation guidance.

* **Documentation**
  * Added severity, risk, recommendation, and CLI/console remediation details.

* **Tests**
  * Added coverage for enabled, disabled, and unconfigured key rotation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->