### PR TITLE
fix(api): purge git from the container image to drop perl CVEs

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -28,7 +28,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libtool \
     libxslt1-dev \
     python3-dev \
-    git \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PowerShell
@@ -109,9 +108,11 @@ RUN .venv/bin/python -m prowler.providers.m365.lib.powershell.m365_powershell
 USER root
 
 # Remove build-only packages from the final image after Python dependencies are installed.
+# git is only needed by uv sync for the `prowler @ git+...` dependency; purging it drops perl too.
 RUN apt-get purge -y --auto-remove \
     gcc \
     g++ \
+    git \
     make \
     libxml2-dev \
     libxmlsec1-dev \

--- a/api/changelog.d/api-container-purge-git.security.md
+++ b/api/changelog.d/api-container-purge-git.security.md
@@ -1,0 +1,1 @@
+The API container image no longer ships `git` and the perl packages it pulled in, removing 12 critical CVEs


### PR DESCRIPTION
### Context

PROWLER-2296, part of PROWLER-2291 (container vulnerability remediation).

A Trivy scan of the Private Cloud image estate found 18 criticals on the API image. 16 are perl: 4 CVEs across 4 packages. Only `perl-base` is unavoidable (Debian `Essential: yes`); the other three are pulled in by `git`.

`git` is installed so `uv sync` can resolve the `prowler @ git+https://github.com/prowler-cloud/prowler.git@master` dependency in `api/pyproject.toml`. Nothing in the API calls git at runtime, and the SDK image (`prowlercloud/prowler`) never installs it at all, which is why the same bookworm base reports 4 perl criticals there instead of 16. It was also listed twice in the install block.

### Description

- Add `git` to the existing `apt-get purge --auto-remove` block, which already drops `gcc`, `make`, `libtool` and `python3-dev`. `--auto-remove` then takes `perl`, `perl-modules-5.36`, `libperl5.36` and `liberror-perl` with it.
- Remove the duplicate `git` from the install list.
- The purge runs after `uv sync`, so the build-time need is unaffected.

Base is `integration/PROWLER-2291`, not `master` — this programme lands as one merge once the whole estate is verified.

### Steps to review

Build the image and confirm the packages are gone and it still runs:

```
docker build -f api/Dockerfile -t prowler-api:test api/
docker run --rm --entrypoint sh prowler-api:test -c \
  'for p in git perl perl-modules-5.36 libperl5.36 liberror-perl perl-base; do \
     printf "%-20s " $p; dpkg -s $p >/dev/null 2>&1 && echo PRESENT || echo absent; done'
```

Results on a local `linux/arm64` build:

| Package | Before | After |
|---|---|---|
| `git`, `git-man`, `liberror-perl` | present | **absent** |
| `perl`, `perl-modules-5.36`, `libperl5.36` | present | **absent** |
| `perl-base` | present | present (Essential, expected) |

Trivy criticals: **18 → 6**. The remainder is `perl-base` ×4 plus `libsqlite3-0` and `zlib1g`, which the trixie rebase (PROWLER-2299) clears.

Runtime verification on the built image:

- `python 3.12.13`, `django 5.1.15`
- `import prowler` OK
- `import xmlsec, lxml.etree` OK (native extensions still build)
- `M365PowerShell` imports OK; `pwsh --version` → PowerShell 7.5.0; `ExchangeOnlineManagement`, `MSAL.PS`, `MicrosoftTeams` all present
- `manage.py check` → System check identified no issues

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if backport is needed. Not needed — targets the integration branch.
- [x] Ensure a changelog fragment is added under api/changelog.d/

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Any other relevant evidence of the implementation — see the table above
