### PR TITLE
docs(mcp): document the Cloud-only prowler_cloud_* tool namespace

### DIFF
--- a/docs/getting-started/basic-usage/prowler-mcp-tools.mdx
+++ b/docs/getting-started/basic-usage/prowler-mcp-tools.mdx
@@ -6,11 +6,16 @@ Complete reference guide for all tools available in the Prowler MCP Server. Tool
 
 ## Tool Categories Summary
 
-| Category | Tool Count | Authentication Required |
-|----------|------------|------------------------|
-| Prowler Hub | 10 tools | No |
-| Prowler Documentation | 2 tools | No |
-| Prowler Cloud, Private Cloud & Local Server | 42 tools | Yes |
+| Category | Tool Count | Authentication Required | Availability |
+|----------|------------|------------------------|--------------|
+| Prowler Hub | 10 tools | No | Cloud and Local MCP Server |
+| Prowler Documentation | 2 tools | No | Cloud and Local MCP Server |
+| Prowler Cloud, Private Cloud & Local Server | 49 tools | Yes | Cloud and Local MCP Server |
+| Prowler Cloud management | 32 tools | Yes | Cloud MCP Server only |
+
+<Note>
+48 of the 49 Prowler tools are available on both servers. `prowler_schedule_daily_scan` is the exception: it is Local-only, because the Cloud MCP Server supersedes it with the `prowler_cloud_*` [Scan Scheduling](#scan-scheduling) tools.
+</Note>
 
 ## Tool Naming Convention
 
@@ -19,6 +24,11 @@ All tools follow a consistent naming pattern with prefixes:
 - `prowler_hub_*` - Prowler Hub catalog and compliance tools
 - `prowler_docs_*` - Prowler documentation search and retrieval
 - `prowler_*` - Prowler Cloud, Prowler Private Cloud & Prowler Local Server management tools
+- `prowler_cloud_*` - Prowler Cloud-only management tools
+
+<Note>
+`prowler_cloud_*` tools are exposed only by the [Cloud MCP Server](/getting-started/products/prowler-mcp#cloud-vs-local-mcp-server) at `https://mcp.prowler.com/mcp`, because they manage features that exist only in Prowler Cloud. Every other tool is available on both the Cloud and Local MCP Server.
+</Note>
 
 ## Prowler Tools
 
@@ -59,8 +69,12 @@ Tools for managing and monitoring security scans.
 - **`prowler_list_scans`** - List and filter security scans across all providers
 - **`prowler_get_scan`** - Get comprehensive details about a specific scan (progress, duration, resource counts)
 - **`prowler_trigger_scan`** - Trigger a manual security scan for a provider
-- **`prowler_schedule_daily_scan`** - Schedule automated daily scans for continuous monitoring
+- **`prowler_schedule_daily_scan`** - Schedule automated daily scans for continuous monitoring (**Local MCP Server only**)
 - **`prowler_update_scan`** - Update scan name for better organization
+
+<Note>
+`prowler_schedule_daily_scan` is the scheduling tool for a self-hosted deployment, and it only does one thing: a daily scan. The Cloud MCP Server does not expose it — Prowler Cloud replaces it with the richer [Scan Scheduling](#scan-scheduling) tools, which add interval, weekly, and monthly frequencies, per-provider schedule retrieval, and bulk apply across providers.
+</Note>
 
 ### Resources Management
 
@@ -145,6 +159,78 @@ Tools for browsing RBAC roles and managing the role assigned to a user. A user h
 - **`prowler_get_user_roles`** - List the roles assigned to a specific user, with the capabilities each role grants
 - **`prowler_set_user_role`** - Set the role a user holds, replacing the role they had before (idempotent)
 
+## Prowler Cloud Tools
+
+Manage Prowler Cloud-only features and configuration. **Requires authentication.**
+
+<Note>
+These tools are available **only on the Cloud MCP Server** (`https://mcp.prowler.com/mcp`). A Local MCP Server does not expose them, because the features they manage exist only in Prowler Cloud.
+</Note>
+
+### Scan Configurations
+
+Tools for managing reusable scan configurations — per-provider check and compliance selections — and attaching them to providers. Providers without a configuration attached use the default.
+
+- **`prowler_cloud_list_scan_configurations`** - List and filter the scan configurations defined in the tenant
+- **`prowler_cloud_get_scan_configuration`** - Retrieve a scan configuration including its full configuration body
+- **`prowler_cloud_get_scan_configuration_schema`** - Fetch the JSON Schema describing the keys a valid configuration body may set, optionally filtered to a single provider type
+- **`prowler_cloud_create_scan_configuration`** - Create a scan configuration and optionally attach it to providers
+- **`prowler_cloud_update_scan_configuration`** - Update a configuration's name, body, and/or attached providers
+- **`prowler_cloud_delete_scan_configuration`** - Delete a scan configuration; attached providers revert to the default
+
+### Findings Triage
+
+Tools for recording a review decision on a finding and documenting the reasoning. Triage is keyed on the stable finding UID returned by `prowler_search_security_findings` and `prowler_get_finding_details`.
+
+<Note>
+Triage is distinct from [muting](#muting-management). Use mute rules and the mutelist to **suppress** findings; use triage to **record a decision** and its rationale while the finding stays visible. See the [Findings Triage tutorial](/user-guide/tutorials/prowler-app-findings-triage).
+</Note>
+
+- **`prowler_cloud_list_finding_triages`** - List and filter persisted triage records by status, provider, check, and more
+- **`prowler_cloud_get_finding_triage`** - Retrieve a single finding's triage state by finding UID
+- **`prowler_cloud_set_finding_triage_status`** - Set a finding's triage status (`open`, `under_review`, `remediating`, `risk_accepted`, `false_positive`), optionally attaching a note. The `resolved` and `reopened` statuses are system-managed and cannot be set directly
+- **`prowler_cloud_list_finding_triage_notes`** - List the notes attached to a finding's triage, newest first
+- **`prowler_cloud_create_finding_triage_note`** - Add a new note to a finding's triage
+- **`prowler_cloud_update_finding_triage_note`** - Update the body of an existing note
+- **`prowler_cloud_delete_finding_triage_note`** - Delete a note from a finding's triage
+
+### Scan Scheduling
+
+Tools for configuring recurring scans. One schedule exists per provider, with daily, interval, weekly, or monthly frequency. These replace the Local-only `prowler_schedule_daily_scan`, which can only set up a daily scan. See the [Scan Scheduling tutorial](/user-guide/tutorials/prowler-scan-scheduling).
+
+- **`prowler_cloud_list_scan_schedules`** - List scan schedules, one per visible provider
+- **`prowler_cloud_get_scan_schedule`** - Retrieve a provider's schedule including all per-frequency fields
+- **`prowler_cloud_set_scan_schedule`** - Configure or update a single provider's recurring scan schedule
+- **`prowler_cloud_bulk_set_scan_schedules`** - Apply one schedule to many providers at once
+- **`prowler_cloud_delete_scan_schedule`** - Delete a provider's scan schedule
+
+### Alerts
+
+Tools for notifying recipients when scan results match a rule condition. See the [Alerts tutorial](/user-guide/tutorials/prowler-alerts).
+
+#### Alert Rules
+
+- **`prowler_cloud_list_alert_rules`** - List and filter the custom alert rules defined in the tenant
+- **`prowler_cloud_get_alert_rule`** - Retrieve an alert rule including its condition DSL and recipient emails
+- **`prowler_cloud_create_alert_rule`** - Create a tenant-scoped alert rule
+- **`prowler_cloud_update_alert_rule`** - Update an alert rule; only the fields provided change
+- **`prowler_cloud_delete_alert_rule`** - Delete an alert rule
+- **`prowler_cloud_list_alert_rule_events`** - List the fired-alert history for a single rule, newest first
+- **`prowler_cloud_build_alert_rule_condition`** - Build a condition from a findings filter and dry-run it in one call to preview what would match. Nothing is persisted
+
+#### Alert Recipients
+
+- **`prowler_cloud_list_alert_recipients`** - List alert recipients with their confirmation status
+- **`prowler_cloud_get_alert_recipient`** - Retrieve a single recipient with its confirmation status
+- **`prowler_cloud_create_alert_recipient`** - Register a new recipient email
+- **`prowler_cloud_resend_alert_recipient_confirmation`** - Re-send the confirmation email to a pending or unsubscribed recipient
+- **`prowler_cloud_delete_alert_recipient`** - Delete an alert recipient
+
+#### Alert Events
+
+- **`prowler_cloud_list_alert_events`** - List the fired alert events for the tenant
+- **`prowler_cloud_get_alert_event`** - Retrieve a single alert event including its matched rule and scan
+
 ## Prowler Hub Tools
 
 Access Prowler's security check catalog and compliance frameworks. **No authentication required.**
@@ -185,7 +271,8 @@ Search and access official Prowler documentation. **No authentication required.*
 - Use natural language to interact with the tools through your AI assistant
 - Tools can be combined for complex workflows
 - Filter options are available on most list tools
-- Authentication is only required for Prowler tools (Prowler Cloud, Prowler Private Cloud, or Prowler Local Server)
+- Authentication is only required for the `prowler_*` and `prowler_cloud_*` tools; Prowler Hub and Prowler Documentation tools work without a key
+- If a `prowler_cloud_*` tool is missing from your client, you are connected to a Local MCP Server — point it at `https://mcp.prowler.com/mcp` instead
 
 ## Additional Resources
 

--- a/docs/getting-started/products/prowler-mcp.mdx
+++ b/docs/getting-started/products/prowler-mcp.mdx
@@ -30,7 +30,7 @@ The fastest way to get started is the **Cloud MCP Server** at `https://mcp.prowl
 </Card>
 
 <Note>
-Prefer to run it yourself? The **Local MCP Server** runs on your own machine or infrastructure. The Cloud MCP Server additionally provides tools for Prowler Cloud-specific features such as [Alerts](/user-guide/tutorials/prowler-alerts), [Scan Scheduling](/user-guide/tutorials/prowler-scan-scheduling), and [Findings Triage](/user-guide/tutorials/prowler-app-findings-triage). See [Cloud vs Local MCP Server](#cloud-vs-local-mcp-server).
+Prefer to run it yourself? The **Local MCP Server** runs on your own machine or infrastructure. The Cloud MCP Server additionally provides the `prowler_cloud_*` tools for Prowler Cloud-specific features: [Alerts](/user-guide/tutorials/prowler-alerts), [Findings Triage](/user-guide/tutorials/prowler-app-findings-triage), [Scan Scheduling](/user-guide/tutorials/prowler-scan-scheduling), and Scan Configurations. See [Cloud vs Local MCP Server](#cloud-vs-local-mcp-server).
 </Note>
 
 ## What is the Model Context Protocol?
@@ -39,20 +39,30 @@ The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open s
 
 ## Key Capabilities
 
-The Prowler MCP Server provides three main integration points:
+The Prowler MCP Server provides four integration points:
 
 ### 1. Prowler Cloud, Private Cloud & Local Server
 
 Full access to your Prowler deployment — Prowler Cloud, Prowler Private Cloud, or Prowler Local Server — for:
 - **Findings Analysis**: Query, filter, and analyze security findings across all your cloud environments
 - **Provider Management**: Create, configure, and manage your configured Prowler providers (AWS, Azure, GCP, etc.)
-- **Scan Orchestration**: Trigger on-demand scans and schedule recurring security assessments
+- **Scan Orchestration**: Trigger on-demand scans, track their progress, and schedule a daily scan
 - **Resource Inventory**: Search and view detailed information about your audited resources
 - **Muting Management**: Create and manage muting lists/rules to suppress non-relevant findings
 - **Attack Paths Analysis**: Analyze privilege escalation chains and security misconfigurations through graph-based analysis of cloud resource relationships
+- **Integrations Management**: Set up and troubleshoot where Prowler sends its results (Amazon S3, AWS Security Hub, Jira), and turn findings into Jira work items
 - **User & Role Management**: List the users in your tenant, identify the authenticated user, browse RBAC roles, and set the role a user holds
 
-### 2. Prowler Hub
+### 2. Prowler Cloud Management
+
+Prowler Cloud-only tools for configuration and workflows that a Prowler Local Server does not provide. These are exposed only by the [Cloud MCP Server](#cloud-vs-local-mcp-server):
+
+- **Scan Configurations**: Create reusable check and compliance selections and attach them to providers.
+- **Findings Triage**: Record review statuses and notes for individual findings, without suppressing them.
+- **Scan Scheduling**: Configure daily, interval, weekly, or monthly recurring scans, one provider at a time or in bulk.
+- **Alerts**: Build and dry-run alert rule conditions, manage email recipients, and review fired alerts.
+
+### 3. Prowler Hub
 
 Access to Prowler's comprehensive security knowledge base:
 - **Security Checks Catalog**: Browse and search **over 2,000 security checks** across multiple cloud providers.
@@ -61,7 +71,7 @@ Access to Prowler's comprehensive security knowledge base:
 - **Compliance Frameworks**: Explore mappings to **over 70 compliance standards and frameworks**.
 - **Provider Services**: View available services and checks for each cloud provider.
 
-### 3. Prowler Documentation
+### 4. Prowler Documentation
 
 Search and retrieve official Prowler documentation:
 - **Intelligent Search**: Full-text search across all Prowler documentation.
@@ -70,7 +80,7 @@ Search and retrieve official Prowler documentation:
 
 ## MCP Server Architecture
 
-The following diagram illustrates the Prowler MCP Server architecture and its integration points. MCP clients connect to either the **Cloud MCP Server** (recommended) or a **Local MCP Server**; both expose the same tools and reach the same Prowler backends:
+The following diagram illustrates the Prowler MCP Server architecture and its integration points. MCP clients connect to either the **Cloud MCP Server** (recommended) or a **Local MCP Server**. Both reach the same Prowler backends and share the `prowler_*`, `prowler_hub_*`, and `prowler_docs_*` tools; the Cloud MCP Server additionally exposes the Cloud-only `prowler_cloud_*` tools:
 
 ```mermaid
 flowchart LR
@@ -82,12 +92,13 @@ flowchart LR
 
     subgraph SERVERS["Prowler MCP Server"]
         direction TB
-        cloud["☁️ Cloud MCP Server (Recommended)<br/>mcp.prowler.com/mcp · HTTP<br/>Managed by Prowler · always up to date<br/>Adds Cloud-only tools (Alerts,<br/>Scan Scheduling, Findings Triage)"]
-        local["💻 Local MCP Server<br/>Self-run · STDIO or HTTP<br/>Python 3.12+ or Docker<br/>You manage updates"]
+        cloud["Cloud MCP Server (Recommended)<br/>mcp.prowler.com/mcp · HTTP<br/>Managed by Prowler · always up to date<br/>Adds the Cloud-only prowler_cloud_* tools"]
+        local["Local MCP Server<br/>Self-run · STDIO or HTTP<br/>Python 3.12+ or Docker<br/>You manage updates"]
     end
 
     subgraph TOOLS["Prowler MCP Tools"]
-        prowler_tools["prowler_* tools<br/>(API key or JWT auth)<br/>Findings · Providers · Scans<br/>Resources · Muting · Compliance<br/>Attack Paths"]
+        prowler_tools["prowler_* tools<br/>(API key or JWT auth)<br/>Findings · Finding Groups · Providers<br/>Scans · Resources · Muting · Compliance<br/>Attack Paths · Integrations · Users · Roles"]
+        cloud_tools["prowler_cloud_* tools<br/>(API key or JWT auth · Cloud only)<br/>Alerts · Findings Triage<br/>Scan Scheduling · Scan Configurations"]
         hub_tools["prowler_hub_* tools<br/>(no auth)<br/>Checks Catalog · Check Code<br/>Fixers · Compliance Frameworks"]
         docs_tools["prowler_docs_* tools<br/>(no auth)<br/>Search · Document Retrieval"]
     end
@@ -104,6 +115,7 @@ flowchart LR
     apps -->|STDIO or HTTP| local
 
     cloud --> prowler_tools
+    cloud --> cloud_tools
     cloud --> hub_tools
     cloud --> docs_tools
     local --> prowler_tools
@@ -111,12 +123,14 @@ flowchart LR
     local --> docs_tools
 
     prowler_tools -->|REST| api
+    cloud_tools -->|REST| api
     hub_tools -->|REST| hub
     docs_tools -->|REST| docs
 ```
 
-The architecture shows how AI assistants connect through the MCP protocol to access Prowler's three main components:
+The architecture shows how AI assistants connect through the MCP protocol to access Prowler's four namespaced components:
 - Prowler Cloud, Prowler Private Cloud, or Prowler Local Server for security operations
+- Prowler Cloud management for Cloud-only configuration and workflows
 - Prowler Hub for security knowledge
 - Prowler Documentation for guidance and reference.
 
@@ -127,8 +141,15 @@ The Prowler MCP Server enables powerful workflows through AI assistants:
 **Security Operations**
 - "Show me all critical findings from my AWS production accounts"
 - "Register my new AWS account in Prowler and run a scheduled scan every day"
-- "List all muted findings and detect what findgings are muted by a not enough good reason in relation to their severity"
+- "List all muted findings and flag the ones whose mute reason is too weak for their severity"
 - "Run an attack paths query to find EC2 instances exposed to the Internet with access to sensitive S3 buckets"
+- "Send my failed CIS findings for this provider to Jira as work items"
+
+**Prowler Cloud Management** (Cloud MCP Server only)
+- "Preview an alert rule for critical AWS findings and create it for my confirmed recipients"
+- "Show the triage notes for this finding and mark it as under review"
+- "Apply a weekly Monday 06:00 scan schedule to every AWS provider"
+- "Create a scan configuration that runs only CIS checks and attach it to my production providers"
 
 **Security Research**
 - "Explain what the S3 bucket public access Prowler check does"
@@ -199,17 +220,17 @@ There are two ways to run the Prowler MCP Server. For almost everyone, the **Clo
 
 | | ☁️ **Cloud MCP Server** (Recommended) | 💻 **Local MCP Server** |
 |---|---|---|
+| **Cloud-only tools** (`prowler_cloud_*`) | ✅ Alerts, Findings Triage, Scan Scheduling, Scan Configurations | ❌ Not available |
 | **Endpoint** | `https://mcp.prowler.com/mcp` | Runs on your machine or infrastructure |
 | **Setup** | Just configure your MCP client | Install via Docker, or source |
 | **Transport** | HTTP | STDIO (subprocess) or self-hosted HTTP |
 | **Maintenance** | Managed by Prowler, always up to date | You manage updates |
 | **Requirements** | None (just an MCP client) | Python 3.12+ or Docker |
-| **Cloud-only tools** | ✅ Alerts, Scan Scheduling, Findings Triage | ❌ Not available |
 | **Authentication** | API key or JWT token | API key/JWT (HTTP) or env vars (STDIO) |
 
 ### ☁️ Cloud MCP Server (Recommended)
 
-Prowler's managed MCP server at `https://mcp.prowler.com/mcp`. No installation, always up to date, and it includes tools for Prowler Cloud-specific features such as Alerts, Scan Scheduling, and Findings Triage. This is the path we recommend for nearly all users — go straight to the [Configuration guide](/getting-started/basic-usage/prowler-mcp#cloud-mcp-server-configuration-recommended).
+Prowler's managed MCP server at `https://mcp.prowler.com/mcp`. No installation, always up to date, and it includes the `prowler_cloud_*` tools for Prowler Cloud-specific features: Alerts, Findings Triage, Scan Scheduling, and Scan Configurations. This is the path we recommend for nearly all users — go straight to the [Configuration guide](/getting-started/basic-usage/prowler-mcp#cloud-mcp-server-configuration-recommended).
 
 ### 💻 Local MCP Server
 

--- a/docs/images/prowler_mcp_schema.mmd
+++ b/docs/images/prowler_mcp_schema.mmd
@@ -7,12 +7,13 @@ flowchart LR
 
     subgraph SERVERS["Prowler MCP Server"]
         direction TB
-        cloud["☁️ Cloud MCP Server (Recommended)<br/>mcp.prowler.com/mcp · HTTP<br/>Managed by Prowler · always up to date<br/>Adds Cloud-only tools (Alerts,<br/>Scan Scheduling, Findings Triage)"]
+        cloud["☁️ Cloud MCP Server (Recommended)<br/>mcp.prowler.com/mcp · HTTP<br/>Managed by Prowler · always up to date<br/>Adds the Cloud-only prowler_cloud_* tools"]
         local["💻 Local MCP Server<br/>Self-run · STDIO or HTTP<br/>Python 3.12+ or Docker<br/>You manage updates"]
     end
 
     subgraph TOOLS["Prowler MCP Tools"]
-        prowler_tools["prowler_* tools<br/>(API key or JWT auth)<br/>Findings · Providers · Scans<br/>Resources · Muting · Compliance<br/>Attack Paths"]
+        prowler_tools["prowler_* tools<br/>(API key or JWT auth)<br/>Findings · Finding Groups · Providers<br/>Scans · Resources · Muting · Compliance<br/>Attack Paths · Integrations · Users · Roles"]
+        cloud_tools["prowler_cloud_* tools<br/>(API key or JWT auth · Cloud only)<br/>Alerts · Findings Triage<br/>Scan Scheduling · Scan Configurations"]
         hub_tools["prowler_hub_* tools<br/>(no auth)<br/>Checks Catalog · Check Code<br/>Fixers · Compliance Frameworks"]
         docs_tools["prowler_docs_* tools<br/>(no auth)<br/>Search · Document Retrieval"]
     end
@@ -29,6 +30,7 @@ flowchart LR
     apps -->|STDIO or HTTP| local
 
     cloud --> prowler_tools
+    cloud --> cloud_tools
     cloud --> hub_tools
     cloud --> docs_tools
     local --> prowler_tools
@@ -36,5 +38,6 @@ flowchart LR
     local --> docs_tools
 
     prowler_tools -->|REST| api
+    cloud_tools -->|REST| api
     hub_tools -->|REST| hub
     docs_tools -->|REST| docs

--- a/docs/images/prowler_mcp_schema.mmd
+++ b/docs/images/prowler_mcp_schema.mmd
@@ -7,8 +7,8 @@ flowchart LR
 
     subgraph SERVERS["Prowler MCP Server"]
         direction TB
-        cloud["☁️ Cloud MCP Server (Recommended)<br/>mcp.prowler.com/mcp · HTTP<br/>Managed by Prowler · always up to date<br/>Adds the Cloud-only prowler_cloud_* tools"]
-        local["💻 Local MCP Server<br/>Self-run · STDIO or HTTP<br/>Python 3.12+ or Docker<br/>You manage updates"]
+        cloud["Cloud MCP Server (Recommended)<br/>mcp.prowler.com/mcp · HTTP<br/>Managed by Prowler · always up to date<br/>Adds the Cloud-only prowler_cloud_* tools"]
+        local["Local MCP Server<br/>Self-run · STDIO or HTTP<br/>Python 3.12+ or Docker<br/>You manage updates"]
     end
 
     subgraph TOOLS["Prowler MCP Tools"]

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -12,17 +12,26 @@ Full access to your Prowler data (Prowler Cloud, Prowler Private Cloud, or Prowl
 - **Findings Analysis**: Query, filter, and analyze security findings across all your cloud environments
 - **Finding Groups Analysis**: Triage findings grouped by check ID and drill down into affected resources
 - **Provider Management**: Create, configure, and manage your configured Prowler providers (AWS, Azure, GCP, etc.)
-- **Scan Orchestration**: Trigger on-demand scans and schedule recurring security assessments
+- **Scan Orchestration**: Trigger on-demand scans, track their progress, and schedule a daily scan
 - **Resource Inventory**: Search and view detailed information about your audited resources
 - **Muting Management**: Create and manage muting rules to suppress non-critical findings
 - **Compliance Reporting**: View compliance status across frameworks and drill into requirement-level details
+- **Attack Paths Analysis**: Analyze privilege escalation chains through graph-based analysis of cloud resource relationships
 - **Integrations Management**: Set up and troubleshoot where Prowler sends its results (Amazon S3, AWS Security Hub, Jira), and turn findings into Jira work items
 - **User & Role Management**: List the users in your tenant, identify the authenticated user, browse RBAC roles, and set the role a user holds
+
+### Prowler Cloud Management
+
+Prowler Cloud-only workflow and configuration features (`prowler_cloud_*` tools). These are available only on the [hosted Prowler MCP](#1-hosted-prowler-mcp-recommended), since they manage features that exist only in Prowler Cloud:
+- **Scan Configurations**: Read, create, update, and delete reusable scan configurations and attach them to providers (providers without one use the default)
+- **Findings Triage**: Read and set a finding's triage status and leave notes documenting the decision, without suppressing the finding
+- **Scan Scheduling**: Read and configure recurring scan schedules (daily, interval, weekly, monthly), one provider at a time or in bulk
+- **Alerts**: Read and manage alert rules and recipients, dry-run rule conditions before saving, and browse the fired-alert history
 
 ### Prowler Hub
 
 Access to Prowler's comprehensive security knowledge base:
-- **Security Checks Catalog**: Browse and search **over 1000 security checks** across multiple Prowler providers
+- **Security Checks Catalog**: Browse and search **over 2,000 security checks** across multiple Prowler providers
 - **Check Implementation**: View the Python code that powers each security check
 - **Automated Fixers**: Access remediation scripts for common security issues
 - **Compliance Frameworks**: Explore mappings to **over 70 compliance standards and frameworks**
@@ -129,6 +138,7 @@ For complete tool descriptions and parameters, see the [Tools Reference](https:/
 
 All tools follow a consistent naming pattern with prefixes:
 - `prowler_*` - Prowler Cloud, Prowler Private Cloud & Prowler Local Server management tools
+- `prowler_cloud_*` - Prowler Cloud-only management tools (hosted Prowler MCP only)
 - `prowler_hub_*` - Prowler Hub catalog and compliance tools
 - `prowler_docs_*` - Prowler documentation search and retrieval
 
@@ -136,7 +146,7 @@ All tools follow a consistent naming pattern with prefixes:
 
 ```text
 prowler_mcp_server/
-├── server.py                 # Main orchestrator (imports sub-servers with prefixes)
+├── server.py                 # Main orchestrator (mounts sub-servers with namespaces)
 ├── main.py                   # CLI entry point
 ├── prowler_hub/              # tools - no authentication required
 ├── prowler_app/              # tools - authentication required
@@ -160,7 +170,15 @@ The Prowler MCP Server enables powerful workflows through AI assistants:
 
 - "Show me all critical findings from my AWS production accounts"
 - "Register my new AWS account in Prowler and run a scheduled scan every day"
-- "List all muted findings and detect what findgings are muted by a not enough good reason in relation to their severity"
+- "List all muted findings and flag the ones whose mute reason is too weak for their severity"
+- "Send my failed CIS findings for this provider to Jira as work items"
+
+### Prowler Cloud Management
+
+- "Preview an alert rule for critical AWS findings and create it for my confirmed recipients"
+- "Show the triage notes for this finding and mark it as under review"
+- "Apply a weekly Monday 06:00 scan schedule to every AWS provider"
+- "Create a scan configuration that runs only CIS checks and attach it to my production providers"
 
 ### Security Research
 
@@ -186,7 +204,7 @@ The Prowler MCP Server enables powerful workflows through AI assistants:
   - `https://docs.prowler.com` (for Prowler Documentation)
   - Prowler Cloud API or Prowler Local Server API (for Prowler features)
 
-> **No Authentication Required**: Prowler Hub and Prowler Documentation features work without authentication. A Prowler API key is only required to access Prowler features (Prowler Cloud, Prowler Private Cloud, or Prowler Local Server).
+> **No Authentication Required**: Prowler Hub and Prowler Documentation features work without authentication. A Prowler API key is only required for the `prowler_*` and `prowler_cloud_*` tools (Prowler Cloud, Prowler Private Cloud, or Prowler Local Server).
 
 ## Configuring MCP Hosts
 

--- a/mcp_server/changelog.d/mcp-docs-cloud-namespace.changed.md
+++ b/mcp_server/changelog.d/mcp-docs-cloud-namespace.changed.md
@@ -1,0 +1,1 @@
+README now documents the Cloud-only `prowler_cloud_*` tools available on the hosted Prowler MCP (alerts, findings triage, scan scheduling, scan configurations), and corrects the Prowler Hub check count and the scan orchestration capabilities


### PR DESCRIPTION
### Context

This release added a dedicated `prowler_cloud_*` namespace to the Cloud MCP Server — 32 tools covering Alerts, Findings Triage, Scan Scheduling, and Scan Configurations — but the MCP documentation was never updated for it.

The result was a Tools Reference that advertised the `prowler_cloud_*` prefix in its naming convention section and then documented none of the tools, so there was no way for a user to discover what the Cloud MCP Server actually exposes. Along the way the docs had drifted from the source in a few other places.

This PR documents the new namespace and makes the Cloud vs Local split explicit throughout the MCP docs and the `mcp_server` README.

### Description

**Documented the new namespace**

- New **Prowler Cloud Tools** section in the Tools Reference covering all 32 `prowler_cloud_*` tools, grouped by domain (Scan Configurations, Findings Triage, Scan Scheduling, Alerts) with the Alerts group split into rules / recipients / events.
- New **Prowler Cloud Management** capability section on the Overview page and in the README, plus example prompts for the Cloud-only workflows.
- Architecture diagram updated with a `prowler_cloud_*` node and its Cloud-only edge. The inline Mermaid in `products/prowler-mcp.mdx` and the `docs/images/prowler_mcp_schema.mmd` source had drifted apart; they are now generated from the same content and verified identical.

**Made the Cloud vs Local split explicit**

- Added an **Availability** column to the tool categories table.
- `prowler_schedule_daily_scan` is now flagged **Local MCP Server only**, with a note explaining that Prowler Cloud supersedes it with the richer `prowler_cloud_*` scheduling tools (interval/weekly/monthly, per-provider retrieval, bulk apply). This is the one tool where the two servers genuinely diverge: the OSS server exposes 49 `prowler_*` tools, the Cloud one 48.

**Corrected drift from the source**

- Tool categories table said 42 `prowler_*` tools; the actual count is 49.
- Prowler Hub check count in the README said "over 1000"; the docs site says "over 2,000". Aligned on 2,000.
- README capability list was missing Attack Paths and Integrations.
- README claimed `prowler_*` could "schedule recurring security assessments" — recurring scheduling beyond a daily scan is Cloud-only.
- Fixed a typo ("findgings") in an example prompt shared by the README and the Overview page.

**Not in this PR**

- **Release highlights** — going in a separate PR.
- **`docs/developer-guide/mcp-server.mdx`** — deliberately untouched. It documents how to add tools to the server, and the `prowler_cloud/` module lives in the Prowler Cloud codebase, so OSS contributors reading that guide cannot act on it.
- **Screenshots** — `claude-desktop-prowler-tools.png` and `vscode-agent-tools.png` show client tool pickers that predate the Cloud tools. Not blocking; the text is correct either way.

### Steps to review

The tool lists are mechanical, so the fastest review is to check them against the source rather than read them.

**1. Verify every documented tool exists, and every tool is documented.** From the repo root, this compares the Tools Reference against the registered tools in `mcp_server/`:

```bash
# prowler_* tools: doc vs source (expect no output, 49 tools)
diff <(grep -oE '\*\*`prowler_[a-z0-9_]+`\*\*' docs/getting-started/basic-usage/prowler-mcp-tools.mdx \
        | grep -vE 'prowler_hub_|prowler_docs_|prowler_cloud_' | sed 's/[*`]//g' | sort) \
     <(grep -hoE "^    async def [a-z0-9_]+" mcp_server/prowler_mcp_server/prowler_app/tools/*.py \
        | sed 's/    async def /prowler_/' | grep -v '^prowler__' | sort)
```

The 32 `prowler_cloud_*` tools cannot be verified this way from this repo — that module only exists in the Prowler Cloud codebase. They were cross-checked against `prowler_cloud/tools/*.py` there and match exactly, 32 for 32, with descriptions taken from each tool's docstring.

**2. Confirm the diagram source is in sync** — the inline Mermaid in `products/prowler-mcp.mdx` and `docs/images/prowler_mcp_schema.mmd` should be identical. Extract the fenced `mermaid` block from the `.mdx` and diff it against the `.mmd`; the two match as of the last commit on this branch.

**3. Spot-check the Local-only claim.** `prowler_schedule_daily_scan` is defined in `mcp_server/prowler_mcp_server/prowler_app/tools/scans.py`; it is intentionally absent from the Cloud build, which is why the counts differ by one.

**4. Read the two new sections** for accuracy of the capability descriptions: "Prowler Cloud Tools" in the Tools Reference and "2. Prowler Cloud Management" on the Overview page.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests. — N/A, documentation only, no code changes.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings — N/A, no code changes.
- [x] Review if backport is needed. — Not needed; documents functionality new in this release.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) — Reviewed. The root README references the MCP Server only at architecture level and carries no tool counts or namespaces, so it needs no change. `mcp_server/README.md` is updated in this PR.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. — N/A, no SDK changes. Fragment added under `mcp_server/changelog.d/` instead.

#### SDK/CLI
- Are there new checks included in this PR? **No**

#### UI
- N/A, no UI changes.

#### API
- N/A, no API changes.

#### MCP Server
- [x] All issue/task requirements work as expected on the MCP Server — Documentation only; no runtime behaviour changes. Documented tool names were verified against the registered tools in source.
- [x] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable. — Added `mcp-docs-cloud-namespace.changed.md`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified which MCP tools are available in Cloud versus Local deployments.
  - Added documentation for Cloud-only alert management, findings triage, scan scheduling, and scan configuration workflows.
  - Updated architecture diagrams, use cases, tool counts, authentication guidance, and scan orchestration details.
  - Documented expanded capabilities, including scan tracking, resource inventory, muting, and attack-path analysis.
  - Added changelog notes for the new Cloud tool namespace and updated security-check information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->