### PR TITLE
fix(ui): stabilize SAML ACS URL field

### DIFF
--- a/ui/changelog.d/saml-acs-url-field.fixed.md
+++ b/ui/changelog.d/saml-acs-url-field.fixed.md
@@ -1,0 +1,1 @@
+SAML ACS URL field remains visible while generating the callback URL from the email domain

--- a/ui/components/integrations/saml/saml-config-form.test.tsx
+++ b/ui/components/integrations/saml/saml-config-form.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderToString } from "react-dom/server";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  RUNTIME_CONFIG_SCRIPT_ID,
+  type RuntimePublicConfig,
+} from "@/lib/runtime-config.shared";
+
+import { SamlConfigForm } from "./saml-config-form";
+
+vi.mock("@/actions/integrations", () => ({
+  createSamlConfig: vi.fn(),
+  updateSamlConfig: vi.fn(),
+}));
+
+vi.mock("@/components/shadcn", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+const runtimeConfig: RuntimePublicConfig = {
+  sentryDsn: null,
+  sentryEnvironment: null,
+  googleTagManagerId: null,
+  apiBaseUrl: "https://api.example.com/api/v1",
+  apiDocsUrl: null,
+  posthogEnabled: false,
+  posthogKey: null,
+  posthogHost: null,
+  reoDevClientId: null,
+  cloudEnabled: false,
+  cloudBillingEnabled: false,
+  stripePublishableKey: null,
+  stripePublishableKeyV2: null,
+};
+
+beforeAll(() => {
+  const runtimeConfigScript = document.createElement("script");
+  runtimeConfigScript.id = RUNTIME_CONFIG_SCRIPT_ID;
+  runtimeConfigScript.type = "application/json";
+  runtimeConfigScript.textContent = JSON.stringify(runtimeConfig);
+  document.head.append(runtimeConfigScript);
+});
+
+afterAll(() => {
+  document.getElementById(RUNTIME_CONFIG_SCRIPT_ID)?.remove();
+});
+
+describe("SamlConfigForm", () => {
+  it("keeps the ACS field container while generating the URL", async () => {
+    // Given
+    const serverHtml = renderToString(<SamlConfigForm setIsOpen={vi.fn()} />);
+    const user = userEvent.setup();
+    const container = document.body.appendChild(document.createElement("div"));
+    container.innerHTML = serverHtml;
+    render(<SamlConfigForm setIsOpen={vi.fn()} />, {
+      container,
+      hydrate: true,
+    });
+
+    const acsGuidance = screen.getByText(
+      "Enter your email domain above to generate the ACS URL.",
+    );
+    const acsField = acsGuidance.parentElement;
+
+    expect(acsField).toHaveClass("h-10", "w-full");
+    expect(
+      screen.queryByRole("button", { name: "Copy ACS URL" }),
+    ).not.toBeInTheDocument();
+
+    // When
+    await user.type(screen.getByLabelText("Email Domain*"), "example.com");
+
+    // Then
+    const acsUrl = screen.getByText(
+      "https://api.example.com/api/v1/accounts/saml/example.com/acs/",
+    );
+
+    expect(acsUrl.parentElement).toBe(acsField);
+    expect(screen.getByRole("button", { name: "Copy ACS URL" })).toBeVisible();
+  });
+});

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -316,17 +316,15 @@ export const SamlConfigForm = ({
               <span className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
                 ACS URL:
               </span>
-              {acsUrl ? (
-                <CodeSnippet
-                  value={acsUrl}
-                  ariaLabel="Copy ACS URL"
-                  className="h-10 w-full"
-                />
-              ) : (
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Enter your email domain above to generate the ACS URL.
-                </p>
-              )}
+              <CodeSnippet
+                value={
+                  acsUrl ||
+                  "Enter your email domain above to generate the ACS URL."
+                }
+                ariaLabel="Copy ACS URL"
+                hideCopyButton={!acsUrl}
+                className="h-10 w-full"
+              />
             </div>
 
             <div>


### PR DESCRIPTION
### Context

The SAML configuration modal replaced its ACS guidance text with a code field only after an email domain was entered, causing the modal content to shift.

This addresses [PROWLER-2290](https://prowlerpro.atlassian.net/browse/PROWLER-2290).

### Description

- Keep the ACS URL field rendered before and after domain entry
- Show the guidance message inside the field until the callback URL is available
- Hide the copy action until there is a generated URL
- Add regression coverage for the hydrated form transition

No new dependencies are required.

### Steps to review

1. Open the user profile and select **Enable SAML**
2. Confirm the ACS URL field contains the guidance message before entering a domain
3. Enter `example.com` in **Email Domain**
4. Confirm the tenant-specific ACS URL replaces the guidance without resizing the modal
5. Confirm the copy action is only available for the generated URL

Validation completed locally:

- `pnpm exec vitest run components/integrations/saml/saml-config-form.test.tsx`
- `pnpm run typecheck`
- ESLint and Prettier checks
- Repository pre-commit hooks

### Evidence

#### Empty email domain

<img width="563" height="826" alt="SAML configuration with an empty email domain" src="https://github.com/user-attachments/assets/a73cd2a7-168b-487a-894f-f62fc9704e71" />

#### Generated ACS URL

<img width="569" height="823" alt="SAML configuration with a generated ACS URL" src="https://github.com/user-attachments/assets/b76274c5-5000-4197-b7ab-c5411566d746" />

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the open issues or roadmap
- [ ] It is assigned to me
- [x] I reviewed the open pull requests and found no duplicate implementation

</details>

- [x] Review if the code is being covered by tests
- [x] Review if code documentation is needed
- [ ] Review if backport is needed
- [x] Review if README changes are needed

#### SDK/CLI

- Are there new checks included in this PR? No

#### UI

- [x] All issue/task requirements work as expected on the UI
- [x] No npm dependencies were added or updated
- [x] Screenshots of the functionality flow - Mobile (X < 640px)
- [ ] Screenshots of the functionality flow - Tablet (640px < X < 1024px)
- [ ] Screenshots of the functionality flow - Desktop (X > 1024px)
- [x] A changelog fragment is included under `ui/changelog.d/`

#### API

- No API changes

#### MCP Server

- No MCP Server changes

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[PROWLER-2290]: https://prowlerpro.atlassian.net/browse/PROWLER-2290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The SAML ACS URL field now remains visible while the callback URL is being generated from an email domain.
  * The copy button appears only after a valid ACS URL is available.
  * Added a clear placeholder while the URL is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->