### PR TITLE
chore(security): renew and prune .trivyignore before the 2026-08-15 expiry

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,9 +10,8 @@
 # Scanned by: .github/actions/trivy-scan via .github/workflows/sdk-container-checks.yml
 # and .github/workflows/api-container-checks.yml
 
-# perl-base is Debian "Essential: yes" and cannot be removed. Trivy attributes
-# src:perl CVEs to every binary package it produces, so perl-base gets flagged for
-# modules that ship in perl-modules-5.36 — which these images do not install.
+# perl-base is Debian "Essential: yes". Trivy spreads src:perl CVEs across every
+# binary package, so perl-base gets flagged for modules only perl-modules-5.36 ships.
 
 # Archive::Tar path traversal. Not installed: `perl -MArchive::Tar -e1` cannot locate it.
 CVE-2026-42496 pkg:perl-base exp:2027-01-31
@@ -23,24 +22,18 @@ CVE-2026-57433 pkg:perl-base exp:2027-01-31
 # Regex heap overflow on 32-bit builds only; both published arches are 64-bit.
 CVE-2026-8376 pkg:perl-base exp:2027-01-31
 
-# Regex trie overflow. Upstream says 5.36.0 predates the regression; Debian still
-# marks bookworm vulnerable. Shorter expiry — needs Debian or NVD to correct.
+# Regex trie overflow. Upstream says 5.36.0 predates it; Debian disagrees. Short expiry.
 # Ref: https://github.com/Perl/perl5/issues/23388
 CVE-2026-13221 pkg:perl-base exp:2026-11-30
 
-# The next two are fixed in trixie, so their expiries land after PROWLER-2299
-# rebases onto it and they get retired rather than renewed.
+# The next two are fixed in trixie; expiries land after PROWLER-2299 retires them.
 
-# SQLite overflow affecting 3.39.2-3.41.1, via CPython's stdlib sqlite3. Prowler
-# never opens user-supplied databases. trixie ships 3.46.1.
+# SQLite overflow via CPython's stdlib sqlite3; Prowler never opens user-supplied DBs.
 CVE-2025-7458 pkg:libsqlite3-0 exp:2026-10-31
 
-# zlib MiniZip overflow. Debian marks bookworm <ignored> because minizip is not
-# built, so the symbol is absent from the shipped libz.so. trixie ships 1.3.1.
+# zlib MiniZip overflow. Debian marks bookworm <ignored> — minizip is not built.
 # Ref: https://security-tracker.debian.org/tracker/CVE-2023-45853
 CVE-2023-45853 pkg:zlib1g exp:2026-10-31
 
-# libssh2 OOB write, reachable only when acting as an SSH/SCP/SFTP client. Arrives
-# via libcurl in the SDK image; Prowler uses HTTPS only. Gone from the API image
-# since git was purged. No bookworm fix.
+# libssh2 OOB write, only reachable as an SSH/SCP/SFTP client; Prowler uses HTTPS only.
 CVE-2026-55200 pkg:libssh2-1 exp:2026-10-15

--- a/.trivyignore
+++ b/.trivyignore
@@ -5,89 +5,42 @@
 # Entries are scoped per-package so suppressions cannot drift onto unrelated
 # packages that may be assigned the same CVE in the future.
 #
-# Expiries are deliberately staggered. They previously all shared one date, which
-# meant every container gate would have gone red on the same day.
-#
-# Reviewed 2026-07-30 against a build of both images. 23 entries were dropped as
-# dead: the packages are not installed, so a suppression only implied an exposure
-# that does not exist. If a future change reintroduces one, the finding should
-# surface and force a fresh decision rather than be silently pre-suppressed.
-#   - perl, perl-modules-5.36, libperl5.36 (12 entries): removed from the API image
-#     along with git, which was the only thing pulling them in.
-#   - python3.11 / libpython3.11* (7 entries): never present in either image; the
-#     "python3-dev pulls in a system python3.11" premise did not hold.
-#   - libunbound8 (2), linux-libc-dev (1), zlib1g-dev (1): never present.
+# Keep expiries staggered, and only suppress packages the images actually install.
 #
 # Scanned by: .github/actions/trivy-scan via .github/workflows/sdk-container-checks.yml
 # and .github/workflows/api-container-checks.yml
 
-# --- perl-base ---
-# perl-base is in Debian's "Essential: yes" set and cannot be removed without
-# breaking dpkg. It is the only perl package left in either image; the full perl
-# distribution and perl-modules-5.36 are no longer installed. Trivy attributes
-# CVEs from the `perl` source package to every binary package it produces, which
-# is why perl-base is flagged for modules it does not ship.
+# perl-base is Debian "Essential: yes" and cannot be removed. Trivy attributes
+# src:perl CVEs to every binary package it produces, so perl-base gets flagged for
+# modules that ship in perl-modules-5.36 — which these images do not install.
 
-# CVE-2026-42496 — path traversal via crafted symlinks in Archive::Tar.
-# Not applicable: Archive::Tar ships in perl-modules-5.36, which is not installed.
-# Verified in-image: absent from `dpkg -L perl-base`, absent from disk, and
-# `perl -MArchive::Tar -e1` fails with "Can't locate Archive/Tar.pm in @INC".
+# Archive::Tar path traversal. Not installed: `perl -MArchive::Tar -e1` cannot locate it.
 CVE-2026-42496 pkg:perl-base exp:2027-01-31
 
-# CVE-2026-57433 — signed integer overflow in Storable when deserializing a
-# crafted SX_HOOK record (retrieve_hook_common passes a wrapped negative count
-# to av_extend).
-# Not applicable: Storable ships in perl-modules-5.36, which is not installed.
-# Verified in-image the same way — `perl -MStorable -e1` cannot locate it.
+# Storable integer overflow. Not installed: `perl -MStorable -e1` cannot locate it.
 CVE-2026-57433 pkg:perl-base exp:2027-01-31
 
-# CVE-2026-8376 — heap buffer overflow compiling regexes with a repeated fixed
-# string, "on 32-bit builds": Perl_study_chunk sizes the joined substring buffer
-# in characters rather than bytes, and mincount * l overflows SSize_t.
-# Not applicable: both published architectures are 64-bit (linux/amd64 and
-# linux/arm64), so the overflow cannot be reached.
+# Regex heap overflow on 32-bit builds only; both published arches are 64-bit.
 CVE-2026-8376 pkg:perl-base exp:2027-01-31
 
-# CVE-2026-13221 — Perl regex trie overflow producing silently incorrect matches
-# above 65535 fixed-string alternation branches.
-# Why ignored: upstream confirms Perl 5.36.0 is not affected; the regression was
-# introduced after this version. Debian still marks bookworm vulnerable, which is
-# what Trivy reports. Shorter expiry than the entries above because this depends
-# on Debian or NVD correcting the record rather than on a structural fact.
+# Regex trie overflow. Upstream says 5.36.0 predates the regression; Debian still
+# marks bookworm vulnerable. Shorter expiry — needs Debian or NVD to correct.
 # Ref: https://github.com/Perl/perl5/issues/23388
 CVE-2026-13221 pkg:perl-base exp:2026-11-30
 
-# --- Cleared by the Debian 13 (trixie) rebase — see PROWLER-2299 ---
-# Both entries below are fixed in trixie and verified absent there. Expiries land
-# after that rebase so they are retired rather than renewed.
+# The next two are fixed in trixie, so their expiries land after PROWLER-2299
+# rebases onto it and they get retired rather than renewed.
 
-# CVE-2025-7458 — SQLite integer overflow in sqlite3KeyInfoFromExprList,
-# affecting 3.39.2 through 3.41.1.
-# Why ignored: transitive dependency of CPython's stdlib sqlite3 module. Prowler
-# does not open user-supplied SQLite databases; usage is internal and bounded.
-# No Debian bookworm fix. trixie ships 3.46.1, outside the affected range.
+# SQLite overflow affecting 3.39.2-3.41.1, via CPython's stdlib sqlite3. Prowler
+# never opens user-supplied databases. trixie ships 3.46.1.
 CVE-2025-7458 pkg:libsqlite3-0 exp:2026-10-31
 
-# CVE-2023-45853 — zlib MiniZip integer overflow and resultant heap overflow in
-# zipOpenNewFileInZip4_64.
-# Why ignored: Debian's status for bookworm is <ignored>, with the published
-# rationale "contrib/minizip not built and src:zlib not producing binary
-# packages" — the vulnerable symbol is not in the libz.so Debian ships. The NVD
-# text also notes MiniZip is not a supported part of zlib. Real-not-affected
-# rather than unpatched. trixie ships 1.3.1.
+# zlib MiniZip overflow. Debian marks bookworm <ignored> because minizip is not
+# built, so the symbol is absent from the shipped libz.so. trixie ships 1.3.1.
 # Ref: https://security-tracker.debian.org/tracker/CVE-2023-45853
 CVE-2023-45853 pkg:zlib1g exp:2026-10-31
 
-# --- SDK image only ---
-
-# CVE-2026-55200 — libssh2 out-of-bounds write in ssh2_transport_read() from an
-# unchecked packet_length field (heap corruption, possible RCE).
-# Why ignored: libssh2-1 arrives only as a transitive dependency of libcurl in
-# the SDK image. The vulnerable path is reached exclusively when libssh2 acts as
-# an SSH/SCP/SFTP client parsing transport packets from a server. Prowler never
-# uses libcurl's SSH/SCP/SFTP transports; it talks to cloud provider HTTPS
-# endpoints only. No longer present in the API image at all — purging git took
-# libcurl3-gnutls and libssh2-1 with it. Fixed upstream in commit 97acf3df
-# (PR #2052); no Debian bookworm fix yet.
-# Ref: https://security-tracker.debian.org/tracker/CVE-2026-55200
+# libssh2 OOB write, reachable only when acting as an SSH/SCP/SFTP client. Arrives
+# via libcurl in the SDK image; Prowler uses HTTPS only. Gone from the API image
+# since git was purged. No bookworm fix.
 CVE-2026-55200 pkg:libssh2-1 exp:2026-10-15

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,123 +1,93 @@
-# Trivy ignore file for prowlercloud/prowler SDK container image.
+# Trivy ignore file for the prowlercloud/prowler SDK and API container images.
 # Each entry below documents (a) the affected package and why it ships in the
 # image, (b) why the CVE is not exploitable in Prowler's runtime, and (c) the
 # upstream fix status. Entries carry an expiry so they auto-force re-review.
 # Entries are scoped per-package so suppressions cannot drift onto unrelated
 # packages that may be assigned the same CVE in the future.
 #
+# Expiries are deliberately staggered. They previously all shared one date, which
+# meant every container gate would have gone red on the same day.
+#
+# Reviewed 2026-07-30 against a build of both images. 23 entries were dropped as
+# dead: the packages are not installed, so a suppression only implied an exposure
+# that does not exist. If a future change reintroduces one, the finding should
+# surface and force a fresh decision rather than be silently pre-suppressed.
+#   - perl, perl-modules-5.36, libperl5.36 (12 entries): removed from the API image
+#     along with git, which was the only thing pulling them in.
+#   - python3.11 / libpython3.11* (7 entries): never present in either image; the
+#     "python3-dev pulls in a system python3.11" premise did not hold.
+#   - libunbound8 (2), linux-libc-dev (1), zlib1g-dev (1): never present.
+#
 # Scanned by: .github/actions/trivy-scan via .github/workflows/sdk-container-checks.yml
+# and .github/workflows/api-container-checks.yml
 
-# CVE-2026-42496 — perl-archive-tar path traversal via crafted symlinks.
-# CVE-2026-8376  — perl heap buffer overflow when compiling regex.
-# Packages: perl, perl-base, perl-modules-5.36, libperl5.36.
-# Why ignored: perl-base is part of Debian's "Essential: yes" set; it cannot be
-# removed without breaking dpkg. The Prowler SDK does not invoke perl at runtime;
-# neither vulnerable code path (Archive::Tar parsing or regex compilation of
-# attacker-controlled input) is reachable from Prowler. No Debian bookworm fix
-# is available yet.
-CVE-2026-42496 pkg:perl exp:2026-08-15
-CVE-2026-42496 pkg:perl-base exp:2026-08-15
-CVE-2026-42496 pkg:perl-modules-5.36 exp:2026-08-15
-CVE-2026-42496 pkg:libperl5.36 exp:2026-08-15
-CVE-2026-8376 pkg:perl exp:2026-08-15
-CVE-2026-8376 pkg:perl-base exp:2026-08-15
-CVE-2026-8376 pkg:perl-modules-5.36 exp:2026-08-15
-CVE-2026-8376 pkg:libperl5.36 exp:2026-08-15
+# --- perl-base ---
+# perl-base is in Debian's "Essential: yes" set and cannot be removed without
+# breaking dpkg. It is the only perl package left in either image; the full perl
+# distribution and perl-modules-5.36 are no longer installed. Trivy attributes
+# CVEs from the `perl` source package to every binary package it produces, which
+# is why perl-base is flagged for modules it does not ship.
 
-# CVE-2026-13221 - Perl regex trie overflow.
-# Packages: perl, perl-base, perl-modules-5.36, libperl5.36.
-# Why ignored: upstream confirms Perl 5.36.0 is not affected; the regression
-# was introduced after this version. Debian currently marks bookworm as
-# vulnerable, which causes Trivy to report a false positive.
-# Ref: https://github.com/Perl/perl5/issues/23388
-CVE-2026-13221 pkg:perl exp:2026-08-15
-CVE-2026-13221 pkg:perl-base exp:2026-08-15
-CVE-2026-13221 pkg:perl-modules-5.36 exp:2026-08-15
-CVE-2026-13221 pkg:libperl5.36 exp:2026-08-15
+# CVE-2026-42496 — path traversal via crafted symlinks in Archive::Tar.
+# Not applicable: Archive::Tar ships in perl-modules-5.36, which is not installed.
+# Verified in-image: absent from `dpkg -L perl-base`, absent from disk, and
+# `perl -MArchive::Tar -e1` fails with "Can't locate Archive/Tar.pm in @INC".
+CVE-2026-42496 pkg:perl-base exp:2027-01-31
 
-# CVE-2026-57433 — Perl Storable signed integer overflow when deserializing a
+# CVE-2026-57433 — signed integer overflow in Storable when deserializing a
 # crafted SX_HOOK record (retrieve_hook_common passes a wrapped negative count
 # to av_extend).
-# Packages: perl, perl-base, perl-modules-5.36, libperl5.36.
-# Why ignored: perl-base is part of Debian's "Essential: yes" set; it cannot be
-# removed without breaking dpkg. Prowler does not invoke perl at runtime and
-# never calls Storable's thaw/retrieve on attacker-controlled blobs, so the
-# vulnerable deserialization path is unreachable. Fixed upstream in
-# Storable 3.41; no Debian bookworm fix is available yet.
-CVE-2026-57433 pkg:perl exp:2026-08-15
-CVE-2026-57433 pkg:perl-base exp:2026-08-15
-CVE-2026-57433 pkg:perl-modules-5.36 exp:2026-08-15
-CVE-2026-57433 pkg:libperl5.36 exp:2026-08-15
+# Not applicable: Storable ships in perl-modules-5.36, which is not installed.
+# Verified in-image the same way — `perl -MStorable -e1` cannot locate it.
+CVE-2026-57433 pkg:perl-base exp:2027-01-31
 
-# CVE-2025-7458 — SQLite integer overflow.
-# Package: libsqlite3-0.
-# Why ignored: transitive dependency of CPython's stdlib sqlite3 module. The
-# Prowler SDK does not open user-supplied SQLite databases; SQLite usage is
-# internal and bounded. No Debian bookworm fix is available.
-CVE-2025-7458 pkg:libsqlite3-0 exp:2026-08-15
+# CVE-2026-8376 — heap buffer overflow compiling regexes with a repeated fixed
+# string, "on 32-bit builds": Perl_study_chunk sizes the joined substring buffer
+# in characters rather than bytes, and mincount * l overflows SSize_t.
+# Not applicable: both published architectures are 64-bit (linux/amd64 and
+# linux/arm64), so the overflow cannot be reached.
+CVE-2026-8376 pkg:perl-base exp:2027-01-31
 
-# CVE-2026-43185 — Linux kernel ksmbd signedness bug.
-# Package: linux-libc-dev.
-# Why ignored: linux-libc-dev ships kernel headers for build-time compilation,
-# not a running kernel. Containers execute against the host kernel, so these
-# headers are inert at runtime. The upstream fix landed in kernel 7.0-rc2 and
-# has not been backported to Debian's 6.1 LTS line.
-CVE-2026-43185 pkg:linux-libc-dev exp:2026-08-15
+# CVE-2026-13221 — Perl regex trie overflow producing silently incorrect matches
+# above 65535 fixed-string alternation branches.
+# Why ignored: upstream confirms Perl 5.36.0 is not affected; the regression was
+# introduced after this version. Debian still marks bookworm vulnerable, which is
+# what Trivy reports. Shorter expiry than the entries above because this depends
+# on Debian or NVD correcting the record rather than on a structural fact.
+# Ref: https://github.com/Perl/perl5/issues/23388
+CVE-2026-13221 pkg:perl-base exp:2026-11-30
 
-# CVE-2023-45853 — zlib MiniZip integer overflow / heap overflow in
+# --- Cleared by the Debian 13 (trixie) rebase — see PROWLER-2299 ---
+# Both entries below are fixed in trixie and verified absent there. Expiries land
+# after that rebase so they are retired rather than renewed.
+
+# CVE-2025-7458 — SQLite integer overflow in sqlite3KeyInfoFromExprList,
+# affecting 3.39.2 through 3.41.1.
+# Why ignored: transitive dependency of CPython's stdlib sqlite3 module. Prowler
+# does not open user-supplied SQLite databases; usage is internal and bounded.
+# No Debian bookworm fix. trixie ships 3.46.1, outside the affected range.
+CVE-2025-7458 pkg:libsqlite3-0 exp:2026-10-31
+
+# CVE-2023-45853 — zlib MiniZip integer overflow and resultant heap overflow in
 # zipOpenNewFileInZip4_64.
-# Packages: zlib1g, zlib1g-dev.
-# Why ignored: Debian Security Tracker status for bookworm is <ignored>, with
-# the published rationale "contrib/minizip not built and src:zlib not producing
-# binary packages" — i.e. the vulnerable symbol is not present in the libz.so
-# shipped by Debian. Real-not-affected, not unpatched. Upstream fix is in
-# zlib 1.3.1, available in Debian trixie (13); migrating the base image would
-# clear it fully.
+# Why ignored: Debian's status for bookworm is <ignored>, with the published
+# rationale "contrib/minizip not built and src:zlib not producing binary
+# packages" — the vulnerable symbol is not in the libz.so Debian ships. The NVD
+# text also notes MiniZip is not a supported part of zlib. Real-not-affected
+# rather than unpatched. trixie ships 1.3.1.
 # Ref: https://security-tracker.debian.org/tracker/CVE-2023-45853
-CVE-2023-45853 pkg:zlib1g exp:2026-08-15
-CVE-2023-45853 pkg:zlib1g-dev exp:2026-08-15
+CVE-2023-45853 pkg:zlib1g exp:2026-10-31
 
-# CVE-2026-55200 — libssh2 out-of-bounds write in ssh2_transport_read() due to
-# an unchecked packet_length field in transport.c (heap corruption, possible RCE).
-# Package: libssh2-1.
-# Why ignored: libssh2-1 is pulled in only as a transitive dependency of libcurl4
-# (installed in the SDK Dockerfile for the networking/PowerShell stack). The
-# vulnerable path is reached exclusively when libssh2 acts as an SSH/SCP/SFTP
-# client parsing transport packets from a server. Prowler never uses libcurl's
-# SSH/SCP/SFTP transports; it talks to cloud provider HTTPS endpoints only, so the
-# affected code is unreachable at runtime. Fixed upstream in libssh2 commit
-# 97acf3df (PR #2052); no Debian bookworm fix is available yet.
+# --- SDK image only ---
+
+# CVE-2026-55200 — libssh2 out-of-bounds write in ssh2_transport_read() from an
+# unchecked packet_length field (heap corruption, possible RCE).
+# Why ignored: libssh2-1 arrives only as a transitive dependency of libcurl in
+# the SDK image. The vulnerable path is reached exclusively when libssh2 acts as
+# an SSH/SCP/SFTP client parsing transport packets from a server. Prowler never
+# uses libcurl's SSH/SCP/SFTP transports; it talks to cloud provider HTTPS
+# endpoints only. No longer present in the API image at all — purging git took
+# libcurl3-gnutls and libssh2-1 with it. Fixed upstream in commit 97acf3df
+# (PR #2052); no Debian bookworm fix yet.
 # Ref: https://security-tracker.debian.org/tracker/CVE-2026-55200
-CVE-2026-55200 pkg:libssh2-1 exp:2026-08-15
-
-# --- API container image (api/Dockerfile) ---
-# The entries below are specific to the Prowler API image, which ships
-# PowerShell and additional build tooling on top of the same bookworm base.
-
-# CVE-2026-7210 — CPython/Expat hash-flooding denial of service in
-# `xml.parsers.expat` and `xml.etree.ElementTree`.
-# Packages: the Debian system Python 3.11 (python3.11*, libpython3.11*).
-# Why ignored: the API runs under the Python 3.12 interpreter shipped in its
-# `.venv`; the system `python3.11` is only present because `python3-dev` is
-# pulled in to compile native extensions (xmlsec, lxml) and is never executed
-# at runtime. The vulnerable path requires parsing attacker-controlled XML with
-# the affected interpreter, which Prowler does not do with the system Python.
-# Full mitigation also needs libexpat >= 2.8.0; no Debian bookworm fix yet.
-CVE-2026-7210 pkg:python3.11 exp:2026-08-15
-CVE-2026-7210 pkg:python3.11-dev exp:2026-08-15
-CVE-2026-7210 pkg:python3.11-minimal exp:2026-08-15
-CVE-2026-7210 pkg:libpython3.11 exp:2026-08-15
-CVE-2026-7210 pkg:libpython3.11-dev exp:2026-08-15
-CVE-2026-7210 pkg:libpython3.11-minimal exp:2026-08-15
-CVE-2026-7210 pkg:libpython3.11-stdlib exp:2026-08-15
-
-# CVE-2026-33278 — Unbound DNSSEC validator use-after-free (DoS, possible RCE).
-# CVE-2026-42960 — Unbound DNS cache poisoning via promiscuous additional records.
-# Package: libunbound8.
-# Why ignored: libunbound8 is a transitive apt dependency of the TLS/networking
-# stack (GnuTLS DANE support); only the shared library ships in the image. Both
-# vulnerabilities require operating a live Unbound recursive DNSSEC validator
-# that processes attacker-influenced DNS responses. Prowler never starts an
-# Unbound resolver, so neither code path is reachable. No Debian bookworm fix yet.
-CVE-2026-33278 pkg:libunbound8 exp:2026-08-15
-CVE-2026-42960 pkg:libunbound8 exp:2026-08-15
+CVE-2026-55200 pkg:libssh2-1 exp:2026-10-15


### PR DESCRIPTION
### Context

PROWLER-2295, part of PROWLER-2291 (container vulnerability remediation).

All 30 CVE entries in `.trivyignore` carried `exp:2026-08-15`. Every container gate sets `fail-on-critical`, so on 2026-08-16 they would all have lapsed at once and turned master red regardless of this programme's progress.

Rather than extend the date, each entry was reviewed against a build of both images it covers.

### Description

**30 entries → 7.** 23 were dropped as dead — the packages are not installed, so the suppression only implied an exposure that does not exist. If a future change reintroduces one, the finding should surface and force a fresh decision rather than be silently pre-suppressed.

| Dropped | Count | Why |
|---|---|---|
| `perl`, `perl-modules-5.36`, `libperl5.36` | 12 | Left the API image along with `git` (#12238) |
| `python3.11`, `libpython3.11*` | 7 | Never present in either image — the "python3-dev pulls in a system python3.11" premise did not hold |
| `libunbound8` | 2 | Never present |
| `linux-libc-dev`, `zlib1g-dev` | 2 | Never present |

**7 kept**, with staggered expiries and stronger reasoning where the evidence allows:

| CVE | Package | Expiry | Basis |
|---|---|---|---|
| CVE-2026-42496 | `perl-base` | 2027-01-31 | Archive::Tar not installed — structural |
| CVE-2026-57433 | `perl-base` | 2027-01-31 | Storable not installed — structural |
| CVE-2026-8376 | `perl-base` | 2027-01-31 | 32-bit only; both arches are 64-bit |
| CVE-2026-13221 | `perl-base` | 2026-11-30 | Upstream says 5.36.0 unaffected; depends on Debian/NVD correcting |
| CVE-2025-7458 | `libsqlite3-0` | 2026-10-31 | Retired by the trixie rebase |
| CVE-2023-45853 | `zlib1g` | 2026-10-31 | Retired by the trixie rebase |
| CVE-2026-55200 | `libssh2-1` | 2026-10-15 | SDK image only; unreachable |

Two entries moved from "unreachable at runtime" to a much firmer basis. Trivy attributes CVEs from the `perl` source package to every binary package it produces, which is why `perl-base` is flagged for modules it does not ship. With `perl-modules-5.36` gone, this is verifiable rather than argued:

```
$ docker run --rm --entrypoint sh prowler-api:test -c 'perl -MArchive::Tar -e1; perl -MStorable -e1'
Can't locate Archive/Tar.pm in @INC (you may need to install the Archive::Tar module)
Can't locate Storable.pm in @INC (you may need to install the Storable module)
```

Both are also absent from `dpkg -L perl-base` and from disk entirely.

Base is `integration/PROWLER-2291`, not `master`.

### Steps to review

The risk in pruning an ignore file is dropping an entry a gate still needs. Both images this file covers were checked to still report **0 criticals** under the new file:

```
trivy image --severity CRITICAL --ignorefile .trivyignore <image>
```

| Image | Criticals surviving |
|---|---|
| API (built from this branch) | **0** |
| SDK (`prowlercloud/prowler:5.36.0`) | **0** |

Expiries now spread across four dates (2026-10-15, 2026-10-31, 2026-11-30, 2027-01-31) instead of one cliff.

### Notes

Worth knowing for the trixie rebase (PROWLER-2299): purging `git` removed more than the perl packages. It also took `libcurl3-gnutls` and `libssh2-1` out of the API image, which is why the `libssh2-1` entry is now scoped to the SDK image only.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if backport is needed. Not needed — targets the integration branch.
- [x] Ensure a changelog fragment is added — not applicable, `.trivyignore` is not in a monitored folder
