### PR TITLE
chore(ui): reclassify deployment mode changelog

### DIFF
--- a/ui/changelog.d/drop-unused-deployment-mode-env.deprecated.md
+++ b/ui/changelog.d/drop-unused-deployment-mode-env.deprecated.md
@@ -1,0 +1,1 @@
+Unused `NEXT_PUBLIC_PROWLER_DEPLOYMENT_MODE` variable and its `getDeploymentMode` helper; Cloud versus self-hosted behavior is decided solely by the runtime `UI_CLOUD_ENABLED` flag

--- a/ui/changelog.d/drop-unused-deployment-mode-env.removed.md
+++ b/ui/changelog.d/drop-unused-deployment-mode-env.removed.md
@@ -1,1 +1,0 @@
-Removed the unused `NEXT_PUBLIC_PROWLER_DEPLOYMENT_MODE` variable and its `getDeploymentMode` helper; no build ever set it and nothing read the result, so Cloud versus self-hosted behavior is decided solely by the runtime `UI_CLOUD_ENABLED` flag


### PR DESCRIPTION
### Context

The Prowler v5.37.0 changelog compilation failed because the deployment-mode cleanup was classified as a removed fragment, which requires a UI major version bump.

Related change: #12131
Failed release workflow: https://github.com/prowler-cloud/prowler/actions/runs/30811788976

### Description

Reclassifies the deployment-mode changelog fragment as deprecated and adjusts its text for that section. This allows the v5.37.0 release workflow to derive the intended UI minor version instead of requiring UI 2.0.0.

### Steps to review

- Confirm the removed fragment no longer exists.
- Confirm the replacement uses the deprecated fragment type.
- Re-run Tools: Compile Changelogs for Prowler 5.37.0 on master after merge.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This is release-blocker maintenance related to an already merged PR.
- [x] I reviewed open pull requests for duplicate work.

</details>

- [x] No runtime code changed.
- [x] Git diff validation and repository commit hooks passed.
- [x] Review if backport is needed — not needed; v5.37.0 has not been cut.
- [x] The existing UI changelog fragment was reclassified.

#### UI

- [x] No UI behavior or visual output changed.
- [x] Screenshots are not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the unused `NEXT_PUBLIC_PROWLER_DEPLOYMENT_MODE` variable and related helper are deprecated.
  * Documented that deployment behavior is determined by the runtime cloud-enabled setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->