### PR TITLE
fix(check): return a set when check loading fails

### DIFF
--- a/prowler/changelog.d/check-loading-implicit-none.fixed.md
+++ b/prowler/changelog.d/check-loading-implicit-none.fixed.md
@@ -1,0 +1,1 @@
+﻿Check loading no longer returns `None` when it fails: `parse_checks_from_file` and `recover_checks_from_service` now return an empty set, and `update_checks_to_execute_with_aliases` falls back to the requested checks, preventing `TypeError: 'NoneType' object is not iterable` when a checks file has no section for the scanned provider or check discovery fails

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -70,6 +70,8 @@ def parse_checks_from_file(input_file: str, provider: str) -> set:
         logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )
+        # Callers iterate the result, so always return a set.
+        return set()
 
 
 # Load checks from custom folder

--- a/prowler/lib/check/checks_loader.py
+++ b/prowler/lib/check/checks_loader.py
@@ -271,3 +271,6 @@ def update_checks_to_execute_with_aliases(
         logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )
+        # Alias expansion is best effort; fall back to the requested checks so
+        # callers always receive a set.
+        return checks_to_execute

--- a/prowler/lib/check/utils.py
+++ b/prowler/lib/check/utils.py
@@ -151,6 +151,8 @@ def recover_checks_from_service(service_list: list, provider: str) -> set:
         logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
+        # Callers iterate the result, so always return a set.
+        return set()
 
 
 def list_compliance_modules():

--- a/tests/lib/check/check_loader_test.py
+++ b/tests/lib/check/check_loader_test.py
@@ -361,6 +361,26 @@ class TestCheckLoader:
             checks_to_execute, check_aliases
         )
 
+    def test_update_checks_to_execute_with_aliases_falls_back_on_error(self):
+        """Alias expansion is best effort and must still return a set.
+
+        The result is returned straight out of `load_checks_to_execute`, so
+        returning None propagates a non-iterable value to every caller.
+        """
+        checks_to_execute = {"renamed_check"}
+
+        class ExplodingAliases(dict):
+            def __contains__(self, key):
+                raise RuntimeError("alias lookup failed")
+
+        result = update_checks_to_execute_with_aliases(
+            checks_to_execute, ExplodingAliases()
+        )
+
+        assert result is not None
+        # Falls back to the checks originally requested.
+        assert result == {"renamed_check"}
+
     def test_threat_detection_category(self):
         bulk_checks_metadata = {
             CLOUDTRAIL_THREAT_DETECTION_ENUMERATION_NAME: self.get_threat_detection_check_metadata()

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -702,6 +702,38 @@ class TestCheck:
         recovered_checks = recover_checks_from_service(service_list, provider)
         assert recovered_checks == expected_checks
 
+    def test_parse_checks_from_file_returns_empty_set_on_error(self):
+        """A checks file with no section for the provider must return a set.
+
+        `__main__` passes the result straight to `list(...)`, so returning None
+        raises `TypeError: 'NoneType' object is not iterable`. Note a *missing*
+        file cannot be used to reach this handler, because `open_file` exits on
+        `OSError` first.
+        """
+        # The fixture only contains an "aws" section.
+        result = parse_checks_from_file(
+            f"{pathlib.Path().absolute()}/tests/lib/check/fixtures/checklistA.json",
+            "gcp",
+        )
+
+        assert result is not None
+        assert result == set()
+
+    def test_recover_checks_from_service_returns_empty_set_on_error(self):
+        """A failure while recovering checks must still return a set.
+
+        `AwsProvider` iterates the result directly, so returning None raises
+        `TypeError: 'NoneType' object is not iterable`.
+        """
+        with mock.patch(
+            "prowler.lib.check.utils.recover_checks_from_provider",
+            side_effect=Exception("cannot list modules"),
+        ):
+            result = recover_checks_from_service(["accessanalyzer"], "aws")
+
+        assert result is not None
+        assert result == set()
+
     # def test_parse_checks_from_compliance_framework_two(self):
     #     test_case = {
     #         "input": {"compliance_frameworks": ["cis_v1.4_aws", "ens_v3_aws"]},


### PR DESCRIPTION
﻿### Context

Three check-loading helpers are annotated `-> set` but place their `return` inside the `try` block, so when the body raises, the `except` handler only logs and the function falls through to an implicit `return None`.

| function | consumer | result of `None` |
| --- | --- | --- |
| `parse_checks_from_file` (`lib/check/check.py`) | `__main__.py` -> `list(excluded_checks_from_file)` | `TypeError: 'NoneType' object is not iterable` |
| `recover_checks_from_service` (`lib/check/utils.py`) | `aws_provider.py` -> `for check in checks:` | `TypeError: 'NoneType' object is not iterable` |
| `update_checks_to_execute_with_aliases` (`lib/check/checks_loader.py`) | returned straight out of `load_checks_to_execute` | `None` propagates to every caller |

The first one is reachable without any unusual failure: pass a `--checks-file` whose JSON has no section for the provider being scanned, and `json_file[provider]` raises `KeyError`.

`recover_checks_from_service` already returns `set()` on its tool-wrapper branch, so returning a set is its own contract; the error path was just missing it.

### Description

* `parse_checks_from_file` and `recover_checks_from_service` return an empty set on failure.
* `update_checks_to_execute_with_aliases` falls back to the checks originally requested, since alias expansion is a best-effort transformation and the caller's selection is the safe fallback.

Three lines of production code plus a comment each.

### Steps to review

Reproduce on `master` — keep the tests, drop the fixes:

```bash
git stash push -- prowler/lib/check/check.py prowler/lib/check/utils.py prowler/lib/check/checks_loader.py
pytest tests/lib/check -k "returns_empty_set_on_error or falls_back_on_error"
```

All three fail with `assert None is not None`. With the fixes, `3 passed`.

One note on the test for `parse_checks_from_file`: a *missing* file cannot be used to reach that handler, because `open_file` logs critical and calls `sys.exit(1)` on `OSError` first. The test therefore uses an existing fixture with no section for the requested provider, which is the realistic path into the handler.

Full `tests/lib/check` run: **28 failures before and after, identical sets, none introduced by this change.** Those pre-existing failures are all `universal_compliance_models_test.py::TestSmokeLoadAllJSONs` compliance-JSON loading cases, unrelated to check loading.

Linters on the touched files: `black`, `isort`, `flake8`, `bandit` — all clean.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the README.md
- [x] Ensure a changelog fragment is added under `prowler/changelog.d/`, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **No** — no permission changes required.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved check discovery reliability when configuration sections are missing or errors occur.
  * Prevented failures caused by unavailable check results during provider scans.
  * Preserved requested checks when alias expansion cannot be completed.

* **Tests**
  * Added coverage for check-loading failures, recovery errors, and alias expansion fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->