### PR TITLE
fix(mcp): prevent prowler_list_integrations 500 on tenants with a Jira integration

### DIFF
--- a/mcp_server/changelog.d/list-integrations-jira.fixed.md
+++ b/mcp_server/changelog.d/list-integrations-jira.fixed.md
@@ -1,0 +1,1 @@
+`prowler_list_integrations` failing with a 500 error on tenants with a Jira integration, caused by the request leaving `configuration` out of the sparse fieldset

--- a/mcp_server/prowler_mcp_server/prowler_app/models/integrations.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/models/integrations.py
@@ -225,7 +225,7 @@ class JiraIssueTypes(MinimalSerializerMixin, BaseModel):
     model_config = ConfigDict(frozen=True)
 
     project_key: str = Field(
-        description="Jira project key the issue types belong to (e.g. 'PRWLR')"
+        description="Jira project key the issue types belong to (e.g. 'PROJ')"
     )
     issue_types: list[str] = Field(
         description="Issue types that can be used when sending findings to this project (e.g. 'Task', 'Bug', 'Story')"

--- a/mcp_server/prowler_mcp_server/prowler_app/tools/integrations.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/tools/integrations.py
@@ -25,7 +25,7 @@ from prowler_mcp_server.prowler_app.tools.base import BaseTool
 # detailed view returned by prowler_get_integration
 INTEGRATION_LIST_FIELDS = (
     "enabled,connected,connection_last_checked_at,integration_type,providers,"
-    "inserted_at,updated_at"
+    "configuration,inserted_at,updated_at"
 )
 
 CONNECTION_CHECK_TIMEOUT = 120
@@ -639,7 +639,7 @@ class IntegrationsTools(BaseTool):
             description="UUID of the Jira integration. Use prowler_list_integrations with integration_type=['jira'] to find it."
         ),
         project_key: str = Field(
-            description="Key of the Jira project to read the issue types from (e.g. 'PRWLR'). It must be one of the keys in the 'projects' mapping of the integration configuration."
+            description="Key of the Jira project to read the issue types from (e.g. 'PROJ'). It must be one of the keys in the 'projects' mapping of the integration configuration."
         ),
     ) -> dict[str, Any]:
         """List the issue types available in a Jira project.
@@ -677,7 +677,7 @@ class IntegrationsTools(BaseTool):
             description="UUID of the Jira integration to send the findings through. It must be enabled."
         ),
         project_key: str = Field(
-            description="Key of the Jira project the work items are created in (e.g. 'PRWLR'). It must be one of the keys in the 'projects' mapping of the integration configuration."
+            description="Key of the Jira project the work items are created in (e.g. 'PROJ'). It must be one of the keys in the 'projects' mapping of the integration configuration."
         ),
         issue_type: str = Field(
             description="Jira issue type for the created work items (e.g. 'Task', 'Bug', 'Story'). It must be one of the values returned by prowler_get_jira_issue_types for this project."


### PR DESCRIPTION
### Context

`prowler_list_integrations` fails for any tenant that has a Jira integration configured:

```
Error calling tool 'list_integrations': API request failed: 500 -
<!doctype html>
<html lang="en">
<head>
  <title>Server Error (500)</title>
</head>
<body>
  <h1>Server Error (500)</h1><p></p>
</body>
</html>
```

The tool was the only caller in the module sending a sparse fieldset, and it deliberately left `configuration` out to keep the list view lightweight:

```
GET /api/v1/integrations
  ?fields[integrations]=enabled,connected,connection_last_checked_at,integration_type,providers,inserted_at,updated_at
  &page[size]=50&page[number]=1
```

`IntegrationSerializer.to_representation` (`api/src/backend/api/v1/serializers.py:3005`) unconditionally does `representation["configuration"].update(...)` for Jira integrations, but `SparseFieldsetsMixin` has already dropped that key from the representation. The resulting `KeyError` is unhandled, so Django returns its plain HTML 500 page.

This is why a plain `GET /api/v1/integrations` from an API client looks healthy: the crash needs both the sparse fieldset **and** an integration of type `jira` in the tenant.

Reproduced in isolation against the installed `rest_framework_json_api`:

```
no sparse fieldset -> {'enabled': True, 'integration_type': 'jira', 'configuration': {..., 'domain': 'acme'}}
sparse fieldset without 'configuration' -> KeyError: 'configuration'
```

### Description

Request `configuration` in `INTEGRATION_LIST_FIELDS` so the API never hits that branch with a missing key.

The list output is unchanged: `SimplifiedIntegration.from_api_response` never reads `configuration`, so the extra attribute is discarded by the model and the integration-type specific configuration still belongs exclusively to `prowler_get_integration`, as documented in the tool docstring.

Also replaces the `PRWLR` Jira project key example with the generic `PROJ` in the three places it appeared:

- `get_jira_issue_types.project_key`
- `send_findings_to_jira.project_key`
- `JiraIssueTypes.project_key`

**Scope of the fix**

This is the client-side fix that unblocks the MCP Server. The underlying API bug is not addressed here and is worth a separate PR, because the same unguarded line exists twice:

- `IntegrationSerializer.to_representation` — `serializers.py:3005`, hit by `GET /integrations`
- `IntegrationUpdateSerializer.to_representation` — `serializers.py:3142`, reachable through `PATCH /integrations/{id}?fields[integrations]=...` on a Jira integration

A `and "configuration" in representation` guard on both would mirror the one already present in `hide_restricted_providers`, which explicitly handles the same case for `providers`. The existing coverage, `test_integrations_list_with_sparse_fields` (`api/src/backend/api/tests/test_rbac.py:1384`), does exercise the sparse path, but passes only because `integrations_fixture` creates two `amazon_s3` integrations and no Jira one.

Nothing else is affected: the UI never requests sparse fieldsets on integrations, and no other MCP integration tool sends a `fields[...]` parameter.

### Steps to review

1. Confirm the root cause against the API. On a tenant with a Jira integration, this returns 500:

   ```
   GET /api/v1/integrations?fields[integrations]=enabled,connected,integration_type
   ```

   Dropping the `fields` parameter, or running it on a tenant with only `amazon_s3` integrations, returns 200.

2. Check that the extra field does not leak into what the model sees. `SimplifiedIntegration` has no `configuration` field and `from_api_response` only reads `id`, `integration_type`, `enabled`, `connected`, `connection_last_checked_at`, the `providers` relationship, `inserted_at` and `updated_at`.

3. Run `prowler_list_integrations` against a tenant that has a Jira integration and confirm it returns the list instead of the 500, and that no `configuration` key is present in the output.

Verified locally by stubbing the API client and calling the tool with a Jira integration in the response:

```
GET /integrations
  fields[integrations] = enabled,connected,connection_last_checked_at,integration_type,providers,configuration,inserted_at,updated_at
  page[size] = 50
  page[number] = 1

tool output: {'integrations': [{'id': '019ac0d6-...', 'integration_type': 'jira', 'enabled': True, 'connected': True,
              'connection_last_checked_at': '...', 'inserted_at': '...', 'updated_at': '...'}], ...}

OK: `configuration` requested from the API but absent from the output
```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests. The MCP Server has no test suite for the `prowler_app` tools yet, only `tests/test_health.py`, so this was verified with a stubbed API client instead.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) — not needed.
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. Not applicable, no SDK change.

#### SDK/CLI
- Are there new checks included in this PR? No

#### MCP Server
- [x] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error when listing integrations for accounts with Jira integrations.
  * Integration list results now include configuration details.

* **Documentation**
  * Updated Jira project key examples from `PRWLR` to `PROJ`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->