### PR TITLE
fix(check): handle audit metadata with no expected checks

### DIFF
--- a/prowler/changelog.d/audit-metadata-no-expected-checks.fixed.md
+++ b/prowler/changelog.d/audit-metadata-no-expected-checks.fixed.md
@@ -1,0 +1,1 @@
+﻿`update_audit_metadata` no longer raises `ZeroDivisionError` and return `None` for providers that run no checks (`iac`, `llm`, `image`, `alibabacloud` and `huaweicloud`), which build their audit metadata with an empty `expected_checks` list

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -846,8 +846,13 @@ def update_audit_metadata(
     try:
         audit_metadata.services_scanned = len(services_executed)
         audit_metadata.completed_checks = len(checks_executed)
+        # Providers that do not run checks (`iac`, `llm`, `image`,
+        # `alibabacloud` and `huaweicloud`) build their `Audit_Metadata` with
+        # `expected_checks=[]`, so guard the division.
         audit_metadata.audit_progress = (
             100 * len(checks_executed) / len(audit_metadata.expected_checks)
+            if audit_metadata.expected_checks
+            else 0
         )
 
         return audit_metadata
@@ -856,3 +861,6 @@ def update_audit_metadata(
         logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
+        # Callers assign the result to `provider.audit_metadata`, so return the
+        # metadata unchanged rather than replacing it with `None`.
+        return audit_metadata

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -827,6 +827,34 @@ class TestCheck:
         assert audit_metadata.expected_checks == expected_checks
         assert audit_metadata.completed_checks == 1
 
+    def test_update_audit_metadata_no_expected_checks(self):
+        """Providers that run no checks build `Audit_Metadata` with no expected checks.
+
+        `iac`, `llm`, `image`, `alibabacloud` and `huaweicloud` all construct it
+        with `expected_checks=[]`, so dividing by that length raises
+        `ZeroDivisionError`. The handler only logged, so the function returned
+        `None` despite being annotated `-> Audit_Metadata`, and callers assign
+        the result straight to `provider.audit_metadata`.
+        """
+        from prowler.providers.common.models import Audit_Metadata
+
+        audit_metadata = Audit_Metadata(
+            services_scanned=0,
+            expected_checks=[],
+            completed_checks=0,
+            audit_progress=0,
+        )
+
+        result = update_audit_metadata(audit_metadata, set(), set())
+
+        assert result is not None, (
+            "update_audit_metadata returned None, so provider.audit_metadata "
+            "is replaced with a non-object"
+        )
+        assert result.audit_progress == 0
+        assert result.services_scanned == 0
+        assert result.completed_checks == 0
+
     def test_list_checks_json_aws_lambda_and_s3(self):
         provider = "aws"
         check_list = {


### PR DESCRIPTION
﻿### Context

`update_audit_metadata` computes the progress percentage with no zero guard:

```python
        audit_metadata.audit_progress = (
            100 * len(checks_executed) / len(audit_metadata.expected_checks)
        )
```

Five providers construct their `Audit_Metadata` with an empty `expected_checks` list, two of them with a comment saying so explicitly:

| provider | line |
| --- | --- |
| `iac_provider.py` | `expected_checks=[],  # IAC doesn't use checks` |
| `llm_provider.py` | `expected_checks=[],  # LLM doesn't use checks` |
| `image_provider.py` | `expected_checks=[]` |
| `alibabacloud_provider.py` | `expected_checks=[]` |
| `huaweicloud_provider.py` | `expected_checks=[]` |

So for those providers the division raises `ZeroDivisionError`. The handler only logs, so the function falls through to an implicit `return None` despite being annotated `-> Audit_Metadata` — and all three call sites assign the result straight onto the provider:

```python
global_provider.audit_metadata = update_audit_metadata(...)   # check.py:598
global_provider.audit_metadata = update_audit_metadata(...)   # check.py:679
self._provider.audit_metadata = update_audit_metadata(...)    # scan.py:509
```

which replaces the metadata object with `None`.

Reproduced directly:

```python
md = Audit_Metadata(
    services_scanned=0, expected_checks=[], completed_checks=0, audit_progress=0
)
print(update_audit_metadata(md, set(), set()))
```

```
ZeroDivisionError[850]: division by zero
None
```

### Description

* Guard the division, reporting 0 when there are no expected checks.
* Return the metadata unchanged from the handler, so the annotated contract holds on every path instead of silently yielding `None`.

### Steps to review

Reproduce on `master` — keep the test, drop the fix:

```bash
git stash push -- prowler/lib/check/check.py
pytest tests/lib/check/check_test.py -k update_audit_metadata
```

The new test fails with `update_audit_metadata returned None`, logging `ZeroDivisionError[850]: division by zero`. The two existing `update_audit_metadata` tests pass either way, so they act as regression guards showing non-empty behaviour is unchanged.

With the fix: `3 passed`.

Full `tests/lib/check`: **28 failures before and after, identical sets, none introduced.** Those pre-existing failures are `universal_compliance_models_test.py` cases failing with `UnicodeDecodeError` when loading compliance JSON on Windows, unrelated to this change.

Linters on the touched files: `black`, `flake8` — clean.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the README.md
- [x] Ensure a changelog fragment is added under `prowler/changelog.d/`, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **No** — no permission changes required.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audit metadata updates for providers with no expected checks.
  * Prevented division-by-zero errors in audit progress calculations.
  * Audit metadata now remains available with progress set to 0 when no checks apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->