### PR TITLE
fix(compose): align postgres and valkey pins with the rest of the estate

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -64,7 +64,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: postgres:16.3-alpine3.20@sha256:36ed71227ae36305d26382657c0b96cbaf298427b3f1eaeb10d77a6dea3eec41
+    image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
     hostname: "postgres-db"
     volumes:
       - ./_data/postgres:/var/lib/postgresql/data
@@ -88,7 +88,7 @@ services:
       retries: 5
 
   valkey:
-    image: valkey/valkey:7-alpine3.19@sha256:4054fe7fc607b9326ac7c4691ed26e9670d2ff17a9fb28c2577adecf928acbcc
+    image: valkey/valkey:8-alpine@sha256:a038175878d66b9d274fbf8be73c0305e93798b83917647f167e18cef3c71eec
     hostname: "valkey"
     volumes:
       - ./_data/valkey:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       start_period: 60s
 
   postgres:
-    image: postgres:16.3-alpine3.20@sha256:36ed71227ae36305d26382657c0b96cbaf298427b3f1eaeb10d77a6dea3eec41
+    image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
     hostname: "postgres-db"
     volumes:
       - ./_data/postgres:/var/lib/postgresql/data
@@ -80,7 +80,7 @@ services:
       retries: 5
 
   valkey:
-    image: valkey/valkey:7-alpine3.19@sha256:4054fe7fc607b9326ac7c4691ed26e9670d2ff17a9fb28c2577adecf928acbcc
+    image: valkey/valkey:8-alpine@sha256:a038175878d66b9d274fbf8be73c0305e93798b83917647f167e18cef3c71eec
     hostname: "valkey"
     volumes:
       - ./_data/valkey:/data

--- a/prowler/changelog.d/compose-infra-pin-alignment.security.md
+++ b/prowler/changelog.d/compose-infra-pin-alignment.security.md
@@ -1,0 +1,1 @@
+Aligned the `postgres` and `valkey` image pins in the compose files with the rest of the estate, clearing 10 criticals


### PR DESCRIPTION
### Context

PROWLER-2307, part of PROWLER-2291.

The same infrastructure services were pinned four different ways across the estate. Anyone running the OSS `docker-compose.yml` got materially worse infrastructure than a Private Cloud install — **11 criticals against 4**, for postgres and valkey alone.

| Repo | postgres | valkey |
|---|---|---|
| prowler / prowler-cloud | `16.3-alpine3.20` pinned | `7-alpine3.19` pinned |
| prowler-registry / prowler-enterprise | `16-alpine` floating | `8-alpine` floating |

Three problems at once: version divergence, opposite pinning philosophies, and the pinned half frozen on `alpine3.19` because a digest with no refresh mechanism is how you get stale.

### Description

| | From | To | Effect |
|---|---|---|---|
| postgres | `16.3-alpine3.20` | `16-alpine` @digest | 7 CRIT / 175 → **1 CRIT / 39** |
| valkey | `7-alpine3.19` | `8-alpine` @digest | 4 CRIT / 126 → **0 CRIT / 0** |

**Staying on postgres 16 deliberately.** Measured across majors:

| | CRIT | HIGH |
|---|---:|---:|
| `16-alpine` | 1 | 14 |
| `17-alpine` | 1 | 14 |
| `18-alpine` | 1 | 15 |
| `16` / `16-bookworm` / `16-trixie` | **18–20** | 45–52 |

No security gain from a major bump, and the Debian variants are far worse. The residue is a single package — `stdlib v1.24.6`, the Go toolchain that built the image's `gosu` helper, not PostgreSQL. It is present on every major, is upstream-owned, and is not reachable from the database. A major upgrade would need `pg_upgrade` on every self-hosted install for nothing; 16 is supported until November 2028.

**valkey 7 → 8** is the one real version change, but prowler-registry and prowler-enterprise already run 8, so this moves to what is already shipped elsewhere rather than to something new.

### Steps to review

Brought both services up from this compose:

```
postgres: Up (healthy)   /var/run/postgresql:5432 - accepting connections   PostgreSQL 16.14
valkey:   Up (healthy)   PONG                                              Valkey 8.1.9
```

Postgres stays within major 16, so the data directory is compatible. Valkey is used as a cache and Celery broker, and reads an existing RDB from 7 fine.

### Why digests, evidenced

During a single day of testing, **`valkey/valkey:8-alpine` moved from Alpine 3.23.3 to 3.24.1** — 73 findings to 0, under an unchanged tag, hours apart. That is exactly the drift a digest prevents, and it moves in both directions: the same mechanism that silently improved this could silently regress it.

Renovate already has `docker:enableMajor` and `customManagers:dockerfileVersions`, so once digests are consistent across the estate it can keep them current — which fixes the staleness permanently instead of us re-pinning by hand in six months.

### Companion PRs

Same alignment in the other three repos, all landing on the same versions and digests:

- prowler-cloud/prowler-registry — digest-pins postgres, valkey, and MinIO (which carried no tag at all)
- prowler-cloud/prowler-enterprise — digest-pins all 8 infrastructure images in `compose.yml.tmpl`

### Out of scope

`dozerdb` (9 criticals, Debian 11, built 2025-02-24) needs a base-image decision, and MinIO is the post-EOL migration. Both are separate tickets. `busybox:1.37.0` and `nginx:alpine` already report zero findings.
