### PR TITLE
fix(container): keep wget in the api image for the compose healthcheck

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -109,6 +109,7 @@ USER root
 
 # Remove build-only packages from the final image after Python dependencies are installed.
 # git is only needed by uv sync for the `prowler @ git+...` dependency; purging it drops perl too.
+# wget stays: the compose healthcheck shells out to it.
 RUN apt-get purge -y --auto-remove \
     gcc \
     g++ \
@@ -123,7 +124,6 @@ RUN apt-get purge -y --auto-remove \
     libtool \
     libxslt1-dev \
     python3-dev \
-    wget \
     gnupg \
     apt-transport-https \
     && rm -rf /var/lib/apt/lists/*

--- a/api/changelog.d/api-container-keep-wget.fixed.md
+++ b/api/changelog.d/api-container-keep-wget.fixed.md
@@ -1,0 +1,1 @@
+Restored `wget` in the API container image, which the Compose healthcheck depends on


### PR DESCRIPTION
## Description

Regression from PROWLER-2312 (#12265). That PR purged `wget` from both runtime images, but the API healthcheck shells out to it:

```yaml
test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:${DJANGO_PORT:-8080}/health/live || exit 1"]
```

Present in **`docker-compose.yml`** (production) at line 36 and `docker-compose-dev.yml` at line 40. With `wget` gone the check can never pass, so the container is marked unhealthy indefinitely and every service with `depends_on: service_healthy` refuses to start.

`api/Dockerfile` purges at line 112, while `FROM build AS dev` is line 139 and the production stage is line 144 — **both inherit it**, so this affects the shipped image, not just dev.

## How it was found

Bringing up `docker-compose-dev.yml` from the integration branch. The stack died with `dependency failed to start: container api-dev is unhealthy`, while the API's own logs showed gunicorn ready, all four workers booted and compliance caches warming. The application was fine; the healthcheck could not run.

I initially misread this as a slow-start timeout. It was not — `start_period` is 60s with 12 retries, which is ample.

## Fix

Restore `wget` in `api/Dockerfile` only. `gnupg` and `apt-transport-https` stay purged, and the SDK image keeps the full purge since nothing healthchecks it.

| | Before #12265 | After #12265 | Now |
|---|---:|---:|---:|
| `prowler-api` HIGH | 40 | 36 (broken) | **38** |

7 of the 9 findings stay cleared. The 2 that return are `wget`'s.

## Why not switch the healthcheck instead

Using `python -c "urllib.request.urlopen(...)"` is better engineering — the image always has Python, and it drops the package dependency entirely. I did not do it because the same healthcheck exists in four compose files across three repos: prowler's two, prowler-cloud's `docker-compose.yml` (4 references) and prowler-enterprise's shipped `compose.yml.tmpl` (line 538, the cloud-api). They would have to change in lockstep, and any repo that ports the purge before the healthcheck change breaks on install.

That is worth doing deliberately, not as a hotfix ahead of a deadline. **PROWLER-2317 must not port the `wget` purge to prowler-cloud** until then — noted on that ticket.

## Verification

```
$ docker run --rm --entrypoint sh prowler-api:wgetfix -c 'command -v wget'
/usr/bin/wget

$ ... -c 'wget -q -O /dev/null http://127.0.0.1:8080/health/live; echo $?'
4          # network unreachable, no server running — not 127, command not found

$ ... -c 'command -v gpg'
(absent)   # gnupg purge still in effect
```

Scanned: 4 CRITICAL / 38 HIGH, with 0 gnupg-family findings and `wget`'s 2 back.

Also added a one-line comment above the purge so the next person does not remove it again.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.