### PR TITLE
fix(ci): use bot token for release freeze

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Enable release freeze
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}
       run: |
         gh variable set RELEASE_FREEZE --body true --repo "${GITHUB_REPOSITORY}"
 
@@ -389,3 +389,4 @@ jobs:
       if: always()
       run: |
         rm -f prowler_changelog.md api_changelog.md ui_changelog.md mcp_changelog.md combined_changelog.md
+


### PR DESCRIPTION
### Context

Backports the Prepare Release permission fix from #12295 to the protected `v5.37` release branch. The first v5.37.0 preparation run failed before creating release artifacts because `github.token` could not update the `RELEASE_FREEZE` repository variable.

### Description

Uses `PROWLER_BOT_ACCESS_TOKEN` for the release-freeze variable update and removes the now-unused `actions: write` permission.

### Steps to review

- Confirm this commit matches the merged fix from #12295.
- Confirm the PR targets `v5.37`.
- After merge, rerun Prepare Release for `5.37.0`.

### Checklist

- [x] No runtime product code changed.
- [x] No changelog entry is required.
- [x] This PR only backports the release workflow fix.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.