### PR TITLE
fix(ui): keep page-size selector when table fits one page

### DIFF
--- a/ui/changelog.d/table-page-size-selector.fixed.md
+++ b/ui/changelog.d/table-page-size-selector.fixed.md
@@ -1,0 +1,1 @@
+Rows-per-page selector no longer disappears when the chosen page size collapses a table to a single page

--- a/ui/components/shadcn/table/data-table-pagination.test.tsx
+++ b/ui/components/shadcn/table/data-table-pagination.test.tsx
@@ -1,12 +1,14 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { MetaDataProps } from "@/types";
+
+const mocks = vi.hoisted(() => ({ searchParams: new URLSearchParams() }));
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/providers",
   useRouter: () => ({ push: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => mocks.searchParams,
 }));
 
 vi.mock("@/lib", () => ({
@@ -19,8 +21,17 @@ vi.mock("@/lib", () => ({
 }));
 
 vi.mock("@/components/shadcn/select/select", () => ({
-  Select: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
+  // data-value stands in for the trigger label
+  Select: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => (
+    <div data-testid="page-size-select" data-value={value}>
+      {children}
+    </div>
   ),
   SelectContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -35,7 +46,7 @@ vi.mock("@/components/shadcn/select/select", () => ({
   SelectTrigger: ({ children }: { children: React.ReactNode }) => (
     <button type="button">{children}</button>
   ),
-  SelectValue: () => <span>10</span>,
+  SelectValue: () => null,
 }));
 
 import { DataTablePagination } from "./data-table-pagination";
@@ -51,6 +62,10 @@ const metadata: MetaDataProps = {
 };
 
 describe("DataTablePagination", () => {
+  beforeEach(() => {
+    mocks.searchParams = new URLSearchParams();
+  });
+
   it("keeps navigation arrows visible on hover in light theme", () => {
     render(<DataTablePagination metadata={metadata} />);
 
@@ -84,5 +99,81 @@ describe("DataTablePagination", () => {
 
     // Then - No wrapper remains to add extra DataTable gap
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("keeps the rows-per-page selector when the chosen page size collapses the table to a single page", () => {
+    const collapsedByPageSize: MetaDataProps = {
+      pagination: {
+        page: 1,
+        pages: 1,
+        count: 85,
+        itemsPerPage: [10, 20, 30, 50, 100],
+      },
+      version: "latest",
+    };
+    mocks.searchParams = new URLSearchParams("pageSize=100");
+
+    render(<DataTablePagination metadata={collapsedByPageSize} />);
+
+    expect(screen.getByText("Rows per page")).toBeInTheDocument();
+    expect(screen.getByTestId("page-size-select")).toHaveAttribute(
+      "data-value",
+      "100",
+    );
+    expect(screen.queryByLabelText("Go to next page")).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Page \d+ of \d+$/)).not.toBeInTheDocument();
+  });
+
+  it("keeps the selector when the smallest configured page size would still paginate", () => {
+    const smallestOptionPaginates: MetaDataProps = {
+      pagination: {
+        page: 1,
+        pages: 1,
+        count: 7,
+        itemsPerPage: [5, 10, 25],
+      },
+      version: "latest",
+    };
+
+    render(<DataTablePagination metadata={smallestOptionPaginates} />);
+
+    expect(screen.getByText("Rows per page")).toBeInTheDocument();
+  });
+
+  it("hides the selector when no page size option would split the table", () => {
+    const nothingToPaginate: MetaDataProps = {
+      pagination: {
+        page: 1,
+        pages: 1,
+        count: 7,
+        itemsPerPage: [10, 20, 50],
+      },
+      version: "latest",
+    };
+
+    const { container } = render(
+      <DataTablePagination metadata={nothingToPaginate} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("follows the page size in the URL when it changes under the mounted selector", () => {
+    mocks.searchParams = new URLSearchParams("pageSize=100");
+    const { rerender } = render(<DataTablePagination metadata={metadata} />);
+
+    expect(screen.getByTestId("page-size-select")).toHaveAttribute(
+      "data-value",
+      "100",
+    );
+
+    // URL changes without remounting: back/forward, filter reset
+    mocks.searchParams = new URLSearchParams("pageSize=20");
+    rerender(<DataTablePagination metadata={metadata} />);
+
+    expect(screen.getByTestId("page-size-select")).toHaveAttribute(
+      "data-value",
+      "20",
+    );
   });
 });

--- a/ui/components/shadcn/table/data-table-pagination.tsx
+++ b/ui/components/shadcn/table/data-table-pagination.tsx
@@ -8,7 +8,6 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
 
 import {
   Select,
@@ -65,11 +64,10 @@ export function DataTablePagination({
   const pageParam = paramPrefix ? `${paramPrefix}Page` : "page";
   const pageSizeParam = paramPrefix ? `${paramPrefix}PageSize` : "pageSize";
 
-  const initialPageSize = isControlled
+  // Derived, not stored, so it survives back/forward and filter resets
+  const selectedPageSize = isControlled
     ? String(controlledPageSize ?? 10)
     : (searchParams.get(pageSizeParam) ?? "10");
-
-  const [selectedPageSize, setSelectedPageSize] = useState(initialPageSize);
 
   if (!metadata) return null;
 
@@ -80,7 +78,16 @@ export function DataTablePagination({
     itemsPerPageOptions,
   } = getPaginationInfo(metadata);
 
-  if (totalPages <= 1) return null;
+  // Gated separately: a large page size collapses the table to one page, and the
+  // selector is the only way back to a smaller one.
+  const smallestPageSize = itemsPerPageOptions.length
+    ? Math.min(...itemsPerPageOptions)
+    : 10;
+  const showPageSizeSelector = totalEntries > smallestPageSize;
+  const showPageNavigation = totalPages > 1;
+
+  // No wrapper when empty: it would add a stray gap to DataTable's flex column
+  if (!showPageSizeSelector && !showPageNavigation) return null;
 
   // For controlled mode, use controlled values; for prefixed, read from URL; otherwise use metadata
   const currentPage = isControlled
@@ -130,216 +137,213 @@ export function DataTablePagination({
 
   return (
     <div className="flex w-full items-center justify-end gap-6 py-1.5">
-      {totalEntries > 10 && (
-        <>
-          {/* Rows per page selector */}
-          <div className="flex items-center gap-3">
-            <span className="text-text-neutral-secondary text-xs font-medium whitespace-nowrap">
-              Rows per page
-            </span>
-            <Select
-              value={selectedPageSize}
-              onValueChange={(value) => {
-                setSelectedPageSize(value);
+      {/* Rows per page selector */}
+      {showPageSizeSelector && (
+        <div className="flex items-center gap-3">
+          <span className="text-text-neutral-secondary text-xs font-medium whitespace-nowrap">
+            Rows per page
+          </span>
+          <Select
+            value={selectedPageSize}
+            onValueChange={(value) => {
+              if (isControlled) {
+                onPageSizeChange?.(parseInt(value, 10));
+                onPageChange(1); // Reset to first page
+                return;
+              }
 
-                if (isControlled) {
-                  onPageSizeChange?.(parseInt(value, 10));
-                  onPageChange(1); // Reset to first page
-                  return;
-                }
+              const params = new URLSearchParams(searchParams);
 
-                const params = new URLSearchParams(searchParams);
+              // Preserve all important parameters
+              const scanId = searchParams.get("scanId");
+              const id = searchParams.get("id");
+              const version = searchParams.get("version");
 
-                // Preserve all important parameters
-                const scanId = searchParams.get("scanId");
-                const id = searchParams.get("id");
-                const version = searchParams.get("version");
+              params.set(pageSizeParam, value);
+              params.set(pageParam, "1");
 
-                params.set(pageSizeParam, value);
-                params.set(pageParam, "1");
+              // Ensure that scanId, id and version are preserved
+              if (scanId) params.set("scanId", scanId);
+              if (id) params.set("id", id);
+              if (version) params.set("version", version);
 
-                // Ensure that scanId, id and version are preserved
-                if (scanId) params.set("scanId", scanId);
-                if (id) params.set("id", id);
-                if (version) params.set("version", version);
-
-                // This pushes the URL without reloading the page
-                if (disableScroll) {
-                  const url = `${pathname}?${params.toString()}`;
-                  router.push(url, { scroll: false });
-                } else {
-                  router.push(`${pathname}?${params.toString()}`);
-                }
-              }}
+              // This pushes the URL without reloading the page
+              if (disableScroll) {
+                const url = `${pathname}?${params.toString()}`;
+                router.push(url, { scroll: false });
+              } else {
+                router.push(`${pathname}?${params.toString()}`);
+              }
+            }}
+          >
+            <SelectTrigger
+              iconSize="sm"
+              className="bg-bg-neutral-tertiary border-border-neutral-tertiary !h-auto !w-auto !min-w-0 !gap-1 !rounded-full !px-[19px] !py-[9px] !text-xs !font-medium backdrop-blur-[46px]"
             >
-              <SelectTrigger
-                iconSize="sm"
-                className="bg-bg-neutral-tertiary border-border-neutral-tertiary !h-auto !w-auto !min-w-0 !gap-1 !rounded-full !px-[19px] !py-[9px] !text-xs !font-medium backdrop-blur-[46px]"
-              >
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent side="top">
-                {itemsPerPageOptions.map((pageSize) => (
-                  <SelectItem
-                    key={pageSize}
-                    value={`${pageSize}`}
-                    className="cursor-pointer"
-                  >
-                    {pageSize}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Page info and navigation */}
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent side="top">
+              {itemsPerPageOptions.map((pageSize) => (
+                <SelectItem
+                  key={pageSize}
+                  value={`${pageSize}`}
+                  className="cursor-pointer"
+                >
+                  {pageSize}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+      {/* Page info and navigation */}
+      {showPageNavigation && (
+        <div className="flex items-center gap-3">
+          <span className="text-text-neutral-secondary hidden text-xs font-medium sm:inline">
+            Page {currentPage} of {totalPages}
+          </span>
           <div className="flex items-center gap-3">
-            <span className="text-text-neutral-secondary hidden text-xs font-medium sm:inline">
-              Page {currentPage} of {totalPages}
-            </span>
-            <div className="flex items-center gap-3">
-              {isControlled ? (
-                <>
-                  <button
-                    type="button"
-                    aria-label="Go to first page"
-                    className={cn(
-                      NAV_BUTTON_STYLES.base,
-                      isFirstPage
-                        ? NAV_BUTTON_STYLES.disabled
-                        : NAV_BUTTON_STYLES.enabled,
-                    )}
-                    disabled={isFirstPage}
-                    onClick={() => handlePageChange(1)}
-                  >
-                    <ChevronFirst className="size-6" aria-hidden="true" />
-                  </button>
-                  <button
-                    type="button"
-                    aria-label="Go to previous page"
-                    className={cn(
-                      NAV_BUTTON_STYLES.base,
-                      isFirstPage
-                        ? NAV_BUTTON_STYLES.disabled
-                        : NAV_BUTTON_STYLES.enabled,
-                    )}
-                    disabled={isFirstPage}
-                    onClick={() => handlePageChange(currentPage - 1)}
-                  >
-                    <ChevronLeft className="size-6" aria-hidden="true" />
-                  </button>
-                  <button
-                    type="button"
-                    aria-label="Go to next page"
-                    className={cn(
-                      NAV_BUTTON_STYLES.base,
-                      isLastPage
-                        ? NAV_BUTTON_STYLES.disabled
-                        : NAV_BUTTON_STYLES.enabled,
-                    )}
-                    disabled={isLastPage}
-                    onClick={() => handlePageChange(currentPage + 1)}
-                  >
-                    <ChevronRight className="size-6" aria-hidden="true" />
-                  </button>
-                  <button
-                    type="button"
-                    aria-label="Go to last page"
-                    className={cn(
-                      NAV_BUTTON_STYLES.base,
-                      isLastPage
-                        ? NAV_BUTTON_STYLES.disabled
-                        : NAV_BUTTON_STYLES.enabled,
-                    )}
-                    disabled={isLastPage}
-                    onClick={() => handlePageChange(totalPages)}
-                  >
-                    <ChevronLast className="size-6" aria-hidden="true" />
-                  </button>
-                </>
-              ) : (
-                <>
-                  <Link
-                    aria-label="Go to first page"
-                    className={cn(
-                      NAV_BUTTON_STYLES.base,
-                      isFirstPage
-                        ? NAV_BUTTON_STYLES.disabled
-                        : NAV_BUTTON_STYLES.enabled,
-                    )}
-                    href={
-                      isFirstPage
-                        ? pathname + "?" + searchParams.toString()
-                        : createPageUrl(1)
-                    }
-                    scroll={!disableScroll}
-                    aria-disabled={isFirstPage}
-                    onClick={(e) => isFirstPage && e.preventDefault()}
-                  >
-                    <ChevronFirst className="size-6" aria-hidden="true" />
-                  </Link>
-                  <Link
-                    aria-label="Go to previous page"
-                    className={cn(
-                      NAV_BUTTON_STYLES.base,
-                      isFirstPage
-                        ? NAV_BUTTON_STYLES.disabled
-                        : NAV_BUTTON_STYLES.enabled,
-                    )}
-                    href={
-                      isFirstPage
-                        ? pathname + "?" + searchParams.toString()
-                        : createPageUrl(currentPage - 1)
-                    }
-                    scroll={!disableScroll}
-                    aria-disabled={isFirstPage}
-                    onClick={(e) => isFirstPage && e.preventDefault()}
-                  >
-                    <ChevronLeft className="size-6" aria-hidden="true" />
-                  </Link>
-                  <Link
-                    aria-label="Go to next page"
-                    className={cn(
-                      NAV_BUTTON_STYLES.base,
-                      isLastPage
-                        ? NAV_BUTTON_STYLES.disabled
-                        : NAV_BUTTON_STYLES.enabled,
-                    )}
-                    href={
-                      isLastPage
-                        ? pathname + "?" + searchParams.toString()
-                        : createPageUrl(currentPage + 1)
-                    }
-                    scroll={!disableScroll}
-                    aria-disabled={isLastPage}
-                    onClick={(e) => isLastPage && e.preventDefault()}
-                  >
-                    <ChevronRight className="size-6" aria-hidden="true" />
-                  </Link>
-                  <Link
-                    aria-label="Go to last page"
-                    className={cn(
-                      NAV_BUTTON_STYLES.base,
-                      isLastPage
-                        ? NAV_BUTTON_STYLES.disabled
-                        : NAV_BUTTON_STYLES.enabled,
-                    )}
-                    href={
-                      isLastPage
-                        ? pathname + "?" + searchParams.toString()
-                        : createPageUrl(totalPages)
-                    }
-                    scroll={!disableScroll}
-                    aria-disabled={isLastPage}
-                    onClick={(e) => isLastPage && e.preventDefault()}
-                  >
-                    <ChevronLast className="size-6" aria-hidden="true" />
-                  </Link>
-                </>
-              )}
-            </div>
+            {isControlled ? (
+              <>
+                <button
+                  type="button"
+                  aria-label="Go to first page"
+                  className={cn(
+                    NAV_BUTTON_STYLES.base,
+                    isFirstPage
+                      ? NAV_BUTTON_STYLES.disabled
+                      : NAV_BUTTON_STYLES.enabled,
+                  )}
+                  disabled={isFirstPage}
+                  onClick={() => handlePageChange(1)}
+                >
+                  <ChevronFirst className="size-6" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Go to previous page"
+                  className={cn(
+                    NAV_BUTTON_STYLES.base,
+                    isFirstPage
+                      ? NAV_BUTTON_STYLES.disabled
+                      : NAV_BUTTON_STYLES.enabled,
+                  )}
+                  disabled={isFirstPage}
+                  onClick={() => handlePageChange(currentPage - 1)}
+                >
+                  <ChevronLeft className="size-6" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Go to next page"
+                  className={cn(
+                    NAV_BUTTON_STYLES.base,
+                    isLastPage
+                      ? NAV_BUTTON_STYLES.disabled
+                      : NAV_BUTTON_STYLES.enabled,
+                  )}
+                  disabled={isLastPage}
+                  onClick={() => handlePageChange(currentPage + 1)}
+                >
+                  <ChevronRight className="size-6" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Go to last page"
+                  className={cn(
+                    NAV_BUTTON_STYLES.base,
+                    isLastPage
+                      ? NAV_BUTTON_STYLES.disabled
+                      : NAV_BUTTON_STYLES.enabled,
+                  )}
+                  disabled={isLastPage}
+                  onClick={() => handlePageChange(totalPages)}
+                >
+                  <ChevronLast className="size-6" aria-hidden="true" />
+                </button>
+              </>
+            ) : (
+              <>
+                <Link
+                  aria-label="Go to first page"
+                  className={cn(
+                    NAV_BUTTON_STYLES.base,
+                    isFirstPage
+                      ? NAV_BUTTON_STYLES.disabled
+                      : NAV_BUTTON_STYLES.enabled,
+                  )}
+                  href={
+                    isFirstPage
+                      ? pathname + "?" + searchParams.toString()
+                      : createPageUrl(1)
+                  }
+                  scroll={!disableScroll}
+                  aria-disabled={isFirstPage}
+                  onClick={(e) => isFirstPage && e.preventDefault()}
+                >
+                  <ChevronFirst className="size-6" aria-hidden="true" />
+                </Link>
+                <Link
+                  aria-label="Go to previous page"
+                  className={cn(
+                    NAV_BUTTON_STYLES.base,
+                    isFirstPage
+                      ? NAV_BUTTON_STYLES.disabled
+                      : NAV_BUTTON_STYLES.enabled,
+                  )}
+                  href={
+                    isFirstPage
+                      ? pathname + "?" + searchParams.toString()
+                      : createPageUrl(currentPage - 1)
+                  }
+                  scroll={!disableScroll}
+                  aria-disabled={isFirstPage}
+                  onClick={(e) => isFirstPage && e.preventDefault()}
+                >
+                  <ChevronLeft className="size-6" aria-hidden="true" />
+                </Link>
+                <Link
+                  aria-label="Go to next page"
+                  className={cn(
+                    NAV_BUTTON_STYLES.base,
+                    isLastPage
+                      ? NAV_BUTTON_STYLES.disabled
+                      : NAV_BUTTON_STYLES.enabled,
+                  )}
+                  href={
+                    isLastPage
+                      ? pathname + "?" + searchParams.toString()
+                      : createPageUrl(currentPage + 1)
+                  }
+                  scroll={!disableScroll}
+                  aria-disabled={isLastPage}
+                  onClick={(e) => isLastPage && e.preventDefault()}
+                >
+                  <ChevronRight className="size-6" aria-hidden="true" />
+                </Link>
+                <Link
+                  aria-label="Go to last page"
+                  className={cn(
+                    NAV_BUTTON_STYLES.base,
+                    isLastPage
+                      ? NAV_BUTTON_STYLES.disabled
+                      : NAV_BUTTON_STYLES.enabled,
+                  )}
+                  href={
+                    isLastPage
+                      ? pathname + "?" + searchParams.toString()
+                      : createPageUrl(totalPages)
+                  }
+                  scroll={!disableScroll}
+                  aria-disabled={isLastPage}
+                  onClick={(e) => isLastPage && e.preventDefault()}
+                >
+                  <ChevronLast className="size-6" aria-hidden="true" />
+                </Link>
+              </>
+            )}
           </div>
-        </>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
### Context

Reported on `/providers`: with a page size of 50 or 100 on a tenant holding ~81-100 providers, the table footer is unreachable — no `Page X of Y`, no navigation arrows and, critically, no `Rows per page` selector. Since the selector is the only UI that can lower the page size, the user is trapped at that size and the only way out is editing `?pageSize=` by hand in the URL.

The initial suspicion was a `max-height` clipping the card. There is none: the chain from `<body>` down to the pagination row carries no `max-h-*`, `h-[…]`, `min-h-*` or `overflow-hidden` that could cut it, and `<main>` is a `100dvh` scroller the card grows freely inside.

The cause is `DataTablePagination` unmounting wholesale:

```tsx
if (totalPages <= 1) return null;
```

A large page size collapses the table to a single page, which takes the selector down along with the navigation it was meant to gate. This lives in the shared `DataTable`, so it affects every table in the app — `/providers` is just where the row count lands in the window that triggers it.

### Description

`ui/components/shadcn/table/data-table-pagination.tsx`:

- The selector and the page navigation are now gated separately. The navigation still hides when there is a single page; the selector stays as long as some configured page size would split the table.
- The component returns `null` only when both are hidden, preserving the existing guarantee that no empty wrapper contributes a stray gap to `DataTable`'s flex column.
- The selector threshold now comes from the smallest configured option instead of a hardcoded `10`, so tables offering 5 per page (`actions/attack-paths/scans.adapter.ts`) behave correctly.
- `selectedPageSize` is derived from the URL (or `controlledPageSize`) instead of being seeded once with `useState`. That stale-state bug was masked by the footer disappearing; with the selector now persisting, back/forward or a filter reset would otherwise leave the trigger showing a size the table is no longer using.

No layout, styling or height changes.

### Steps to review

Quickest repro on any list page, no large tenant needed — the trigger is "everything fits on one page, but a smaller option exists":

1. Open a page whose table holds 11-19 entries (e.g. `/providers`, `/scans`, `/findings`).
2. Set `Rows per page` to 20 → one page.
3. **Before:** the whole footer disappears, including the selector, with no way back to 10.
   **After:** the selector stays (showing `20`); only `Page X of Y` and the arrows are gone, which is correct — there is nowhere to navigate.
4. Lower it back to 10 → the navigation returns.
5. Press browser Back → the trigger follows the URL instead of keeping the previous value.

The original report reproduces the same way with 81-100 providers at page size 100.

Unit tests (`components/shadcn/table/data-table-pagination.test.tsx`) cover: selector kept when a large page size collapses the table, navigation hidden in that state, the smallest-option threshold, nothing rendered when no option would paginate, and the URL-follows-through case.

Collateral checked across existing suites: `resources-table-with-selection` (count 17) and `findings-group-table` (count 12) now render the selector where they previously rendered no footer, but both query by accessible name/testid so their assertions are unaffected. Every other fixture sits below the threshold. Both controlled-mode consumers (`scan-list-table.tsx`, `resource-detail-content.tsx`) pass `controlledPageSize` alongside `onPageSizeChange`, so deriving the value is correct for them.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

Internally reported bug, no tracking issue.

- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed. Worth considering: user-facing fix with no API surface change.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) — not needed.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. — N/A, UI-only.

#### SDK/CLI
- Are there new checks included in this PR? **No**

#### UI
- [ ] All issue/task requirements work as expected on the UI — verified by unit tests; **not yet verified in a running browser**.
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient. — no dependency changes.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable. — `ui/changelog.d/table-page-size-selector.fixed.md`

#### API
- [x] All issue/task requirements work as expected on the API — N/A, no API changes.
- [x] Endpoint response output (if applicable) — N/A
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable) — N/A
- [x] Performance test results (if applicable) — N/A
- [x] Any other relevant evidence of the implementation (if applicable) — N/A
- [x] Verify if API specs need to be regenerated. — not needed.
- [x] Check if version updates are required (e.g., specs, uv, etc.). — not needed.
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable. — N/A

#### MCP Server
- [x] All issue/task requirements work as expected on the MCP Server — N/A, no MCP changes.
- [x] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable. — N/A

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The rows-per-page selector remains available when a selected page size reduces the table to a single page.
  - Page-size selection and page navigation now appear independently, allowing users to change page size even when navigation is unnecessary.
  - Pagination controls remain hidden when the table requires neither option.
  - Page-size changes reflected in the URL now update the displayed selection correctly while preserving existing pagination behavior.
  - Pagination state and controls now remain consistent after changing page-size configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->