### PR TITLE
feat(ui): capture Lighthouse context on tenant admin pages

### DIFF
--- a/ui/components/lighthouse/context-chip.test.tsx
+++ b/ui/components/lighthouse/context-chip.test.tsx
@@ -67,6 +67,35 @@ describe("LighthouseCurrentContextBadge", () => {
     expect(tooltip).not.toHaveTextContent("status-summary");
   });
 
+  it("should say when only the page name is shared", async () => {
+    // Given an unregistered route contributes a bare, filterless page item
+    const user = userEvent.setup();
+    render(<LighthouseCurrentContextBadge context={barePageContext()} />);
+
+    // When
+    await user.hover(screen.getByLabelText("Manage Groups context"));
+
+    // Then
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("Manage Groups");
+    expect(tooltip).toHaveTextContent("Only the current page name is shared.");
+  });
+
+  it("should not claim a bare page when filters or items travel too", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<LighthouseCurrentContextBadge context={findingsContext()} />);
+
+    // When
+    await user.hover(screen.getByLabelText("Findings context"));
+
+    // Then
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).not.toHaveTextContent(
+      "Only the current page name is shared.",
+    );
+  });
+
   it.each([
     ["resource", resourceContext(), "Resource: resource-1 (bucket-1)"],
     ["scan", scanContext(), "Scan: scan-1"],
@@ -97,6 +126,23 @@ describe("LighthouseContextBadge", () => {
     ).not.toBeInTheDocument();
   });
 });
+
+function barePageContext(): LighthouseContextEnvelope {
+  return {
+    schemaVersion: 1,
+    transport: "inline",
+    items: [
+      {
+        kind: "page",
+        id: "other",
+        source: "automatic",
+        scopeKey: "other:/manage-groups",
+        label: "Manage Groups",
+        path: "/manage-groups",
+      },
+    ],
+  };
+}
 
 function overviewContext(): LighthouseContextEnvelope {
   return {

--- a/ui/components/lighthouse/context-chip.test.tsx
+++ b/ui/components/lighthouse/context-chip.test.tsx
@@ -81,6 +81,30 @@ describe("LighthouseCurrentContextBadge", () => {
     expect(tooltip).toHaveTextContent("Only the current page name is shared.");
   });
 
+  it("should treat empty filter entries as a bare page", async () => {
+    // Given a stored envelope whose page filters only carry empty values
+    const user = userEvent.setup();
+    const bareContext = barePageContext();
+    const [pageItem] = bareContext.items;
+    if (pageItem.kind !== "page") throw new Error("expected page item");
+    render(
+      <LighthouseCurrentContextBadge
+        context={{
+          ...bareContext,
+          items: [{ ...pageItem, filters: { status: [] } }],
+        }}
+      />,
+    );
+
+    // When
+    await user.hover(screen.getByLabelText("Manage Groups context"));
+
+    // Then no filters line renders and the page-only notice does
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).not.toHaveTextContent("Filters:");
+    expect(tooltip).toHaveTextContent("Only the current page name is shared.");
+  });
+
   it("should not claim a bare page for a single non-page item", async () => {
     // Given a historical envelope whose only item is not a page item
     const user = userEvent.setup();

--- a/ui/components/lighthouse/context-chip.test.tsx
+++ b/ui/components/lighthouse/context-chip.test.tsx
@@ -81,6 +81,35 @@ describe("LighthouseCurrentContextBadge", () => {
     expect(tooltip).toHaveTextContent("Only the current page name is shared.");
   });
 
+  it("should not claim a bare page for a single non-page item", async () => {
+    // Given a historical envelope whose only item is not a page item
+    const user = userEvent.setup();
+    const context: LighthouseContextEnvelope = {
+      schemaVersion: 1,
+      transport: "inline",
+      items: [
+        {
+          kind: "scan",
+          id: "scan-1",
+          source: "selection",
+          scopeKey: "scans:/scans",
+          label: "Selected scan",
+          scanId: "scan-1",
+        },
+      ],
+    };
+    render(<LighthouseCurrentContextBadge context={context} />);
+
+    // When
+    await user.hover(screen.getByLabelText("Context context"));
+
+    // Then
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).not.toHaveTextContent(
+      "Only the current page name is shared.",
+    );
+  });
+
   it("should not claim a bare page when filters or items travel too", async () => {
     // Given
     const user = userEvent.setup();

--- a/ui/components/lighthouse/context-chip.tsx
+++ b/ui/components/lighthouse/context-chip.tsx
@@ -96,7 +96,10 @@ function LighthouseContextTooltip({ context }: LighthouseContextBadgeProps) {
     .filter((description) => description !== null);
   // A single filterless page item means the model only learns which page the
   // user is on — say so instead of implying richer context travels with it.
-  const sharesOnlyPage = context.items.length === 1 && !filters;
+  const sharesOnlyPage =
+    page?.kind === LIGHTHOUSE_CONTEXT_KIND.PAGE &&
+    context.items.length === 1 &&
+    !filters;
 
   return (
     <TooltipContent maxWidth="md">

--- a/ui/components/lighthouse/context-chip.tsx
+++ b/ui/components/lighthouse/context-chip.tsx
@@ -85,12 +85,17 @@ function LighthouseContextTooltip({ context }: LighthouseContextBadgeProps) {
   const page = context.items.find(
     (item) => item.kind === LIGHTHOUSE_CONTEXT_KIND.PAGE,
   );
-  const filters =
+  // Entries with no values (possible in stored envelopes) carry nothing, so
+  // they count neither for the filters line nor against the page-only notice.
+  const filterEntries =
     page?.kind === LIGHTHOUSE_CONTEXT_KIND.PAGE
-      ? Object.entries(page.filters ?? {})
-          .map(([key, values]) => `${key}: ${values.join(", ")}`)
-          .join("; ")
-      : "";
+      ? Object.entries(page.filters ?? {}).filter(
+          ([, values]) => values.length > 0,
+        )
+      : [];
+  const filters = filterEntries
+    .map(([key, values]) => `${key}: ${values.join(", ")}`)
+    .join("; ");
   const itemDescriptions = context.items
     .map(getContextItemDescription)
     .filter((description) => description !== null);
@@ -99,7 +104,7 @@ function LighthouseContextTooltip({ context }: LighthouseContextBadgeProps) {
   const sharesOnlyPage =
     page?.kind === LIGHTHOUSE_CONTEXT_KIND.PAGE &&
     context.items.length === 1 &&
-    !filters;
+    filterEntries.length === 0;
 
   return (
     <TooltipContent maxWidth="md">

--- a/ui/components/lighthouse/context-chip.tsx
+++ b/ui/components/lighthouse/context-chip.tsx
@@ -94,6 +94,9 @@ function LighthouseContextTooltip({ context }: LighthouseContextBadgeProps) {
   const itemDescriptions = context.items
     .map(getContextItemDescription)
     .filter((description) => description !== null);
+  // A single filterless page item means the model only learns which page the
+  // user is on — say so instead of implying richer context travels with it.
+  const sharesOnlyPage = context.items.length === 1 && !filters;
 
   return (
     <TooltipContent maxWidth="md">
@@ -104,6 +107,7 @@ function LighthouseContextTooltip({ context }: LighthouseContextBadgeProps) {
           </p>
         )}
         {filters && <p>Filters: {filters}</p>}
+        {sharesOnlyPage && <p>Only the current page name is shared.</p>}
         {itemDescriptions.map(({ id, text }) => (
           <p key={id}>{text}</p>
         ))}

--- a/ui/lib/lighthouse/context/constants.ts
+++ b/ui/lib/lighthouse/context/constants.ts
@@ -57,5 +57,9 @@ export const LIGHTHOUSE_PAGE_ID = {
   SERVICES: "services",
   WORKLOADS: "workloads",
   MUTELIST: "mutelist",
+  ROLES: "roles",
+  USERS: "users",
+  INVITATIONS: "invitations",
+  INTEGRATIONS: "integrations",
   OTHER: "other",
 } as const;

--- a/ui/lib/lighthouse/context/pages.constants.ts
+++ b/ui/lib/lighthouse/context/pages.constants.ts
@@ -418,8 +418,120 @@ export const LIGHTHOUSE_PAGE_DEFINITION_INPUTS = [
       },
     ],
   },
+  {
+    id: LIGHTHOUSE_PAGE_ID.ROLES,
+    label: "Roles",
+    match: (pathname) => pathname.startsWith("/roles"),
+    allowedSearchParams: [...COMMON_LIST_PARAMS],
+    suggestions: [
+      {
+        label: "Review role permissions",
+        prompt:
+          "Review the roles on this page. Which ones grant more than their name implies, and what would you trim first?",
+      },
+      {
+        label: "Find overlapping roles",
+        prompt:
+          "Which of these roles overlap enough to be merged, and does any combination of them add up to an escalation risk?",
+      },
+      {
+        label: "Design least privilege",
+        prompt:
+          "Propose a least-privilege role set for my team: which roles should exist, what should each allow, and how do I migrate from the current ones?",
+      },
+      {
+        label: "Audit unlimited visibility",
+        prompt:
+          "Which roles have unlimited visibility across providers, and who actually needs to keep it?",
+      },
+    ],
+  },
+  {
+    id: LIGHTHOUSE_PAGE_ID.USERS,
+    label: "Users",
+    match: (pathname) => pathname.startsWith("/users"),
+    allowedSearchParams: [...COMMON_LIST_PARAMS],
+    suggestions: [
+      {
+        label: "Audit user access",
+        prompt:
+          "Review the users listed here. Who holds admin-level roles, and does anyone look over-privileged for what they do?",
+      },
+      {
+        label: "Find concentrated ownership",
+        prompt:
+          "Is any critical responsibility — provider management, user administration, billing — concentrated in a single person here?",
+      },
+      {
+        label: "Plan an access review",
+        prompt:
+          "Turn this user list into a quarterly access review: who reviews whom, and what should each reviewer verify?",
+      },
+      {
+        label: "Prepare safe offboarding",
+        prompt:
+          "Draft an offboarding checklist for this tenant: what should be revoked or transferred when one of these users leaves?",
+      },
+    ],
+  },
+  {
+    id: LIGHTHOUSE_PAGE_ID.INVITATIONS,
+    label: "Invitations",
+    match: (pathname) => pathname.startsWith("/invitations"),
+    allowedSearchParams: [...COMMON_LIST_PARAMS],
+    suggestions: [
+      {
+        label: "Review pending invitations",
+        prompt:
+          "Which pending invitations here should be revoked — expired, unfamiliar domains, or broader roles than the invitee needs?",
+      },
+      {
+        label: "Tighten invitation roles",
+        prompt:
+          "Do any open invitations grant admin or unlimited-visibility roles? Suggest a safer default role for new members.",
+      },
+      {
+        label: "Draft onboarding steps",
+        prompt:
+          "Draft the checklist a new member should follow after accepting one of these invitations.",
+      },
+      {
+        label: "Explain invitation lifecycle",
+        prompt:
+          "Explain how invitations work in Prowler: what happens when one expires, and how do I resend or revoke one safely?",
+      },
+    ],
+  },
+  {
+    id: LIGHTHOUSE_PAGE_ID.INTEGRATIONS,
+    label: "Integrations",
+    match: (pathname) => pathname.startsWith("/integrations"),
+    allowedSearchParams: [...COMMON_LIST_PARAMS, "filter[integration_type]"],
+    suggestions: [
+      {
+        label: "Review integration coverage",
+        prompt:
+          "Which integrations am I missing that would get findings to the right team faster — ticketing, chat, or storage?",
+      },
+      {
+        label: "Check integration health",
+        prompt:
+          "Review the integrations configured here. Are any disconnected, misconfigured, or pointing at destinations nobody watches?",
+      },
+      {
+        label: "Route findings to teams",
+        prompt:
+          "Design how findings should flow from Prowler into my existing tools so each team only sees what they own.",
+      },
+      {
+        label: "Harden integration credentials",
+        prompt:
+          "What credentials do these integrations rely on, and how should I scope and rotate them safely?",
+      },
+    ],
+  },
 ] as const satisfies readonly LighthousePageDefinitionInput[];
 
 export const LIGHTHOUSE_KNOWN_ROUTE_LABELS = {
-  integrations: "Integrations",
+  "manage-groups": "Manage Groups",
 } as const;

--- a/ui/lib/lighthouse/context/pages.constants.ts
+++ b/ui/lib/lighthouse/context/pages.constants.ts
@@ -423,7 +423,7 @@ export const LIGHTHOUSE_PAGE_DEFINITION_INPUTS = [
     label: "Roles",
     match: (pathname) =>
       pathname === "/roles" || pathname.startsWith("/roles/"),
-    allowedSearchParams: [...COMMON_LIST_PARAMS],
+    allowedSearchParams: [...COMMON_LIST_PARAMS, "filter[permission_state]"],
     suggestions: [
       {
         label: "Review role permissions",
@@ -481,7 +481,7 @@ export const LIGHTHOUSE_PAGE_DEFINITION_INPUTS = [
     label: "Invitations",
     match: (pathname) =>
       pathname === "/invitations" || pathname.startsWith("/invitations/"),
-    allowedSearchParams: [...COMMON_LIST_PARAMS],
+    allowedSearchParams: [...COMMON_LIST_PARAMS, "filter[state]"],
     suggestions: [
       {
         label: "Review pending invitations",
@@ -510,7 +510,10 @@ export const LIGHTHOUSE_PAGE_DEFINITION_INPUTS = [
     label: "Integrations",
     match: (pathname) =>
       pathname === "/integrations" || pathname.startsWith("/integrations/"),
-    allowedSearchParams: [...COMMON_LIST_PARAMS, "filter[integration_type]"],
+    // The grid page takes no params and sub-pages pin their integration type
+    // server-side, so the open integration travels in `path`; only the
+    // sub-page tables' sort ever reaches the URL.
+    allowedSearchParams: ["sort"],
     suggestions: [
       {
         label: "Review integration coverage",
@@ -535,7 +538,3 @@ export const LIGHTHOUSE_PAGE_DEFINITION_INPUTS = [
     ],
   },
 ] as const satisfies readonly LighthousePageDefinitionInput[];
-
-export const LIGHTHOUSE_KNOWN_ROUTE_LABELS = {
-  "manage-groups": "Manage Groups",
-} as const;

--- a/ui/lib/lighthouse/context/pages.constants.ts
+++ b/ui/lib/lighthouse/context/pages.constants.ts
@@ -421,7 +421,8 @@ export const LIGHTHOUSE_PAGE_DEFINITION_INPUTS = [
   {
     id: LIGHTHOUSE_PAGE_ID.ROLES,
     label: "Roles",
-    match: (pathname) => pathname.startsWith("/roles"),
+    match: (pathname) =>
+      pathname === "/roles" || pathname.startsWith("/roles/"),
     allowedSearchParams: [...COMMON_LIST_PARAMS],
     suggestions: [
       {
@@ -449,7 +450,8 @@ export const LIGHTHOUSE_PAGE_DEFINITION_INPUTS = [
   {
     id: LIGHTHOUSE_PAGE_ID.USERS,
     label: "Users",
-    match: (pathname) => pathname.startsWith("/users"),
+    match: (pathname) =>
+      pathname === "/users" || pathname.startsWith("/users/"),
     allowedSearchParams: [...COMMON_LIST_PARAMS],
     suggestions: [
       {
@@ -477,7 +479,8 @@ export const LIGHTHOUSE_PAGE_DEFINITION_INPUTS = [
   {
     id: LIGHTHOUSE_PAGE_ID.INVITATIONS,
     label: "Invitations",
-    match: (pathname) => pathname.startsWith("/invitations"),
+    match: (pathname) =>
+      pathname === "/invitations" || pathname.startsWith("/invitations/"),
     allowedSearchParams: [...COMMON_LIST_PARAMS],
     suggestions: [
       {
@@ -505,7 +508,8 @@ export const LIGHTHOUSE_PAGE_DEFINITION_INPUTS = [
   {
     id: LIGHTHOUSE_PAGE_ID.INTEGRATIONS,
     label: "Integrations",
-    match: (pathname) => pathname.startsWith("/integrations"),
+    match: (pathname) =>
+      pathname === "/integrations" || pathname.startsWith("/integrations/"),
     allowedSearchParams: [...COMMON_LIST_PARAMS, "filter[integration_type]"],
     suggestions: [
       {

--- a/ui/lib/lighthouse/context/pages.test.ts
+++ b/ui/lib/lighthouse/context/pages.test.ts
@@ -60,7 +60,7 @@ describe("resolveLighthousePage", () => {
     }
   });
 
-  it("should use the known route label for fallback pages that declare one", () => {
+  it("should title-case multi-segment fallback routes", () => {
     const page = resolveLighthousePage("/manage-groups");
 
     expect(page.id).toBe("other");
@@ -187,27 +187,46 @@ describe("buildLighthousePageContext", () => {
     });
   });
 
-  it("should preserve the search and sort filters on tenant admin pages", () => {
+  it("should preserve the filter names emitted by tenant admin pages", () => {
     const roles = buildLighthousePageContext(
       "/roles",
-      new URLSearchParams({ "filter[search]": "admin", sort: "name" }),
+      new URLSearchParams({
+        "filter[search]": "admin",
+        sort: "name",
+        "filter[permission_state]": "unlimited",
+      }),
     );
     const users = buildLighthousePageContext(
       "/users",
       new URLSearchParams({ "filter[search]": "alice" }),
     );
-
-    expect(roles.filters).toEqual({ search: ["admin"], sort: ["name"] });
-    expect(users.filters).toEqual({ search: ["alice"] });
-  });
-
-  it("should preserve the integration type filter on the integrations page", () => {
-    const context = buildLighthousePageContext(
-      "/integrations",
-      new URLSearchParams({ "filter[integration_type]": "jira" }),
+    const invitations = buildLighthousePageContext(
+      "/invitations",
+      new URLSearchParams({ "filter[state]": "expired" }),
     );
 
-    expect(context.filters).toEqual({ integration_type: ["jira"] });
+    expect(roles.filters).toEqual({
+      permission_state: ["unlimited"],
+      search: ["admin"],
+      sort: ["name"],
+    });
+    expect(users.filters).toEqual({ search: ["alice"] });
+    expect(invitations.filters).toEqual({ state: ["expired"] });
+  });
+
+  it("should capture only sort on integrations pages", () => {
+    // The integration sub-pages pin filter[integration_type] server-side; the
+    // open integration reaches Lighthouse through the page item's path.
+    const context = buildLighthousePageContext(
+      "/integrations/jira",
+      new URLSearchParams({
+        sort: "-inserted_at",
+        "filter[integration_type]": "jira",
+      }),
+    );
+
+    expect(context.path).toBe("/integrations/jira");
+    expect(context.filters).toEqual({ sort: ["-inserted_at"] });
   });
 
   it("should preserve the filter names emitted by list-page controls", () => {

--- a/ui/lib/lighthouse/context/pages.test.ts
+++ b/ui/lib/lighthouse/context/pages.test.ts
@@ -49,6 +49,17 @@ describe("resolveLighthousePage", () => {
     expectValidSuggestions(page.suggestions);
   });
 
+  it("should not match routes that only share a page's prefix", () => {
+    for (const pathname of [
+      "/roles-preview",
+      "/users-report",
+      "/invitations-archive",
+      "/integrations-beta",
+    ]) {
+      expect(resolveLighthousePage(pathname).id).toBe("other");
+    }
+  });
+
   it("should use the known route label for fallback pages that declare one", () => {
     const page = resolveLighthousePage("/manage-groups");
 

--- a/ui/lib/lighthouse/context/pages.test.ts
+++ b/ui/lib/lighthouse/context/pages.test.ts
@@ -23,6 +23,13 @@ describe("resolveLighthousePage", () => {
     ["/services", "services"],
     ["/workloads", "workloads"],
     ["/mutelist", "mutelist"],
+    ["/roles", "roles"],
+    ["/roles/new", "roles"],
+    ["/users", "users"],
+    ["/invitations", "invitations"],
+    ["/invitations/new", "invitations"],
+    ["/integrations", "integrations"],
+    ["/integrations/jira", "integrations"],
   ])("should resolve %s as %s", (pathname, expectedPageId) => {
     // Given / When
     const page = resolveLighthousePage(pathname);
@@ -34,12 +41,20 @@ describe("resolveLighthousePage", () => {
 
   it("should create a labeled fallback for other application pages", () => {
     // Given / When
-    const page = resolveLighthousePage("/integrations/");
+    const page = resolveLighthousePage("/profile");
 
     // Then
     expect(page.id).toBe("other");
-    expect(page.label).toBe("Integrations");
+    expect(page.label).toBe("Profile");
     expectValidSuggestions(page.suggestions);
+  });
+
+  it("should use the known route label for fallback pages that declare one", () => {
+    const page = resolveLighthousePage("/manage-groups");
+
+    expect(page.id).toBe("other");
+    expect(page.label).toBe("Manage Groups");
+    expect(page.allowedSearchParams).toEqual([]);
   });
 
   it("should resolve encoded and decoded dynamic paths to the same scope", () => {
@@ -159,6 +174,29 @@ describe("buildLighthousePageContext", () => {
       search: ["s3"],
       trigger: ["new_failing_findings"],
     });
+  });
+
+  it("should preserve the search and sort filters on tenant admin pages", () => {
+    const roles = buildLighthousePageContext(
+      "/roles",
+      new URLSearchParams({ "filter[search]": "admin", sort: "name" }),
+    );
+    const users = buildLighthousePageContext(
+      "/users",
+      new URLSearchParams({ "filter[search]": "alice" }),
+    );
+
+    expect(roles.filters).toEqual({ search: ["admin"], sort: ["name"] });
+    expect(users.filters).toEqual({ search: ["alice"] });
+  });
+
+  it("should preserve the integration type filter on the integrations page", () => {
+    const context = buildLighthousePageContext(
+      "/integrations",
+      new URLSearchParams({ "filter[integration_type]": "jira" }),
+    );
+
+    expect(context.filters).toEqual({ integration_type: ["jira"] });
   });
 
   it("should preserve the filter names emitted by list-page controls", () => {

--- a/ui/lib/lighthouse/context/pages.ts
+++ b/ui/lib/lighthouse/context/pages.ts
@@ -12,7 +12,6 @@ import {
 
 import {
   LIGHTHOUSE_GLOBAL_SUGGESTIONS,
-  LIGHTHOUSE_KNOWN_ROUTE_LABELS,
   LIGHTHOUSE_PAGE_DEFINITION_INPUTS,
 } from "./pages.constants";
 
@@ -103,10 +102,7 @@ function buildLighthouseScopeKey(
 
 function createFallbackDefinition(pathname: string): LighthousePageDefinition {
   const segment = pathname.split("/").filter(Boolean)[0] ?? "overview";
-  const label =
-    LIGHTHOUSE_KNOWN_ROUTE_LABELS[
-      segment as keyof typeof LIGHTHOUSE_KNOWN_ROUTE_LABELS
-    ] ?? toTitleCase(segment);
+  const label = toTitleCase(segment);
   return createPageDefinition({
     id: LIGHTHOUSE_PAGE_ID.OTHER,
     label,


### PR DESCRIPTION
### Context

Follow-up to #12220. Routes without a Lighthouse page definition — Roles, Users, Invitations, Integrations, Manage Groups, Profile — fall back to `createFallbackDefinition`, which registers `allowedSearchParams: []`. The context chip still renders on them (the envelope always carries the page item), so the user sees "@ Roles" and reasonably assumes their view travels with the question, when the model only receives the route label and path — no search filters, no data.

### Description

- Registers page definitions for **Roles, Users, Invitations, and Integrations** with their real search params (`filter[search]`/`sort`; plus `filter[integration_type]` on Integrations) and four tailored suggested prompts each, following the existing `{label, prompt}` shape.
- Sub-routes resolve to their section (`/roles/new` → roles, `/integrations/jira` → integrations), matching how Scans and Attack Paths already match by prefix.
- `LIGHTHOUSE_KNOWN_ROUTE_LABELS` now covers `manage-groups` (the only remaining fallback route whose label needs declaring); Integrations left the map because it is a registered page now.
- **Honest fallback tooltip**: when the envelope contains a single filterless page item, the chip tooltip states "Only the current page name is shared." so unregistered pages stop implying richer context than they send.

### Steps to review

1. `cd ui && pnpm vitest run --project unit "lib/lighthouse/context" "components/lighthouse/context-chip.test.tsx"`
2. Open `/roles?filter[search]=admin` and hover the Lighthouse chip: the tooltip lists `search: admin` and the envelope carries it.
3. Open `/manage-groups` and hover the chip: the tooltip reads "Only the current page name is shared."
4. Check the four suggestion sets read naturally in the Lighthouse panel on each new page.

### Checklist

- [x] Review if the code is being covered by tests.
- [ ] Review if backport is needed.

#### UI

- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video — tooltip copy change only; no layout change.
- [ ] Changelog fragment — not applicable (`no-changelog`, Lighthouse is cloud-gated; same as #12220).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lighthouse context support for Roles, Users, Invitations, and Integrations pages.
  * Added page-specific suggestions and support for relevant filters, sorting, and search parameters.
  * Improved route labeling for clearer navigation context.
  * Context tooltips now clarify when only a filterless page is shared.

* **Bug Fixes**
  * Improved preservation and resolution of page filters, sorting, and search context.
  * Empty filters no longer appear in tooltips or affect page-only context detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->