### PR TITLE
fix(api): prevent 500 on Jira integrations with sparse fieldsets

### DIFF
--- a/api/changelog.d/integrations-sparse-fieldset-jira.fixed.md
+++ b/api/changelog.d/integrations-sparse-fieldset-jira.fixed.md
@@ -1,0 +1,1 @@
+Requesting integrations with a sparse fieldset that leaves out `configuration` no longer returns HTTP 500 errors when the tenant has a Jira integration

--- a/api/src/backend/api/tests/test_rbac.py
+++ b/api/src/backend/api/tests/test_rbac.py
@@ -1292,22 +1292,6 @@ class TestLimitedVisibility:
         )
 
     @pytest.fixture
-    def jira_integration(self, tenants_fixture):
-        # Jira is a tenant-wide integration: it is not attached to any provider
-        return Integration.objects.create(
-            tenant_id=tenants_fixture[0].id,
-            enabled=True,
-            connected=True,
-            integration_type=Integration.IntegrationChoices.JIRA,
-            configuration={"projects": {"TEST": "Test project"}},
-            credentials={
-                "domain": "test",
-                "user_mail": "a@b.com",
-                "api_token": "token",
-            },
-        )
-
-    @pytest.fixture
     def out_of_scope_integration(self, tenants_fixture, provider_factory):
         tenant_id = tenants_fixture[0].id
         integration = Integration.objects.create(
@@ -1332,7 +1316,7 @@ class TestLimitedVisibility:
         self,
         authenticated_client_rbac_limited,
         integrations_fixture,
-        jira_integration,
+        jira_integration_fixture,
         aws_provider_pair,
     ):
         # Integration 2 is attached to both providers, so make both visible to the role
@@ -1348,13 +1332,16 @@ class TestLimitedVisibility:
         assert response.status_code == status.HTTP_200_OK
         integration_ids = [item["id"] for item in response.json()["data"]]
         # The tenant-wide Jira integration is visible without unlimited visibility
-        assert str(jira_integration.id) in integration_ids
+        assert str(jira_integration_fixture.id) in integration_ids
         # Integrations attached to more than one visible provider are not duplicated
         assert integration_ids.count(str(integrations_fixture[1].id)) == 1
         assert response.json()["meta"]["pagination"]["count"] == len(integration_ids)
 
     def test_integrations_list_without_provider_groups_keeps_tenant_wide_integration(
-        self, authenticated_client_rbac_limited, integrations_fixture, jira_integration
+        self,
+        authenticated_client_rbac_limited,
+        integrations_fixture,
+        jira_integration_fixture,
     ):
         # A role with no provider group at all sees no provider, but still needs Jira
         RoleProviderGroupRelationship.objects.all().delete()
@@ -1363,7 +1350,7 @@ class TestLimitedVisibility:
 
         assert response.status_code == status.HTTP_200_OK
         integration_ids = [item["id"] for item in response.json()["data"]]
-        assert integration_ids == [str(jira_integration.id)]
+        assert integration_ids == [str(jira_integration_fixture.id)]
 
     def test_integrations_include_providers_hides_out_of_scope_providers(
         self, authenticated_client_rbac_limited, integrations_fixture, aws_provider_pair
@@ -1382,13 +1369,19 @@ class TestLimitedVisibility:
         assert str(hidden_provider.id) not in included_ids
 
     def test_integrations_list_with_sparse_fields(
-        self, authenticated_client_rbac_limited, integrations_fixture
+        self,
+        authenticated_client_rbac_limited,
+        integrations_fixture,
+        jira_integration_fixture,
     ):
         response = authenticated_client_rbac_limited.get(
             reverse("integration-list"), {"fields[integrations]": "enabled"}
         )
 
         assert response.status_code == status.HTTP_200_OK
+        assert str(jira_integration_fixture.id) in [
+            item["id"] for item in response.json()["data"]
+        ]
         assert all(
             list(item["attributes"].keys()) == ["enabled"]
             for item in response.json()["data"]
@@ -1424,7 +1417,10 @@ class TestLimitedVisibility:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_integration_update_allowed_when_fully_visible(
-        self, authenticated_client_rbac_limited, integrations_fixture, jira_integration
+        self,
+        authenticated_client_rbac_limited,
+        integrations_fixture,
+        jira_integration_fixture,
     ):
         # Integration 1 is only related to provider1, which the role can access
         integration = integrations_fixture[0]
@@ -1458,20 +1454,20 @@ class TestLimitedVisibility:
         payload = {
             "data": {
                 "type": "integrations",
-                "id": str(jira_integration.id),
+                "id": str(jira_integration_fixture.id),
                 "attributes": {"enabled": False},
             }
         }
 
         response = authenticated_client_rbac_limited.patch(
-            reverse("integration-detail", kwargs={"pk": jira_integration.id}),
+            reverse("integration-detail", kwargs={"pk": jira_integration_fixture.id}),
             data=json.dumps(payload),
             content_type="application/vnd.api+json",
         )
 
         assert response.status_code == status.HTTP_200_OK
-        jira_integration.refresh_from_db()
-        assert jira_integration.enabled is False
+        jira_integration_fixture.refresh_from_db()
+        assert jira_integration_fixture.enabled is False
 
     def test_integration_create_rejects_out_of_scope_provider(
         self, authenticated_client_rbac_limited, aws_provider_pair
@@ -1571,7 +1567,10 @@ class TestLimitedVisibility:
         assert Integration.objects.filter(id=integration.id).exists()
 
     def test_integration_delete_allowed_when_fully_visible(
-        self, authenticated_client_rbac_limited, integrations_fixture, jira_integration
+        self,
+        authenticated_client_rbac_limited,
+        integrations_fixture,
+        jira_integration_fixture,
     ):
         # Integration 1 is only related to provider1, which the role can access
         integration = integrations_fixture[0]
@@ -1585,20 +1584,20 @@ class TestLimitedVisibility:
 
         # Tenant-wide integrations have no provider restricting the role
         response = authenticated_client_rbac_limited.delete(
-            reverse("integration-detail", kwargs={"pk": jira_integration.id})
+            reverse("integration-detail", kwargs={"pk": jira_integration_fixture.id})
         )
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
     def test_jira_issue_types_allowed_without_unlimited_visibility(
-        self, authenticated_client_rbac_limited, jira_integration
+        self, authenticated_client_rbac_limited, jira_integration_fixture
     ):
         with patch("api.v1.views.initialize_prowler_integration") as mock_jira:
             mock_jira.return_value.get_available_issue_types.return_value = ["Task"]
             response = authenticated_client_rbac_limited.get(
                 reverse(
                     "integration-jira-issue-types",
-                    kwargs={"integration_pk": jira_integration.id},
+                    kwargs={"integration_pk": jira_integration_fixture.id},
                 ),
                 {"project_key": "TEST"},
             )
@@ -1634,12 +1633,12 @@ class TestLimitedVisibility:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_jira_dispatches_allowed_without_unlimited_visibility(
-        self, authenticated_client_rbac_limited, jira_integration
+        self, authenticated_client_rbac_limited, jira_integration_fixture
     ):
         response = authenticated_client_rbac_limited.post(
             reverse(
                 "integration-jira-dispatches",
-                kwargs={"integration_pk": jira_integration.id},
+                kwargs={"integration_pk": jira_integration_fixture.id},
             ),
             data=json.dumps({}),
             content_type="application/vnd.api+json",

--- a/api/src/backend/api/tests/test_rbac.py
+++ b/api/src/backend/api/tests/test_rbac.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import ANY, Mock, patch
 
 import pytest
+from api.db_utils import rls_transaction
 from api.models import (
     Integration,
     IntegrationProviderRelationship,
@@ -1466,7 +1467,8 @@ class TestLimitedVisibility:
         )
 
         assert response.status_code == status.HTTP_200_OK
-        jira_integration_fixture.refresh_from_db()
+        with rls_transaction(str(jira_integration_fixture.tenant_id)):
+            jira_integration_fixture.refresh_from_db()
         assert jira_integration_fixture.enabled is False
 
     def test_integration_create_rejects_out_of_scope_provider(

--- a/api/src/backend/api/tests/test_serializers.py
+++ b/api/src/backend/api/tests/test_serializers.py
@@ -6,10 +6,13 @@ from api.v1.serializer_utils.integrations import (
 from api.v1.serializer_utils.providers import ProviderSecretField
 from api.v1.serializers import (
     ImageProviderSecret,
+    IntegrationSerializer,
+    IntegrationUpdateSerializer,
     KubernetesProviderSecret,
     OracleCloudProviderSecret,
 )
 from rest_framework.exceptions import ValidationError
+from rest_framework.test import APIRequestFactory
 
 
 class TestS3ConfigSerializer:
@@ -352,3 +355,25 @@ current-context: test-context
 
         assert not serializer.is_valid()
         assert "kubeconfig_content" in serializer.errors
+
+
+@pytest.mark.django_db
+class TestIntegrationSerializerJiraDomain:
+    """The serialized Jira `domain` must not reach the model instance."""
+
+    @pytest.mark.parametrize(
+        "serializer_class", [IntegrationSerializer, IntegrationUpdateSerializer]
+    )
+    def test_to_representation_does_not_mutate_configuration(
+        self, serializer_class, jira_integration_fixture
+    ):
+        # `IntegrationUpdateSerializer` exposes a `HyperlinkedIdentityField`
+        context = {"request": APIRequestFactory().get("/")}
+        representation = serializer_class(
+            jira_integration_fixture, context=context
+        ).data
+
+        assert representation["configuration"]["domain"] == "test"
+        assert jira_integration_fixture.configuration == {
+            "projects": {"TEST": "Test project"}
+        }

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -23,6 +23,7 @@ from api.attack_paths import (
 )
 from api.compliance import get_compliance_frameworks
 from api.db_router import MainRouter
+from api.db_utils import rls_transaction
 from api.models import (
     AttackSurfaceOverview,
     ComplianceOverviewSummary,
@@ -13544,7 +13545,8 @@ class TestIntegrationViewSet:
 
         assert response.status_code == status.HTTP_200_OK
         assert "configuration" not in response.json()["data"]["attributes"]
-        jira_integration_fixture.refresh_from_db()
+        with rls_transaction(str(jira_integration_fixture.tenant_id)):
+            jira_integration_fixture.refresh_from_db()
         assert jira_integration_fixture.enabled is False
 
     def test_integrations_retrieve_jira_keeps_domain_in_configuration(

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -13498,6 +13498,67 @@ class TestIntegrationViewSet:
                 f"Expected type '{expected_type}' not found in included data"
             )
 
+    # Serializing a Jira integration reads `configuration` to add the domain from the
+    # credentials, and a sparse fieldset can leave that field out of the representation
+
+    def test_integrations_list_sparse_fields_without_configuration(
+        self, authenticated_client, jira_integration_fixture
+    ):
+        response = authenticated_client.get(
+            reverse("integration-list"),
+            {"fields[integrations]": "enabled,integration_type"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        attributes = response.json()["data"][0]["attributes"]
+        assert sorted(attributes.keys()) == ["enabled", "integration_type"]
+
+    def test_integrations_retrieve_sparse_fields_without_configuration(
+        self, authenticated_client, jira_integration_fixture
+    ):
+        response = authenticated_client.get(
+            reverse("integration-detail", kwargs={"pk": jira_integration_fixture.id}),
+            {"fields[integrations]": "enabled,integration_type"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "configuration" not in response.json()["data"]["attributes"]
+
+    def test_integrations_partial_update_sparse_fields_without_configuration(
+        self, authenticated_client, jira_integration_fixture
+    ):
+        data = {
+            "data": {
+                "type": "integrations",
+                "id": str(jira_integration_fixture.id),
+                "attributes": {"enabled": False},
+            }
+        }
+
+        url = reverse("integration-detail", kwargs={"pk": jira_integration_fixture.id})
+        response = authenticated_client.patch(
+            f"{url}?fields[integrations]=enabled,integration_type",
+            data=json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "configuration" not in response.json()["data"]["attributes"]
+        jira_integration_fixture.refresh_from_db()
+        assert jira_integration_fixture.enabled is False
+
+    def test_integrations_retrieve_jira_keeps_domain_in_configuration(
+        self, authenticated_client, jira_integration_fixture
+    ):
+        response = authenticated_client.get(
+            reverse("integration-detail", kwargs={"pk": jira_integration_fixture.id})
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        configuration = response.json()["data"]["attributes"]["configuration"]
+        assert configuration["domain"] == "test"
+        assert configuration["projects"] == {"TEST": "Test project"}
+
     @pytest.mark.parametrize(
         "integration_type, configuration, credentials",
         [

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -13548,6 +13548,11 @@ class TestIntegrationViewSet:
         with rls_transaction(str(jira_integration_fixture.tenant_id)):
             jira_integration_fixture.refresh_from_db()
         assert jira_integration_fixture.enabled is False
+        # Omitting `configuration` from the fieldset must not rewrite it, and the
+        # serialized `domain` must not leak into the stored value
+        assert jira_integration_fixture.configuration == {
+            "projects": {"TEST": "Test project"}
+        }
 
     def test_integrations_retrieve_jira_keeps_domain_in_configuration(
         self, authenticated_client, jira_integration_fixture

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -3006,7 +3006,11 @@ class IntegrationSerializer(IntegrationProviderVisibilityMixin, RLSSerializer):
         representation = self.hide_restricted_providers(
             super().to_representation(instance)
         )
-        if instance.integration_type == Integration.IntegrationChoices.JIRA:
+        # `configuration` is missing when the request asks for a subset of the fields
+        if (
+            instance.integration_type == Integration.IntegrationChoices.JIRA
+            and "configuration" in representation
+        ):
             representation["configuration"].update(
                 {"domain": instance.credentials.get("domain")}
             )
@@ -3143,8 +3147,12 @@ class IntegrationUpdateSerializer(
         representation = self.hide_restricted_providers(
             super().to_representation(instance)
         )
-        # Ensure JIRA integrations show updated domain in configuration from credentials
-        if instance.integration_type == Integration.IntegrationChoices.JIRA:
+        # Ensure JIRA integrations show updated domain in configuration from credentials.
+        # `configuration` is missing when the request asks for a subset of the fields
+        if (
+            instance.integration_type == Integration.IntegrationChoices.JIRA
+            and "configuration" in representation
+        ):
             representation["configuration"].update(
                 {"domain": instance.credentials.get("domain")}
             )

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -3011,9 +3011,10 @@ class IntegrationSerializer(IntegrationProviderVisibilityMixin, RLSSerializer):
             instance.integration_type == Integration.IntegrationChoices.JIRA
             and "configuration" in representation
         ):
-            representation["configuration"].update(
-                {"domain": instance.credentials.get("domain")}
-            )
+            representation["configuration"] = {
+                **representation["configuration"],
+                "domain": instance.credentials.get("domain"),
+            }
         return representation
 
 
@@ -3153,9 +3154,10 @@ class IntegrationUpdateSerializer(
             instance.integration_type == Integration.IntegrationChoices.JIRA
             and "configuration" in representation
         ):
-            representation["configuration"].update(
-                {"domain": instance.credentials.get("domain")}
-            )
+            representation["configuration"] = {
+                **representation["configuration"],
+                "domain": instance.credentials.get("domain"),
+            }
         return representation
 
 

--- a/api/src/backend/conftest.py
+++ b/api/src/backend/conftest.py
@@ -1454,18 +1454,20 @@ def integrations_fixture(aws_provider_pair):
 def jira_integration_fixture(tenants_fixture):
     # Jira is a tenant-wide integration: it is not attached to any provider, and its
     # `domain` is read from the credentials when the integration is serialized
-    return Integration.objects.create(
-        tenant_id=tenants_fixture[0].id,
-        enabled=True,
-        connected=True,
-        integration_type=Integration.IntegrationChoices.JIRA,
-        configuration={"projects": {"TEST": "Test project"}},
-        credentials={
-            "domain": "test",
-            "user_mail": "a@b.com",
-            "api_token": "token",
-        },
-    )
+    tenant_id = tenants_fixture[0].id
+    with rls_transaction(str(tenant_id)):
+        return Integration.objects.create(
+            tenant_id=tenant_id,
+            enabled=True,
+            connected=True,
+            integration_type=Integration.IntegrationChoices.JIRA,
+            configuration={"projects": {"TEST": "Test project"}},
+            credentials={
+                "domain": "test",
+                "user_mail": "a@b.com",
+                "api_token": "token",
+            },
+        )
 
 
 @pytest.fixture

--- a/api/src/backend/conftest.py
+++ b/api/src/backend/conftest.py
@@ -1451,6 +1451,24 @@ def integrations_fixture(aws_provider_pair):
 
 
 @pytest.fixture
+def jira_integration_fixture(tenants_fixture):
+    # Jira is a tenant-wide integration: it is not attached to any provider, and its
+    # `domain` is read from the credentials when the integration is serialized
+    return Integration.objects.create(
+        tenant_id=tenants_fixture[0].id,
+        enabled=True,
+        connected=True,
+        integration_type=Integration.IntegrationChoices.JIRA,
+        configuration={"projects": {"TEST": "Test project"}},
+        credentials={
+            "domain": "test",
+            "user_mail": "a@b.com",
+            "api_token": "token",
+        },
+    )
+
+
+@pytest.fixture
 def backfill_scan_metadata_fixture(scans_fixture, findings_fixture):
     for scan_instance in scans_fixture:
         tenant_id = scan_instance.tenant_id


### PR DESCRIPTION
### Context

`GET /api/v1/integrations` returns Django's plain HTML 500 page when the request uses a sparse fieldset that leaves `configuration` out **and** the tenant has a Jira integration:

```
GET /api/v1/integrations?fields[integrations]=enabled,connected,integration_type
→ 500 Server Error
```

`IntegrationSerializer.to_representation` adds the Jira domain from the credentials into the configuration, without checking that the key is there:

```python
if instance.integration_type == Integration.IntegrationChoices.JIRA:
    representation["configuration"].update({"domain": instance.credentials.get("domain")})
```

DJA's `SparseFieldsetsMixin._readable_fields` has already dropped `configuration` from the representation by that point, so this raises an unhandled `KeyError` and Django falls back to its HTML 500 page — no JSON:API error body.

Both conditions are needed, which is why it went unnoticed: a plain `GET /api/v1/integrations` is healthy, and so is a tenant whose integrations are all `amazon_s3`.

Reproduced in isolation against the installed `rest_framework_json_api`:

```
no sparse fieldset -> {'enabled': True, 'integration_type': 'jira', 'configuration': {..., 'domain': 'acme'}}
sparse fieldset without 'configuration' -> KeyError: 'configuration'
```

Found from the MCP Server, whose `prowler_list_integrations` requests a sparse fieldset and was failing for every tenant with a Jira integration.

### Description

Guards the domain injection with a presence check in the two serializers that perform it:

- `IntegrationSerializer.to_representation` — `GET /integrations` and `GET /integrations/{id}`
- `IntegrationUpdateSerializer.to_representation` — `PATCH /integrations/{id}?fields[integrations]=...`

The guard mirrors the one already in `IntegrationProviderVisibilityMixin.hide_restricted_providers`, which handles the same situation for `providers` and documents it as *"`providers` is missing when the request asks for a subset of the fields"*.

Behaviour is otherwise unchanged: when `configuration` **is** part of the representation, the Jira domain is still injected from the credentials exactly as before.

**Tests**

`test_integrations_list_with_sparse_fields` already exercised the sparse path with `fields[integrations]=enabled`, but passed because `integrations_fixture` only creates `amazon_s3` integrations and the crash is gated on `integration_type == jira`. It now uses a Jira integration too, so it fails without this fix.

- Adds a shared `jira_integration_fixture` to `conftest.py`, replacing the identical fixture that was defined locally inside `test_rbac.py` (its 15 references now point at the shared one).
- Adds four tests to `TestIntegrationViewSet`:
  - `test_integrations_list_sparse_fields_without_configuration` — the reported 500
  - `test_integrations_retrieve_sparse_fields_without_configuration` — detail endpoint, same serializer
  - `test_integrations_partial_update_sparse_fields_without_configuration` — covers `IntegrationUpdateSerializer`
  - `test_integrations_retrieve_jira_keeps_domain_in_configuration` — asserts the domain is still injected when `configuration` **is** requested, so the guard cannot be "simplified" into removing the feature

The first four fail with a 500 on `master` and pass with this change. The last passes either way.

**Not in scope**

While tracing this, `domain` turned out to be stored twice: in the Fernet-encrypted `credentials` blob and, in plaintext, in `configuration` — the API writes it there itself at creation time (`serializers.py:2944`). A Jira update rejects a `configuration` payload, so changing the credentials updates the encrypted copy and leaves the stored `configuration["domain"]` stale; the read-time injection is what hides that drift. It has a real consequence: the create-time duplicate guard (`serializers.py:2860`) queries the stale stored value, so after a domain change a second integration can be created for the same Jira site. Worth fixing separately, since resolving it means deciding whether `domain` is configuration or a credential. No secret is exposed either way — `credentials` is `write_only` on the write serializers and absent from `IntegrationSerializer.Meta.fields`, so `user_mail` and `api_token` are never serialized.

### Steps to review

1. Check out `master` and confirm the failure, on a tenant with a Jira integration:

   ```
   GET /api/v1/integrations?fields[integrations]=enabled,connected,integration_type
   ```

   It returns the HTML 500. Dropping the `fields` parameter, or running it against a tenant with only `amazon_s3` integrations, returns 200.

2. Confirm the new tests are red without the fix — stash the `serializers.py` hunks and run:

   ```
   pytest api/src/backend/api/tests/test_views.py::TestIntegrationViewSet \
          api/src/backend/api/tests/test_rbac.py -k "sparse or jira"
   ```

3. Confirm the Jira domain is still exposed on the normal read path, which `test_integrations_retrieve_jira_keeps_domain_in_configuration` and the existing `test_integrations_update_jira_credentials_domain_reflects_in_configuration` both cover.

4. The `test_rbac.py` diff is mostly mechanical: the local `jira_integration` fixture is deleted and its references renamed to the shared `jira_integration_fixture`. The only behavioural change in that file is `test_integrations_list_with_sparse_fields` gaining the fixture.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) — not needed.
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. Not applicable, no SDK change.

#### SDK/CLI
- Are there new checks included in this PR? No

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable) — see **Context** and **Steps to review**
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable) — not applicable, no query or index change.
- [ ] Performance test results (if applicable) — not applicable.
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated — not needed, no schema change. The `fields[integrations]` parameter is already documented in `api/src/backend/api/specs/v1.yaml`.
- [x] Check if version updates are required (e.g., specs, uv, etc.) — none.
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed integration list, retrieve, and update requests that omit configuration, preventing unexpected HTTP 500 errors for Jira integrations.
  * Improved sparse-field responses when requesting selected integration details.
  * Preserved Jira domain and project information when configuration is included in responses.
  * Ensured partial updates continue to save successfully without requiring the full configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->