### PR TITLE
fix(container): rebase the SDK and API images onto Debian 13 (trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.13-slim-bookworm@sha256:8a7e7cc04fd3e2bd787f7f24e22d5d119aa590d429b50c95dfe12b3abe52f48b AS build
+FROM python:3.12.13-slim-trixie@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS build
 
 LABEL maintainer="https://github.com/prowler-cloud/prowler"
 LABEL org.opencontainers.image.source="https://github.com/prowler-cloud/prowler"
@@ -16,7 +16,7 @@ ENV ZIZMOR_VERSION=${ZIZMOR_VERSION}
 
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    wget libicu72 libunwind8 libssl3 libcurl4 ca-certificates apt-transport-https gnupg \
+    wget libicu76 libunwind8 libssl3 libcurl4 ca-certificates apt-transport-https gnupg \
     build-essential pkg-config libzstd-dev zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.13-slim-bookworm@sha256:8a7e7cc04fd3e2bd787f7f24e22d5d119aa590d429b50c95dfe12b3abe52f48b AS build
+FROM python:3.12.13-slim-trixie@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS build
 
 LABEL maintainer="https://github.com/prowler-cloud/api"
 
@@ -17,7 +17,7 @@ ENV ZIZMOR_VERSION=${ZIZMOR_VERSION}
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     git \
-    libicu72 \
+    libicu76 \
     gcc \
     g++ \
     make \
@@ -117,6 +117,8 @@ RUN apt-get purge -y --auto-remove \
     libxml2-dev \
     libxmlsec1-dev \
     libxmlsec1-openssl \
+    libxmlsec1t64 \
+    libxmlsec1t64-openssl \
     pkg-config \
     libtool \
     libxslt1-dev \

--- a/api/changelog.d/api-container-trixie.security.md
+++ b/api/changelog.d/api-container-trixie.security.md
@@ -1,0 +1,1 @@
+The API container image now builds on Debian 13 (trixie), taking its critical CVE count from 18 to 4

--- a/prowler/changelog.d/sdk-container-trixie.security.md
+++ b/prowler/changelog.d/sdk-container-trixie.security.md
@@ -1,0 +1,1 @@
+The SDK container image now builds on Debian 13 (trixie), clearing the unfixable `libsqlite3-0` and `zlib1g` criticals


### PR DESCRIPTION
### Context

PROWLER-2299, part of PROWLER-2291 (container vulnerability remediation).

Both images pinned `python:3.12.13-slim-bookworm`. Debian 12 will not fix `libsqlite3-0` (CVE-2025-7458) or `zlib1g` (CVE-2023-45853); trixie ships versions where both are resolved — sqlite 3.46.1 is outside the affected 3.39.2–3.41.1 range, and zlib is 1.3.1.

`python:3.12.13-slim-trixie` keeps the **exact same Python patch version**, so this isolates the Debian 12 → 13 change. If something regresses, it is the OS.

### Description

| File | Change |
|---|---|
| `Dockerfile`, `api/Dockerfile` | base digest → `python:3.12.13-slim-trixie@sha256:57cd7c3a…` |
| both | `libicu72` → `libicu76` (the only package in either install list that does not exist on trixie) |
| `api/Dockerfile` | purge list gains `libxmlsec1t64` and `libxmlsec1t64-openssl` |

Every package in both install lists was checked against trixie first. Notably `libssl3` and `libcurl4` still resolve despite the 64-bit time_t transition adding `libssl3t64`/`libcurl4t64`, so no renames were needed there.

**The purge addition matters.** On trixie, `libxmlsec1-dev` and `libxmlsec1-openssl` are transitional packages. Purging the old names left the real `libxmlsec1t64*` installed, so `--auto-remove` could not cascade `libxml2` and `libxslt1.1` away — which leaked a **new critical** into the runtime image (`libxml2` CVE-2026-6653, no fix on trixie). bookworm's image has none of these packages at all, because `lxml` and `xmlsec` bundle their own libraries in the wheels. Reproduced and fixed:

```
# before: purging the old names only
LEFT: libxml2 2.12.7+dfsg+really2.9.14-2.1+deb13u3
LEFT: libxmlsec1t64, libxmlsec1t64-openssl, libxslt1.1
# after: adding the two t64 names
(nothing left — clean)
```

Base is `integration/PROWLER-2291`, not `master`.

### Steps to review

```
docker build -f api/Dockerfile -t prowler-api:test api/
docker build -f Dockerfile -t prowler-sdk:test .
```

**API image** — criticals **18 → 4**, total findings **402 → 255**:

| | bookworm (published 5.36.0) | this branch |
|---|---:|---:|
| CRITICAL | 18 | **4** |
| HIGH | 92 | 63 |
| MEDIUM | 140 | 84 |
| LOW | 138 | 74 |
| **total** | **402** | **255** |

All 4 remaining criticals are `perl-base` (CVE-2026-13221 / -42496 / -57433 / -8376), unfixable on any Debian release and already suppressed with documented rationale. Combined with the git purge already on this branch, that is the floor.

**SDK image** — criticals **6 → 4**.

Its HIGH count reads 60 → 68, but that is a package-granularity artifact, not a regression. Measured by **distinct CVE**, C+H goes **51 → 50** (6 new, 7 resolved): gnupg's single `CVE-2026-24882` is attributed across 7 binary packages (`gnupg`, `gpg`, `gpgsm`, `gpgconf`, `gpg-agent`, `dirmngr`, `gnupg-l10n`), and `libcurl4` → `libcurl4t64` moved 5 CVEs to 7. Resolved in exchange: `libssh2-1` (3), `libcurl4` (5), `libldap-2.5-0`, `util-linux-extra`.

**Functional verification** on the API image — the ICU version change was the main risk:

| Check | Result |
|---|---|
| Debian | 13.6 |
| `pwsh` executes | PowerShell 7.5.0 on ICU 76 |
| `Import-Module ExchangeOnlineManagement` + `MicrosoftTeams` | OK (in pwsh, not just file presence) |
| Python / Django | 3.12.13 / 5.1.15 |
| `import xmlsec, lxml.etree` | OK after the purge |
| `import prowler`, M365 PowerShell wrapper | OK |
| bundled trivy | 0.71.2 |
| `manage.py check` | No issues (0 silenced) |

### Notes

This retires two `.trivyignore` entries rather than renewing them — `CVE-2025-7458` (`libsqlite3-0`) and `CVE-2023-45853` (`zlib1g`) were given expiries in #12242 deliberately timed to land after this rebase. They can be deleted once this merges.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if backport is needed. Not needed — targets the integration branch.
- [x] Ensure a changelog fragment is added under prowler/changelog.d/ and api/changelog.d/

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Check if version updates are required — base image digest updated; Python version unchanged
- [x] Any other relevant evidence of the implementation — see tables above
