### PR TITLE
chore(ci): repin trivy-action to a resolvable tag

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -54,7 +54,7 @@ runs:
           trivy-db-${{ runner.os }}-
 
     - name: Run Trivy vulnerability scan (JSON)
-      uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         image-ref: ${{ inputs.image-name }}:${{ inputs.image-tag }}
         format: 'json'
@@ -67,7 +67,7 @@ runs:
 
     - name: Run Trivy vulnerability scan (SARIF)
       if: inputs.upload-sarif == 'true' && github.event_name == 'push'
-      uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         image-ref: ${{ inputs.image-name }}:${{ inputs.image-tag }}
         format: 'sarif'

--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -105,7 +105,9 @@ jobs:
         id: check-changes
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          files: api/**
+          files: |
+            api/**
+            .github/actions/trivy-scan/**
           files_ignore: |
             api/docs/**
             api/README.md

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -98,7 +98,9 @@ jobs:
         id: check-changes
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          files: mcp_server/**
+          files: |
+            mcp_server/**
+            .github/actions/trivy-scan/**
           files_ignore: |
             mcp_server/README.md
             mcp_server/CHANGELOG.md

--- a/.github/workflows/sdk-container-checks.yml
+++ b/.github/workflows/sdk-container-checks.yml
@@ -113,6 +113,7 @@ jobs:
             pyproject.toml
             uv.lock
             .github/workflows/sdk-container-checks.yml
+            .github/actions/trivy-scan/**
           files_ignore: |
             prowler/CHANGELOG.md
             prowler/changelog.d/**

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -99,7 +99,9 @@ jobs:
         id: check-changes
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          files: ui/**
+          files: |
+            ui/**
+            .github/actions/trivy-scan/**
           files_ignore: |
             ui/CHANGELOG.md
             ui/changelog.d/**


### PR DESCRIPTION
## Description

`.github/actions/trivy-scan` pins `aquasecurity/trivy-action@e368e32`, commented `# 0.34.1`. No tag points at that SHA any more, so the comment cannot be resolved and zizmor reports `ref-version-mismatch` (medium, high confidence). The pin still works — it is a valid commit — but the comment no longer tells you what version you are running, which is the entire point of pinning by SHA with a version comment.

Repinned to `ed142fd`, which is `v0.36.0`. Both inputs sets are unchanged: `image-ref`, `format`, `output`, `severity`, `exit-code`, `scanners`, `timeout` and `version` all still exist in v0.36.0.

Found while adding an equivalent scan to `prowler-enterprise`, where I copied this pin and zizmor rejected it there.

## Why the second change

The composite action decides how every container image in this repo gets scanned, but nothing re-runs a scan when it changes. All four `*-container-checks` workflows gate their scan step on `tj-actions/changed-files` against the project directory (`api/**`, `ui/**`, `prowler/**`, `mcp_server/**`), so a PR that touches only `.github/actions/trivy-scan/**` triggers the workflows and then skips every scan inside them.

That means a change to the scanner merges without ever having been run — including this one. Adding the action path to each gate makes the four container scans execute on this PR, which is how it gets validated.

## Not included

The `version: 'v0.71.2'` trivy pin is one minor behind (`v0.72.0`). Left alone deliberately: bumping the scanner changes which findings surface, and `.trivyignore` was tuned against v0.71.2 in PROWLER-2295. That belongs in its own PR where a red result is diagnostic rather than confusing.

## Checklist

- [x] `zizmor` clean on all five changed files (online audits, with token)
- [x] Tag resolved against the GitHub API, not copied from another repo
- [x] v0.36.0 verified to accept every input the composite action passes

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container security scanning to a newer Trivy action version.
  * Expanded automated container validation to run when shared security scanning configuration changes.
  * Improved change detection across API, MCP, SDK, and UI container checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->