### PR TITLE
fix(scan): avoid ZeroDivisionError in progress with no checks

### DIFF
--- a/prowler/changelog.d/scan-progress-zero-checks.fixed.md
+++ b/prowler/changelog.d/scan-progress-zero-checks.fixed.md
@@ -1,0 +1,1 @@
+﻿`Scan.progress` now returns 0 instead of raising `ZeroDivisionError` when a scan has no checks to execute, which happens when a severity or category filter matches nothing

--- a/prowler/lib/scan/scan.py
+++ b/prowler/lib/scan/scan.py
@@ -263,6 +263,10 @@ class Scan:
 
     @property
     def progress(self) -> float:
+        # A scan can legitimately end up with no checks to execute, e.g. when a
+        # severity or category filter matches nothing, so guard the division.
+        if not self._number_of_checks_to_execute:
+            return 0.0
         return (
             self._number_of_checks_completed / self._number_of_checks_to_execute * 100
         )

--- a/tests/lib/scan/scan_test.py
+++ b/tests/lib/scan/scan_test.py
@@ -261,6 +261,34 @@ class TestScan:
             assert scan.get_completed_checks() == set()
 
     @patch("prowler.lib.scan.scan.load_checks_to_execute")
+    def test_progress_with_no_checks_to_execute(
+        self, mock_load_checks_to_execute, mock_provider
+    ):
+        """`progress` must not divide by zero when no check matched the filters.
+
+        `Scan.__init__` deliberately tolerates an empty scope: it only raises
+        `ScanInvalidCheckError` when exclusions emptied a *non-empty* scope, and
+        the comment there notes that a severity or category filter may
+        legitimately match nothing. Severity validation only checks the value is
+        a valid `Severity` member, not that any check declares it, so a valid but
+        unmatched severity yields zero checks.
+        """
+        mock_load_checks_to_execute.return_value = set()
+
+        with mock.patch(
+            "prowler.lib.check.models.CheckMetadata.get_bulk"
+        ) as mock_get_bulk:
+            mock_metadata = MagicMock()
+            mock_metadata.Categories = []
+            mock_get_bulk.return_value = {"accessanalyzer_enabled": mock_metadata}
+
+            scan = Scan(mock_provider, severities=["critical"])
+
+            assert scan.checks_to_execute == []
+            # Must report 0% rather than raising ZeroDivisionError.
+            assert scan.progress == 0
+
+    @patch("prowler.lib.scan.scan.load_checks_to_execute")
     @patch("prowler.lib.scan.scan.update_checks_metadata_with_compliance")
     @patch("prowler.lib.scan.scan.Compliance.get_bulk")
     @patch("prowler.lib.scan.scan.CheckMetadata.get_bulk")


### PR DESCRIPTION
﻿### Context

`Scan.progress` divides by `_number_of_checks_to_execute` with no guard:

```python
    @property
    def progress(self) -> float:
        return (
            self._number_of_checks_completed / self._number_of_checks_to_execute * 100
        )
```

That value is assigned from `len(self._checks_to_execute)`, and an empty scope is explicitly tolerated by `__init__`. The exclusion validation only raises when exclusions emptied a *non-empty* scope, and its own comment spells out the other case:

```python
            # Only complain when exclusions actually emptied a non-empty
            # scope. If the scope was already empty (e.g. a severity or
            # category filter matched nothing) the exclusions did not
            # cause the emptiness and the misleading error would obscure
            # the real reason.
            if previous_scope and not selected_checks:
                raise ScanInvalidCheckError(...)
```

Severity validation only confirms the value is a valid `Severity` member:

```python
        if severities:
            for severity in severities:
                try:
                    Severity(severity)
                except ValueError:
                    raise ScanInvalidSeverityError(...)
```

so a valid severity that no check declares passes validation, yields zero checks, and reading `progress` raises `ZeroDivisionError`.

### Description

Return `0.0` when there is nothing to execute. One guard, no behaviour change for non-empty scans.

### Steps to review

Reproduce on `master` — keep the test, drop the fix:

```bash
git stash push -- prowler/lib/scan/scan.py
pytest tests/lib/scan/scan_test.py -k no_checks_to_execute
```

```
E       ZeroDivisionError: division by zero
prowler\lib\scan\scan.py:267: ZeroDivisionError
```

With the fix:

```bash
pytest tests/lib/scan/scan_test.py -k no_checks_to_execute   # 1 passed
pytest tests/lib/scan                                        # 25 passed
```

The existing tests assert `scan.progress == 0` only for scans that do have checks, so the empty-scope path had no coverage.

Linters on the touched files: `black`, `isort`, `flake8` — all clean.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the README.md
- [x] Ensure a changelog fragment is added under `prowler/changelog.d/`, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **No** — no permission changes required.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scan progress now displays 0% when no checks are selected, including when filters match no available checks.
  * Prevented an error from occurring during scans with no checks to execute.

* **Tests**
  * Added coverage to verify correct progress reporting for empty scan selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->