### PR TITLE
feat(providers/huaweicloud): add iam_password_policy_not_username check

### DIFF
--- a/prowler/changelog.d/iam-password-policy-not-username.added.md
+++ b/prowler/changelog.d/iam-password-policy-not-username.added.md
@@ -1,0 +1,1 @@
+`iam_password_policy_not_username` check for Huawei Cloud provider: IAM password policy prevents using username in passwords

--- a/prowler/providers/huaweicloud/services/iam/iam_password_policy_not_username/iam_password_policy_not_username.metadata.json
+++ b/prowler/providers/huaweicloud/services/iam/iam_password_policy_not_username/iam_password_policy_not_username.metadata.json
@@ -1,0 +1,36 @@
+{
+  "Provider": "huaweicloud",
+  "CheckID": "iam_password_policy_not_username",
+  "CheckTitle": "IAM password policy prevents using username in passwords",
+  "CheckType": [],
+  "ServiceName": "iam",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "HUAWEICLOUD::IAM::PasswordPolicy",
+  "ResourceGroup": "IAM",
+  "Description": "Huawei Cloud IAM password policies can prevent users from including their username or its inversion in their passwords. It is recommended that this restriction be enabled to reduce predictable password patterns.",
+  "Risk": "Allowing usernames in passwords makes them more predictable and easier to guess or crack via targeted attacks, increasing the risk of unauthorized access.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://support.huaweicloud.com/intl/en-us/usermanual-iam/iam_01_0605.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "hcloud IAM SetDomainPasswordPolicy --password_not_username_or_invert true",
+      "NativeIaC": "",
+      "Other": "1. Log on to the Huawei Cloud console.\n2. Choose IAM & Security.\n3. Click the Password Policy tab.\n4. Enable 'Password cannot contain the username or its inversion'.\n5. Click OK.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Configure the IAM password policy to prevent using the username or its inversion in passwords.",
+      "Url": "https://hub.prowler.com/check/iam_password_policy_not_username"
+    }
+  },
+  "Categories": [
+    "secrets"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/huaweicloud/services/iam/iam_password_policy_not_username/iam_password_policy_not_username.py
+++ b/prowler/providers/huaweicloud/services/iam/iam_password_policy_not_username/iam_password_policy_not_username.py
@@ -1,0 +1,31 @@
+from prowler.lib.check.models import Check, CheckReportHuaweiCloud
+from prowler.providers.huaweicloud.services.iam.iam_client import iam_client
+
+
+class iam_password_policy_not_username(Check):
+    """Check if Huawei Cloud IAM password policy prevents using the username in passwords."""
+
+    def execute(self) -> list[CheckReportHuaweiCloud]:
+        findings = []
+
+        if iam_client.password_policy:
+            report = CheckReportHuaweiCloud(
+                metadata=self.metadata(), resource=iam_client.password_policy
+            )
+            report.region = iam_client.region
+            report.resource_id = f"{iam_client.audited_account}-password-policy"
+            report.resource_name = "password-policy"
+            report.resource_arn = (
+                f"HUAWEICLOUD::IAM::{iam_client.audited_account}:password-policy"
+            )
+
+            if iam_client.password_policy.password_not_username_or_invert:
+                report.status = "PASS"
+                report.status_extended = "IAM password policy prevents using the username (or its inversion) in passwords."
+            else:
+                report.status = "FAIL"
+                report.status_extended = "IAM password policy does not prevent using the username (or its inversion) in passwords, increasing the risk of predictable passwords."
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/huaweicloud/services/iam/iam_password_policy_not_username/iam_password_policy_not_username_test.py
+++ b/tests/providers/huaweicloud/services/iam/iam_password_policy_not_username/iam_password_policy_not_username_test.py
@@ -1,0 +1,99 @@
+from unittest import mock
+
+from tests.providers.huaweicloud.huaweicloud_fixtures import (
+    set_mocked_huaweicloud_provider,
+)
+
+
+class TestIamPasswordPolicyNotUsername:
+    def test_not_username_true_passes(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_password_policy_not_username.iam_password_policy_not_username.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_password_policy_not_username.iam_password_policy_not_username import (
+                iam_password_policy_not_username,
+            )
+            from prowler.providers.huaweicloud.services.iam.iam_service import (
+                PasswordPolicy,
+            )
+
+            iam_client.password_policy = PasswordPolicy(
+                password_not_username_or_invert=True,
+            )
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_password_policy_not_username()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert "prevents using the username" in result[0].status_extended
+
+    def test_not_username_false_fails(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_password_policy_not_username.iam_password_policy_not_username.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_password_policy_not_username.iam_password_policy_not_username import (
+                iam_password_policy_not_username,
+            )
+            from prowler.providers.huaweicloud.services.iam.iam_service import (
+                PasswordPolicy,
+            )
+
+            iam_client.password_policy = PasswordPolicy(
+                password_not_username_or_invert=False,
+            )
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_password_policy_not_username()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "does not prevent" in result[0].status_extended
+
+    def test_no_password_policy(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_password_policy_not_username.iam_password_policy_not_username.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_password_policy_not_username.iam_password_policy_not_username import (
+                iam_password_policy_not_username,
+            )
+
+            iam_client.password_policy = None
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_password_policy_not_username()
+            result = check.execute()
+
+            assert len(result) == 0


### PR DESCRIPTION
## New Check: `iam_password_policy_not_username`

**Service:** iam
**Severity:** medium
**Categories:** secrets

### Description

Huawei Cloud IAM password policies can prevent users from including their username or its inversion in their passwords. It is recommended that this restriction be enabled to reduce predictable password patterns.

### Risk

Allowing usernames in passwords makes them more predictable and easier to guess or crack via targeted attacks, increasing the risk of unauthorized access.

### Remediation

Configure the IAM password policy to prevent using the username or its inversion in passwords.

### Implementation Details



This is part of the Huawei Cloud provider expansion. See #11950 for the initial provider PR.
