### PR TITLE
fix(aws): return empty dict when regional client generation fails

### DIFF
--- a/prowler/changelog.d/aws-generate-regional-clients-none.fixed.md
+++ b/prowler/changelog.d/aws-generate-regional-clients-none.fixed.md
@@ -1,0 +1,1 @@
+`AwsProvider.generate_regional_clients` now returns an empty dictionary instead of `None` when region resolution fails, preventing `AttributeError: 'NoneType' object has no attribute 'values'` in every AWS service, and matching the behaviour of the Alibaba Cloud, Huawei Cloud and Oracle Cloud providers

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -902,6 +902,7 @@ class AwsProvider(Provider):
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
+            return {}
 
     @staticmethod
     def get_available_aws_service_regions(

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -1075,6 +1075,31 @@ aws:
         assert response == {}
 
     @mock_aws
+    def test_generate_regional_clients_returns_empty_dict_on_error(self):
+        """A failed region lookup must not yield a non-mapping ``None``.
+
+        ``AWSService.__init__`` assigns the result straight to
+        ``self.regional_clients``, and ``__threading_call__`` calls
+        ``self.regional_clients.values()``, so returning ``None`` turns a
+        transient error into ``AttributeError: 'NoneType' object has no
+        attribute 'values'`` for every AWS service.
+        """
+        aws_provider = AwsProvider()
+
+        with patch.object(
+            AwsProvider,
+            "get_available_aws_service_regions",
+            side_effect=Exception("service region lookup failed"),
+        ):
+            response = aws_provider.generate_regional_clients("ec2")
+
+        assert response is not None, (
+            "generate_regional_clients returned None, so AWSService.regional_clients "
+            "becomes None and every AWS service raises AttributeError on .values()"
+        )
+        assert response == {}
+
+    @mock_aws
     def test_get_default_region(self):
         region = [AWS_REGION_EU_WEST_1]
         aws_provider = AwsProvider(


### PR DESCRIPTION
### Context

`AwsProvider.generate_regional_clients` is annotated `-> dict`, but its `return`
sits inside the `try` block:

```python
def generate_regional_clients(self, service: str) -> dict:
    try:
        regional_clients = {}
        service_regions = AwsProvider.get_available_aws_service_regions(...)
        ...
        return regional_clients        # only reached on success
    except Exception as error:
        logger.error(...)              # falls through -> implicit return None
```

When region resolution or client construction raises, the `except` branch only
logs and the function falls through to an implicit `return None`.

`AWSService.__init__` assigns that result straight to the attribute every AWS
service relies on, with no guard:

```python
if not global_service:
    self.regional_clients = provider.generate_regional_clients(self.service)
```

and `__threading_call__` dereferences it:

```python
items = iterator if iterator is not None else self.regional_clients.values()
```

So a transient failure turns into
`AttributeError: 'NoneType' object has no attribute 'values'` rather than a
service that degrades to zero findings. **66 service modules reference
`self.regional_clients`**, across 180 usages.

The other providers that implement the same method already guard this. In
`alibabacloud_provider.py`, `huaweicloud_provider.py` and
`oraclecloud_provider.py` the handler ends with `return {}`; AWS is the
inconsistent one:

```python
# alibabacloud / huaweicloud / oraclecloud
except Exception as error:
    logger.error(...)
    return {}
```

### Description

Return `{}` from the handler so the annotated `-> dict` contract holds on every
path, bringing AWS in line with the three sibling providers.

One line of production code, plus a regression test.

### Steps to review

The existing suite already asserts the empty-dict shape on a *success* path
(`test_generate_regional_clients_cn_partition_not_present_service`), so the new
test covers the *error* path by making region resolution raise.

Reproduce on `master`:

```bash
git stash push -- prowler/providers/aws/aws_provider.py
pytest tests/providers/aws/aws_provider_test.py -k generate_regional_clients
```

`test_generate_regional_clients_returns_empty_dict_on_error` fails with
`assert None is not None`.

With the fix:

```bash
pytest tests/providers/aws/aws_provider_test.py -k generate_regional_clients  # 6 passed
pytest tests/providers/aws/aws_provider_test.py                              # 112 passed
```

Linters on the touched files: `black`, `isort`, `flake8`, `vulture`, `bandit` —
all clean. `pylint` reports pre-existing `E1101` warnings on
`botocore.config.Config` attributes elsewhere in the test file; these appear on
an unmodified tree too, and the repo's own hook runs `pylint --disable=W,C,R,E`.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the README.md
- [x] Ensure a changelog fragment is added under `prowler/changelog.d/`, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **No** — no permission changes required.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when AWS regional information cannot be resolved.
  * Regional client generation now safely returns an empty result instead of causing downstream errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->