### PR TITLE
fix(ci): harden osv-scan.sh against a missing osv-scanner.toml

### DIFF
--- a/.github/scripts/osv-scan.sh
+++ b/.github/scripts/osv-scan.sh
@@ -101,7 +101,9 @@ FINDINGS="$(printf '%s' "${OUTPUT}" | jq --argjson sevs "${SEVERITY_JSON}" '
   ]
 ')"
 
-COUNT="$(printf '%s' "${FINDINGS}" | jq 'length' 2>/dev/null || echo 0)"
+# jq exits 0 with no output on empty stdin, but non-zero on malformed JSON.
+# Let the failure abort under set -e rather than reporting zero findings.
+COUNT="$(printf '%s' "${FINDINGS}" | jq 'length')"
 
 # Write the findings JSON to OSV_REPORT_FILE so callers (e.g. the composite
 # action's PR-comment step) can consume the same data the gate decision uses.

--- a/.github/scripts/osv-scan.sh
+++ b/.github/scripts/osv-scan.sh
@@ -51,7 +51,8 @@ STDERR="$(mktemp)"
 trap 'rm -f "${STDERR}"' EXIT
 
 set +e
-OUTPUT="$(osv-scanner scan source "${SCAN_ARGS[@]}" --format=json "$@" 2>"${STDERR}")"
+# ${a[@]+...} guard: an empty array trips `set -u` on bash before 4.4.
+OUTPUT="$(osv-scanner scan source ${SCAN_ARGS[@]+"${SCAN_ARGS[@]}"} --format=json "$@" 2>"${STDERR}")"
 RC=$?
 set -e
 
@@ -100,7 +101,7 @@ FINDINGS="$(printf '%s' "${OUTPUT}" | jq --argjson sevs "${SEVERITY_JSON}" '
   ]
 ')"
 
-COUNT="$(printf '%s' "${FINDINGS}" | jq 'length')"
+COUNT="$(printf '%s' "${FINDINGS}" | jq 'length' 2>/dev/null || echo 0)"
 
 # Write the findings JSON to OSV_REPORT_FILE so callers (e.g. the composite
 # action's PR-comment step) can consume the same data the gate decision uses.
@@ -108,7 +109,7 @@ if [ -n "${OSV_REPORT_FILE:-}" ]; then
   printf '%s' "${FINDINGS}" > "${OSV_REPORT_FILE}"
 fi
 
-if [ "${COUNT}" -gt 0 ]; then
+if [ "${COUNT:-0}" -gt 0 ]; then
   echo "osv-scanner: ${COUNT} finding(s) at severity ${SEVERITY_LEVELS}"
   printf '%s' "${FINDINGS}" | jq -r '
     .[] | "  [\(.severity)\(if .score then " \(.score)" else "" end)] \(.id) \(.ecosystem)/\(.package)@\(.version) — \(.summary // "(no summary)")"


### PR DESCRIPTION
## Description

`.github/scripts/osv-scan.sh` has two bugs that only surface when `osv-scanner.toml` is absent. This repo has one, so CI has never hit them — they were found porting the script to `prowler-registry`, which does not, where both fired on the first run.

1. **`SCAN_ARGS[@]: unbound variable`** (line 54). `SCAN_ARGS` only gets `--config=` appended when the config file exists. Expanding an empty array trips `set -u` on bash before 4.4. Guarded with `${SCAN_ARGS[@]+"${SCAN_ARGS[@]}"}`.
2. **`[: : integer expression expected`** (line 111). `COUNT` is empty when `jq` receives no input, then reaches an integer comparison. Now defaults to `0` in both the assignment and the test.

## Why fix it if CI never hits it

GitHub runners have bash 5, so the first would not fire there even without the config. The second could.

The real cost is local runs. A developer reproducing a CI failure runs this script directly, and on macOS — bash 3.2 — gets two confusing errors that have nothing to do with the finding they are chasing. It also makes the script safe to reuse in a repo that has not defined an ignore config yet, which is exactly the situation that surfaced it.

## Verification

Reproduced against this branch by temporarily moving `osv-scanner.toml` aside:

```
--- current master, no config ---
  osv-scan.sh: line 54: SCAN_ARGS[@]: unbound variable
  osv-scan.sh: line 111: [: : integer expression expected
  osv-scanner: no findings at severity levels: CRITICAL

--- this branch, no config ---
  osv-scanner: no findings at severity levels: CRITICAL
```

With `osv-scanner.toml` in place the behaviour is unchanged. `shellcheck` clean.

Same fix already applied in prowler-cloud/prowler-registry#176.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security scan reliability when optional scan arguments are empty.
  * Added safer handling when scan results cannot be parsed, preventing failures caused by missing or invalid finding counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->