### PR TITLE
fix(ui): wrap long Lighthouse chat messages

### DIFF
--- a/ui/app/(prowler)/lighthouse/_components/chat/message-bubble.browser.test.tsx
+++ b/ui/app/(prowler)/lighthouse/_components/chat/message-bubble.browser.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { render } from "@/__tests__/render-browser";
+import {
+  LIGHTHOUSE_V2_MESSAGE_ROLE,
+  LIGHTHOUSE_V2_PART_TYPE,
+  type LighthouseV2Message,
+} from "@/app/(prowler)/lighthouse/_types";
+
+import { MessageBubble } from "./message-bubble";
+
+describe("MessageBubble", () => {
+  it("should wrap long user text inside the message bubble", async () => {
+    // Given
+    const longText = "a".repeat(500);
+    const userMessage: LighthouseV2Message = {
+      id: "message-user-long-text",
+      role: LIGHTHOUSE_V2_MESSAGE_ROLE.USER,
+      model: null,
+      tokenUsage: null,
+      insertedAt: "2026-06-25T10:00:00Z",
+      parts: [
+        {
+          id: "part-user-long-text",
+          type: LIGHTHOUSE_V2_PART_TYPE.TEXT,
+          content: { text: longText },
+          toolCallOutcome: null,
+          insertedAt: "2026-06-25T10:00:00Z",
+          updatedAt: "2026-06-25T10:00:00Z",
+        },
+      ],
+    };
+
+    // When
+    const { getByText } = await render(
+      <div style={{ width: 320 }}>
+        <MessageBubble message={userMessage} />
+      </div>,
+    );
+    const messageText = getByText(longText).element();
+
+    // Then
+    expect(messageText.scrollWidth).toBeLessThanOrEqual(
+      messageText.clientWidth,
+    );
+  });
+});

--- a/ui/app/(prowler)/lighthouse/_components/chat/message-bubble.tsx
+++ b/ui/app/(prowler)/lighthouse/_components/chat/message-bubble.tsx
@@ -76,7 +76,7 @@ export function MessageBubble({ message }: { message: LighthouseV2Message }) {
           {/* User text stays plain to preserve HTML-like tags; assistant
               renders parts in order so tool calls sit between text blocks. */}
           {isUser ? (
-            <p className="whitespace-pre-wrap">{messageText}</p>
+            <p className="break-words whitespace-pre-wrap">{messageText}</p>
           ) : (
             <AssistantParts parts={message.parts} />
           )}

--- a/ui/app/(prowler)/lighthouse/_components/chat/message-bubble.tsx
+++ b/ui/app/(prowler)/lighthouse/_components/chat/message-bubble.tsx
@@ -76,7 +76,7 @@ export function MessageBubble({ message }: { message: LighthouseV2Message }) {
           {/* User text stays plain to preserve HTML-like tags; assistant
               renders parts in order so tool calls sit between text blocks. */}
           {isUser ? (
-            <p className="break-words whitespace-pre-wrap">{messageText}</p>
+            <p className="wrap-break-word whitespace-pre-wrap">{messageText}</p>
           ) : (
             <AssistantParts parts={message.parts} />
           )}

--- a/ui/changelog.d/lighthouse-chat-message-overflow.fixed.md
+++ b/ui/changelog.d/lighthouse-chat-message-overflow.fixed.md
@@ -1,0 +1,1 @@
+Long unbroken messages in Lighthouse chat no longer overflow their message bubble


### PR DESCRIPTION
### Context

Lighthouse user messages containing long unbroken strings overflowed the message bubble and extended beyond the chat viewport. Dark mode masked the overflow because the text inherited the dark bubble text color, while light mode exposed it.

### Description

- Wrap long unbroken user-message text inside the Lighthouse chat bubble while preserving explicit line breaks
- Add a Chromium browser regression test that verifies rendered text stays within a constrained message bubble
- Add the required UI changelog fragment

### Steps to review

1. Open Lighthouse chat.
2. Send a message containing a long string without spaces.
3. Verify the text wraps inside the green message bubble in both light and dark modes.
4. Run the focused tests:
   - `pnpm exec vitest run --project unit 'app/(prowler)/lighthouse/_components/chat/message-bubble.test.tsx'`
   - `pnpm exec vitest run --project browser 'app/(prowler)/lighthouse/_components/chat/message-bubble.browser.test.tsx'`
5. Run `pnpm run healthcheck`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the open issues or roadmap.prowler.com
- [ ] It is assigned to me
- [x] I reviewed open pull requests for an existing implementation

</details>

- [x] Code is covered by tests
- [x] No documentation changes are required
- [ ] Review if backport is needed
- [x] No README changes are required

#### SDK/CLI

- New checks included: No

#### UI

- [x] UI requirement works as expected
- [x] No npm dependencies were added or updated by this PR
- [x] Browser regression test covers constrained chat width
- [x] UI changelog fragment added under `ui/changelog.d/`

#### API

- Not applicable

#### MCP Server

- Not applicable

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Long, unbroken text in Lighthouse chat messages now wraps within the message bubble instead of overflowing horizontally.
* **Tests**
  * Added a browser test to verify lengthy messages stay contained within the chat layout.
* **Documentation**
  * Updated the changelog entry to note the message overflow fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->