### PR TITLE
refactor(ui): type overview action results as ApiResult

### DIFF
--- a/ui/actions/overview/attack-surface/attack-surface.adapter.ts
+++ b/ui/actions/overview/attack-surface/attack-surface.adapter.ts
@@ -1,3 +1,5 @@
+import type { ApiResult } from "@/types/server-actions";
+
 import { AttackSurfaceOverview, AttackSurfaceOverviewResponse } from "./types";
 
 const ATTACK_SURFACE_IDS = {
@@ -49,7 +51,7 @@ function mapAttackSurfaceItem(item: AttackSurfaceOverview): AttackSurfaceItem {
  * @returns An array of AttackSurfaceItem objects sorted by the predefined order
  */
 export function adaptAttackSurfaceOverview(
-  response: AttackSurfaceOverviewResponse | undefined,
+  response: ApiResult<AttackSurfaceOverviewResponse> | undefined,
 ): AttackSurfaceItem[] {
   if (!response?.data || response.data.length === 0) {
     return [];

--- a/ui/actions/overview/attack-surface/attack-surface.ts
+++ b/ui/actions/overview/attack-surface/attack-surface.ts
@@ -3,6 +3,7 @@
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
+import type { ApiResult } from "@/types/server-actions";
 
 import { AttackSurfaceOverviewResponse } from "./types";
 
@@ -10,7 +11,7 @@ export const getAttackSurfaceOverview = async ({
   filters = {},
 }: {
   filters?: Record<string, string | string[] | undefined>;
-} = {}): Promise<AttackSurfaceOverviewResponse | undefined> => {
+} = {}): Promise<ApiResult<AttackSurfaceOverviewResponse> | undefined> => {
   const headers = await getAuthHeaders({ contentType: false });
 
   const url = new URL(`${apiBaseUrl}/overviews/attack-surfaces`);

--- a/ui/actions/overview/compliance-watchlist/compliance-watchlist.adapter.ts
+++ b/ui/actions/overview/compliance-watchlist/compliance-watchlist.adapter.ts
@@ -1,5 +1,6 @@
 import { getComplianceIcon } from "@/components/icons/compliance/IconCompliance";
 import { formatLabel } from "@/lib/categories";
+import type { ApiResult } from "@/types/server-actions";
 
 import { ComplianceWatchlistResponse } from "./compliance-watchlist.types";
 
@@ -36,7 +37,7 @@ function formatComplianceLabel(complianceId: string): string {
 }
 
 export function adaptComplianceWatchlistResponse(
-  response: ComplianceWatchlistResponse | undefined,
+  response: ApiResult<ComplianceWatchlistResponse> | undefined,
 ): EnrichedComplianceWatchlistItem[] {
   if (!response?.data) {
     return [];

--- a/ui/actions/overview/compliance-watchlist/compliance-watchlist.ts
+++ b/ui/actions/overview/compliance-watchlist/compliance-watchlist.ts
@@ -3,6 +3,7 @@
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
+import type { ApiResult } from "@/types/server-actions";
 
 import { ComplianceWatchlistResponse } from "./compliance-watchlist.types";
 
@@ -10,7 +11,7 @@ export const getComplianceWatchlist = async ({
   filters = {},
 }: {
   filters?: Record<string, string | string[] | undefined>;
-} = {}): Promise<ComplianceWatchlistResponse | undefined> => {
+} = {}): Promise<ApiResult<ComplianceWatchlistResponse> | undefined> => {
   const headers = await getAuthHeaders({ contentType: false });
   const url = new URL(`${apiBaseUrl}/overviews/compliance-watchlist`);
 

--- a/ui/actions/overview/findings/findings.ts
+++ b/ui/actions/overview/findings/findings.ts
@@ -5,8 +5,12 @@ import { redirect } from "next/navigation";
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
+import type { ApiResult } from "@/types/server-actions";
 
-import { FindingsSeverityOverviewResponse } from "./types";
+import {
+  FindingsSeverityOverviewResponse,
+  FindingsStatusOverviewResponse,
+} from "./types";
 
 export const getFindingsByStatus = async ({
   page = 1,
@@ -18,7 +22,7 @@ export const getFindingsByStatus = async ({
   query?: string;
   sort?: string;
   filters?: Record<string, string | string[] | undefined>;
-} = {}) => {
+} = {}): Promise<ApiResult<FindingsStatusOverviewResponse> | undefined> => {
   const headers = await getAuthHeaders({ contentType: false });
 
   if (isNaN(Number(page)) || page < 1) redirect("/");
@@ -49,7 +53,7 @@ export const getFindingsBySeverity = async ({
   filters = {},
 }: {
   filters?: Record<string, string | string[] | undefined>;
-} = {}): Promise<FindingsSeverityOverviewResponse | undefined> => {
+} = {}): Promise<ApiResult<FindingsSeverityOverviewResponse> | undefined> => {
   const headers = await getAuthHeaders({ contentType: false });
 
   const url = new URL(`${apiBaseUrl}/overviews/findings_severity`);

--- a/ui/actions/overview/findings/types/findings.types.ts
+++ b/ui/actions/overview/findings/types/findings.types.ts
@@ -5,6 +5,34 @@ interface OverviewResponseMeta {
   version: string;
 }
 
+// Corresponds to the /overviews/findings endpoint (OverviewFindingSerializer)
+export interface FindingsStatusAttributes {
+  new: number;
+  changed: number;
+  unchanged: number;
+  fail_new: number;
+  fail_changed: number;
+  pass_new: number;
+  pass_changed: number;
+  muted_new: number;
+  muted_changed: number;
+  total: number;
+  pass: number;
+  fail: number;
+  muted: number;
+}
+
+export interface FindingsStatusOverview {
+  type: "findings-overview";
+  id: string;
+  attributes: FindingsStatusAttributes;
+}
+
+export interface FindingsStatusOverviewResponse {
+  data: FindingsStatusOverview;
+  meta: OverviewResponseMeta;
+}
+
 export interface FindingsSeverityAttributes {
   critical: number;
   high: number;

--- a/ui/actions/overview/providers/providers.ts
+++ b/ui/actions/overview/providers/providers.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
+import type { ApiResult } from "@/types/server-actions";
 
 import { ProvidersOverviewResponse } from "./types";
 
@@ -18,7 +19,7 @@ export const getProvidersOverview = async ({
   query?: string;
   sort?: string;
   filters?: Record<string, string | string[] | undefined>;
-} = {}): Promise<ProvidersOverviewResponse | undefined> => {
+} = {}): Promise<ApiResult<ProvidersOverviewResponse> | undefined> => {
   const headers = await getAuthHeaders({ contentType: false });
 
   if (isNaN(Number(page)) || page < 1) redirect("/providers-overview");

--- a/ui/actions/overview/regions/regions.ts
+++ b/ui/actions/overview/regions/regions.ts
@@ -3,6 +3,7 @@
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
+import type { ApiResult } from "@/types/server-actions";
 
 import { RegionsOverviewResponse } from "./types";
 
@@ -10,7 +11,7 @@ export const getRegionsOverview = async ({
   filters = {},
 }: {
   filters?: Record<string, string | string[] | undefined>;
-} = {}): Promise<RegionsOverviewResponse | undefined> => {
+} = {}): Promise<ApiResult<RegionsOverviewResponse> | undefined> => {
   const headers = await getAuthHeaders({ contentType: false });
 
   const url = new URL(`${apiBaseUrl}/overviews/regions`);

--- a/ui/actions/overview/regions/threat-map.adapter.ts
+++ b/ui/actions/overview/regions/threat-map.adapter.ts
@@ -1,4 +1,5 @@
 import { getProviderDisplayName } from "@/types/providers";
+import type { ApiResult } from "@/types/server-actions";
 
 import { RegionsOverviewResponse } from "./types";
 
@@ -366,7 +367,7 @@ function formatRegionName(providerType: string, region: string): string {
  * Adapts regions overview API response to threat map format.
  */
 export function adaptRegionsOverviewToThreatMap(
-  regionsResponse: RegionsOverviewResponse | undefined,
+  regionsResponse: ApiResult<RegionsOverviewResponse> | undefined,
 ): ThreatMapData {
   if (!regionsResponse?.data || regionsResponse.data.length === 0) {
     return {

--- a/ui/actions/overview/resources-inventory/resources-inventory.adapter.ts
+++ b/ui/actions/overview/resources-inventory/resources-inventory.adapter.ts
@@ -19,6 +19,8 @@ import {
   Webhook,
 } from "lucide-react";
 
+import type { ApiResult } from "@/types/server-actions";
+
 import {
   ResourceGroupOverview,
   ResourceGroupOverviewResponse,
@@ -191,7 +193,7 @@ function formatResourceGroupLabel(id: string): string {
  * @returns An array of ResourceInventoryItem objects sorted by the predefined order
  */
 export function adaptResourceGroupOverview(
-  response: ResourceGroupOverviewResponse | undefined,
+  response: ApiResult<ResourceGroupOverviewResponse> | undefined,
 ): ResourceInventoryItem[] {
   if (!response?.data || response.data.length === 0) {
     return [];

--- a/ui/actions/overview/resources-inventory/resources-inventory.ts
+++ b/ui/actions/overview/resources-inventory/resources-inventory.ts
@@ -3,6 +3,7 @@
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
+import type { ApiResult } from "@/types/server-actions";
 
 import { ResourceGroupOverviewResponse } from "./types";
 
@@ -10,7 +11,7 @@ export const getResourceGroupOverview = async ({
   filters = {},
 }: {
   filters?: Record<string, string | string[] | undefined>;
-} = {}): Promise<ResourceGroupOverviewResponse | undefined> => {
+} = {}): Promise<ApiResult<ResourceGroupOverviewResponse> | undefined> => {
   const headers = await getAuthHeaders({ contentType: false });
 
   const url = new URL(`${apiBaseUrl}/overviews/resource-groups`);

--- a/ui/actions/overview/risk-radar/risk-radar.adapter.ts
+++ b/ui/actions/overview/risk-radar/risk-radar.adapter.ts
@@ -1,5 +1,6 @@
 import type { RadarDataPoint } from "@/components/graphs/types";
 import { getCategoryLabel } from "@/lib/categories";
+import type { ApiResult } from "@/types/server-actions";
 
 import { CategoryOverview, CategoryOverviewResponse } from "./types";
 
@@ -44,7 +45,7 @@ function mapCategoryToRadarPoint(item: CategoryOverview): RadarDataPoint {
  * @returns An array of RadarDataPoint objects for the radar chart
  */
 export function adaptCategoryOverviewToRadarData(
-  response: CategoryOverviewResponse | undefined,
+  response: ApiResult<CategoryOverviewResponse> | undefined,
 ): RadarDataPoint[] {
   if (!response?.data || response.data.length === 0) {
     return [];

--- a/ui/actions/overview/risk-radar/risk-radar.ts
+++ b/ui/actions/overview/risk-radar/risk-radar.ts
@@ -3,6 +3,7 @@
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
+import type { ApiResult } from "@/types/server-actions";
 
 import { CategoryOverviewResponse } from "./types";
 
@@ -10,7 +11,7 @@ export const getCategoryOverview = async ({
   filters = {},
 }: {
   filters?: Record<string, string | string[] | undefined>;
-} = {}): Promise<CategoryOverviewResponse | undefined> => {
+} = {}): Promise<ApiResult<CategoryOverviewResponse> | undefined> => {
   const headers = await getAuthHeaders({ contentType: false });
 
   const url = new URL(`${apiBaseUrl}/overviews/categories`);

--- a/ui/actions/overview/services/services.ts
+++ b/ui/actions/overview/services/services.ts
@@ -3,6 +3,7 @@
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
+import type { ApiResult } from "@/types/server-actions";
 
 import { ServicesOverviewResponse } from "./types";
 
@@ -10,7 +11,7 @@ export const getServicesOverview = async ({
   filters = {},
 }: {
   filters?: Record<string, string | string[] | undefined>;
-} = {}): Promise<ServicesOverviewResponse | undefined> => {
+} = {}): Promise<ApiResult<ServicesOverviewResponse> | undefined> => {
   const headers = await getAuthHeaders({ contentType: false });
 
   const url = new URL(`${apiBaseUrl}/overviews/services`);

--- a/ui/actions/overview/severity-trends/severity-trends.test.ts
+++ b/ui/actions/overview/severity-trends/severity-trends.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchMock, getAuthHeadersMock, handleApiResponseMock } = vi.hoisted(
+  () => ({
+    fetchMock: vi.fn(),
+    getAuthHeadersMock: vi.fn(),
+    handleApiResponseMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib", () => ({
+  apiBaseUrl: "https://api.example.com/api/v1",
+  getAuthHeaders: getAuthHeadersMock,
+}));
+
+vi.mock("@/lib/server-actions-helper", () => ({
+  handleApiResponse: handleApiResponseMock,
+}));
+
+import { getFindingsSeverityTrends } from "./severity-trends";
+
+describe("getFindingsSeverityTrends", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    getAuthHeadersMock.mockResolvedValue({ Authorization: "Bearer token" });
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+  });
+
+  it("returns an error status on a 4xx response shape", async () => {
+    // handleApiResponse resolves truthy {error, status} objects for 4xx.
+    handleApiResponseMock.mockResolvedValueOnce({
+      error: "Invalid filter",
+      status: 400,
+    });
+
+    const result = await getFindingsSeverityTrends();
+
+    expect(result).toEqual({ status: "error" });
+  });
+
+  it("returns an empty status on a no-content response shape", async () => {
+    // handleApiResponse resolves {success, status} for 204 and empty bodies.
+    handleApiResponseMock.mockResolvedValueOnce({
+      success: true,
+      status: 204,
+    });
+
+    const result = await getFindingsSeverityTrends();
+
+    expect(result).toEqual({ status: "empty" });
+  });
+
+  it("returns an empty status when the trend list has no entries", async () => {
+    handleApiResponseMock.mockResolvedValueOnce({ data: [] });
+
+    const result = await getFindingsSeverityTrends();
+
+    expect(result).toEqual({ status: "empty" });
+  });
+});

--- a/ui/actions/overview/severity-trends/severity-trends.ts
+++ b/ui/actions/overview/severity-trends/severity-trends.ts
@@ -39,7 +39,13 @@ const getFindingsSeverityTrends = async ({
     const apiResponse: ApiResult<FindingsSeverityOverTimeResponse> | undefined =
       await handleApiResponse(response);
 
-    if (!apiResponse?.data || !Array.isArray(apiResponse.data)) {
+    // 4xx resolves a truthy {error, status} shape — surface it as an error
+    // instead of misreporting the trend as empty.
+    if (!apiResponse || "error" in apiResponse) {
+      return { status: "error" };
+    }
+
+    if (!apiResponse.data || !Array.isArray(apiResponse.data)) {
       return { status: "empty" };
     }
 

--- a/ui/actions/overview/severity-trends/severity-trends.ts
+++ b/ui/actions/overview/severity-trends/severity-trends.ts
@@ -7,6 +7,7 @@ import {
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
+import type { ApiResult } from "@/types/server-actions";
 
 import { adaptSeverityTrendsResponse } from "./severity-trends.adapter";
 import {
@@ -35,7 +36,7 @@ const getFindingsSeverityTrends = async ({
       headers,
     });
 
-    const apiResponse: FindingsSeverityOverTimeResponse | undefined =
+    const apiResponse: ApiResult<FindingsSeverityOverTimeResponse> | undefined =
       await handleApiResponse(response);
 
     if (!apiResponse?.data || !Array.isArray(apiResponse.data)) {

--- a/ui/actions/overview/threat-score/threat-score.ts
+++ b/ui/actions/overview/threat-score/threat-score.ts
@@ -3,12 +3,15 @@
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
+import type { ApiResult } from "@/types/server-actions";
+
+import type { ThreatScoreResponse } from "./types";
 
 export const getThreatScore = async ({
   filters = {},
 }: {
   filters?: Record<string, string | string[] | undefined>;
-} = {}) => {
+} = {}): Promise<ApiResult<ThreatScoreResponse> | undefined> => {
   const headers = await getAuthHeaders({ contentType: false });
 
   const url = new URL(`${apiBaseUrl}/overviews/threatscore`);

--- a/ui/app/(prowler)/_overview/check-findings/check-findings.ssr.tsx
+++ b/ui/app/(prowler)/_overview/check-findings/check-findings.ssr.tsx
@@ -11,7 +11,9 @@ export const CheckFindingsSSR = async ({ searchParams }: SSRComponentProps) => {
 
   const findingsByStatus = await getFindingsByStatus({ filters });
 
-  if (!findingsByStatus) {
+  // handleApiResponse resolves truthy on 4xx ({error, status}) and empty
+  // bodies ({success, status}), so only a payload with attributes is data.
+  if (!findingsByStatus?.data?.attributes) {
     return (
       <div className="flex h-[400px] w-full max-w-md items-center justify-center rounded-xl border border-zinc-900 bg-stone-950">
         <p className="text-zinc-400">Failed to load findings data</p>
@@ -19,9 +21,12 @@ export const CheckFindingsSSR = async ({ searchParams }: SSRComponentProps) => {
     );
   }
 
-  const attributes = findingsByStatus?.data?.attributes || {};
-
-  const { fail = 0, pass = 0, fail_new = 0, pass_new = 0 } = attributes;
+  const {
+    fail = 0,
+    pass = 0,
+    fail_new = 0,
+    pass_new = 0,
+  } = findingsByStatus.data.attributes;
 
   return (
     <>

--- a/ui/app/(prowler)/_overview/threat-score/threat-score.ssr.test.tsx
+++ b/ui/app/(prowler)/_overview/threat-score/threat-score.ssr.test.tsx
@@ -54,7 +54,7 @@ describe("ThreatScoreSSR", () => {
           },
         },
       ],
-    });
+    } as unknown as Awaited<ReturnType<typeof getThreatScore>>);
 
     render(await ThreatScoreSSR({ searchParams: {} }));
 
@@ -91,7 +91,7 @@ describe("ThreatScoreSSR", () => {
           },
         },
       ],
-    });
+    } as unknown as Awaited<ReturnType<typeof getThreatScore>>);
 
     render(await ThreatScoreSSR({ searchParams: {} }));
 

--- a/ui/app/(prowler)/compliance/[compliancetitle]/page.tsx
+++ b/ui/app/(prowler)/compliance/[compliancetitle]/page.tsx
@@ -267,7 +267,13 @@ export default async function ComplianceDetail({
       const snapshot = threatScoreResponse.data[0];
       threatScoreData = {
         overallScore: parseFloat(snapshot.attributes.overall_score),
-        sectionScores: snapshot.attributes.section_scores,
+        // The multi-provider aggregation branch serializes section scores as
+        // decimal strings.
+        sectionScores: Object.fromEntries(
+          Object.entries(snapshot.attributes.section_scores).map(
+            ([name, value]) => [name, Number(value)],
+          ),
+        ),
       };
     }
   }

--- a/ui/types/server-actions.ts
+++ b/ui/types/server-actions.ts
@@ -15,3 +15,23 @@ export interface ServerActionFailure {
 export type ServerActionResult<TData> =
   | ServerActionSuccess<TData>
   | ServerActionFailure;
+
+export interface ApiErrorResult extends ServerActionFailure {
+  status: number;
+  data?: never;
+}
+
+export interface ApiNoContentResult {
+  success: true;
+  status: number;
+  data?: never;
+}
+
+// handleApiResponse resolves the raw JSON:API payload on success, but also
+// resolves truthy no-data shapes: {error, status} for 4xx and
+// {success, status} for 204/empty bodies. `data?: never` on those members
+// keeps `result?.data?.attributes` guards compiling and narrowing correctly.
+export type ApiResult<TResponse> =
+  | TResponse
+  | ApiErrorResult
+  | ApiNoContentResult;


### PR DESCRIPTION
### Context

Follow-up to #12220 and companion to #12284. `handleApiResponse` returns `any`, so every declared return type on an overview action was a fiction: `getFindingsBySeverity` claimed `Promise<FindingsSeverityOverviewResponse | undefined>` while actually resolving `{error, status}` on 4xx and `{success, status}` on 204/empty bodies. With `data` non-optional in those declared types, TypeScript positively asserted that error guards were dead code — which is exactly how the fabricated-zeros bug fixed in #12284 got through review.

### Description

- New `ApiResult<T>` in `types/server-actions.ts`: `T | ApiErrorResult | ApiNoContentResult`, with `data?: never` on the two no-data members so existing `result?.data?.attributes` guards keep compiling **and** now narrow correctly.
- Every `actions/overview` action that returns `handleApiResponse` is annotated with `ApiResult<…>` (findings status/severity, threat score, services, risk radar, regions, compliance watchlist, providers, resources inventory, attack surface, severity trends). `getFindingsByStatus` gets its previously missing response type, mirrored from the API's `OverviewFindingSerializer`.
- Adapter signatures widened to accept `ApiResult<…> | undefined`; their existing `response?.data` guards already handle the error shapes.
- Two real issues the stricter types surfaced immediately:
  - `check-findings.ssr.tsx` failed to compile against the truthful type — its guard is replaced with the same `?.data?.attributes` hunk as #12284 (identical content, so the branches merge cleanly in either order).
  - The compliance detail page passed `section_scores` straight into a `Record<string, number>` prop, but the API's multi-provider aggregation branch serializes those values as decimal strings. Now coerced with `Number(...)`, same as the Overview ThreatScore card.

### Steps to review

1. `cd ui && pnpm run typecheck` — the annotations compile with no `as` escape hatches outside test mocks.
2. Check `ApiResult<T>`'s `data?: never` trick against the three shapes `handleApiResponse` can resolve (`lib/server-actions-helper.ts`).
3. `pnpm run test:unit` — 389 files green; no runtime behavior changes outside the two fixes listed above.

### Checklist

- [x] Review if the code is being covered by tests.
- [ ] Review if backport is needed.

#### UI

- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video — not applicable: type-level change plus a numeric coercion.
- [ ] Changelog fragment — not applicable (`no-changelog`; internal typing refactor).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of errors, empty responses, and incomplete findings data to prevent invalid overview displays.
  * Corrected threat score breakdown values so decimal scores display accurately.
  * Standardized response handling across overview sections for more consistent loading and failure states.

* **Reliability**
  * Added clearer support for successful, failed, and no-content API outcomes across overview data.
  * Added coverage for error, empty, and no-content response scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->