### PR TITLE
fix(ocsf): avoid missing MITRE catalog errors

### DIFF
--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -351,9 +351,10 @@ def _build_analytic(finding: Finding) -> Analytic:
 def _load_mitre_technique_map(provider: str) -> Dict[str, dict]:
     """Load and cache MITRE ATT&CK techniques for a provider."""
     try:
-        mitre_file = resources.files("prowler.compliance").joinpath(
-            provider,
-            f"mitre_attack_{provider}.json",
+        mitre_file = (
+            resources.files("prowler.compliance")
+            .joinpath(provider)
+            .joinpath(f"mitre_attack_{provider}.json")
         )
         if not mitre_file.is_file():
             logger.debug(

--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -2,6 +2,7 @@ import json
 import os
 from datetime import datetime, timezone
 from functools import lru_cache
+from importlib import resources
 from random import getrandbits
 from typing import Dict, List, Optional
 
@@ -350,16 +351,17 @@ def _build_analytic(finding: Finding) -> Analytic:
 def _load_mitre_technique_map(provider: str) -> Dict[str, dict]:
     """Load and cache MITRE ATT&CK techniques for a provider."""
     try:
-        mitre_file = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "..",
-            "compliance",
+        mitre_file = resources.files("prowler.compliance").joinpath(
             provider,
             f"mitre_attack_{provider}.json",
         )
-        with open(mitre_file) as file:
+        if not mitre_file.is_file():
+            logger.debug(
+                f"MITRE ATT&CK catalog is not available for provider {provider}"
+            )
+            return {}
+
+        with mitre_file.open(encoding="utf-8") as file:
             data = json.load(file)
         return {
             requirement["Id"]: requirement
@@ -382,9 +384,13 @@ def _build_mitre_attacks(finding: Finding) -> Optional[List[MITREAttack]]:
         Optional[List[MITREAttack]]: MITRE attacks for known provider techniques,
             or None when none can be built.
     """
+    technique_ids = finding.compliance.get("MITRE-ATTACK", [])
+    if not technique_ids:
+        return None
+
     technique_map = _load_mitre_technique_map(finding.provider)
     attacks = []
-    for technique_id in finding.compliance.get("MITRE-ATTACK", []):
+    for technique_id in technique_ids:
         requirement = technique_map.get(technique_id)
         if not requirement:
             continue

--- a/tests/lib/outputs/ocsf/ocsf_test.py
+++ b/tests/lib/outputs/ocsf/ocsf_test.py
@@ -289,8 +289,10 @@ class TestOCSF:
         mitre_file = MagicMock()
         mitre_file.is_file.return_value = True
         mitre_file.open.side_effect = OSError("catalog unavailable")
+        provider_directory = MagicMock()
+        provider_directory.joinpath.return_value = mitre_file
         compliance_package = MagicMock()
-        compliance_package.joinpath.return_value = mitre_file
+        compliance_package.joinpath.return_value = provider_directory
 
         _load_mitre_technique_map.cache_clear()
         try:
@@ -305,6 +307,8 @@ class TestOCSF:
 
             message = mock_error.call_args.args[0]
             assert re.fullmatch(r"OSError\[\d+\]: catalog unavailable", message)
+            compliance_package.joinpath.assert_called_once_with("aws")
+            provider_directory.joinpath.assert_called_once_with("mitre_attack_aws.json")
         finally:
             _load_mitre_technique_map.cache_clear()
 

--- a/tests/lib/outputs/ocsf/ocsf_test.py
+++ b/tests/lib/outputs/ocsf/ocsf_test.py
@@ -239,13 +239,66 @@ class TestOCSF:
             ocsf = OCSF([finding])
         assert ocsf.data[0].finding_info.attacks is None
 
-    def test_load_mitre_technique_map_logs_failure(self):
+    def test_transform_without_mitre_ids_does_not_load_catalog(self):
+        finding = generate_finding_output(provider="kubernetes")
+
+        with patch(
+            "prowler.lib.outputs.ocsf.ocsf._load_mitre_technique_map"
+        ) as mock_load_catalog:
+            ocsf = OCSF([finding])
+
+        assert ocsf.data[0].finding_info.attacks is None
+        mock_load_catalog.assert_not_called()
+
+    def test_load_mitre_technique_map_missing_catalog_is_expected(self):
         from prowler.lib.outputs.ocsf.ocsf import _load_mitre_technique_map
 
         _load_mitre_technique_map.cache_clear()
         try:
             with (
-                patch("builtins.open", side_effect=OSError("catalog unavailable")),
+                patch("prowler.lib.outputs.ocsf.ocsf.logger.debug") as mock_debug,
+                patch("prowler.lib.outputs.ocsf.ocsf.logger.error") as mock_error,
+            ):
+                assert _load_mitre_technique_map("unsupported") == {}
+
+            mock_debug.assert_called_once_with(
+                "MITRE ATT&CK catalog is not available for provider unsupported"
+            )
+            mock_error.assert_not_called()
+        finally:
+            _load_mitre_technique_map.cache_clear()
+
+    def test_load_mitre_technique_map_existing_catalog(self):
+        from prowler.lib.outputs.ocsf.ocsf import _load_mitre_technique_map
+
+        _load_mitre_technique_map.cache_clear()
+        try:
+            technique_map = _load_mitre_technique_map("aws")
+
+            assert technique_map
+            assert all(
+                technique_id == requirement["Id"]
+                for technique_id, requirement in technique_map.items()
+            )
+        finally:
+            _load_mitre_technique_map.cache_clear()
+
+    def test_load_mitre_technique_map_logs_failure(self):
+        from prowler.lib.outputs.ocsf.ocsf import _load_mitre_technique_map
+
+        mitre_file = MagicMock()
+        mitre_file.is_file.return_value = True
+        mitre_file.open.side_effect = OSError("catalog unavailable")
+        compliance_package = MagicMock()
+        compliance_package.joinpath.return_value = mitre_file
+
+        _load_mitre_technique_map.cache_clear()
+        try:
+            with (
+                patch(
+                    "prowler.lib.outputs.ocsf.ocsf.resources.files",
+                    return_value=compliance_package,
+                ),
                 patch("prowler.lib.outputs.ocsf.ocsf.logger.error") as mock_error,
             ):
                 assert _load_mitre_technique_map("aws") == {}


### PR DESCRIPTION
### Context

Follow-up to #12157 and related to #7176.

PR #12157 moved OCSF MITRE ATT&CK enrichment to provider-specific catalogs. The package-relative filesystem lookup introduced an error path for providers that do not bundle a `mitre_attack_<provider>.json` catalog. Those missing catalogs are expected, but the broad exception handler logged them as errors and generated noisy Sentry events.

Sentry issue: https://prowler.sentry.io/issues/7640121514/

### Description

- Resolve bundled MITRE catalogs through `importlib.resources` instead of a source-tree-relative filesystem path
- Check whether the provider catalog exists before opening it, returning an empty map with debug-level context for unsupported providers
- Preserve error-level logging for genuine failures while reading an existing catalog
- Skip catalog discovery entirely when a finding has no MITRE ATT&CK technique IDs

### Steps to review

1. Review `_load_mitre_technique_map` and `_build_mitre_attacks` in `prowler/lib/outputs/ocsf/ocsf.py`.
2. Confirm providers without a bundled MITRE catalog do not emit an error log.
3. Confirm existing catalog read or parse failures still emit an error log.
4. Run:

   ```bash
   uv run pytest tests/lib/outputs/ocsf/ocsf_test.py -q
   ```

5. Expected result: `29 passed`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This fix follows #12157 and the related work in #7176
- [x] The regression is covered by focused tests

</details>

- [x] The code is covered by tests.
- [x] Docstrings follow the Google Python style guidance.
- [x] Backport is not needed because #12157 has not been released.
- [x] README changes are not needed.
- [x] No changelog fragment is needed because this corrects the unreleased #12157 behavior; `no-changelog` is applied.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MITRE ATT&CK catalog loading by using packaged resources rather than filesystem-based paths.
  * Skips MITRE catalog processing when a finding has no MITRE-ATT&CK compliance IDs.
  * Handles missing or unreadable provider catalogs more gracefully, returning empty results and emitting clearer error messaging.
* **Tests**
  * Expanded OCSF MITRE ATT&CK coverage, including cases with no MITRE IDs, unsupported providers, and catalog load failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->