### PR TITLE
feat(providers/huaweicloud): add rds_instance_high_availability check

### DIFF
--- a/prowler/changelog.d/rds-instance-high-availability.added.md
+++ b/prowler/changelog.d/rds-instance-high-availability.added.md
@@ -1,0 +1,1 @@
+`rds_instance_high_availability` check for Huawei Cloud provider: RDS instances have high availability configured

--- a/prowler/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability.metadata.json
+++ b/prowler/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability.metadata.json
@@ -1,0 +1,36 @@
+{
+  "Provider": "huaweicloud",
+  "CheckID": "rds_instance_high_availability",
+  "CheckTitle": "RDS instances have high availability configured",
+  "CheckType": [],
+  "ServiceName": "rds",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "HUAWEICLOUD::RDS::Instance",
+  "ResourceGroup": "database",
+  "Description": "Ensure that RDS instances have high availability (HA) configured with a standby instance.",
+  "Risk": "RDS instances without high availability do not have a standby instance, leading to downtime during maintenance windows or instance failures.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://support.huaweicloud.com/intl/en-us/usermanual-rds-mysql/rds_02_0025.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "1. Log on to the Huawei Cloud console.\n2. Navigate to Relational Database Service.\n3. Select the instance.\n4. Click More > Create Standby Instance.\n5. Configure the standby instance and click Save.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Enable high availability for RDS instances by creating a standby instance.",
+      "Url": "https://hub.prowler.com/check/rds_instance_high_availability"
+    }
+  },
+  "Categories": [
+    "resilience"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability.metadata.json
+++ b/prowler/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability.metadata.json
@@ -9,21 +9,22 @@
   "Severity": "medium",
   "ResourceType": "HUAWEICLOUD::RDS::Instance",
   "ResourceGroup": "database",
-  "Description": "Ensure that RDS instances have high availability (HA) configured with a standby instance.",
-  "Risk": "RDS instances without high availability do not have a standby instance, leading to downtime during maintenance windows or instance failures.",
+  "Description": "Check whether RDS instances use the primary/standby high availability (Ha) deployment type.",
+  "Risk": "Single-node RDS instances have no standby node for failover, increasing downtime risk during node failures and maintenance.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://support.huaweicloud.com/intl/en-us/usermanual-rds-mysql/rds_02_0025.html"
+    "https://support.huaweicloud.com/intl/en-us/api-rds/rds_01_0004.html",
+    "https://registry.terraform.io/providers/huaweicloud/huaweicloud/latest/docs/resources/rds_instance"
   ],
   "Remediation": {
     "Code": {
       "CLI": "",
       "NativeIaC": "",
-      "Other": "1. Log on to the Huawei Cloud console.\n2. Navigate to Relational Database Service.\n3. Select the instance.\n4. Click More > Create Standby Instance.\n5. Configure the standby instance and click Save.",
-      "Terraform": ""
+      "Other": "Create a primary/standby RDS instance or change the single-node instance to the primary/standby deployment type. High availability and multi-AZ placement are separate controls; select distinct AZs when multi-AZ resilience is also required.",
+      "Terraform": "```hcl\nresource \"huaweicloud_rds_instance\" \"example\" {\n  flavor              = \"rds.pg.n1.large.2.ha\"\n  ha_replication_mode = \"async\"\n  availability_zone   = [var.primary_az, var.standby_az]\n\n  # Configure the remaining required instance arguments.\n}\n```"
     },
     "Recommendation": {
-      "Text": "Enable high availability for RDS instances by creating a standby instance.",
+      "Text": "Use the RDS primary/standby (Ha) deployment type to provide a standby node for failover.",
       "Url": "https://hub.prowler.com/check/rds_instance_high_availability"
     }
   },

--- a/prowler/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability.py
+++ b/prowler/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability.py
@@ -1,0 +1,36 @@
+from prowler.lib.check.models import Check, CheckReportHuaweiCloud
+from prowler.providers.huaweicloud.services.rds.rds_client import rds_client
+
+
+class rds_instance_high_availability(Check):
+    """Check if RDS instances have high availability configured."""
+
+    def execute(self) -> list[CheckReportHuaweiCloud]:
+        findings = []
+
+        for instance in rds_client.instances:
+            report = CheckReportHuaweiCloud(
+                metadata=self.metadata(), resource=instance
+            )
+            report.region = instance.region
+            report.resource_id = instance.id
+            report.resource_arn = (
+                f"huaweicloud:rds:{instance.region}:{rds_client.audited_account}:instance/{instance.id}"
+            )
+
+            if instance.is_ha:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"RDS instance {instance.name} ({instance.id}) "
+                    f"has high availability configured."
+                )
+            else:
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"RDS instance {instance.name} ({instance.id}) "
+                    f"does not have high availability configured (single instance deployment)."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability.py
+++ b/prowler/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability.py
@@ -9,14 +9,10 @@ class rds_instance_high_availability(Check):
         findings = []
 
         for instance in rds_client.instances:
-            report = CheckReportHuaweiCloud(
-                metadata=self.metadata(), resource=instance
-            )
+            report = CheckReportHuaweiCloud(metadata=self.metadata(), resource=instance)
             report.region = instance.region
             report.resource_id = instance.id
-            report.resource_arn = (
-                f"huaweicloud:rds:{instance.region}:{rds_client.audited_account}:instance/{instance.id}"
-            )
+            report.resource_arn = f"huaweicloud:rds:{instance.region}:{rds_client.audited_account}:instance/{instance.id}"
 
             if instance.is_ha:
                 report.status = "PASS"

--- a/prowler/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability.py
+++ b/prowler/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability.py
@@ -6,6 +6,11 @@ class rds_instance_high_availability(Check):
     """Check if RDS instances have high availability configured."""
 
     def execute(self) -> list[CheckReportHuaweiCloud]:
+        """Evaluate high availability for each RDS instance.
+
+        Returns:
+            A list of Huawei Cloud check reports.
+        """
         findings = []
 
         for instance in rds_client.instances:

--- a/prowler/providers/huaweicloud/services/rds/rds_service.py
+++ b/prowler/providers/huaweicloud/services/rds/rds_service.py
@@ -57,6 +57,9 @@ class RDS(HuaweiCloudService):
                             id=getattr(inst_data, "id", None) or "",
                             name=getattr(inst_data, "name", None) or "",
                             status=getattr(inst_data, "status", None) or "",
+                            is_ha=(
+                                (getattr(inst_data, "type", None) or "").lower() == "ha"
+                            ),
                             engine=engine,
                             engine_version=engine_version,
                             public_ip=public_ip,
@@ -81,6 +84,7 @@ class RDSInstance(HuaweiCloudBaseModel):
     id: str
     name: str
     status: str = ""
+    is_ha: bool = False
     engine: str = ""
     engine_version: str = ""
     public_ip: str = ""

--- a/tests/providers/huaweicloud/services/rds/huaweicloud_rds_service_test.py
+++ b/tests/providers/huaweicloud/services/rds/huaweicloud_rds_service_test.py
@@ -28,6 +28,7 @@ class TestRDSService:
             id="rds-public",
             name="public-db",
             status="ACTIVE",
+            type="Ha",
             public_ips=["1.2.3.4"],
             backup_strategy=SimpleNamespace(keep_days=7),
             datastore=SimpleNamespace(type="MySQL", version="8.0"),
@@ -37,6 +38,7 @@ class TestRDSService:
             id="rds-private",
             name="private-db",
             status="ACTIVE",
+            type="Single",
             public_ips=[],
             backup_strategy=SimpleNamespace(keep_days=0),
             datastore=SimpleNamespace(type="PostgreSQL", version="14"),
@@ -65,6 +67,7 @@ class TestRDSService:
         # backup_enabled derives from backup_strategy.keep_days
         assert public_db.backup_enabled is True
         assert public_db.disk_encryption_id == "kms-key-1"
+        assert public_db.is_ha is True
 
         private_db = by_id["rds-private"]
         assert private_db.is_public is False
@@ -72,6 +75,7 @@ class TestRDSService:
         assert private_db.backup_enabled is False
         assert private_db.engine == "PostgreSQL"
         assert private_db.disk_encryption_id == ""
+        assert private_db.is_ha is False
 
     def test_list_instances_empty(self):
         regional_client = mock.MagicMock(region=REGION)

--- a/tests/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability_test.py
+++ b/tests/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability_test.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 from tests.providers.huaweicloud.huaweicloud_fixtures import (
@@ -102,3 +103,14 @@ class TestRdsInstanceHighAvailability:
             result = check.execute()
 
             assert len(result) == 0
+
+            metadata = json.loads(check.metadata())
+            assert (
+                "https://support.huaweicloud.com/intl/en-us/api-rds/rds_01_0004.html"
+                in metadata["AdditionalURLs"]
+            )
+            assert "ha_replication_mode" in metadata["Remediation"]["Code"]["Terraform"]
+            assert (
+                "Create Standby Instance"
+                not in metadata["Remediation"]["Code"]["Other"]
+            )

--- a/tests/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability_test.py
+++ b/tests/providers/huaweicloud/services/rds/rds_instance_high_availability/rds_instance_high_availability_test.py
@@ -1,0 +1,104 @@
+from unittest import mock
+
+from tests.providers.huaweicloud.huaweicloud_fixtures import (
+    set_mocked_huaweicloud_provider,
+)
+
+
+class TestRdsInstanceHighAvailability:
+    def test_ha_enabled_passes(self):
+        rds_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.rds.rds_instance_high_availability.rds_instance_high_availability.rds_client",
+                new=rds_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.rds.rds_instance_high_availability.rds_instance_high_availability import (
+                rds_instance_high_availability,
+            )
+            from prowler.providers.huaweicloud.services.rds.rds_service import (
+                RDSInstance,
+            )
+
+            instance = RDSInstance(
+                id="rds-1",
+                name="ha-db",
+                is_ha=True,
+                region="la-south-2",
+            )
+            rds_client.instances = [instance]
+            rds_client.audited_account = "123456789012"
+
+            check = rds_instance_high_availability()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert "high availability configured" in result[0].status_extended
+
+    def test_ha_disabled_fails(self):
+        rds_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.rds.rds_instance_high_availability.rds_instance_high_availability.rds_client",
+                new=rds_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.rds.rds_instance_high_availability.rds_instance_high_availability import (
+                rds_instance_high_availability,
+            )
+            from prowler.providers.huaweicloud.services.rds.rds_service import (
+                RDSInstance,
+            )
+
+            instance = RDSInstance(
+                id="rds-1",
+                name="single-db",
+                is_ha=False,
+                region="la-south-2",
+            )
+            rds_client.instances = [instance]
+            rds_client.audited_account = "123456789012"
+
+            check = rds_instance_high_availability()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "does not have high availability" in result[0].status_extended
+
+    def test_no_instances(self):
+        rds_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_huaweicloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.huaweicloud.services.rds.rds_instance_high_availability.rds_instance_high_availability.rds_client",
+                new=rds_client,
+            ),
+        ):
+            from prowler.providers.huaweicloud.services.rds.rds_instance_high_availability.rds_instance_high_availability import (
+                rds_instance_high_availability,
+            )
+
+            rds_client.instances = []
+            rds_client.audited_account = "123456789012"
+
+            check = rds_instance_high_availability()
+            result = check.execute()
+
+            assert len(result) == 0


### PR DESCRIPTION
## New Check: `rds_instance_high_availability`

**Service:** rds
**Severity:** medium
**Categories:** resilience

### Description

Ensure that RDS instances have high availability (HA) configured with a standby instance.

### Risk

RDS instances without high availability do not have a standby instance, leading to downtime during maintenance windows or instance failures.

### Remediation

Enable high availability for RDS instances by creating a standby instance.

### Implementation Details



This is part of the Huawei Cloud provider expansion. See #11950 for the initial provider PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Huawei Cloud RDS check to verify that database instances have high availability enabled.
  * Findings include clear pass/fail status, severity, remediation guidance, and resilience classification.
  * RDS instance details now identify whether high availability is configured.

* **Tests**
  * Added coverage for highly available, single-instance, and empty-resource scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->