### PR TITLE
fix(api): refresh Security Hub connection status

### DIFF
--- a/api/changelog.d/security-hub-connection-status.fixed.md
+++ b/api/changelog.d/security-hub-connection-status.fixed.md
@@ -1,0 +1,1 @@
+AWS Security Hub integrations now persist successful connection checks during finding delivery so their connection status and last checked timestamp stay current

--- a/api/src/backend/tasks/jobs/integrations.py
+++ b/api/src/backend/tasks/jobs/integrations.py
@@ -1,5 +1,6 @@
 import os
 import time
+from datetime import UTC, datetime
 from glob import glob
 
 from api.db_router import READ_REPLICA_ALIAS, MainRouter
@@ -214,8 +215,10 @@ def get_security_hub_client_from_integration(
         for region in set(all_security_hub_regions):
             regions_status[region] = region in connection.enabled_regions
 
-        # Save regions information in the integration configuration
+        # Persist the successful connection check and regions information
         with rls_transaction(tenant_id, using=MainRouter.default_db):
+            integration.connected = True
+            integration.connection_last_checked_at = datetime.now(tz=UTC)
             integration.configuration["regions"] = regions_status
             integration.save()
 

--- a/api/src/backend/tasks/tests/test_integrations.py
+++ b/api/src/backend/tasks/tests/test_integrations.py
@@ -726,15 +726,22 @@ class TestSecurityHubIntegrationUploads:
             # Configure the test_connection to return our mock_connection
             mock_security_hub_class.test_connection = mock_test_connection
 
+            checked_at_before = datetime.now(tz=UTC)
             connected, security_hub = get_security_hub_client_from_integration(
                 mock_integration, tenant_id, mock_findings
             )
+            checked_at_after = datetime.now(tz=UTC)
 
         assert connected is True
         assert security_hub == mock_security_hub
         assert mock_integration.connected is True
-        assert isinstance(mock_integration.connection_last_checked_at, datetime)
-        assert mock_integration.connection_last_checked_at <= datetime.now(tz=UTC)
+        assert mock_integration.connection_last_checked_at.tzinfo is UTC
+        assert (
+            checked_at_before
+            <= mock_integration.connection_last_checked_at
+            <= checked_at_after
+        )
+        mock_integration.save.assert_called_once()
 
         # Verify SecurityHub was called once to create the client
         assert mock_security_hub_class.call_count == 1

--- a/api/src/backend/tasks/tests/test_integrations.py
+++ b/api/src/backend/tasks/tests/test_integrations.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -671,6 +672,8 @@ class TestSecurityHubIntegrationUploads:
         mock_integration = MagicMock()
         mock_integration.configuration = {"send_only_fails": True}
         mock_integration.credentials = {}  # Empty credentials, use provider
+        mock_integration.connected = False
+        mock_integration.connection_last_checked_at = None
 
         # Mock tenant_id
         tenant_id = "550e8400-e29b-41d4-a716-446655440000"  # Valid UUID
@@ -729,6 +732,9 @@ class TestSecurityHubIntegrationUploads:
 
         assert connected is True
         assert security_hub == mock_security_hub
+        assert mock_integration.connected is True
+        assert isinstance(mock_integration.connection_last_checked_at, datetime)
+        assert mock_integration.connection_last_checked_at <= datetime.now(tz=UTC)
 
         # Verify SecurityHub was called once to create the client
         assert mock_security_hub_class.call_count == 1


### PR DESCRIPTION
### Context

AWS Security Hub finding delivery revalidates the integration connection before sending findings. When that check recovered from a previous failure, the delivery succeeded but only the region configuration was persisted. The integration could therefore remain marked as disconnected with a stale last-checked timestamp while findings continued to reach Security Hub.

### Description

- Persist successful Security Hub connection checks during finding delivery
- Update the connection status and last-checked timestamp together with the region configuration
- Cover disconnected-to-connected recovery with a regression test
- Add an API changelog fragment

### Steps to review

1. Run `cd api && uv run pytest src/backend/tasks/tests/test_integrations.py -q`
2. Run `cd api && uv run ruff check src/backend/tasks/jobs/integrations.py src/backend/tasks/tests/test_integrations.py`
3. Verify that a successful Security Hub connection check changes a previously disconnected integration to connected and refreshes `connection_last_checked_at`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### SDK/CLI

- Are there new checks included in this PR? No

#### UI

Not applicable.

#### API

- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (not applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (not applicable)
- [ ] Performance test results (not applicable)
- [x] Validation evidence: `41 passed` in `tasks/tests/test_integrations.py`; Ruff check and format passed
- [x] Verify if API specs need to be regenerated. No regeneration needed.
- [x] Check if version updates are required. No version update required.
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server

Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AWS Security Hub integrations now retain a successful connection status when findings are delivered.
  * The integration’s last-checked timestamp is updated with the current UTC time.
  * Connection status and related integration information remain current after successful connection checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->