### PR TITLE
feat(providers/huaweicloud): add iam_user_password_not_expired check

### DIFF
--- a/prowler/changelog.d/iam-user-password-not-expired.added.md
+++ b/prowler/changelog.d/iam-user-password-not-expired.added.md
@@ -1,0 +1,1 @@
+`iam_user_password_not_expired` check for Huawei Cloud provider: IAM user passwords are not expired

--- a/prowler/providers/huaweicloud/services/iam/iam_user_password_not_expired/iam_user_password_not_expired.metadata.json
+++ b/prowler/providers/huaweicloud/services/iam/iam_user_password_not_expired/iam_user_password_not_expired.metadata.json
@@ -1,0 +1,36 @@
+{
+  "Provider": "huaweicloud",
+  "CheckID": "iam_user_password_not_expired",
+  "CheckTitle": "IAM user passwords are not expired",
+  "CheckType": [],
+  "ServiceName": "iam",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "HUAWEICLOUD::IAM::User",
+  "ResourceGroup": "IAM",
+  "Description": "Huawei Cloud IAM user passwords can have an expiration date. It is recommended to ensure that enabled users do not have expired passwords, as expired passwords may indicate stale or abandoned accounts.",
+  "Risk": "Users with expired passwords may indicate abandoned accounts or credentials that have not been rotated. While expired passwords prevent login, they still represent an attack surface if the password policy is changed or the expiration is removed without proper review.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://support.huaweicloud.com/intl/en-us/usermanual-iam/iam_01_0605.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "1. Log on to the Huawei Cloud console.\n2. Choose IAM & Security.\n3. Identify users with expired passwords.\n4. Either reset the user's password or disable/delete the account if no longer needed.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Ensure that IAM users do not have expired passwords. Reset passwords for users with expired credentials or remove inactive accounts.",
+      "Url": "https://hub.prowler.com/check/iam_user_password_not_expired"
+    }
+  },
+  "Categories": [
+    "identity-access"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/huaweicloud/services/iam/iam_user_password_not_expired/iam_user_password_not_expired.py
+++ b/prowler/providers/huaweicloud/services/iam/iam_user_password_not_expired/iam_user_password_not_expired.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timezone
+
+from prowler.lib.check.models import Check, CheckReportHuaweiCloud
+from prowler.providers.huaweicloud.services.iam.iam_client import iam_client
+
+
+class iam_user_password_not_expired(Check):
+    """Check if Huawei Cloud IAM users do not have expired passwords."""
+
+    def execute(self) -> list[CheckReportHuaweiCloud]:
+        findings = []
+
+        for user in iam_client.users:
+            if user.is_domain_owner:
+                continue
+
+            report = CheckReportHuaweiCloud(metadata=self.metadata(), resource=user)
+            report.region = iam_client.region
+            report.resource_id = user.id
+            report.resource_arn = (
+                f"HUAWEICLOUD::IAM::{iam_client.audited_account}:user/{user.id}"
+            )
+
+            if user.password_expires_at is None:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"IAM user {user.name} has no password expiration configured."
+                )
+            else:
+                try:
+                    expires_at = datetime.fromisoformat(
+                        user.password_expires_at.replace("Z", "+00:00")
+                    )
+                    now = datetime.now(timezone.utc)
+
+                    if expires_at > now:
+                        report.status = "PASS"
+                        report.status_extended = (
+                            f"IAM user {user.name} password expires at "
+                            f"{user.password_expires_at}."
+                        )
+                    else:
+                        report.status = "FAIL"
+                        report.status_extended = (
+                            f"IAM user {user.name} password expired at "
+                            f"{user.password_expires_at}."
+                        )
+                except (ValueError, AttributeError):
+                    report.status = "PASS"
+                    report.status_extended = (
+                        f"IAM user {user.name} has password expiration set to "
+                        f"{user.password_expires_at}."
+                    )
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/huaweicloud/services/iam/iam_user_password_not_expired/iam_user_password_not_expired_test.py
+++ b/tests/providers/huaweicloud/services/iam/iam_user_password_not_expired/iam_user_password_not_expired_test.py
@@ -1,0 +1,155 @@
+from unittest import mock
+
+from tests.providers.huaweicloud.huaweicloud_fixtures import (
+    set_mocked_huaweicloud_provider,
+)
+
+
+class TestIamUserPasswordNotExpired:
+    def test_user_no_expiration_passes(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_user_password_not_expired.iam_user_password_not_expired.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_user_password_not_expired.iam_user_password_not_expired import (
+                iam_user_password_not_expired,
+            )
+            from prowler.providers.huaweicloud.services.iam.iam_service import (
+                IAMUser,
+            )
+
+            user = IAMUser(
+                id="user-1",
+                name="active-user",
+                enabled=True,
+                is_domain_owner=False,
+            )
+            iam_client.users = [user]
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_user_password_not_expired()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert "no password expiration" in result[0].status_extended
+
+    def test_user_future_expiration_passes(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_user_password_not_expired.iam_user_password_not_expired.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_user_password_not_expired.iam_user_password_not_expired import (
+                iam_user_password_not_expired,
+            )
+            from prowler.providers.huaweicloud.services.iam.iam_service import (
+                IAMUser,
+            )
+
+            user = IAMUser(
+                id="user-1",
+                name="active-user",
+                enabled=True,
+                is_domain_owner=False,
+                password_expires_at="2099-12-31T23:59:59.000Z",
+            )
+            iam_client.users = [user]
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_user_password_not_expired()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert "expires at" in result[0].status_extended
+
+    def test_user_past_expiration_fails(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_user_password_not_expired.iam_user_password_not_expired.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_user_password_not_expired.iam_user_password_not_expired import (
+                iam_user_password_not_expired,
+            )
+            from prowler.providers.huaweicloud.services.iam.iam_service import (
+                IAMUser,
+            )
+
+            user = IAMUser(
+                id="user-1",
+                name="expired-user",
+                enabled=True,
+                is_domain_owner=False,
+                password_expires_at="2020-01-01T00:00:00.000Z",
+            )
+            iam_client.users = [user]
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_user_password_not_expired()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "expired at" in result[0].status_extended
+
+    def test_root_user_skipped(self):
+        iam_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.iam.iam_user_password_not_expired.iam_user_password_not_expired.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.iam.iam_user_password_not_expired.iam_user_password_not_expired import (
+                iam_user_password_not_expired,
+            )
+            from prowler.providers.huaweicloud.services.iam.iam_service import (
+                IAMUser,
+            )
+
+            root_user = IAMUser(
+                id="123456789012",
+                name="root",
+                enabled=True,
+                is_domain_owner=True,
+            )
+            iam_client.users = [root_user]
+            iam_client.audited_account = "123456789012"
+            iam_client.region = "la-south-2"
+
+            check = iam_user_password_not_expired()
+            result = check.execute()
+
+            assert len(result) == 0


### PR DESCRIPTION
## New Check: `iam_user_password_not_expired`

**Service:** iam
**Severity:** medium
**Categories:** identity-access

### Description

Huawei Cloud IAM user passwords can have an expiration date. It is recommended to ensure that enabled users do not have expired passwords, as expired passwords may indicate stale or abandoned accounts.

### Risk

Users with expired passwords may indicate abandoned accounts or credentials that have not been rotated. While expired passwords prevent login, they still represent an attack surface if the password policy is changed or the expiration is removed without proper review.

### Remediation

Ensure that IAM users do not have expired passwords. Reset passwords for users with expired credentials or remove inactive accounts.

### Implementation Details



This is part of the Huawei Cloud provider expansion. See #11950 for the initial provider PR.
