### PR TITLE
feat(ui): improve Lighthouse per-page suggested prompts

### DIFF
--- a/ui/app/(prowler)/lighthouse/_components/chat/empty-state.tsx
+++ b/ui/app/(prowler)/lighthouse/_components/chat/empty-state.tsx
@@ -1,11 +1,26 @@
 "use client";
 
-import { Cloud, FileCheck2, Network, ShieldAlert } from "lucide-react";
+import {
+  Cloud,
+  FileCheck2,
+  type LucideIcon,
+  Network,
+  ShieldAlert,
+} from "lucide-react";
 import { type ReactNode, type SubmitEvent } from "react";
 
 import { LighthouseIconWithAura } from "@/components/icons";
 import { Button } from "@/components/shadcn/button/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/shadcn/tooltip";
 import { cn } from "@/lib/utils";
+import type {
+  LighthousePageSuggestion,
+  LighthousePageSuggestions,
+} from "@/types/lighthouse-context";
 
 import { ChatComposerPanel } from "./composer";
 import { DecryptedText } from "./decrypted-text";
@@ -47,7 +62,7 @@ interface ChatEmptyStateProps {
   onInputChange: (value: string) => void;
   onSubmit: (event: SubmitEvent<HTMLFormElement>) => void;
   onSubmitText: (text: string) => Promise<void>;
-  suggestions?: readonly string[];
+  suggestions?: LighthousePageSuggestions;
   footer?: ReactNode;
   // Side-panel variant: smaller logo and static (non-animated) copy — the
   // decrypt animation reflows multi-line text in narrow widths.
@@ -61,6 +76,9 @@ export function ChatEmptyState({
   compact = false,
   ...composerPanelProps
 }: ChatEmptyStateProps) {
+  const displayedSuggestions: readonly ChatSuggestion[] =
+    suggestions ?? LIGHTHOUSE_V2_SUGGESTIONS;
+
   return (
     <div className="flex min-h-0 flex-1 items-center justify-center px-4 py-10 md:px-8">
       <div className="mx-auto flex w-full max-w-5xl flex-col items-center gap-5">
@@ -113,36 +131,46 @@ export function ChatEmptyState({
           <span className="text-text-neutral-secondary basis-full text-center text-sm font-medium">
             Try Lighthouse AI for...
           </span>
-          {suggestions
-            ? suggestions.map((suggestion) => (
-                <Button
-                  key={suggestion}
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => onInputChange(suggestion)}
-                >
-                  {suggestion}
-                </Button>
-              ))
-            : LIGHTHOUSE_V2_SUGGESTIONS.map((suggestion) => {
-                const Icon = suggestion.icon;
-                return (
-                  <Button
-                    key={suggestion.label}
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => onInputChange(suggestion.prompt)}
-                  >
-                    <Icon className="size-4" />
-                    {suggestion.label}
-                  </Button>
-                );
-              })}
+          {displayedSuggestions.map((suggestion) => (
+            <SuggestionButton
+              key={suggestion.prompt}
+              suggestion={suggestion}
+              onSelect={onInputChange}
+            />
+          ))}
         </div>
         {footer ? <div className="w-full max-w-4xl">{footer}</div> : null}
       </div>
     </div>
+  );
+}
+
+interface ChatSuggestion extends LighthousePageSuggestion {
+  icon?: LucideIcon;
+}
+
+interface SuggestionButtonProps {
+  suggestion: ChatSuggestion;
+  onSelect: (prompt: string) => void;
+}
+
+function SuggestionButton({ suggestion, onSelect }: SuggestionButtonProps) {
+  const Icon = suggestion.icon;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onSelect(suggestion.prompt)}
+        >
+          {Icon ? <Icon className="size-4" /> : null}
+          {suggestion.label}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent maxWidth="md">{suggestion.prompt}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/ui/app/(prowler)/lighthouse/_components/panel/lighthouse-panel-chat.test.tsx
+++ b/ui/app/(prowler)/lighthouse/_components/panel/lighthouse-panel-chat.test.tsx
@@ -202,6 +202,33 @@ describe("LighthousePanelChat", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows the full contextual prompt on hover and prefills it without sending", async () => {
+    // Given
+    const user = userEvent.setup();
+    const prompt =
+      "Give me the actual remediation for the top failing check here: the commands and IaC changes (if possible, with Terraform preferred), the blast radius of applying them, and what to verify afterward.";
+    render(<LighthousePanelChat />);
+    const suggestion = await screen.findByRole("button", {
+      name: "Generate concrete remediation",
+    });
+
+    // When
+    await user.hover(suggestion);
+
+    // Then
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(prompt);
+
+    // When
+    await user.click(suggestion);
+
+    // Then
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+      prompt,
+    );
+    expect(createSessionMock).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
   it("submits a queued contextual analysis when the panel chat becomes ready", async () => {
     // Given
     const context = {

--- a/ui/changelog.d/lighthouse-contextual-suggestions.changed.md
+++ b/ui/changelog.d/lighthouse-contextual-suggestions.changed.md
@@ -1,0 +1,1 @@
+Lighthouse contextual suggestions now show concise actions while preserving detailed prompts for chat

--- a/ui/lib/lighthouse/context/pages.constants.ts
+++ b/ui/lib/lighthouse/context/pages.constants.ts
@@ -1,0 +1,327 @@
+import {
+  LIGHTHOUSE_PAGE_ID,
+  type LighthousePageDefinitionInput,
+  type LighthousePageSuggestions,
+} from "@/types/lighthouse-context";
+
+const PROVIDER_SCOPE_PARAMS = [
+  "filter[provider__in]",
+  "filter[provider_id__in]",
+  "filter[provider_uid]",
+  "filter[provider_uid__in]",
+  "filter[provider_type__in]",
+  "filter[provider]",
+  "filter[provider_type]",
+  "filter[provider_groups__in]",
+] as const;
+
+const COMMON_LIST_PARAMS = [
+  "query",
+  "search",
+  "filter[search]",
+  "sort",
+] as const;
+
+export const LIGHTHOUSE_GLOBAL_SUGGESTIONS = [
+  {
+    label: "Identify biggest security risk",
+    prompt:
+      "Pull my findings, compliance gaps, and attack paths together into one picture. What's my single biggest security risk right now, and how confident are you?",
+  },
+  {
+    label: "Review stale mute rules",
+    prompt:
+      "Which of my mute rules are hiding something that now matters — rules written for a resource that changed, or an exception nobody has revisited?",
+  },
+  {
+    label: "Find missing alerts",
+    prompt:
+      "Look at my most serious findings from the last month. Which of them produced no alert from Prowler, and what rule would have caught them?",
+  },
+  {
+    label: "Create Jira tickets",
+    prompt:
+      "Turn my top security work into Jira tickets: group related findings into one ticket per root cause, write each so an engineer can act on it without coming back to ask me questions, and tell me which project each should go to.",
+  },
+] as const satisfies LighthousePageSuggestions;
+
+export const LIGHTHOUSE_PAGE_DEFINITION_INPUTS = [
+  {
+    id: LIGHTHOUSE_PAGE_ID.OVERVIEW,
+    label: "Overview",
+    match: (pathname) => pathname === "/",
+    allowedSearchParams: PROVIDER_SCOPE_PARAMS,
+    suggestions: [
+      {
+        label: "Prioritize this overview",
+        prompt: "What should I prioritize from this overview?",
+      },
+      {
+        label: "Improve my ThreatScore",
+        prompt:
+          "According to the Prowler ThreatScore, what do I need to improve, and why?",
+      },
+      {
+        label: "Plan today's security work",
+        prompt: "Build a practical security plan for today.",
+      },
+      {
+        label: "Find coverage blind spots",
+        prompt:
+          "What's missing from this dashboard that should worry me — providers not onboarded, regions or services with no scan coverage, checks that never run?",
+      },
+    ],
+  },
+  {
+    id: LIGHTHOUSE_PAGE_ID.FINDINGS,
+    label: "Findings",
+    match: (pathname) => pathname === "/findings",
+    allowedSearchParams: [
+      ...PROVIDER_SCOPE_PARAMS,
+      ...COMMON_LIST_PARAMS,
+      "filter[region__in]",
+      "filter[service__in]",
+      "filter[severity__in]",
+      "filter[status__in]",
+      "filter[delta]",
+      "filter[delta__in]",
+      "filter[resource_type__in]",
+      "filter[category__in]",
+      "filter[resource_groups__in]",
+      "filter[scan]",
+      "filter[scan__in]",
+      "filter[scan_id]",
+      "filter[scan_id__in]",
+      "filter[inserted_at]",
+      "filter[muted]",
+    ],
+    suggestions: [
+      {
+        label: "Generate concrete remediation",
+        prompt:
+          "Give me the actual remediation for the top failing check here: the commands and IaC changes (if possible, with Terraform preferred), the blast radius of applying them, and what to verify afterward.",
+      },
+      {
+        label: "Re-rank by real exposure",
+        prompt:
+          "Severity here is the check's label, not my actual risk. Re-rank these by real exposure, whether the affected resource is internet-facing, production, or holds data; and give me the true top five.",
+      },
+      {
+        label: "Group by shared fix",
+        prompt:
+          "Group these by the underlying change that fixes them, the same IAM policy, module, or baseline; not by check. Which single change clears the most findings?",
+      },
+      {
+        label: "Build remediation plan",
+        prompt: "Create a remediation plan for this findings view.",
+      },
+    ],
+  },
+  {
+    id: LIGHTHOUSE_PAGE_ID.RESOURCES,
+    label: "Resources",
+    match: (pathname) => pathname === "/resources",
+    allowedSearchParams: [
+      ...PROVIDER_SCOPE_PARAMS,
+      ...COMMON_LIST_PARAMS,
+      "filter[region__in]",
+      "filter[service__in]",
+      "filter[type__in]",
+      "filter[groups__in]",
+    ],
+    suggestions: [
+      {
+        label: "Choose attacker's first target",
+        prompt:
+          "What's the first thing among these resources you'd target in an attack, what would it give you, and how far could you pivot from there?",
+      },
+      {
+        label: "Find architectural security debt",
+        prompt:
+          "What does this inventory tell you about how this environment was built, and where does that design create security debt?",
+      },
+      {
+        label: "Create team action lists",
+        prompt:
+          "Turn this inventory into a per-team action list. Infer likely owners from tags and naming, and give each team their top three fixes.",
+      },
+      {
+        label: "Build hardening plan",
+        prompt: "Recommend a hardening plan for this resource scope.",
+      },
+    ],
+  },
+  {
+    id: LIGHTHOUSE_PAGE_ID.COMPLIANCE_DETAIL,
+    label: "Compliance detail",
+    match: (pathname) => pathname.startsWith("/compliance/"),
+    allowedSearchParams: [
+      ...PROVIDER_SCOPE_PARAMS,
+      "scanId",
+      "scan_id",
+      "complianceId",
+      "section",
+      "mode",
+      "version",
+      "filter[cis_profile_level]",
+      "filter[region__in]",
+      "filter[status__in]",
+    ],
+    suggestions: [
+      {
+        label: "Prioritize failed requirements",
+        prompt: "Which failed requirements need attention first?",
+      },
+      {
+        label: "Identify manual evidence",
+        prompt:
+          "Which requirements here can't be satisfied by scanning at all? Tell me exactly what evidence to collect, who owns it, and what good evidence looks like.",
+      },
+      {
+        label: "Rehearse weakest-section audit",
+        prompt:
+          "Play the auditor for my weakest section. What will you ask me, what evidence will you want to see, and where am I going to struggle?",
+      },
+      {
+        label: "Improve framework score",
+        prompt: "Create a plan to improve this framework score.",
+      },
+    ],
+  },
+  {
+    id: LIGHTHOUSE_PAGE_ID.COMPLIANCE,
+    label: "Compliance",
+    match: (pathname) => pathname === "/compliance",
+    allowedSearchParams: [
+      ...PROVIDER_SCOPE_PARAMS,
+      "tab",
+      "scanId",
+      "scan_id",
+      "framework",
+      "version",
+      "mode",
+      "section",
+      "filter[compliance_id]",
+      "filter[region__in]",
+    ],
+    suggestions: [
+      {
+        label: "Summarize compliance gaps",
+        prompt: "Summarize the most important compliance gaps.",
+      },
+      {
+        label: "Prioritize frameworks",
+        prompt: "Which frameworks should I prioritize?",
+      },
+      {
+        label: "Explain compliance score",
+        prompt: "Explain the visible compliance score.",
+      },
+      {
+        label: "Estimate path to passing",
+        prompt:
+          "How much work is it to take my weakest framework to passing? Break it down by provider account into a few sprints, with what lands first.",
+      },
+    ],
+  },
+  {
+    id: LIGHTHOUSE_PAGE_ID.ATTACK_PATHS,
+    label: "Attack Paths",
+    match: (pathname) => pathname.startsWith("/attack-paths"),
+    allowedSearchParams: ["scanId", "queryId"],
+    suggestions: [
+      {
+        label: "Explain current attack path",
+        prompt: "Explain the current attack path.",
+      },
+      {
+        label: "Find critical graph nodes",
+        prompt: "Which nodes are most critical in this graph?",
+      },
+      {
+        label: "Choose first break point",
+        prompt: "Where should I break this attack path first?",
+      },
+      {
+        label: "Recommend attack path fixes",
+        prompt: "Recommend remediations for the current attack path.",
+      },
+    ],
+  },
+  {
+    id: LIGHTHOUSE_PAGE_ID.SCANS,
+    label: "Scans",
+    match: (pathname) => pathname.startsWith("/scans"),
+    allowedSearchParams: [
+      ...PROVIDER_SCOPE_PARAMS,
+      ...COMMON_LIST_PARAMS,
+      "tab",
+      "scanId",
+      "filter[state]",
+      "filter[state__in]",
+      "filter[trigger]",
+    ],
+    suggestions: [
+      {
+        label: "Summarize scan activity",
+        prompt: "Summarize recent scan activity.",
+      },
+      {
+        label: "Check release regressions",
+        prompt:
+          "I'm shipping to production. Scan now and tell me if anything regressed versus the last run.",
+      },
+      {
+        label: "Rescan stale providers",
+        prompt:
+          "Which providers have never been scanned or haven't been scanned recently? Rescan the ones that matter.",
+      },
+      {
+        label: "Set recurring scans",
+        prompt:
+          "Which of my providers don't have a recurring scan? Tell me which ones should, and set up scheduled scans with the right frequency.",
+      },
+    ],
+  },
+  {
+    id: LIGHTHOUSE_PAGE_ID.PROVIDERS,
+    label: "Providers",
+    match: (pathname) => pathname === "/providers",
+    allowedSearchParams: [
+      ...PROVIDER_SCOPE_PARAMS,
+      ...COMMON_LIST_PARAMS,
+      "tab",
+      "filter[status]",
+      "filter[connected]",
+    ],
+    suggestions: [
+      {
+        label: "Prioritize providers",
+        prompt: "Which visible providers need attention?",
+      },
+      {
+        label: "Find unmonitored cloud accounts",
+        prompt:
+          "What parts of my cloud estate aren't onboarded? Provider accounts that exist but Prowler isn't scanning.",
+      },
+      {
+        label: "Design provider groups",
+        prompt:
+          "Group these provider accounts by what they're actually for, based on names, tags, and what's running in them. Which of those groupings should exist as provider groups in Prowler but don't?",
+      },
+      {
+        label: "Complete provider setup",
+        prompt:
+          "Which accounts were added recently but never fully configured — no schedule, no groups, no successful scan?",
+      },
+    ],
+  },
+] as const satisfies readonly LighthousePageDefinitionInput[];
+
+export const LIGHTHOUSE_KNOWN_ROUTE_LABELS = {
+  alerts: "Alerts",
+  integrations: "Integrations",
+  mutelist: "Mute list",
+  services: "Services",
+  workloads: "Workloads",
+} as const;

--- a/ui/lib/lighthouse/context/pages.test.ts
+++ b/ui/lib/lighthouse/context/pages.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import type { LighthousePageSuggestions } from "@/types/lighthouse-context";
+
 import { LIGHTHOUSE_CONTEXT_LIMIT } from "./constants";
 import {
   buildLighthousePageContext,
@@ -23,17 +25,7 @@ describe("resolveLighthousePage", () => {
 
     // Then
     expect(page.id).toBe(expectedPageId);
-    expect(page.suggestions).toHaveLength(4);
-    for (const suggestion of page.suggestions) {
-      expect(suggestion).toEqual(
-        expect.objectContaining({
-          label: expect.any(String),
-          prompt: expect.any(String),
-        }),
-      );
-      expect(suggestion.label).not.toBe("");
-      expect(suggestion.prompt).not.toBe("");
-    }
+    expectValidSuggestions(page.suggestions);
   });
 
   it("should create a labeled fallback for other application pages", () => {
@@ -43,17 +35,7 @@ describe("resolveLighthousePage", () => {
     // Then
     expect(page.id).toBe("other");
     expect(page.label).toBe("Alerts");
-    expect(page.suggestions).toHaveLength(4);
-    for (const suggestion of page.suggestions) {
-      expect(suggestion).toEqual(
-        expect.objectContaining({
-          label: expect.any(String),
-          prompt: expect.any(String),
-        }),
-      );
-      expect(suggestion.label).not.toBe("");
-      expect(suggestion.prompt).not.toBe("");
-    }
+    expectValidSuggestions(page.suggestions);
   });
 
   it("should resolve encoded and decoded dynamic paths to the same scope", () => {
@@ -76,6 +58,24 @@ describe("resolveLighthousePage", () => {
     );
   });
 });
+
+function expectValidSuggestions(suggestions: LighthousePageSuggestions) {
+  expect(suggestions).toHaveLength(4);
+  expect(new Set(suggestions.map(({ prompt }) => prompt)).size).toBe(
+    suggestions.length,
+  );
+
+  for (const suggestion of suggestions) {
+    expect(suggestion).toEqual(
+      expect.objectContaining({
+        label: expect.any(String),
+        prompt: expect.any(String),
+      }),
+    );
+    expect(suggestion.label.trim()).not.toBe("");
+    expect(suggestion.prompt.trim()).not.toBe("");
+  }
+}
 
 describe("buildLighthousePageContext", () => {
   it("should include only declared search parameters with semantic filter keys", () => {

--- a/ui/lib/lighthouse/context/pages.test.ts
+++ b/ui/lib/lighthouse/context/pages.test.ts
@@ -24,6 +24,16 @@ describe("resolveLighthousePage", () => {
     // Then
     expect(page.id).toBe(expectedPageId);
     expect(page.suggestions).toHaveLength(4);
+    for (const suggestion of page.suggestions) {
+      expect(suggestion).toEqual(
+        expect.objectContaining({
+          label: expect.any(String),
+          prompt: expect.any(String),
+        }),
+      );
+      expect(suggestion.label).not.toBe("");
+      expect(suggestion.prompt).not.toBe("");
+    }
   });
 
   it("should create a labeled fallback for other application pages", () => {
@@ -34,6 +44,16 @@ describe("resolveLighthousePage", () => {
     expect(page.id).toBe("other");
     expect(page.label).toBe("Alerts");
     expect(page.suggestions).toHaveLength(4);
+    for (const suggestion of page.suggestions) {
+      expect(suggestion).toEqual(
+        expect.objectContaining({
+          label: expect.any(String),
+          prompt: expect.any(String),
+        }),
+      );
+      expect(suggestion.label).not.toBe("");
+      expect(suggestion.prompt).not.toBe("");
+    }
   });
 
   it("should resolve encoded and decoded dynamic paths to the same scope", () => {

--- a/ui/lib/lighthouse/context/pages.ts
+++ b/ui/lib/lighthouse/context/pages.ts
@@ -4,16 +4,17 @@ import {
   LIGHTHOUSE_CONTEXT_SOURCE,
   LIGHTHOUSE_PAGE_ID,
   type LighthouseContextFilters,
+  type LighthousePageDefinitionInput,
   type LighthousePageContextItem,
   type LighthousePageId,
+  type LighthousePageSuggestions,
 } from "@/types/lighthouse-context";
 
-export type LighthousePageSuggestions = readonly [
-  string,
-  string,
-  string,
-  string,
-];
+import {
+  LIGHTHOUSE_GLOBAL_SUGGESTIONS,
+  LIGHTHOUSE_KNOWN_ROUTE_LABELS,
+  LIGHTHOUSE_PAGE_DEFINITION_INPUTS,
+} from "./pages.constants";
 
 export interface LighthousePageDefinition {
   id: LighthousePageId;
@@ -27,206 +28,8 @@ export interface LighthousePageDefinition {
   ) => LighthousePageContextItem;
 }
 
-interface LighthousePageDefinitionInput {
-  id: LighthousePageId;
-  label: string;
-  match: (pathname: string) => boolean;
-  allowedSearchParams: readonly string[];
-  suggestions: LighthousePageSuggestions;
-}
-
-const PROVIDER_SCOPE_PARAMS = [
-  "filter[provider__in]",
-  "filter[provider_id__in]",
-  "filter[provider_uid]",
-  "filter[provider_uid__in]",
-  "filter[provider_type__in]",
-  "filter[provider]",
-  "filter[provider_type]",
-  "filter[provider_groups__in]",
-] as const;
-
-const COMMON_LIST_PARAMS = [
-  "query",
-  "search",
-  "filter[search]",
-  "sort",
-] as const;
-
-const GLOBAL_SUGGESTIONS = [
-  "Pull my findings, compliance gaps, and attack paths together into one picture. What's my single biggest security risk right now, and how confident are you?",
-  "Which of my mute rules are hiding something that now matters — rules written for a resource that changed, or an exception nobody has revisited?",
-  "Look at my most serious findings from the last month. Which of them produced no alert from Prowler, and what rule would have caught them?",
-  "Turn my top security work into Jira tickets: group related findings into one ticket per root cause, write each so an engineer can act on it without coming back to ask me questions, and tell me which project each should go to.",
-] as const satisfies LighthousePageSuggestions;
-
-const PAGE_DEFINITIONS: readonly LighthousePageDefinition[] = [
-  createPageDefinition({
-    id: LIGHTHOUSE_PAGE_ID.OVERVIEW,
-    label: "Overview",
-    match: (pathname) => pathname === "/",
-    allowedSearchParams: PROVIDER_SCOPE_PARAMS,
-    suggestions: [
-      "What should I prioritize from this overview?",
-      "According to the Prowler ThreatScore, what do I need to improve, and why?",
-      "Build a practical security plan for today.",
-      "What's missing from this dashboard that should worry me — providers not onboarded, regions or services with no scan coverage, checks that never run?",
-    ],
-  }),
-  createPageDefinition({
-    id: LIGHTHOUSE_PAGE_ID.FINDINGS,
-    label: "Findings",
-    match: (pathname) => pathname === "/findings",
-    allowedSearchParams: [
-      ...PROVIDER_SCOPE_PARAMS,
-      ...COMMON_LIST_PARAMS,
-      "filter[region__in]",
-      "filter[service__in]",
-      "filter[severity__in]",
-      "filter[status__in]",
-      "filter[delta]",
-      "filter[delta__in]",
-      "filter[resource_type__in]",
-      "filter[category__in]",
-      "filter[resource_groups__in]",
-      "filter[scan]",
-      "filter[scan__in]",
-      "filter[scan_id]",
-      "filter[scan_id__in]",
-      "filter[inserted_at]",
-      "filter[muted]",
-    ],
-    suggestions: [
-      "Give me the actual remediation for the top failing check here: the commands and IaC changes (of possible and Terraform preferred), the blast radius of applying them, and what to verify afterwards",
-      "Severity here is the check's label, not my actual risk. Re-rank these by real exposure, whether the affected resource is internet-facing, production, or holds data; and give me the true top five.",
-      "Group these by the underlying change that fixes them, the same IAM policy, module, or baseline; not by check. Which single change clears the most findings?",
-      "Create a remediation plan for this findings view.",
-    ],
-  }),
-  createPageDefinition({
-    id: LIGHTHOUSE_PAGE_ID.RESOURCES,
-    label: "Resources",
-    match: (pathname) => pathname === "/resources",
-    allowedSearchParams: [
-      ...PROVIDER_SCOPE_PARAMS,
-      ...COMMON_LIST_PARAMS,
-      "filter[region__in]",
-      "filter[service__in]",
-      "filter[type__in]",
-      "filter[groups__in]",
-    ],
-    suggestions: [
-      "What's the first thing among this resources you'd target in an attack, what would it give you, and how far could you pivot from there?",
-      "What does this inventory tell you about how this environment was built, and where does that design create security debt?",
-      "Turn this inventory into a per-team action list. Infer likely owners from tags and naming, and give each team their top three fixes.",
-      "Recommend a hardening plan for this resource scope.",
-    ],
-  }),
-  createPageDefinition({
-    id: LIGHTHOUSE_PAGE_ID.COMPLIANCE_DETAIL,
-    label: "Compliance detail",
-    match: (pathname) => pathname.startsWith("/compliance/"),
-    allowedSearchParams: [
-      ...PROVIDER_SCOPE_PARAMS,
-      "scanId",
-      "scan_id",
-      "complianceId",
-      "section",
-      "mode",
-      "version",
-      "filter[cis_profile_level]",
-      "filter[region__in]",
-      "filter[status__in]",
-    ],
-    suggestions: [
-      "Which failed requirements need attention first?",
-      "Which requirements here can't be satisfied by scanning at all? Tell me exactly what evidence to collect, who owns it, and what good evidence looks like.",
-      "Play the auditor for my weakest section. What will you ask me, what evidence will you want to see, and where am I going to struggle?",
-      "Create a plan to improve this framework score.",
-    ],
-  }),
-  createPageDefinition({
-    id: LIGHTHOUSE_PAGE_ID.COMPLIANCE,
-    label: "Compliance",
-    match: (pathname) => pathname === "/compliance",
-    allowedSearchParams: [
-      ...PROVIDER_SCOPE_PARAMS,
-      "tab",
-      "scanId",
-      "scan_id",
-      "framework",
-      "version",
-      "mode",
-      "section",
-      "filter[compliance_id]",
-      "filter[region__in]",
-    ],
-    suggestions: [
-      "Summarize the most important compliance gaps.",
-      "Which frameworks should I prioritize?",
-      "Explain the visible compliance score.",
-      "How much work is it to take my weakest framework to passing? Break each provider account it into a few sprints with what lands first",
-    ],
-  }),
-  createPageDefinition({
-    id: LIGHTHOUSE_PAGE_ID.ATTACK_PATHS,
-    label: "Attack Paths",
-    match: (pathname) => pathname.startsWith("/attack-paths"),
-    allowedSearchParams: ["scanId", "queryId"],
-    suggestions: [
-      "Explain the current attack path.",
-      "Which nodes are most critical in this graph?",
-      "Where should I break this attack path first?",
-      "Recommend remediations for the current attack path.",
-    ],
-  }),
-  createPageDefinition({
-    id: LIGHTHOUSE_PAGE_ID.SCANS,
-    label: "Scans",
-    match: (pathname) => pathname.startsWith("/scans"),
-    allowedSearchParams: [
-      ...PROVIDER_SCOPE_PARAMS,
-      ...COMMON_LIST_PARAMS,
-      "tab",
-      "scanId",
-      "filter[state]",
-      "filter[state__in]",
-      "filter[trigger]",
-    ],
-    suggestions: [
-      "Summarize recent scan activity.",
-      "I'm shipping to production. Scan now and tell me if anything regressed versus the last run",
-      "Which providers have never been scanned or haven't been scanned recently? Rescan the ones that matter.",
-      "Which of my providers have no recurring scan? Tell me which ones should, and set up scheduled scans and with what frequency.",
-    ],
-  }),
-  createPageDefinition({
-    id: LIGHTHOUSE_PAGE_ID.PROVIDERS,
-    label: "Providers",
-    match: (pathname) => pathname === "/providers",
-    allowedSearchParams: [
-      ...PROVIDER_SCOPE_PARAMS,
-      ...COMMON_LIST_PARAMS,
-      "tab",
-      "filter[status]",
-      "filter[connected]",
-    ],
-    suggestions: [
-      "Which visible providers need attention?",
-      "What parts of my cloud estate aren't onboarded? Provider accounts that exist but Prowler isn't scanning.",
-      "Group this provider accounts by what they're actually for, based on names, tags, and what's running in them. Which of those groupings should exist as provider groups in Prowler but don't?",
-      "Which accounts were added recently but never fully configured — no schedule, no groups, no successful scan?",
-    ],
-  }),
-];
-
-const KNOWN_ROUTE_LABELS = {
-  alerts: "Alerts",
-  integrations: "Integrations",
-  mutelist: "Mute list",
-  services: "Services",
-  workloads: "Workloads",
-} as const;
+const PAGE_DEFINITIONS: readonly LighthousePageDefinition[] =
+  LIGHTHOUSE_PAGE_DEFINITION_INPUTS.map(createPageDefinition);
 
 function normalizeLighthousePath(pathname: string): string {
   const normalized = `/${pathname
@@ -301,14 +104,15 @@ function buildLighthouseScopeKey(
 function createFallbackDefinition(pathname: string): LighthousePageDefinition {
   const segment = pathname.split("/").filter(Boolean)[0] ?? "overview";
   const label =
-    KNOWN_ROUTE_LABELS[segment as keyof typeof KNOWN_ROUTE_LABELS] ??
-    toTitleCase(segment);
+    LIGHTHOUSE_KNOWN_ROUTE_LABELS[
+      segment as keyof typeof LIGHTHOUSE_KNOWN_ROUTE_LABELS
+    ] ?? toTitleCase(segment);
   return createPageDefinition({
     id: LIGHTHOUSE_PAGE_ID.OTHER,
     label,
     match: () => true,
     allowedSearchParams: [],
-    suggestions: GLOBAL_SUGGESTIONS,
+    suggestions: LIGHTHOUSE_GLOBAL_SUGGESTIONS,
   });
 }
 

--- a/ui/lib/lighthouse/context/pages.ts
+++ b/ui/lib/lighthouse/context/pages.ts
@@ -54,10 +54,10 @@ const COMMON_LIST_PARAMS = [
 ] as const;
 
 const GLOBAL_SUGGESTIONS = [
-  "Summarize my most critical open findings and what to fix first.",
-  "What are my highest-impact compliance gaps right now?",
-  "Find risky attack paths and explain the exposure.",
-  "How can I improve my cloud security posture today?",
+  "Pull my findings, compliance gaps, and attack paths together into one picture. What's my single biggest security risk right now, and how confident are you?",
+  "Which of my mute rules are hiding something that now matters — rules written for a resource that changed, or an exception nobody has revisited?",
+  "Look at my most serious findings from the last month. Which of them produced no alert from Prowler, and what rule would have caught them?",
+  "Turn my top security work into Jira tickets: group related findings into one ticket per root cause, write each so an engineer can act on it without coming back to ask me questions, and tell me which project each should go to.",
 ] as const satisfies LighthousePageSuggestions;
 
 const PAGE_DEFINITIONS: readonly LighthousePageDefinition[] = [
@@ -68,9 +68,9 @@ const PAGE_DEFINITIONS: readonly LighthousePageDefinition[] = [
     allowedSearchParams: PROVIDER_SCOPE_PARAMS,
     suggestions: [
       "What should I prioritize from this overview?",
-      "Explain the visible threat score and its main drivers.",
-      "Which accounts or services appear to carry the most risk?",
+      "According to the Prowler ThreatScore, what do I need to improve, and why?",
       "Build a practical security plan for today.",
+      "What's missing from this dashboard that should worry me — providers not onboarded, regions or services with no scan coverage, checks that never run?",
     ],
   }),
   createPageDefinition({
@@ -97,9 +97,9 @@ const PAGE_DEFINITIONS: readonly LighthousePageDefinition[] = [
       "filter[muted]",
     ],
     suggestions: [
-      "Which visible critical findings need attention first?",
-      "Prioritize remediation for the current findings.",
-      "Identify likely root causes across these findings.",
+      "Give me the actual remediation for the top failing check here: the commands and IaC changes (of possible and Terraform preferred), the blast radius of applying them, and what to verify afterwards",
+      "Severity here is the check's label, not my actual risk. Re-rank these by real exposure, whether the affected resource is internet-facing, production, or holds data; and give me the true top five.",
+      "Group these by the underlying change that fixes them, the same IAM policy, module, or baseline; not by check. Which single change clears the most findings?",
       "Create a remediation plan for this findings view.",
     ],
   }),
@@ -116,9 +116,9 @@ const PAGE_DEFINITIONS: readonly LighthousePageDefinition[] = [
       "filter[groups__in]",
     ],
     suggestions: [
-      "Which visible resources carry the most risk?",
-      "Find likely exposures among these resources.",
-      "Identify security patterns across the current resources.",
+      "What's the first thing among this resources you'd target in an attack, what would it give you, and how far could you pivot from there?",
+      "What does this inventory tell you about how this environment was built, and where does that design create security debt?",
+      "Turn this inventory into a per-team action list. Infer likely owners from tags and naming, and give each team their top three fixes.",
       "Recommend a hardening plan for this resource scope.",
     ],
   }),
@@ -140,8 +140,8 @@ const PAGE_DEFINITIONS: readonly LighthousePageDefinition[] = [
     ],
     suggestions: [
       "Which failed requirements need attention first?",
-      "Prioritize remediation for this compliance framework.",
-      "Which sections are weakest and why?",
+      "Which requirements here can't be satisfied by scanning at all? Tell me exactly what evidence to collect, who owns it, and what good evidence looks like.",
+      "Play the auditor for my weakest section. What will you ask me, what evidence will you want to see, and where am I going to struggle?",
       "Create a plan to improve this framework score.",
     ],
   }),
@@ -165,7 +165,7 @@ const PAGE_DEFINITIONS: readonly LighthousePageDefinition[] = [
       "Summarize the most important compliance gaps.",
       "Which frameworks should I prioritize?",
       "Explain the visible compliance score.",
-      "Which controls need remediation first?",
+      "How much work is it to take my weakest framework to passing? Break each provider account it into a few sprints with what lands first",
     ],
   }),
   createPageDefinition({
@@ -195,9 +195,9 @@ const PAGE_DEFINITIONS: readonly LighthousePageDefinition[] = [
     ],
     suggestions: [
       "Summarize recent scan activity.",
-      "Which visible scans look problematic?",
-      "Explain the most important scan failures.",
-      "What should I investigate next from this scans view?",
+      "I'm shipping to production. Scan now and tell me if anything regressed versus the last run",
+      "Which providers have never been scanned or haven't been scanned recently? Rescan the ones that matter.",
+      "Which of my providers have no recurring scan? Tell me which ones should, and set up scheduled scans and with what frequency.",
     ],
   }),
   createPageDefinition({
@@ -213,9 +213,9 @@ const PAGE_DEFINITIONS: readonly LighthousePageDefinition[] = [
     ],
     suggestions: [
       "Which visible providers need attention?",
-      "Assess security coverage across these providers.",
-      "Which providers may have stale scans?",
-      "What should I improve in provider onboarding?",
+      "What parts of my cloud estate aren't onboarded? Provider accounts that exist but Prowler isn't scanning.",
+      "Group this provider accounts by what they're actually for, based on names, tags, and what's running in them. Which of those groupings should exist as provider groups in Prowler but don't?",
+      "Which accounts were added recently but never fully configured — no schedule, no groups, no successful scan?",
     ],
   }),
 ];

--- a/ui/types/lighthouse-context.ts
+++ b/ui/types/lighthouse-context.ts
@@ -44,6 +44,26 @@ export type LighthouseContextTransport = z.infer<
 export type LighthousePageId =
   (typeof LIGHTHOUSE_PAGE_ID)[keyof typeof LIGHTHOUSE_PAGE_ID];
 
+export interface LighthousePageSuggestion {
+  label: string;
+  prompt: string;
+}
+
+export type LighthousePageSuggestions = readonly [
+  LighthousePageSuggestion,
+  LighthousePageSuggestion,
+  LighthousePageSuggestion,
+  LighthousePageSuggestion,
+];
+
+export interface LighthousePageDefinitionInput {
+  id: LighthousePageId;
+  label: string;
+  match: (pathname: string) => boolean;
+  allowedSearchParams: readonly string[];
+  suggestions: LighthousePageSuggestions;
+}
+
 export type LighthouseContextFilters = z.infer<
   typeof lighthouseContextFiltersSchema
 >;


### PR DESCRIPTION
### Context

The Lighthouse suggested prompts shipped with the contextual page work in #12069 as placeholder copy. In practice most of them asked for information the page already renders, so clicking one returned a slower, wordier version of what was on screen.

Concrete examples from the previous set:

- Findings suggested "Identify likely root causes across these findings", but the Findings page already renders `FindingsGroupTable` grouped by check. That is the default view.
- Resources suggested "Which visible resources carry the most risk?", which is the sortable **Failed Findings** column.
- Providers suggested "Which providers may have stale scans?", which is the sortable **Last Scan** column.
- Compliance detail suggested "Which sections are weakest and why?", which is `TopFailedSectionsCard`.
- Overview suggested "Which accounts or services appear to carry the most risk?", which is the **Service Watchlist** widget.

Several sets also spent three of their four slots on the same intent phrased three ways ("need attention first" / "prioritize remediation" / "create a remediation plan"), and the wording leaned on words like "visible" and "this view" even though the context envelope carries page filters and counts, never the rendered rows.

The stronger prompts require more detail than a compact actionable item can display clearly, so the UI also needs separate concise CTA labels.

### Description

Rewrites the suggested prompts so that each one asks something the dashboard cannot answer on its own. A suggestion earns its slot only if answering it requires a **join, an inference, absence-reasoning, or outside knowledge**. If it maps to sorting a column or applying a filter, the UI already won.

Each contextual suggestion is now a `{ label, prompt }` object:

- The concise `label` renders as the actionable CTA.
- Hovering or focusing the CTA shows the complete prompt in a constrained tooltip.
- Clicking the CTA only prefills the composer with the complete `prompt`; it does not start a conversation.
- Static page configuration, prompt copy, filter allowlists, and known route labels now live in `pages.constants.ts`; `pages.ts` keeps page-resolution and context-building logic.
- `LighthousePageSuggestions` remains a four-element tuple. The Lighthouse context schema, filter handling, and transport envelope are unchanged.

Per page:

- **Global fallback**: cross-surface risk synthesis, stale mute rules that may now be hiding something real, serious findings that produced no alert, and Jira tickets grouped by root cause rather than one per finding.
- **Overview**: ThreatScore-driven guidance and what is missing from the dashboard, including providers not onboarded, regions or services with no coverage, and checks that never run.
- **Findings**: concrete remediation including IaC changes and blast radius, re-ranking by real exposure rather than static severity, and grouping by the underlying change that fixes findings.
- **Resources**: an attacker's first target and pivot reach, an architectural read of how the environment was built, and a per-team action list inferred from tags and naming.
- **Compliance**: the effort required to take the weakest framework to passing, broken into sprints.
- **Compliance detail**: requirements that scanning cannot satisfy and the evidence they need, plus an auditor rehearsal against real scan data.
- **Scans**: pre-deployment regression checks, rescanning stale or never-scanned providers, and setting up missing recurring scans.
- **Providers**: cloud estate that was never onboarded, provider groupings that should exist, and accounts added but never fully configured.

Attack Paths keeps its existing prompt intents, which already ask for chokepoint reasoning rather than restating the graph.

### Steps to review

1. Run `cd ui`.
2. Run `pnpm test --run lib/lighthouse/context/pages.test.ts hooks/use-lighthouse-context.test.ts lib/lighthouse/context/context.test.ts 'app/(prowler)/lighthouse/_components/panel/lighthouse-panel-chat.test.tsx'`.
3. Run `pnpm run healthcheck`.
4. Open Lighthouse in the side panel from Overview, Findings, Resources, Compliance, a Compliance framework, Scans, and Providers.
5. Confirm each empty state renders four concise CTAs.
6. Hover or focus a CTA and confirm its tooltip shows the complete prompt.
7. Click a CTA and confirm the composer is prefilled with that prompt without starting a conversation.
8. Open Lighthouse from an unmatched route such as `/integrations` or `/mutelist` and confirm the global fallback set renders.

Validation performed locally:

- 50 tests passed across `pages.test.ts`, `use-lighthouse-context.test.ts`, `context.test.ts`, and `lighthouse-panel-chat.test.tsx`.
- `pnpm run healthcheck` passes TypeScript, ESLint, and Prettier checks.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the open pull requests and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following the applicable project conventions.
- [x] Review if backport is needed: not needed.
- [x] Review if is needed to change the README.md: no changes needed.
- [x] Ensure a changelog fragment is added under `ui/changelog.d/`.

#### SDK/CLI

- Are there new checks included in this PR? No

#### UI

- [x] All issue/task requirements work as expected on the UI.
- [x] No npm dependencies are added or updated.
- [ ] Screenshots/Video of the functionality flow - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under `ui/changelog.d/`.

#### API

- [x] No API code or API specification changes are included.

#### MCP Server

- [x] No MCP Server changes are included.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refreshed Lighthouse contextual suggestions with updated security- and Jira-focused prompts.
  * Updated the Lighthouse chat empty state: suggestion buttons now support icons and tooltips, while keeping the full contextual prompt available.
  * Clicking a suggestion now pre-fills the chat message with the full prompt to speed up remediation.
* **Tests**
  * Added coverage for hover tooltips and click-to-pre-fill for “Generate concrete remediation.”
  * Strengthened validation for the shape and uniqueness of contextual suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->