### PR TITLE
fix(ui): include sharp's native libvips in the standalone output

### DIFF
--- a/ui/changelog.d/ui-sharp-standalone-tracing.fixed.md
+++ b/ui/changelog.d/ui-sharp-standalone-tracing.fixed.md
@@ -1,0 +1,1 @@
+Fixed image optimization in the production container: Next.js standalone tracing omitted `sharp`'s native `libvips` library, so every image was served unoptimized

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -13,6 +13,10 @@ const nextConfig = {
     !process.env.CI && {
       output: "standalone",
       outputFileTracingRoot: __dirname,
+      // sharp 0.35 loads its native binary dynamically, so tracing misses it.
+      outputFileTracingIncludes: {
+        "**": ["./node_modules/.pnpm/@img+sharp-libvips-linuxmusl-*/**/*"],
+      },
     }),
   // React Compiler is now stable in Next.js 16
   reactCompiler: true,


### PR DESCRIPTION
Found by @Alan-TheGentleman's request on #12243 to exercise a real `/_next/image` request. It would not have surfaced any other way.

## The bug

PROWLER-2298 overrode `sharp` to 0.35.3 to clear a HIGH CVE. **That silently disabled image optimisation in the production image.**

```
Error: Could not load the "sharp" module using the linuxmusl-x64 runtime
ERR_DLOPEN_FAILED: libvips-cpp.so.8.18.3: No such file or directory
```

Next.js catches this and falls back to serving originals. The request returns **HTTP 200**, nothing is logged, and the healthcheck stays green — the only symptom is every image being served unoptimised.

| | master (0.33.5) | this branch, before fix |
|---|---|---|
| `/_next/image` | 20,052 B `image/webp` | 97,549 B `image/png` |

Confirmed on **both amd64 and arm64**.

## Root cause

Not the npm package, and not pnpm. libvips 1.3.2's tarball ships the `.so` (8.1 MB) and it installs correctly:

```
builder node_modules  → libvips-cpp.so.8.18.3   present
.next/standalone      → libvips*.so             0 files
```

sharp 0.33.5 and 0.34.5 loaded their native binary in a way Next's static tracer could follow. **0.35.x resolves it dynamically at runtime**, so tracing never sees it and omits it from `.next/standalone`, which is what the prod stage copies.

## Why not just pin a lower version

There is no version that both fixes the CVE and traces correctly:

| sharp | libvips | CVE fixed | traced |
|---|---|---|---|
| 0.33.5 / 0.34.5 | 1.0.4 / 1.2.4 | ❌ | ✅ |
| 0.35.0 – 0.35.3 | 1.3.0 – 1.3.2 | ✅ | ❌ |

The advisory requires ≥ 0.35.0 and every 0.35.x uses the dynamic loader. So the config has to change.

## Fix

`outputFileTracingIncludes` in `next.config.js`, inside the existing `production && !CI` block so it applies exactly where `output: "standalone"` does. The glob covers `linuxmusl-x64` and `linuxmusl-arm64` from one entry.

## Verification

| | amd64 | arm64 |
|---|---|---|
| `.so` present in image | ✅ | ✅ |
| `require("sharp")` | 0.35.3 loads | 0.35.3 loads |
| `/_next/image` | **20,052 B `image/webp`** | **20,052 B `image/webp`** |

Matches master's behaviour exactly, with the CVE still fixed.

## Also worth knowing

While measuring this I found that **the UI image is not reproducible**. `ui/Dockerfile` pins the base by digest, but `apk upgrade` resolves against Alpine's live repository at build time — two builds of the same commit on different days gave Alpine 3.23.3 and 3.23.4. My first before/after comparison was wrong because of it. Not fixed here; worth its own ticket.

The all-severity numbers Alan asked for, rebuilt with `--no-cache` so the comparison is fair:

| Severity | master | this branch |
|---|---:|---:|
| CRITICAL | 0 | 0 |
| HIGH | 2 | **0** |
| MEDIUM / LOW / UNKNOWN | 0 | 0 |

Note the baseline is **2, not the 8** quoted on #12243. Alpine 3.23.4 fixed musl and zlib upstream in the meantime, so that figure is no longer reproducible.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.