### PR TITLE
feat(ui): show sign-in methods in the Cloud users table

### DIFF
--- a/ui/changelog.d/user-sign-in-method-indicators.added.md
+++ b/ui/changelog.d/user-sign-in-method-indicators.added.md
@@ -1,0 +1,1 @@
+Sign-in method indicators in the Prowler Cloud Users table, including linked SAML domains

--- a/ui/components/users/table/column-users.test.tsx
+++ b/ui/components/users/table/column-users.test.tsx
@@ -1,0 +1,132 @@
+import type { CellContext } from "@tanstack/react-table";
+import { render, screen } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { UserProps } from "@/types";
+import type { UserSignInMethod } from "@/types/users";
+
+vi.mock("@/components/shadcn", () => ({
+  Badge: ({ children, variant }: { children: ReactNode; variant?: string }) => (
+    <span data-variant={variant}>{children}</span>
+  ),
+}));
+
+vi.mock("@/components/shadcn/entities", () => ({
+  DateWithTime: () => <time />,
+}));
+
+vi.mock("@/components/shadcn/table", () => ({
+  DataTableColumnHeader: ({ title }: { title: string }) => <span>{title}</span>,
+}));
+
+vi.mock("@/lib/shared/env", () => ({
+  isCloud: () => false,
+}));
+
+vi.mock("./data-table-row-actions", () => ({
+  DataTableRowActions: () => null,
+}));
+
+import { getColumnsUser } from "./column-users";
+
+const getColumnId = (column: ReturnType<typeof getColumnsUser>[number]) => {
+  if ("accessorKey" in column) {
+    return column.accessorKey;
+  }
+
+  return column.id;
+};
+
+const renderSignInMethodsCell = (signInMethods?: UserSignInMethod[]) => {
+  const signInMethodsColumn = getColumnsUser(true).find(
+    (column) => getColumnId(column) === "sign_in_methods",
+  );
+
+  if (typeof signInMethodsColumn?.cell !== "function") {
+    throw new Error("Sign-in methods cell is not configured");
+  }
+
+  const user = {
+    attributes: {
+      sign_in_methods: signInMethods,
+    },
+  } as unknown as UserProps;
+
+  return render(
+    signInMethodsColumn.cell({
+      row: { original: user },
+    } as CellContext<UserProps, unknown>) as ReactElement,
+  );
+};
+
+describe("getColumnsUser", () => {
+  it("should include non-sortable sign-in methods only in Cloud", () => {
+    // Given
+    const signInMethodsColumnId = "sign_in_methods";
+
+    // When
+    const cloudColumns = getColumnsUser(true);
+    const ossColumns = getColumnsUser(false);
+
+    // Then
+    expect(cloudColumns.map(getColumnId)).toContain(signInMethodsColumnId);
+    expect(ossColumns.map(getColumnId)).not.toContain(signInMethodsColumnId);
+
+    const signInMethodsColumn = cloudColumns.find(
+      (column) => getColumnId(column) === signInMethodsColumnId,
+    );
+    expect(signInMethodsColumn?.enableSorting).toBe(false);
+    expect(signInMethodsColumn?.enableColumnFilter).toBe(false);
+  });
+
+  it("should render every sign-in method in API order", () => {
+    // Given
+    const signInMethods: UserSignInMethod[] = [
+      { method: "email_password" },
+      { method: "google" },
+      { method: "github" },
+      { method: "saml" },
+      { method: "saml", domain: "acme.com" },
+      { method: "saml", domain: "subsidiary.com" },
+      { method: "partner_sso" },
+    ];
+
+    // When
+    renderSignInMethodsCell(signInMethods);
+
+    // Then
+    const renderedMethods = screen.getAllByRole("listitem");
+    expect(renderedMethods.map((item) => item.textContent)).toEqual([
+      "Email/password",
+      "Google",
+      "GitHub",
+      "SAML",
+      "SAML (acme.com)",
+      "SAML (subsidiary.com)",
+      "Partner SSO",
+    ]);
+    expect(
+      renderedMethods.map(
+        (item) => item.querySelector('[data-variant="tag"]') !== null,
+      ),
+    ).toEqual(Array.from({ length: signInMethods.length }, () => true));
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["empty", []],
+  ] as const)(
+    "should render a hyphen when sign-in methods are %s",
+    (_state, signInMethods) => {
+      // Given
+      const methods = signInMethods as UserSignInMethod[] | undefined;
+
+      // When
+      renderSignInMethodsCell(methods);
+
+      // Then
+      expect(screen.getByText("-")).toBeVisible();
+    },
+  );
+});

--- a/ui/components/users/table/column-users.test.tsx
+++ b/ui/components/users/table/column-users.test.tsx
@@ -1,7 +1,7 @@
 import type { CellContext } from "@tanstack/react-table";
 import { render, screen } from "@testing-library/react";
 import type { ReactElement, ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 
 import type { UserProps } from "@/types";
 import type { UserSignInMethod } from "@/types/users";
@@ -61,6 +61,25 @@ const renderSignInMethodsCell = (signInMethods?: UserSignInMethod[]) => {
 };
 
 describe("getColumnsUser", () => {
+  it("should only allow domains on SAML sign-in methods", () => {
+    // Given
+    type NonSamlMethodWithDomain = {
+      method: "google";
+      domain: string;
+    };
+    type SamlMethodWithoutDomain = {
+      method: "saml";
+    };
+
+    // When
+    const nonSamlMethod = expectTypeOf<NonSamlMethodWithDomain>();
+    const samlMethod = expectTypeOf<SamlMethodWithoutDomain>();
+
+    // Then
+    nonSamlMethod.not.toExtend<UserSignInMethod>();
+    samlMethod.toExtend<UserSignInMethod>();
+  });
+
   it("should include non-sortable sign-in methods only in Cloud", () => {
     // Given
     const signInMethodsColumnId = "sign_in_methods";

--- a/ui/components/users/table/column-users.tsx
+++ b/ui/components/users/table/column-users.tsx
@@ -2,9 +2,16 @@
 
 import { ColumnDef } from "@tanstack/react-table";
 
+import { Badge } from "@/components/shadcn";
 import { DateWithTime } from "@/components/shadcn/entities";
 import { DataTableColumnHeader } from "@/components/shadcn/table";
+import { isCloud } from "@/lib/shared/env";
 import { UserProps } from "@/types";
+import {
+  USER_SIGN_IN_METHOD,
+  type UserSignInMethod,
+  type UserSignInMethodType,
+} from "@/types/users";
 
 import { DataTableRowActions } from "./data-table-row-actions";
 
@@ -12,7 +19,29 @@ const getUserData = (row: { original: UserProps }) => {
   return row.original.attributes;
 };
 
-export const ColumnsUser: ColumnDef<UserProps>[] = [
+type NonSamlSignInMethodType = Exclude<
+  UserSignInMethodType,
+  typeof USER_SIGN_IN_METHOD.SAML
+>;
+
+const SIGN_IN_METHOD_LABELS = {
+  [USER_SIGN_IN_METHOD.EMAIL_PASSWORD]: "Email/password",
+  [USER_SIGN_IN_METHOD.GOOGLE]: "Google",
+  [USER_SIGN_IN_METHOD.GITHUB]: "GitHub",
+  [USER_SIGN_IN_METHOD.PARTNER_SSO]: "Partner SSO",
+} as const satisfies Record<NonSamlSignInMethodType, string>;
+
+const getSignInMethodLabel = (signInMethod: UserSignInMethod) => {
+  if (signInMethod.method === USER_SIGN_IN_METHOD.SAML) {
+    return signInMethod.domain ? `SAML (${signInMethod.domain})` : "SAML";
+  }
+
+  return SIGN_IN_METHOD_LABELS[signInMethod.method];
+};
+
+export const getColumnsUser = (
+  isCloudEnvironment: boolean,
+): ColumnDef<UserProps>[] => [
   {
     accessorKey: "name",
     header: ({ column }) => (
@@ -44,6 +73,39 @@ export const ColumnsUser: ColumnDef<UserProps>[] = [
     },
     enableSorting: false,
   },
+  ...(isCloudEnvironment
+    ? [
+        {
+          id: "sign_in_methods",
+          header: ({ column }) => (
+            <DataTableColumnHeader column={column} title="Sign-In Methods" />
+          ),
+          cell: ({ row }) => {
+            const { sign_in_methods: signInMethods } = getUserData(row);
+
+            if (!signInMethods?.length) {
+              return <span>-</span>;
+            }
+
+            return (
+              <ul aria-label="Sign-in methods" className="flex flex-wrap gap-1">
+                {signInMethods.map((signInMethod) => (
+                  <li
+                    key={`${signInMethod.method}:${signInMethod.domain ?? ""}`}
+                  >
+                    <Badge variant="tag">
+                      {getSignInMethodLabel(signInMethod)}
+                    </Badge>
+                  </li>
+                ))}
+              </ul>
+            );
+          },
+          enableSorting: false,
+          enableColumnFilter: false,
+        } satisfies ColumnDef<UserProps>,
+      ]
+    : []),
   {
     accessorKey: "company_name",
     header: ({ column }) => (
@@ -84,3 +146,5 @@ export const ColumnsUser: ColumnDef<UserProps>[] = [
     enableSorting: false,
   },
 ];
+
+export const ColumnsUser = getColumnsUser(isCloud());

--- a/ui/components/users/table/skeleton-table-user.test.tsx
+++ b/ui/components/users/table/skeleton-table-user.test.tsx
@@ -1,0 +1,45 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { isCloudMock } = vi.hoisted(() => ({
+  isCloudMock: vi.fn(),
+}));
+
+vi.mock("@/components/shadcn/skeleton/skeleton", () => ({
+  Skeleton: () => <span />,
+}));
+
+vi.mock("@/lib/shared/env", () => ({
+  isCloud: isCloudMock,
+}));
+
+import { SkeletonTableUser } from "./skeleton-table-user";
+
+const getColumnCounts = (container: HTMLElement) => ({
+  header: container.querySelectorAll("thead th").length,
+  row: container.querySelector("tbody tr")?.querySelectorAll("td").length,
+});
+
+describe("SkeletonTableUser", () => {
+  it("should render seven columns in Cloud", () => {
+    // Given
+    isCloudMock.mockReturnValue(true);
+
+    // When
+    const { container } = render(<SkeletonTableUser />);
+
+    // Then
+    expect(getColumnCounts(container)).toEqual({ header: 7, row: 7 });
+  });
+
+  it("should render six columns in OSS", () => {
+    // Given
+    isCloudMock.mockReturnValue(false);
+
+    // When
+    const { container } = render(<SkeletonTableUser />);
+
+    // Then
+    expect(getColumnCounts(container)).toEqual({ header: 6, row: 6 });
+  });
+});

--- a/ui/components/users/table/skeleton-table-user.tsx
+++ b/ui/components/users/table/skeleton-table-user.tsx
@@ -1,6 +1,11 @@
 import { Skeleton } from "@/components/shadcn/skeleton/skeleton";
+import { isCloud } from "@/lib/shared/env";
 
-const SkeletonTableRow = () => {
+interface SkeletonTableRowProps {
+  isCloudEnvironment: boolean;
+}
+
+const SkeletonTableRow = ({ isCloudEnvironment }: SkeletonTableRowProps) => {
   return (
     <tr className="border-border-neutral-secondary border-b last:border-b-0">
       {/* Name */}
@@ -15,6 +20,11 @@ const SkeletonTableRow = () => {
       <td className="px-3 py-4">
         <Skeleton className="h-4 w-20 rounded" />
       </td>
+      {isCloudEnvironment && (
+        <td className="px-3 py-4">
+          <Skeleton className="h-5 w-28 rounded-full" />
+        </td>
+      )}
       {/* Company name */}
       <td className="px-3 py-4">
         <Skeleton className="h-4 w-24 rounded" />
@@ -33,6 +43,7 @@ const SkeletonTableRow = () => {
 
 export const SkeletonTableUser = () => {
   const rows = 10;
+  const isCloudEnvironment = isCloud();
 
   return (
     <div className="border-border-neutral-secondary bg-bg-neutral-secondary flex w-full flex-col gap-4 overflow-hidden rounded-[14px] border p-4 shadow-sm">
@@ -60,6 +71,11 @@ export const SkeletonTableUser = () => {
             <th className="px-3 py-3 text-left">
               <Skeleton className="h-4 w-10 rounded" />
             </th>
+            {isCloudEnvironment && (
+              <th className="px-3 py-3 text-left">
+                <Skeleton className="h-4 w-28 rounded" />
+              </th>
+            )}
             {/* Company name */}
             <th className="px-3 py-3 text-left">
               <Skeleton className="h-4 w-28 rounded" />
@@ -74,7 +90,7 @@ export const SkeletonTableUser = () => {
         </thead>
         <tbody>
           {Array.from({ length: rows }).map((_, i) => (
-            <SkeletonTableRow key={i} />
+            <SkeletonTableRow key={i} isCloudEnvironment={isCloudEnvironment} />
           ))}
         </tbody>
       </table>

--- a/ui/types/components.ts
+++ b/ui/types/components.ts
@@ -4,6 +4,7 @@ import { SVGProps } from "react";
 import { ProviderCredentialFields } from "@/lib/provider-credentials/provider-credential-fields";
 
 import type { FindingTriageSummary } from "./findings-triage";
+import type { UserSignInMethod } from "./users";
 
 export type IconSvgProps = SVGProps<SVGSVGElement> & {
   size?: number;
@@ -541,6 +542,7 @@ export interface UserProps {
     role: {
       name: string;
     };
+    sign_in_methods?: UserSignInMethod[];
   };
   relationships: {
     memberships: {

--- a/ui/types/users.ts
+++ b/ui/types/users.ts
@@ -9,10 +9,20 @@ export const USER_SIGN_IN_METHOD = {
 export type UserSignInMethodType =
   (typeof USER_SIGN_IN_METHOD)[keyof typeof USER_SIGN_IN_METHOD];
 
-export interface UserSignInMethod {
-  method: UserSignInMethodType;
-  domain?: string;
-}
+type NonSamlUserSignInMethodType = Exclude<
+  UserSignInMethodType,
+  typeof USER_SIGN_IN_METHOD.SAML
+>;
+
+export type UserSignInMethod =
+  | {
+      method: typeof USER_SIGN_IN_METHOD.SAML;
+      domain?: string;
+    }
+  | {
+      method: NonSamlUserSignInMethodType;
+      domain?: never;
+    };
 
 export interface UserAttributes {
   name: string;

--- a/ui/types/users.ts
+++ b/ui/types/users.ts
@@ -1,3 +1,19 @@
+export const USER_SIGN_IN_METHOD = {
+  EMAIL_PASSWORD: "email_password",
+  GOOGLE: "google",
+  GITHUB: "github",
+  SAML: "saml",
+  PARTNER_SSO: "partner_sso",
+} as const;
+
+export type UserSignInMethodType =
+  (typeof USER_SIGN_IN_METHOD)[keyof typeof USER_SIGN_IN_METHOD];
+
+export interface UserSignInMethod {
+  method: UserSignInMethodType;
+  domain?: string;
+}
+
 export interface UserAttributes {
   name: string;
   email: string;


### PR DESCRIPTION
### Context

The Prowler Cloud Users API exposes each user’s linked sign-in methods, but the `/users` UI does not display them.

### Description

- Add a Cloud-only **Sign-In Methods** column to the Users table.
- Render each method as a tag badge in API order.
- Display SAML domains as `SAML (<domain>)`.
- Display `-` when the API field is missing or empty.
- Keep the column non-sortable and non-filterable.
- Update the Cloud table skeleton to include the new column.
- Add focused unit tests and a UI changelog fragment.
- No npm dependencies were added or updated.

### Steps to review

1. Open `/users` in a Cloud environment.
2. Confirm the **Sign-In Methods** column appears after **Role**.
3. Confirm the supported values render as tag badges:
   - `Email/password`
   - `Google`
   - `GitHub`
   - `SAML`
   - `SAML (<domain>)`
   - `Partner SSO`
4. Confirm multiple SAML domains appear as separate badges in API order.
5. Confirm missing or empty `sign_in_methods` displays `-`.
6. Open `/users` in an OSS environment and confirm the column is absent.
7. Run full test suite.

### Evidences

#### User table

<img width="4064" height="1106" alt="image" src="https://github.com/user-attachments/assets/9b81daef-b77f-4bfd-b5a8-022615e491b7" />

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### UI

- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sign-in method indicators to the Cloud Users table.
  * Displays labels and badges for email/password, Google, GitHub, SAML, and partner SSO methods.
  * Shows linked SAML domains when available.
  * Displays a placeholder when sign-in methods are unavailable.
* **UI Improvements**
  * Updated loading placeholders to match the Cloud Users table layout.
  * Preserved the existing layout for non-Cloud environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->