### PR TITLE
fix: skip ECS task definitions when describe fails

### DIFF
--- a/prowler/changelog.d/ecs-task-definitions-fail-open.security.md
+++ b/prowler/changelog.d/ecs-task-definitions-fail-open.security.md
@@ -1,0 +1,1 @@
+AWS ECS task-definition checks no longer report unexamined task definitions as PASS when DescribeTaskDefinition fails

--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -149,8 +149,8 @@ class ECS(AWSService):
                     "TAGS",
                 ],
             )
-            container_definitions = response["taskDefinition"]["containerDefinitions"]
-            for container in container_definitions:
+            container_definitions = []
+            for container in response["taskDefinition"]["containerDefinitions"]:
                 environment = []
                 if "environment" in container:
                     for env_var in container["environment"]:
@@ -159,7 +159,7 @@ class ECS(AWSService):
                                 name=env_var["name"], value=env_var["value"]
                             )
                         )
-                task_definition.container_definitions.append(
+                container_definitions.append(
                     ContainerDefinition(
                         name=container["name"],
                         privileged=container.get("privileged", False),
@@ -176,6 +176,7 @@ class ECS(AWSService):
                         .get("mode", ""),
                     )
                 )
+            task_definition.container_definitions = container_definitions
             task_definition.pid_mode = response["taskDefinition"].get("pidMode", "")
             task_definition.registered_at = response["taskDefinition"].get(
                 "registeredAt"
@@ -298,11 +299,31 @@ class ContainerDefinition(BaseModel):
 
 
 class TaskDefinition(BaseModel):
+    """ECS task definition model.
+
+    Attributes:
+        name: Task definition family name, without the revision suffix.
+        arn: Full task definition ARN.
+        revision: Task definition revision.
+        region: AWS region where the task definition was listed.
+        container_definitions: Container definitions populated only by a
+            successful ``DescribeTaskDefinition`` call.  ``None`` means the
+            call failed and the evidence was never gathered; ``[]`` means a
+            successful describe with no containers.  Checks must skip task
+            definitions whose evidence is ``None`` instead of reporting an
+            unexamined resource as compliant.
+        pid_mode: PID mode of the task definition (``"host"`` when the host
+            process namespace is shared with the containers).
+        registered_at: Registration timestamp of the task definition.
+        tags: Tags attached to the task definition.
+        network_mode: Network mode of the task definition.
+    """
+
     name: str
     arn: str
     revision: str
     region: str
-    container_definitions: list[ContainerDefinition] = []
+    container_definitions: Optional[list[ContainerDefinition]] = None
     pid_mode: Optional[str]
     registered_at: Optional[datetime] = None
     tags: Optional[list] = []

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_containers_readonly_access/ecs_task_definitions_containers_readonly_access.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_containers_readonly_access/ecs_task_definitions_containers_readonly_access.py
@@ -3,24 +3,38 @@ from prowler.providers.aws.services.ecs.ecs_client import ecs_client
 
 
 class ecs_task_definitions_containers_readonly_access(Check):
-    def execute(self):
+    """Verify ECS task definition containers do not have write access to their root filesystems.
+
+    Task definitions whose describe call failed are skipped so an
+    unexamined resource is never reported as compliant.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check.
+
+        Returns:
+            A list of check reports, one per ECS task definition.
+        """
         findings = []
         for task_definition in ecs_client.task_definitions.values():
+            if task_definition.container_definitions is None:
+                continue
             report = Check_Report_AWS(
                 metadata=self.metadata(), resource=task_definition
             )
             report.resource_id = f"{task_definition.name}:{task_definition.revision}"
-            report.status = "PASS"
-            report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} does not have containers with write access to the root filesystems."
 
-            failed_containers = []
-            for container in task_definition.container_definitions:
-                if not container.readonly_rootfilesystem:
-                    report.status = "FAIL"
-                    failed_containers.append(container.name)
-
+            failed_containers = [
+                container.name
+                for container in task_definition.container_definitions
+                if not container.readonly_rootfilesystem
+            ]
             if failed_containers:
+                report.status = "FAIL"
                 report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} has containers with write access to the root filesystem: {', '.join(failed_containers)}"
+            else:
+                report.status = "PASS"
+                report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} does not have containers with write access to the root filesystems."
             findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_host_namespace_not_shared/ecs_task_definitions_host_namespace_not_shared.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_host_namespace_not_shared/ecs_task_definitions_host_namespace_not_shared.py
@@ -3,17 +3,31 @@ from prowler.providers.aws.services.ecs.ecs_client import ecs_client
 
 
 class ecs_task_definitions_host_namespace_not_shared(Check):
-    def execute(self):
+    """Verify ECS task definitions do not share the host process namespace with their containers.
+
+    Task definitions whose describe call failed are skipped so an
+    unexamined resource is never reported as compliant.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check.
+
+        Returns:
+            A list of check reports, one per ECS task definition.
+        """
         findings = []
         for task_definition in ecs_client.task_definitions.values():
+            if task_definition.container_definitions is None:
+                continue
             report = Check_Report_AWS(
                 metadata=self.metadata(), resource=task_definition
             )
             report.resource_id = f"{task_definition.name}:{task_definition.revision}"
-            report.status = "PASS"
-            report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} does not share a host's process namespace with its containers."
             if task_definition.pid_mode == "host":
                 report.status = "FAIL"
                 report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} is configured to share a host's process namespace with its containers."
+            else:
+                report.status = "PASS"
+                report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} does not share a host's process namespace with its containers."
             findings.append(report)
         return findings

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_host_networking_mode_users/ecs_task_definitions_host_networking_mode_users.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_host_networking_mode_users/ecs_task_definitions_host_networking_mode_users.py
@@ -3,27 +3,42 @@ from prowler.providers.aws.services.ecs.ecs_client import ecs_client
 
 
 class ecs_task_definitions_host_networking_mode_users(Check):
-    def execute(self):
+    """Verify ECS task definitions with host networking do not run non-privileged containers as root.
+
+    Task definitions whose describe call failed are skipped so an
+    unexamined resource is never reported as compliant.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check.
+
+        Returns:
+            A list of check reports, one per ECS task definition.
+        """
         findings = []
         for task_definition in ecs_client.task_definitions.values():
+            if task_definition.container_definitions is None:
+                continue
             report = Check_Report_AWS(
                 metadata=self.metadata(), resource=task_definition
             )
             report.resource_id = f"{task_definition.name}:{task_definition.revision}"
-            report.status = "PASS"
-            report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} does not have host network mode."
             failed_containers = []
             if task_definition.network_mode == "host":
                 for container in task_definition.container_definitions:
                     if not container.privileged and (
                         container.user == "root" or container.user == ""
                     ):
-                        report.status = "FAIL"
                         failed_containers.append(container.name)
 
                 if failed_containers:
+                    report.status = "FAIL"
                     report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} has containers with host network mode and non-privileged containers running as root or with no user specified: {', '.join(failed_containers)}"
                 else:
+                    report.status = "PASS"
                     report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} has host network mode but no containers running as root or with no user specified."
+            else:
+                report.status = "PASS"
+                report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} does not have host network mode."
             findings.append(report)
         return findings

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_logging_block_mode/ecs_task_definitions_logging_block_mode.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_logging_block_mode/ecs_task_definitions_logging_block_mode.py
@@ -3,9 +3,22 @@ from prowler.providers.aws.services.ecs.ecs_client import ecs_client
 
 
 class ecs_task_definitions_logging_block_mode(Check):
-    def execute(self):
+    """Verify ECS task definition containers use non-blocking logging mode.
+
+    Task definitions whose describe call failed are skipped so an
+    unexamined resource is never reported as compliant.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check.
+
+        Returns:
+            A list of check reports, one per ECS task definition.
+        """
         findings = []
         for task_definition in ecs_client.task_definitions.values():
+            if task_definition.container_definitions is None:
+                continue
             report = Check_Report_AWS(
                 metadata=self.metadata(), resource=task_definition
             )

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_logging_enabled/ecs_task_definitions_logging_enabled.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_logging_enabled/ecs_task_definitions_logging_enabled.py
@@ -3,23 +3,37 @@ from prowler.providers.aws.services.ecs.ecs_client import ecs_client
 
 
 class ecs_task_definitions_logging_enabled(Check):
-    def execute(self):
+    """Verify ECS task definition containers have logging configured.
+
+    Task definitions whose describe call failed are skipped so an
+    unexamined resource is never reported as compliant.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check.
+
+        Returns:
+            A list of check reports, one per ECS task definition.
+        """
         findings = []
         for task_definition in ecs_client.task_definitions.values():
+            if task_definition.container_definitions is None:
+                continue
             report = Check_Report_AWS(
                 metadata=self.metadata(), resource=task_definition
             )
             report.resource_id = f"{task_definition.name}:{task_definition.revision}"
-            report.status = "PASS"
-            report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} containers have logging configured."
-            failed_containers = []
-            for container in task_definition.container_definitions:
-                if not container.log_driver:
-                    report.status = "FAIL"
-                    failed_containers.append(container.name)
 
+            failed_containers = [
+                container.name
+                for container in task_definition.container_definitions
+                if not container.log_driver
+            ]
             if failed_containers:
+                report.status = "FAIL"
                 report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} has containers running with no logging configuration: {', '.join(failed_containers)}"
-
+            else:
+                report.status = "PASS"
+                report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} containers have logging configured."
             findings.append(report)
         return findings

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -10,13 +10,29 @@ from prowler.providers.aws.services.ecs.ecs_client import ecs_client
 
 
 class ecs_task_definitions_no_environment_secrets(Check):
-    def execute(self):
+    """Verify ECS task definitions do not store secrets in environment variables.
+
+    Task definitions whose describe call failed are skipped so an
+    unexamined resource is never reported as compliant.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check.
+
+        Returns:
+            A list of check reports, one per ECS task definition.
+        """
         findings = []
         secrets_ignore_patterns = ecs_client.audit_config.get(
             "secrets_ignore_patterns", []
         )
         validate = ecs_client.audit_config.get("secrets_validate", False)
         task_definitions = list(ecs_client.task_definitions.values())
+        task_definitions = [
+            task_definition
+            for task_definition in task_definitions
+            if task_definition.container_definitions is not None
+        ]
 
         # Scan every (task definition, container) environment in batched
         # Kingfisher invocations instead of one subprocess per container.

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_privileged_containers/ecs_task_definitions_no_privileged_containers.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_privileged_containers/ecs_task_definitions_no_privileged_containers.py
@@ -3,22 +3,37 @@ from prowler.providers.aws.services.ecs.ecs_client import ecs_client
 
 
 class ecs_task_definitions_no_privileged_containers(Check):
-    def execute(self):
+    """Verify ECS task definitions do not run privileged containers.
+
+    Task definitions whose describe call failed are skipped so an
+    unexamined resource is never reported as compliant.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check.
+
+        Returns:
+            A list of check reports, one per ECS task definition.
+        """
         findings = []
         for task_definition in ecs_client.task_definitions.values():
+            if task_definition.container_definitions is None:
+                continue
             report = Check_Report_AWS(
                 metadata=self.metadata(), resource=task_definition
             )
             report.resource_id = f"{task_definition.name}:{task_definition.revision}"
-            report.status = "PASS"
-            report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} does not have privileged containers."
-            failed_containers = []
-            for container in task_definition.container_definitions:
-                if container.privileged:
-                    report.status = "FAIL"
-                    failed_containers.append(container.name)
 
+            failed_containers = [
+                container.name
+                for container in task_definition.container_definitions
+                if container.privileged
+            ]
             if failed_containers:
+                report.status = "FAIL"
                 report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} has privileged containers: {', '.join(failed_containers)}"
+            else:
+                report.status = "PASS"
+                report.status_extended = f"ECS task definition {task_definition.name} with revision {task_definition.revision} does not have privileged containers."
             findings.append(report)
         return findings

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_containers_readonly_access/test_failed_describe_repro.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_containers_readonly_access/test_failed_describe_repro.py
@@ -1,0 +1,156 @@
+"""Regression tests for #12132 (ECS task-definition checks fail open).
+
+When DescribeTaskDefinition fails, the shared ``EcsTaskDefinition`` model
+must keep ``container_definitions = None`` (evidence not gathered), and the
+task-definition checks must skip such resources instead of reporting a
+default PASS.  A failed gather must never look like compliance.
+"""
+
+from unittest.mock import patch
+
+import botocore
+
+from prowler.providers.aws.services.ecs.ecs_service import (
+    ContainerDefinition,
+    TaskDefinition,
+)
+from tests.providers.aws.utils import (
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_provider,
+)
+
+make_api_call = botocore.client.BaseClient._make_api_call
+
+TASK_ARN = (
+    f"arn:aws:ecs:{AWS_REGION_EU_WEST_1}:123456789012:task-definition/test:1"
+)
+
+
+def mock_make_api_call_failed_describe(self, operation_name, kwarg):
+    if operation_name == "ListTaskDefinitions":
+        return {"taskDefinitionArns": [TASK_ARN]}
+    if operation_name == "DescribeTaskDefinition":
+        raise botocore.exceptions.ClientError(
+            {"Error": {"Code": "ThrottlingException", "Message": "rate exceeded"}},
+            "DescribeTaskDefinition",
+        )
+    if operation_name == "ListClusters":
+        return {"clusterArns": []}
+    return make_api_call(self, operation_name, kwarg)
+
+
+def _run_check(check_name):
+    """Instantiate a check and run it against a real ECS service whose
+    describe call fails, returning the check results."""
+    from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+    mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+    module_path = (
+        "prowler.providers.aws.services.ecs"
+        f".{check_name}.{check_name}"
+    )
+    with (
+        patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ),
+        patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_failed_describe,
+        ),
+        patch(f"{module_path}.ecs_client", new=ECS(mocked_aws_provider)),
+    ):
+        from importlib import import_module
+
+        check_cls = getattr(import_module(module_path), check_name)
+        return check_cls().execute()
+
+
+class TestServiceModel:
+    def test_failed_describe_leaves_container_definitions_none(self):
+        """A failed describe must leave evidence as not-gathered (None)."""
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=mocked_aws_provider,
+            ),
+            patch(
+                "botocore.client.BaseClient._make_api_call",
+                new=mock_make_api_call_failed_describe,
+            ),
+        ):
+            ecs = ECS(mocked_aws_provider)
+
+        task_definition = ecs.task_definitions[TASK_ARN]
+        assert task_definition.container_definitions is None
+
+
+class TestChecksSkipUnexaminedTaskDefinitions:
+    """All task-definition checks must skip a resource whose describe failed."""
+
+    def test_readonly_access_skips_failed_describe(self):
+        assert _run_check("ecs_task_definitions_containers_readonly_access") == []
+
+    def test_host_namespace_skips_failed_describe(self):
+        assert _run_check("ecs_task_definitions_host_namespace_not_shared") == []
+
+    def test_host_networking_mode_skips_failed_describe(self):
+        assert _run_check("ecs_task_definitions_host_networking_mode_users") == []
+
+    def test_logging_enabled_skips_failed_describe(self):
+        assert _run_check("ecs_task_definitions_logging_enabled") == []
+
+    def test_no_environment_secrets_skips_failed_describe(self):
+        assert _run_check("ecs_task_definitions_no_environment_secrets") == []
+
+    def test_no_privileged_skips_failed_describe(self):
+        assert _run_check("ecs_task_definitions_no_privileged_containers") == []
+
+    def test_logging_block_mode_skips_failed_describe(self):
+        # Shares the container_definitions model: without the guard this check
+        # would crash iterating None rather than fail open.
+        assert _run_check("ecs_task_definitions_logging_block_mode") == []
+
+
+class TestSuccessPathStillReports:
+    """Sanity: a successfully described task definition still yields findings."""
+
+    def test_container_definitions_empty_list_is_distinct_from_none(self):
+        """A successful describe with no containers is [] and still evaluated."""
+        task_definition = TaskDefinition(
+            name="test",
+            arn=TASK_ARN,
+            revision="1",
+            region=AWS_REGION_EU_WEST_1,
+            container_definitions=[],
+        )
+        assert task_definition.container_definitions == []
+        assert task_definition.container_definitions is not None
+
+    def test_model_defaults_to_none(self):
+        """Without explicit container_definitions, the sentinel is None."""
+        task_definition = TaskDefinition(
+            name="test",
+            arn=TASK_ARN,
+            revision="1",
+            region=AWS_REGION_EU_WEST_1,
+        )
+        assert task_definition.container_definitions is None
+
+    def test_container_definition_model_unchanged(self):
+        """ContainerDefinition fields remain intact for populated resources."""
+        container = ContainerDefinition(
+            name="c",
+            privileged=False,
+            readonly_rootfilesystem=True,
+            user="appuser",
+            environment=[],
+            log_driver="awslogs",
+            log_option="non-blocking",
+        )
+        assert container.readonly_rootfilesystem is True
+        assert container.name == "c"


### PR DESCRIPTION
## What

When `DescribeTaskDefinition` fails (throttling, permissions, transient errors), the ECS service previously left `container_definitions` as an empty list, so the task-definition checks evaluated the definition with no containers and reported **PASS** — an unexamined resource looked compliant.

## Why

`TaskDefinition.container_definitions` defaulted to `[]`, so "no containers" was indistinguishable from "not retrieved". Any describe failure silently produced a false PASS across the whole task-definition check family (e.g. `ecs_task_definitions_no_privileged_containers` reporting compliant on a definition whose privileged containers were never inspected).

## How

- `TaskDefinition.container_definitions` is now `Optional[list[ContainerDefinition]]` defaulting to `None`; `_describe_task_definition` populates it only on success.
- All seven task-definition checks (`containers_readonly_access`, `host_namespace_not_shared`, `host_networking_mode_users`, `logging_enabled`, `logging_block_mode`, `no_environment_secrets`, `no_privileged_containers`) skip task definitions whose describe call failed, and derive PASS/FAIL from the computed failed-container list, so a failed gather can never be reported as compliant.
- Regression tests simulate a throttled `DescribeTaskDefinition` and assert each check emits no finding for the unexamined resource.

## Verify

```
.venv/Scripts/python.exe -m pytest tests/providers/aws/services/ecs/ -q
```

Fixes #12132


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ECS task-definition checks no longer report resources as compliant when their details cannot be retrieved.
  * Failed retrievals are skipped, while successfully examined definitions—including those with no containers—are evaluated correctly.
  * Findings and status messages now accurately distinguish compliant and non-compliant container configurations.

* **Tests**
  * Added regression coverage for failed task-definition retrievals and empty container definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->