### PR TITLE
docs(security): correct two claims that do not hold

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,8 +2,13 @@
 # Each entry below documents (a) the affected package and why it ships in the
 # image, (b) why the CVE is not exploitable in Prowler's runtime, and (c) the
 # upstream fix status. Entries carry an expiry so they auto-force re-review.
-# Entries are scoped per-package so suppressions cannot drift onto unrelated
-# packages that may be assigned the same CVE in the future.
+# The `pkg:` selector on each line is documentation only. Trivy's classic
+# .trivyignore format parses the CVE ID and ignores the rest, so each entry
+# suppresses its CVE across every package in the image, not just the one named.
+# Verified against Trivy 0.65.0: an entry written `pkg:zlib1g` still suppressed
+# the finding on perl-base. Real per-package scoping needs .trivyignore.yaml
+# with purls — tracked in PROWLER-2327.
+# `exp:` IS honoured: an entry dated in the past correctly lapses.
 #
 # Keep expiries staggered, and only suppress packages the images actually install.
 #

--- a/api/changelog.d/api-container-purge-build-only.security.md
+++ b/api/changelog.d/api-container-purge-build-only.security.md
@@ -1,1 +1,1 @@
-Removed `wget`, `gnupg` and `apt-transport-https` from the API container image, clearing 9 high-severity CVEs with no upstream fix
+Removed `gnupg` and `apt-transport-https` from the API container image; `wget` is retained because the Compose healthcheck invokes it


### PR DESCRIPTION
Addresses the valid findings from @coderabbitai's review on #12258. Two of the ten were real; this fixes both.

## 1. The `.trivyignore` scoping claim is false

The header stated:

> Entries are scoped per-package so suppressions cannot drift onto unrelated packages that may be assigned the same CVE in the future.

They are not scoped. Trivy's classic `.trivyignore` format parses the CVE ID and **ignores the rest of the line**, so `pkg:` is documentation only and every entry suppresses its CVE across the whole image.

Verified against Trivy 0.65.0 on the API image:

```
echo 'CVE-2026-13221 pkg:zlib1g' > mis-scoped.trivyignore
trivy image --ignorefile mis-scoped.trivyignore ...
→ finding on perl-base SUPPRESSED
```

`zlib1g` does not carry that CVE. Had scoping worked, the `perl-base` finding would have remained.

**`exp:` does work** — an entry dated 2020-01-01 correctly lapsed and the finding reappeared. The expiry discipline is sound; only the scoping was illusory.

The header now states what actually happens. Real per-package scoping needs `.trivyignore.yaml` with purls — raised as **PROWLER-2327**, covering all four repos that share this pattern and this false claim.

Worth noting how the flaw survived: my control test compared the file against an **empty** ignore file, which proves entries do *something* but never that they are scoped. Catching this needed a deliberately mis-scoped entry.

## 2. Stale changelog claim

`api-container-purge-build-only.security.md` said `wget` was removed from the API image. #12265 did remove it; #12270 put it back because the Compose healthcheck invokes it, and I never updated the entry. Corrected to name only `gnupg` and `apt-transport-https`, with the reason `wget` stays.

## The finding I checked and rejected

CodeRabbit also flagged that purging `libxmlsec1t64` and `libxmlsec1t64-openssl` would strip xmlsec's runtime dependency. That deserved checking — `xmlsec==1.3.17` and `python3-saml==1.16.0` are genuine runtime dependencies, so broken SAML would have been a serious, invisible regression.

Tested on the built image:

```
import xmlsec                              → 1.3.17
from onelogin.saml2.auth import ...        → OK
ls /usr/lib/*/libxmlsec1*                  → absent
```

Both import with the system library gone, because the Python wheel vendors its own. The purge is safe and stays.

The remaining findings were requests to restate CVE counts in changelog entries; the counts are already substantiated in the PR bodies where the scans were run.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.