### PR TITLE
fix(container): purge wget and gnupg from the runtime images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,9 @@ RUN apt-get purge -y --auto-remove \
     pkg-config \
     libzstd-dev \
     zlib1g-dev \
+    wget \
+    gnupg \
+    apt-transport-https \
     && rm -rf /var/lib/apt/lists/*
 
 USER prowler

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -123,6 +123,9 @@ RUN apt-get purge -y --auto-remove \
     libtool \
     libxslt1-dev \
     python3-dev \
+    wget \
+    gnupg \
+    apt-transport-https \
     && rm -rf /var/lib/apt/lists/*
 
 USER prowler

--- a/api/changelog.d/api-container-purge-build-only.security.md
+++ b/api/changelog.d/api-container-purge-build-only.security.md
@@ -1,0 +1,1 @@
+Removed `wget`, `gnupg` and `apt-transport-https` from the API container image, clearing 9 high-severity CVEs with no upstream fix

--- a/prowler/changelog.d/container-purge-build-only-packages.security.md
+++ b/prowler/changelog.d/container-purge-build-only-packages.security.md
@@ -1,0 +1,1 @@
+Removed `wget`, `gnupg` and `apt-transport-https` from the SDK and API runtime images, clearing 9 high-severity CVEs that have no upstream fix


### PR DESCRIPTION
Stacked on #12263.

## Description

The SDK and API images install `wget`, `gnupg` and `apt-transport-https` to fetch PowerShell, Trivy and zizmor during the build, then never remove them. Between them they carry **9 high-severity CVEs that Debian has not fixed**, so they cannot be resolved any other way.

Both Dockerfiles already end with an `apt-get purge --auto-remove`. This adds the three packages to the list that is already there.

| | Before | After |
|---|---:|---:|
| Debian HIGH findings (SDK) | 35 | **26** |
| Total HIGH (SDK) | 52 | **43** |
| Critical | 4 | 4 (unchanged) |
| Packages installed | 125 | **110** |

Every removed finding came from `wget` (2) or the gnupg suite — `gnupg`, `gpg`, `gpg-agent`, `gpgconf`, `gpgsm`, `dirmngr`, `gnupg-l10n` (7).

## Verification

`--auto-remove` is the risk here: PROWLER-2296 purged `git` the same way and silently took `libxmlsec1t64` with it, letting a `libxml2` critical back in. So this was rebuilt and checked rather than assumed.

```
prowler --version        Prowler 5.37.0
M365 modules             712 cmdlets (ExchangeOnlineManagement + MicrosoftTeams)
aws --list-checks        651 checks, unchanged
```

Runtime dependencies confirmed still present: `libcurl4t64`, `libicu76`, `libunwind8`, `ca-certificates`, `libssl3t64`. The first three matter most — PowerShell needs them, and they were the plausible casualties of `--auto-remove`.

`wget`, `gpg` and `dirmngr` confirmed gone from the dpkg database, and no gnupg-family package appears in the scan output any more.

## What remains

The other 26 Debian findings stay and are not fixable: `libcurl4t64` (7) is required by PowerShell, `perl-base` (4) is `Essential: yes` and already documented in `.trivyignore`, and the remaining 15 are base-image essentials — the util-linux family, ncurses, `gzip`, `libacl1`, `login`, `mount`.

## Note on scope

This was originally scoped as a multi-stage split, on the assumption the images shipped their build toolchain. They do not — `build-essential`, `pkg-config`, `libzstd-dev` and `zlib1g-dev` are already purged, and the 705 MB is dominated by artifacts a runtime stage would copy anyway (virtualenv, PowerShell at 201 MB, Trivy at 149 MB). The real gap was three packages missing from the existing purge list, so that is all this changes.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.