### PR TITLE
fix(sdk): renumber Huawei Cloud off E2E Networks' range, and correct the M365 header comment

### DIFF
--- a/prowler/changelog.d/huaweicloud-exception-code-range.changed.md
+++ b/prowler/changelog.d/huaweicloud-exception-code-range.changed.md
@@ -1,0 +1,1 @@
+Huawei Cloud exception codes moved from `19000`-`19007` to `20000`-`20007`, resolving a collision with E2E Networks which reserves `19000`-`19999`

--- a/prowler/providers/huaweicloud/exceptions/exceptions.py
+++ b/prowler/providers/huaweicloud/exceptions/exceptions.py
@@ -1,40 +1,40 @@
 from prowler.exceptions.exceptions import ProwlerException
 
 
-# Exceptions codes from 19000 to 19099 are reserved for Huawei Cloud exceptions
+# Exceptions codes from 20000 to 20999 are reserved for Huawei Cloud exceptions
 class HuaweiCloudBaseException(ProwlerException):
     """Base class for Huawei Cloud errors."""
 
     HUAWEICLOUD_ERROR_CODES = {
-        (19000, "HuaweiCloudCredentialsError"): {
+        (20000, "HuaweiCloudCredentialsError"): {
             "message": "Huawei Cloud credentials not found or invalid",
             "remediation": "Provide valid Huawei Cloud credentials via the HUAWEICLOUD_ACCESS_KEY_ID and HUAWEICLOUD_SECRET_ACCESS_KEY environment variables.",
         },
-        (19001, "HuaweiCloudAuthenticationError"): {
+        (20001, "HuaweiCloudAuthenticationError"): {
             "message": "Huawei Cloud authentication failed",
             "remediation": "Verify the Access Key ID, Secret Access Key and Project/Domain ID, and ensure the credentials have the required IAM read permissions.",
         },
-        (19002, "HuaweiCloudSetUpSessionError"): {
+        (20002, "HuaweiCloudSetUpSessionError"): {
             "message": "Huawei Cloud session setup failed",
             "remediation": "Review the Huawei Cloud SDK initialization parameters and credentials.",
         },
-        (19003, "HuaweiCloudIdentityError"): {
+        (20003, "HuaweiCloudIdentityError"): {
             "message": "Unable to retrieve Huawei Cloud identity or account information",
             "remediation": "Ensure the credentials allow access to the IAM Keystone APIs (list auth domains/projects and show user).",
         },
-        (19004, "HuaweiCloudInvalidRegionError"): {
+        (20004, "HuaweiCloudInvalidRegionError"): {
             "message": "One or more requested Huawei Cloud regions are invalid",
             "remediation": "Pass a valid Huawei Cloud region id to --region. See https://developer.huaweicloud.com/intl/en-us/endpoint for the current list.",
         },
-        (19005, "HuaweiCloudInvalidProviderIdError"): {
+        (20005, "HuaweiCloudInvalidProviderIdError"): {
             "message": "The provided Huawei Cloud account id does not match the authenticated account",
             "remediation": "Ensure the credentials belong to the expected Huawei Cloud account id.",
         },
-        (19006, "HuaweiCloudServiceError"): {
+        (20006, "HuaweiCloudServiceError"): {
             "message": "Huawei Cloud service error",
             "remediation": "Review the requested service and region, and check the Huawei Cloud API documentation for more details.",
         },
-        (19007, "HuaweiCloudAssumeRoleError"): {
+        (20007, "HuaweiCloudAssumeRoleError"): {
             "message": "Failed to assume the Huawei Cloud agency",
             "remediation": "Verify HUAWEICLOUD_AGENCY_NAME and the target account (HUAWEICLOUD_ASSUME_DOMAIN_ID or HUAWEICLOUD_ASSUME_DOMAIN_NAME), and ensure the agency delegates the required permissions to the authenticated account.",
         },
@@ -65,7 +65,7 @@ class HuaweiCloudCredentialsError(HuaweiCloudBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            19000, file=file, original_exception=original_exception, message=message
+            20000, file=file, original_exception=original_exception, message=message
         )
 
 
@@ -74,7 +74,7 @@ class HuaweiCloudAuthenticationError(HuaweiCloudBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            19001, file=file, original_exception=original_exception, message=message
+            20001, file=file, original_exception=original_exception, message=message
         )
 
 
@@ -83,7 +83,7 @@ class HuaweiCloudSetUpSessionError(HuaweiCloudBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            19002, file=file, original_exception=original_exception, message=message
+            20002, file=file, original_exception=original_exception, message=message
         )
 
 
@@ -92,7 +92,7 @@ class HuaweiCloudIdentityError(HuaweiCloudBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            19003, file=file, original_exception=original_exception, message=message
+            20003, file=file, original_exception=original_exception, message=message
         )
 
 
@@ -101,7 +101,7 @@ class HuaweiCloudInvalidRegionError(HuaweiCloudBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            19004, file=file, original_exception=original_exception, message=message
+            20004, file=file, original_exception=original_exception, message=message
         )
 
 
@@ -110,7 +110,7 @@ class HuaweiCloudInvalidProviderIdError(HuaweiCloudBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            19005, file=file, original_exception=original_exception, message=message
+            20005, file=file, original_exception=original_exception, message=message
         )
 
 
@@ -119,7 +119,7 @@ class HuaweiCloudServiceError(HuaweiCloudBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            19006, file=file, original_exception=original_exception, message=message
+            20006, file=file, original_exception=original_exception, message=message
         )
 
 
@@ -128,5 +128,5 @@ class HuaweiCloudAssumeRoleError(HuaweiCloudBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            19007, file=file, original_exception=original_exception, message=message
+            20007, file=file, original_exception=original_exception, message=message
         )

--- a/prowler/providers/m365/exceptions/exceptions.py
+++ b/prowler/providers/m365/exceptions/exceptions.py
@@ -1,7 +1,7 @@
 from prowler.exceptions.exceptions import ProwlerException
 
 
-# Exceptions codes from 5000 to 5999 are reserved for M365 exceptions
+# Exceptions codes from 6000 to 6999 are reserved for M365 exceptions
 class M365BaseException(ProwlerException):
     """Base class for M365 Errors."""
 

--- a/tests/providers/huaweicloud/huaweicloud_provider_test.py
+++ b/tests/providers/huaweicloud/huaweicloud_provider_test.py
@@ -517,7 +517,7 @@ class TestHuaweiCloudExceptions:
         for cls in classes:
             error = cls(file="huaweicloud_provider.py")
             assert isinstance(error, HuaweiCloudBaseException)
-            assert 19000 <= error.code <= 19099
+            assert 20000 <= error.code <= 20999
             assert error.message
             assert error.remediation
             codes.add(error.code)
@@ -526,4 +526,4 @@ class TestHuaweiCloudExceptions:
     def test_custom_message_override(self):
         error = HuaweiCloudServiceError(message="custom service failure")
         assert error.message == "custom service failure"
-        assert error.code == 19006
+        assert error.code == 20006


### PR DESCRIPTION
Fixes #12275

Scoped to the two points requested by @danibarranqueroo in the issue: renumber Huawei Cloud off E2E Networks' range, and correct the M365 header comment. The docs registry, NHN block and Linode range widening discussed in the issue are deliberately left out.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Huawei Cloud exception codes to the `20000–20007` range, preventing conflicts with another provider’s reserved codes.
  * Updated related error handling and validation to reflect the new Huawei Cloud codes.

* **Documentation**
  * Clarified the reserved exception-code ranges for Huawei Cloud and Microsoft 365.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->