### PR TITLE
fix(api): return 401 instead of 500 for API keys with no owning user

### DIFF
--- a/api/changelog.d/api-key-null-entity-401.fixed.md
+++ b/api/changelog.d/api-key-null-entity-401.fixed.md
@@ -1,0 +1,1 @@
+API keys whose owning user no longer exists now fail authentication with 401 instead of raising a 500

--- a/api/src/backend/api/authentication.py
+++ b/api/src/backend/api/authentication.py
@@ -59,6 +59,10 @@ class TenantAPIKeyAuthentication(BaseAPIKeyAuth):
         if api_key.revoked:
             raise AuthenticationFailed("This API Key has been revoked.")
 
+        # `entity` is SET_NULL, so a key can outlive the user that owned it
+        if api_key.entity is None:
+            raise AuthenticationFailed("No entity matching this api key.")
+
         client_ip = request.META.get(package_settings.IP_ADDRESS_HEADER)
         if api_key.blacklisted_ips and client_ip in api_key.blacklisted_ips:
             raise AuthenticationFailed("Access denied from blacklisted IP.")
@@ -104,7 +108,7 @@ class TenantAPIKeyAuthentication(BaseAPIKeyAuth):
 
         return entity, {
             "tenant_id": str(api_key_instance.tenant_id),
-            "sub": str(api_key_instance.entity.id),
+            "sub": str(entity.id),
             "api_key_prefix": prefix,
         }
 

--- a/api/src/backend/api/tests/test_authentication.py
+++ b/api/src/backend/api/tests/test_authentication.py
@@ -278,6 +278,34 @@ class TestTenantAPIKeyAuthentication:
 
         assert str(exc_info.value.detail) == "No entity matching this api key."
 
+    def test_authenticate_api_key_with_null_entity(
+        self, auth_backend, create_test_user, tenants_fixture, request_factory
+    ):
+        """Test authentication fails when the API key has no owning entity."""
+        tenant = tenants_fixture[0]
+        user = create_test_user
+
+        api_key, raw_key = TenantAPIKey.objects.create_api_key(
+            name="Orphaned API Key",
+            tenant_id=tenant.id,
+            entity=user,
+            expiry_date=datetime.now(UTC) + timedelta(days=30),
+        )
+
+        # Bypass the revoke signal to reproduce the orphaned rows seen in production
+        TenantAPIKey.objects.filter(id=api_key.id).update(entity=None)
+        api_key.refresh_from_db()
+        assert api_key.entity is None
+        assert not api_key.revoked
+
+        request = request_factory.get("/")
+        request.META["HTTP_AUTHORIZATION"] = f"Api-Key {raw_key}"
+
+        with pytest.raises(AuthenticationFailed) as exc_info:
+            auth_backend.authenticate(request)
+
+        assert str(exc_info.value.detail) == "No entity matching this api key."
+
     def test_authenticate_updates_last_used_at(
         self, auth_backend, api_keys_fixture, request_factory
     ):


### PR DESCRIPTION
### Context

Production pro API returned intermittent 500s on `/api/v1/scans`, driving a critical ALB5XXErrors alert (57 breach buckets over 3 days, peaking at 29% error rate).

### Description

`TenantAPIKey.entity` is a ForeignKey with `on_delete=SET_NULL`, so an API key outlives the user that owned it. `TenantAPIKeyAuthentication` then dereferenced `api_key_instance.entity.id` and raised `AttributeError: 'NoneType' object has no attribute 'id'`, surfacing as a 500 during authentication rather than a 401.

The fix rejects a key with a null entity in `_authenticate_credentials` with the existing "No entity matching this api key." message, and reads `sub` from the already-validated entity instead of re-dereferencing the re-fetched instance.

A `pre_delete` signal on `User` revokes keys, so these orphaned rows predate that signal or were created through a path that bypassed it; the guard is defensive regardless.

Adds a regression test, `test_authenticate_api_key_with_null_entity`, which reproduces the production state (entity NULL, revoked False) by bypassing the revoke signal.

### Steps to review

Diff is confined to `api/src/backend/api/authentication.py` and its test file, plus a changelog fragment. All 27 tests in `api/tests/test_authentication.py` pass.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the open issues or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the open issues or Prowler Community Slack
- [ ] I have reviewed the open pull requests and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the README.md
- [x] Ensure a changelog fragment is added under prowler/changelog.d/, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable) — production ALB5XXErrors alert data cited above
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure a changelog fragment is added under api/changelog.d/, if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API keys associated with deleted or unavailable entities now return HTTP 401 Unauthorized instead of causing an internal server error.
  * Authentication safely rejects orphaned API keys with a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->