### PR TITLE
chore(ui): migrate 5243 changes

### DIFF
--- a/ui/actions/auth/auth.test.ts
+++ b/ui/actions/auth/auth.test.ts
@@ -63,4 +63,43 @@ describe("auth actions", () => {
     // Then
     expect(result).toEqual({ ...apiResponse, status: 400 });
   });
+
+  it("should forward attribution params when creating a user", async () => {
+    // Given
+    const apiResponse = {
+      data: {
+        type: "users",
+        id: "019b1234-5678-7abc-9def-0123456789ab",
+      },
+    };
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    // When
+    const result = await createNewUser(
+      {
+        name: "Jane Doe",
+        email: "jane@example.com",
+        password: "TestPassword123!",
+        confirmPassword: "TestPassword123!",
+        company: "Prowler",
+        termsAndConditions: undefined,
+        isSamlMode: false,
+      },
+      {
+        promo_code: "black-hat-2026",
+        utm_source: "blackhat",
+      },
+    );
+
+    // Then
+    expect(result).toEqual(apiResponse);
+    const requestUrl = new URL(fetchMock.mock.calls[0][0]);
+    expect(requestUrl.searchParams.get("promo_code")).toBe("black-hat-2026");
+    expect(requestUrl.searchParams.get("utm_source")).toBe("blackhat");
+  });
 });

--- a/ui/actions/auth/auth.ts
+++ b/ui/actions/auth/auth.ts
@@ -5,6 +5,7 @@ import { AuthError } from "next-auth";
 import { signIn, signOut } from "@/auth.config";
 import { apiBaseUrl } from "@/lib";
 import { addAuthEvent } from "@/lib/sentry-breadcrumbs";
+import type { UtmParams } from "@/lib/utm";
 import type { SignInFormData, SignUpFormData } from "@/types";
 
 export async function authenticate(
@@ -47,11 +48,18 @@ export async function authenticate(
   }
 }
 
-export const createNewUser = async (formData: SignUpFormData) => {
+export const createNewUser = async (
+  formData: SignUpFormData,
+  attribution: UtmParams = {},
+) => {
   const url = new URL(`${apiBaseUrl}/users`);
 
   if (formData.invitationToken) {
     url.searchParams.append("invitation_token", formData.invitationToken);
+  }
+
+  for (const [key, value] of Object.entries(attribution)) {
+    url.searchParams.append(key, value);
   }
 
   const bodyData = {

--- a/ui/app/api/auth/callback/github/route.ts
+++ b/ui/app/api/auth/callback/github/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 
 import { signIn } from "@/auth.config";
 import {
+  getAttributionParamsFromCallbackPath,
   getInvitationTokenFromCallbackPath,
   getSafeCallbackPath,
 } from "@/lib/auth-callback-url";
@@ -15,11 +16,15 @@ export async function GET(req: Request) {
   const code = searchParams.get("code");
   const callbackPath = getSafeCallbackPath(searchParams);
   const invitationToken = getInvitationTokenFromCallbackPath(callbackPath);
+  const attribution = getAttributionParamsFromCallbackPath(callbackPath);
 
   const params = new URLSearchParams();
   params.append("code", code || "");
   if (invitationToken) {
     params.append("invitation_token", invitationToken);
+  }
+  for (const [key, value] of Object.entries(attribution)) {
+    params.append(key, value);
   }
 
   if (!code) {

--- a/ui/app/api/auth/callback/google/route.test.ts
+++ b/ui/app/api/auth/callback/google/route.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchMock, signInMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  signInMock: vi.fn(),
+}));
+
+vi.mock("@/auth.config", () => ({
+  signIn: signInMock,
+}));
+
+vi.mock("@/lib/helper", () => ({
+  apiBaseUrl: "https://api.example.com/api/v1",
+  baseUrl: "https://app.example.com",
+}));
+
+import { GET } from "./route";
+
+describe("Google OAuth callback route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    signInMock.mockResolvedValue({});
+  });
+
+  it("should forward callback attribution to the token exchange", async () => {
+    // Given
+    fetchMock.mockResolvedValue(
+      Response.json({
+        data: {
+          attributes: {
+            access: "access-token",
+            refresh: "refresh-token",
+          },
+        },
+      }),
+    );
+    const state = encodeURIComponent(
+      "/?promo_code=black-hat-2026&utm_source=blackhat",
+    );
+    const request = new Request(
+      `https://app.example.com/api/auth/callback/google?code=oauth-code&state=${state}`,
+    );
+
+    // When
+    await GET(request);
+
+    // Then
+    const body = new URLSearchParams(fetchMock.mock.calls[0][1].body);
+    expect(body.get("code")).toBe("oauth-code");
+    expect(body.get("promo_code")).toBe("black-hat-2026");
+    expect(body.get("utm_source")).toBe("blackhat");
+  });
+});

--- a/ui/app/api/auth/callback/google/route.ts
+++ b/ui/app/api/auth/callback/google/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 
 import { signIn } from "@/auth.config";
 import {
+  getAttributionParamsFromCallbackPath,
   getInvitationTokenFromCallbackPath,
   getSafeCallbackPath,
 } from "@/lib/auth-callback-url";
@@ -15,11 +16,15 @@ export async function GET(req: Request) {
   const code = searchParams.get("code");
   const callbackPath = getSafeCallbackPath(searchParams);
   const invitationToken = getInvitationTokenFromCallbackPath(callbackPath);
+  const attribution = getAttributionParamsFromCallbackPath(callbackPath);
 
   const params = new URLSearchParams();
   params.append("code", code || "");
   if (invitationToken) {
     params.append("invitation_token", invitationToken);
+  }
+  for (const [key, value] of Object.entries(attribution)) {
+    params.append(key, value);
   }
 
   if (!code) {

--- a/ui/changelog.d/campaign-signup-attribution.added.md
+++ b/ui/changelog.d/campaign-signup-attribution.added.md
@@ -1,0 +1,1 @@
+Sign-up campaign attribution preserves `promo_code` and `utm_*` params across auth redirects, sign-in/sign-up links, Google/GitHub OAuth callbacks, and `POST /users`

--- a/ui/components/auth/oss/auth-footer-link.test.tsx
+++ b/ui/components/auth/oss/auth-footer-link.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthFooterLink } from "./auth-footer-link";
+
+const navigationState = vi.hoisted(() => ({
+  searchParams: new URLSearchParams(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => navigationState.searchParams,
+}));
+
+describe("AuthFooterLink", () => {
+  it("should preserve attribution params in the target href", () => {
+    // Given
+    navigationState.searchParams = new URLSearchParams(
+      "promo_code=black-hat-2026&utm_source=blackhat&foo=bar",
+    );
+
+    // When
+    render(
+      <AuthFooterLink
+        text="Need to create an account?"
+        linkText="Sign up"
+        href="/sign-up"
+      />,
+    );
+
+    // Then
+    expect(screen.getByRole("link", { name: "Sign up" })).toHaveAttribute(
+      "href",
+      "/sign-up?promo_code=black-hat-2026&utm_source=blackhat",
+    );
+  });
+});

--- a/ui/components/auth/oss/auth-footer-link.tsx
+++ b/ui/components/auth/oss/auth-footer-link.tsx
@@ -1,4 +1,10 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
 import { CustomLink } from "@/components/shadcn/custom/custom-link";
+import { appendAttributionToCallbackPath } from "@/lib/auth-callback-url";
+import { extractUtmParams } from "@/lib/utm";
 
 interface AuthFooterLinkProps {
   text: string;
@@ -11,10 +17,16 @@ export const AuthFooterLink = ({
   linkText,
   href,
 }: AuthFooterLinkProps) => {
+  const searchParams = useSearchParams();
+  const targetHref = appendAttributionToCallbackPath(
+    href,
+    extractUtmParams(searchParams),
+  );
+
   return (
     <p className="text-center text-sm">
       {text}&nbsp;
-      <CustomLink size="md" href={href} target="_self">
+      <CustomLink size="md" href={targetHref} target="_self">
         {linkText}
       </CustomLink>
     </p>

--- a/ui/components/auth/oss/sign-in-form.tsx
+++ b/ui/components/auth/oss/sign-in-form.tsx
@@ -21,8 +21,12 @@ import {
 } from "@/components/shadcn";
 import { CustomInput } from "@/components/shadcn/custom";
 import { Form } from "@/components/shadcn/form";
-import { getSafeCallbackPath } from "@/lib/auth-callback-url";
+import {
+  appendAttributionToCallbackPath,
+  getSafeCallbackPath,
+} from "@/lib/auth-callback-url";
 import { stripPasswordManagerHighlight } from "@/lib/password-manager";
+import { extractUtmParams } from "@/lib/utm";
 import { SignInFormData, signInSchema } from "@/types";
 
 export const SignInForm = ({
@@ -40,6 +44,10 @@ export const SignInForm = ({
   const searchParams = useSearchParams();
   const { toast } = useToast();
   const callbackUrl = getSafeCallbackPath(searchParams, "callbackUrl");
+  const socialCallbackUrl = appendAttributionToCallbackPath(
+    callbackUrl,
+    extractUtmParams(searchParams),
+  );
 
   useEffect(() => {
     const samlError = searchParams.get("sso_saml_failed");
@@ -198,7 +206,7 @@ export const SignInForm = ({
           <SocialButtons
             googleAuthUrl={googleAuthUrl}
             githubAuthUrl={githubAuthUrl}
-            callbackUrl={callbackUrl}
+            callbackUrl={socialCallbackUrl}
             isGoogleOAuthEnabled={isGoogleOAuthEnabled}
             isGithubOAuthEnabled={isGithubOAuthEnabled}
           />

--- a/ui/components/auth/oss/sign-up-form.tsx
+++ b/ui/components/auth/oss/sign-up-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useForm, useWatch } from "react-hook-form";
 
 import { createNewUser } from "@/actions/auth";
@@ -24,7 +24,9 @@ import {
   FormField,
   FormMessage,
 } from "@/components/shadcn/form";
+import { appendAttributionToCallbackPath } from "@/lib/auth-callback-url";
 import { stripPasswordManagerHighlight } from "@/lib/password-manager";
+import { extractUtmParams } from "@/lib/utm";
 import { ApiError, SignUpFormData, signUpSchema } from "@/types";
 
 const AUTH_ERROR_PATHS = {
@@ -54,10 +56,16 @@ export const SignUpForm = ({
   isGithubOAuthEnabled?: boolean;
 }) => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { toast } = useToast();
-  const callbackUrl = invitationToken
+  const utmParams = extractUtmParams(searchParams);
+  const baseCallbackUrl = invitationToken
     ? `/invitation/accept?invitation_token=${encodeURIComponent(invitationToken)}`
     : "/";
+  const callbackUrl = appendAttributionToCallbackPath(
+    baseCallbackUrl,
+    utmParams,
+  );
 
   const form = useForm<SignUpFormData>({
     resolver: zodResolver(signUpSchema),
@@ -89,7 +97,7 @@ export const SignUpForm = ({
   const isSocialAuthDisabled = Boolean(isCloudEnv && !termsAccepted);
 
   const onSubmit = async (data: SignUpFormData) => {
-    const newUser = await createNewUser(data);
+    const newUser = await createNewUser(data, utmParams);
 
     if (!newUser.errors) {
       toast({

--- a/ui/lib/auth-callback-url.test.ts
+++ b/ui/lib/auth-callback-url.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  appendAttributionToCallbackPath,
   appendCallbackState,
+  getAttributionParamsFromCallbackPath,
   getInvitationTokenFromCallbackPath,
   getSafeCallbackPath,
 } from "@/lib/auth-callback-url";
@@ -103,6 +105,48 @@ describe("auth callback URL helpers", () => {
       const result = getInvitationTokenFromCallbackPath(callbackPath);
 
       expect(result).toBe("test-token");
+    });
+  });
+
+  describe("when carrying campaign attribution", () => {
+    it("should append attribution params to the callback path", () => {
+      const result = appendAttributionToCallbackPath("/", {
+        promo_code: "black-hat-2026",
+        utm_source: "blackhat",
+      });
+
+      expect(result).toBe("/?promo_code=black-hat-2026&utm_source=blackhat");
+    });
+
+    it("should not override params already present in the path", () => {
+      const result = appendAttributionToCallbackPath("/?promo_code=original", {
+        promo_code: "other",
+      });
+
+      expect(result).toBe("/?promo_code=original");
+    });
+
+    it("should return the path untouched without attribution", () => {
+      expect(appendAttributionToCallbackPath("/scans", {})).toBe("/scans");
+    });
+
+    it("should read attribution params back from a callback path", () => {
+      const result = getAttributionParamsFromCallbackPath(
+        "/?promo_code=black-hat-2026&utm_source=blackhat&foo=bar",
+      );
+
+      expect(result).toEqual({
+        promo_code: "black-hat-2026",
+        utm_source: "blackhat",
+      });
+    });
+
+    it("should return no attribution for unsafe callback paths", () => {
+      expect(
+        getAttributionParamsFromCallbackPath(
+          "https://attacker.example/?promo_code=x",
+        ),
+      ).toEqual({});
     });
   });
 });

--- a/ui/lib/auth-callback-url.ts
+++ b/ui/lib/auth-callback-url.ts
@@ -1,3 +1,5 @@
+import { extractUtmParams, type UtmParams } from "@/lib/utm";
+
 const DEFAULT_CALLBACK_PATH = "/";
 const INVITATION_TOKEN_PARAM = "invitation_token";
 // Origin used only to resolve relative paths; never part of the returned value.
@@ -61,5 +63,40 @@ export const getInvitationTokenFromCallbackPath = (callbackPath: string) => {
     return url.searchParams.get(INVITATION_TOKEN_PARAM);
   } catch (_error) {
     return null;
+  }
+};
+
+export const appendAttributionToCallbackPath = (
+  callbackPath: string,
+  attribution: UtmParams,
+): string => {
+  const safeCallbackPath = getSafeCallbackPathFromValue(callbackPath);
+  if (Object.keys(attribution).length === 0) {
+    return safeCallbackPath;
+  }
+
+  try {
+    const url = new URL(safeCallbackPath, INTERNAL_ORIGIN);
+    for (const [key, value] of Object.entries(attribution)) {
+      if (!url.searchParams.has(key)) {
+        url.searchParams.set(key, value);
+      }
+    }
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch (_error) {
+    return safeCallbackPath;
+  }
+};
+
+export const getAttributionParamsFromCallbackPath = (
+  callbackPath: string,
+): UtmParams => {
+  const safeCallbackPath = getSafeCallbackPathFromValue(callbackPath);
+
+  try {
+    const url = new URL(safeCallbackPath, INTERNAL_ORIGIN);
+    return extractUtmParams(url.searchParams);
+  } catch (_error) {
+    return {};
   }
 };

--- a/ui/lib/utm.test.ts
+++ b/ui/lib/utm.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { copyAttributionParams, extractUtmParams } from "./utm";
+
+describe("extractUtmParams", () => {
+  it("captures every utm_* param when utm_source is present", () => {
+    // Given
+    const params = new URLSearchParams(
+      "utm_source=blackhat&utm_medium=conference&utm_content=badge&foo=bar",
+    );
+
+    // When / Then
+    expect(extractUtmParams(params)).toEqual({
+      utm_source: "blackhat",
+      utm_medium: "conference",
+      utm_content: "badge",
+    });
+  });
+
+  it("returns empty for utm params without attribution source", () => {
+    // Given / When / Then
+    expect(extractUtmParams({ utm_content: "alerts" })).toEqual({});
+  });
+
+  it("captures promo_code on its own as valid attribution", () => {
+    // Given
+    const params = new URLSearchParams(
+      "promo_code=95b2c481-f9d5-4fc2-bc34-0b542e25f00b",
+    );
+
+    // When / Then
+    expect(extractUtmParams(params)).toEqual({
+      promo_code: "95b2c481-f9d5-4fc2-bc34-0b542e25f00b",
+    });
+  });
+
+  it("lets promo_code carry sourceless utm params", () => {
+    // Given
+    const params = new URLSearchParams("utm_content=badge&promo_code=abc");
+
+    // When / Then
+    expect(extractUtmParams(params)).toEqual({
+      utm_content: "badge",
+      promo_code: "abc",
+    });
+  });
+});
+
+describe("copyAttributionParams", () => {
+  it("copies attribution params and drops unrelated params", () => {
+    // Given
+    const source = new URLSearchParams(
+      "promo_code=black-hat-2026&utm_source=blackhat&foo=bar",
+    );
+    const target = new URLSearchParams("callbackUrl=/");
+
+    // When
+    copyAttributionParams(source, target);
+
+    // Then
+    expect(target.get("callbackUrl")).toBe("/");
+    expect(target.get("promo_code")).toBe("black-hat-2026");
+    expect(target.get("utm_source")).toBe("blackhat");
+    expect(target.get("foo")).toBeNull();
+  });
+});

--- a/ui/lib/utm.ts
+++ b/ui/lib/utm.ts
@@ -1,0 +1,65 @@
+export const UTM_PARAM_PREFIX = "utm_";
+const UTM_SOURCE_KEY = "utm_source";
+export const PROMO_CODE_KEY = "promo_code";
+
+export type UtmParams = Record<string, string>;
+
+type SearchParamSource = {
+  forEach(callback: (value: string, key: string) => void): void;
+};
+
+type RecordParamSource = Record<string, string | string[] | undefined>;
+
+type UtmSource = SearchParamSource | RecordParamSource;
+
+const isSearchParamSource = (source: UtmSource): source is SearchParamSource =>
+  "forEach" in source && typeof source.forEach === "function";
+
+const toEntries = (source: UtmSource): [string, string][] => {
+  if (isSearchParamSource(source)) {
+    const entries: [string, string][] = [];
+    source.forEach((value, key) => {
+      entries.push([key, value]);
+    });
+    return entries;
+  }
+
+  return Object.entries(source).flatMap(([key, value]) => {
+    if (typeof value === "string") {
+      return [[key, value]];
+    }
+    if (Array.isArray(value) && typeof value[0] === "string") {
+      return [[key, value[0]]];
+    }
+    return [];
+  });
+};
+
+export const extractUtmParams = (source: UtmSource): UtmParams => {
+  const utm: UtmParams = {};
+  let hasAttribution = false;
+
+  for (const [key, value] of toEntries(source)) {
+    const lowerKey = key.toLowerCase();
+    if (lowerKey === PROMO_CODE_KEY) {
+      utm[PROMO_CODE_KEY] = value;
+      hasAttribution = true;
+    } else if (lowerKey.startsWith(UTM_PARAM_PREFIX)) {
+      utm[key] = value;
+      if (lowerKey === UTM_SOURCE_KEY) {
+        hasAttribution = true;
+      }
+    }
+  }
+
+  return hasAttribution ? utm : {};
+};
+
+export const copyAttributionParams = (
+  from: URLSearchParams,
+  to: URLSearchParams,
+): void => {
+  for (const [key, value] of Object.entries(extractUtmParams(from))) {
+    to.set(key, value);
+  }
+};

--- a/ui/proxy.ts
+++ b/ui/proxy.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/integrations";
 import { readEnv } from "@/lib/runtime-env";
 import { isCloud } from "@/lib/shared/env";
+import { copyAttributionParams } from "@/lib/utm";
 
 const publicRoutes = [
   "/sign-in",
@@ -63,12 +64,14 @@ export default auth((req: NextAuthRequest) => {
     const signInUrl = new URL("/sign-in", req.url);
     signInUrl.searchParams.set("error", sessionError);
     signInUrl.searchParams.set("callbackUrl", pathname + req.nextUrl.search);
+    copyAttributionParams(req.nextUrl.searchParams, signInUrl.searchParams);
     return redirect(signInUrl);
   }
 
   if (!user && !isPublicRoute(pathname)) {
     const signInUrl = new URL("/sign-in", req.url);
     signInUrl.searchParams.set("callbackUrl", pathname + req.nextUrl.search);
+    copyAttributionParams(req.nextUrl.searchParams, signInUrl.searchParams);
     return redirect(signInUrl);
   }
 


### PR DESCRIPTION
### Description

This pull request implements comprehensive support for campaign attribution during user sign-up and authentication flows. It ensures that `promo_code` and `utm_*` parameters are preserved and forwarded across all relevant user journeys, including sign-in/sign-up links, OAuth callbacks, and user creation API calls. The changes add utility functions for extracting and appending attribution parameters, update frontend components to propagate these parameters, and include tests to verify correct behavior.

**Campaign Attribution Handling**

* Added utility functions in `ui/lib/utm.ts` to extract and copy `promo_code` and `utm_*` parameters from URLs, and in `ui/lib/auth-callback-url.ts` to append and retrieve attribution parameters from callback paths. [[1]](diffhunk://#diff-2fd018e5387daa67b4a3672641468e118994f59b8a79490492a0baa4b2e83e43R1-R65) [[2]](diffhunk://#diff-3374c722b315a854f09fd75781b74aa395a2c5a4acb02a262c5049ec0c60ca17R1-R2)
* Updated the sign-in and sign-up forms (`sign-in-form.tsx`, `sign-up-form.tsx`) and the `AuthFooterLink` component to preserve and forward attribution parameters in all relevant links and API calls. [[1]](diffhunk://#diff-4ef4398617f52e042f82237c1f354d7087742ef5de74afd6d7b08e00efdb4ab2L24-R29) [[2]](diffhunk://#diff-4ef4398617f52e042f82237c1f354d7087742ef5de74afd6d7b08e00efdb4ab2R47-R50) [[3]](diffhunk://#diff-4ef4398617f52e042f82237c1f354d7087742ef5de74afd6d7b08e00efdb4ab2L201-R209) [[4]](diffhunk://#diff-d9c077b0aaae2fc97d7341c9a6663d8007b53941cad40082a2d6d0dee5ad8b67L4-R4) [[5]](diffhunk://#diff-d9c077b0aaae2fc97d7341c9a6663d8007b53941cad40082a2d6d0dee5ad8b67R27-R29) [[6]](diffhunk://#diff-d9c077b0aaae2fc97d7341c9a6663d8007b53941cad40082a2d6d0dee5ad8b67R59-R68) [[7]](diffhunk://#diff-d9c077b0aaae2fc97d7341c9a6663d8007b53941cad40082a2d6d0dee5ad8b67L92-R100) [[8]](diffhunk://#diff-d19f2c67a65ab41b01ea86d80071553013607a2672b0aeee50b5f18dfd59bacfR1-R7) [[9]](diffhunk://#diff-d19f2c67a65ab41b01ea86d80071553013607a2672b0aeee50b5f18dfd59bacfR20-R29)
* Modified the `createNewUser` action to accept and forward attribution parameters to the `/users` API endpoint. [[1]](diffhunk://#diff-bba23bda316e3e5f1572fb0b215266313c7d60243eac0291a243d69b7cb38cdaR8) [[2]](diffhunk://#diff-bba23bda316e3e5f1572fb0b215266313c7d60243eac0291a243d69b7cb38cdaL50-R64)

**OAuth Callback Support**

* Updated Google and GitHub OAuth callback routes to extract attribution parameters from the callback path and forward them during token exchange. [[1]](diffhunk://#diff-c14e79e5a824f155d831a0ca0eaf996322e6413c14074a5d2508ad15a2e57acfR7) [[2]](diffhunk://#diff-c14e79e5a824f155d831a0ca0eaf996322e6413c14074a5d2508ad15a2e57acfR19-R28) [[3]](diffhunk://#diff-2c2aa6f49d6d6d73c4af6e5dc6360158cb1df93af95ebaad5b72fd8e84f2049cR7) [[4]](diffhunk://#diff-2c2aa6f49d6d6d73c4af6e5dc6360158cb1df93af95ebaad5b72fd8e84f2049cR19-R28)

**Testing and Verification**

* Added tests for attribution parameter extraction, propagation, and preservation in utility functions and UI components. [[1]](diffhunk://#diff-210f873610e849e1556a85a7d11c632404ee4b32c387c16100f3fb2c0f222916R1-R66) [[2]](diffhunk://#diff-697db2be77bbe0b8cee8c7cff0e68b915df9a8577e933eb605128a8fad22baeeR4-R6) [[3]](diffhunk://#diff-697db2be77bbe0b8cee8c7cff0e68b915df9a8577e933eb605128a8fad22baeeR110-R151) [[4]](diffhunk://#diff-2d3575d361c49b385fd77b6d37474c7f4cae0f259629d3f1d2be916a0b26698eR1-R36) [[5]](diffhunk://#diff-3a4e4c162d8e37bd3e92fb41345f74d6250cbe9653e343fa6e391ee8433eee46R1-R54) [[6]](diffhunk://#diff-4c959857638349f9bdce60dc52bd87e78f5739b66eae6ab4569995daa38743cdR66-R104)

**Documentation**

* Added a changelog entry describing the new campaign attribution support.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved promotional codes and UTM campaign parameters throughout sign-up and sign-in flows.
  * Attribution details now persist across authentication redirects and Google/GitHub OAuth callbacks.
  * New users created through campaign links retain the relevant attribution information.

* **Bug Fixes**
  * Prevented attribution parameters from being lost during authentication redirects.
  * Ignored unrelated URL parameters and unsafe callback destinations to keep redirects secure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->