### PR TITLE
ci(workflows): align container build-push workflows across api, ui, mcp and sdk

### DIFF
--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -42,6 +42,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       short-sha: ${{ steps.set-short-sha.outputs.short-sha }}
+      created: ${{ steps.set-short-sha.outputs.created }}
     permissions:
       contents: read
     steps:
@@ -52,7 +53,9 @@ jobs:
 
       - name: Calculate short SHA
         id: set-short-sha
-        run: echo "short-sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+        run: |
+          echo "short-sha=${GITHUB_SHA::7}" >> "${GITHUB_OUTPUT}"
+          echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
 
   notify-release-started:
     if: github.repository == 'prowler-cloud/prowler' && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
@@ -168,8 +171,8 @@ jobs:
             org.opencontainers.image.vendor=ProwlerPro, Inc.
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.created=${{ github.event_name == 'release' && github.event.release.published_at || github.event.head_commit.timestamp }}
-            ${{ github.event_name == 'release' && format('org.opencontainers.image.version={0}', env.RELEASE_TAG) || '' }}
+            org.opencontainers.image.created=${{ needs.setup.outputs.created }}
+            ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && format('org.opencontainers.image.version={0}', env.RELEASE_TAG) || '' }}
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=${{ github.event_name == 'pull_request' && 'min' || 'max' }},scope=${{ matrix.arch }}
 

--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -162,6 +162,14 @@ jobs:
           platforms: ${{ matrix.platform }}
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ needs.setup.outputs.short-sha }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.title=Prowler API
+            org.opencontainers.image.description=Prowler's API (Django/DRF)
+            org.opencontainers.image.vendor=ProwlerPro, Inc.
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event_name == 'release' && github.event.release.published_at || github.event.head_commit.timestamp }}
+            ${{ github.event_name == 'release' && format('org.opencontainers.image.version={0}', env.RELEASE_TAG) || '' }}
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=${{ github.event_name == 'pull_request' && 'min' || 'max' }},scope=${{ matrix.arch }}
 
@@ -179,12 +187,12 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
-            github.com:443
-            release-assets.githubusercontent.com:443
-            registry-1.docker.io:443
             auth.docker.io:443
+            github.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
+            registry-1.docker.io:443
+            release-assets.githubusercontent.com:443
       - name: Login to DockerHub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:

--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -163,8 +163,8 @@ jobs:
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ needs.setup.outputs.short-sha }}-${{ matrix.arch }}
           labels: |
-            org.opencontainers.image.title=Prowler API
-            org.opencontainers.image.description=Prowler's API (Django/DRF)
+            org.opencontainers.image.title=Prowler Local Server API
+            org.opencontainers.image.description=API for Prowler Local Server (Django/DRF)
             org.opencontainers.image.vendor=ProwlerPro, Inc.
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/mcp-container-build-push.yml
+++ b/.github/workflows/mcp-container-build-push.yml
@@ -41,6 +41,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       short-sha: ${{ steps.set-short-sha.outputs.short-sha }}
+      created: ${{ steps.set-short-sha.outputs.created }}
     permissions:
       contents: read
     steps:
@@ -51,7 +52,9 @@ jobs:
 
       - name: Calculate short SHA
         id: set-short-sha
-        run: echo "short-sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+        run: |
+          echo "short-sha=${GITHUB_SHA::7}" >> "${GITHUB_OUTPUT}"
+          echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
 
   notify-release-started:
     if: github.repository == 'prowler-cloud/prowler' && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
@@ -150,8 +153,8 @@ jobs:
             org.opencontainers.image.vendor=ProwlerPro, Inc.
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.created=${{ github.event_name == 'release' && github.event.release.published_at || github.event.head_commit.timestamp }}
-            ${{ github.event_name == 'release' && format('org.opencontainers.image.version={0}', env.RELEASE_TAG) || '' }}
+            org.opencontainers.image.created=${{ needs.setup.outputs.created }}
+            ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && format('org.opencontainers.image.version={0}', env.RELEASE_TAG) || '' }}
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=${{ github.event_name == 'pull_request' && 'min' || 'max' }},scope=${{ matrix.arch }}
 

--- a/.github/workflows/mcp-container-build-push.yml
+++ b/.github/workflows/mcp-container-build-push.yml
@@ -110,15 +110,15 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
-            github.com:443
-            registry-1.docker.io:443
             auth.docker.io:443
+            files.pythonhosted.org:443
+            ghcr.io:443
+            github.com:443
+            pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
-            ghcr.io:443
-            pkg-containers.githubusercontent.com:443
-            files.pythonhosted.org:443
             pypi.org:443
+            registry-1.docker.io:443
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -169,11 +169,11 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
-            registry-1.docker.io:443
             auth.docker.io:443
+            github.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
-            github.com:443
+            registry-1.docker.io:443
             release-assets.githubusercontent.com:443
 
       - name: Login to DockerHub

--- a/.github/workflows/mcp-container-build-push.yml
+++ b/.github/workflows/mcp-container-build-push.yml
@@ -145,7 +145,7 @@ jobs:
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ needs.setup.outputs.short-sha }}-${{ matrix.arch }}
           labels: |
-            org.opencontainers.image.title=Prowler MCP Server
+            org.opencontainers.image.title=Prowler MCP
             org.opencontainers.image.description=Model Context Protocol server for Prowler
             org.opencontainers.image.vendor=ProwlerPro, Inc.
             org.opencontainers.image.source=https://github.com/${{ github.repository }}

--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -54,6 +54,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       prowler_version: ${{ steps.get-prowler-version.outputs.prowler_version }}
+      created: ${{ steps.get-prowler-version.outputs.created }}
       latest_tag: ${{ steps.get-prowler-version.outputs.latest_tag }}
       stable_tag: ${{ steps.get-prowler-version.outputs.stable_tag }}
     permissions:
@@ -86,6 +87,7 @@ jobs:
           fi
           echo "latest_tag=latest" >> "${GITHUB_OUTPUT}"
           echo "stable_tag=stable" >> "${GITHUB_OUTPUT}"
+          echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
 
   notify-release-started:
     if: github.repository == 'prowler-cloud/prowler' && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
@@ -207,8 +209,8 @@ jobs:
             org.opencontainers.image.vendor=ProwlerPro, Inc.
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.created=${{ github.event_name == 'release' && github.event.release.published_at || github.event.head_commit.timestamp }}
-            ${{ github.event_name == 'release' && format('org.opencontainers.image.version={0}', needs.setup.outputs.prowler_version) || '' }}
+            org.opencontainers.image.created=${{ needs.setup.outputs.created }}
+            org.opencontainers.image.version=${{ needs.setup.outputs.prowler_version }}
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=${{ github.event_name == 'pull_request' && 'min' || 'max' }},scope=${{ matrix.arch }}
 

--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -64,9 +64,9 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            files.pythonhosted.org:443
             github.com:443
             pypi.org:443
-            files.pythonhosted.org:443
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -146,24 +146,24 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            _http._tcp.deb.debian.org:443
+            aka.ms:443
             api.ecr-public.us-east-1.amazonaws.com:443
-            public.ecr.aws:443
-            sts.amazonaws.com:443
-            sts.us-east-1.amazonaws.com:443
-            registry-1.docker.io:443
+            auth.docker.io:443
+            cdn.powershellgallery.com:443
+            debian.map.fastlydns.net:80
+            files.pythonhosted.org:443
+            github.com:443
+            powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
-            auth.docker.io:443
-            debian.map.fastlydns.net:80
-            github.com:443
-            release-assets.githubusercontent.com:443
+            public.ecr.aws:443
             pypi.org:443
-            files.pythonhosted.org:443
+            registry-1.docker.io:443
+            release-assets.githubusercontent.com:443
+            sts.amazonaws.com:443
+            sts.us-east-1.amazonaws.com:443
             www.powershellgallery.com:443
-            aka.ms:443
-            cdn.powershellgallery.com:443
-            _http._tcp.deb.debian.org:443
-            powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net:443
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -201,6 +201,14 @@ jobs:
           platforms: ${{ matrix.platform }}
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ needs.setup.outputs.latest_tag }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.title=Prowler
+            org.opencontainers.image.description=Open Source security tool for cloud security assessments, audits, incident response, continuous monitoring, hardening and forensics readiness
+            org.opencontainers.image.vendor=ProwlerPro, Inc.
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event_name == 'release' && github.event.release.published_at || github.event.head_commit.timestamp }}
+            ${{ github.event_name == 'release' && format('org.opencontainers.image.version={0}', needs.setup.outputs.prowler_version) || '' }}
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=${{ github.event_name == 'pull_request' && 'min' || 'max' }},scope=${{ matrix.arch }}
 
@@ -219,14 +227,14 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
-            registry-1.docker.io:443
+            api.ecr-public.us-east-1.amazonaws.com:443
             auth.docker.io:443
-            public.ecr.aws:443
+            github.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
-            github.com:443
+            public.ecr.aws:443
+            registry-1.docker.io:443
             release-assets.githubusercontent.com:443
-            api.ecr-public.us-east-1.amazonaws.com:443
             sts.amazonaws.com:443
             sts.us-east-1.amazonaws.com:443
 

--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -202,7 +202,7 @@ jobs:
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ needs.setup.outputs.latest_tag }}-${{ matrix.arch }}
           labels: |
-            org.opencontainers.image.title=Prowler
+            org.opencontainers.image.title=Prowler CLI
             org.opencontainers.image.description=Open Source security tool for cloud security assessments, audits, incident response, continuous monitoring, hardening and forensics readiness
             org.opencontainers.image.vendor=ProwlerPro, Inc.
             org.opencontainers.image.source=https://github.com/${{ github.repository }}

--- a/.github/workflows/ui-container-build-push.yml
+++ b/.github/workflows/ui-container-build-push.yml
@@ -148,8 +148,8 @@ jobs:
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ needs.setup.outputs.short-sha }}-${{ matrix.arch }}
           labels: |
-            org.opencontainers.image.title=Prowler UI
-            org.opencontainers.image.description=Prowler's web UI (Next.js)
+            org.opencontainers.image.title=Prowler Local Server UI
+            org.opencontainers.image.description=Web UI for Prowler Local Server (Next.js)
             org.opencontainers.image.vendor=ProwlerPro, Inc.
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/ui-container-build-push.yml
+++ b/.github/workflows/ui-container-build-push.yml
@@ -44,10 +44,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
 
       - name: Calculate short SHA
         id: set-short-sha
@@ -111,15 +111,15 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
-            registry-1.docker.io:443
-            production.cloudflare.docker.com:443
-            production.cloudfront.docker.com:443
             auth.docker.io:443
-            registry.npmjs.org:443
             dl-cdn.alpinelinux.org:443
             fonts.googleapis.com:443
             fonts.gstatic.com:443
             github.com:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            registry-1.docker.io:443
+            registry.npmjs.org:443
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -147,6 +147,14 @@ jobs:
           platforms: ${{ matrix.platform }}
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ needs.setup.outputs.short-sha }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.title=Prowler UI
+            org.opencontainers.image.description=Prowler's web UI (Next.js)
+            org.opencontainers.image.vendor=ProwlerPro, Inc.
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event_name == 'release' && github.event.release.published_at || github.event.head_commit.timestamp }}
+            ${{ github.event_name == 'release' && format('org.opencontainers.image.version={0}', env.RELEASE_TAG) || '' }}
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=${{ github.event_name == 'pull_request' && 'min' || 'max' }},scope=${{ matrix.arch }}
 
@@ -164,12 +172,12 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
-            github.com:443
-            release-assets.githubusercontent.com:443
-            registry-1.docker.io:443
             auth.docker.io:443
+            github.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
+            registry-1.docker.io:443
+            release-assets.githubusercontent.com:443
 
       - name: Login to DockerHub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/ui-container-build-push.yml
+++ b/.github/workflows/ui-container-build-push.yml
@@ -41,6 +41,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       short-sha: ${{ steps.set-short-sha.outputs.short-sha }}
+      created: ${{ steps.set-short-sha.outputs.created }}
     permissions:
       contents: read
     steps:
@@ -51,7 +52,9 @@ jobs:
 
       - name: Calculate short SHA
         id: set-short-sha
-        run: echo "short-sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+        run: |
+          echo "short-sha=${GITHUB_SHA::7}" >> "${GITHUB_OUTPUT}"
+          echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
 
   notify-release-started:
     if: github.repository == 'prowler-cloud/prowler' && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
@@ -153,8 +156,8 @@ jobs:
             org.opencontainers.image.vendor=ProwlerPro, Inc.
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.created=${{ github.event_name == 'release' && github.event.release.published_at || github.event.head_commit.timestamp }}
-            ${{ github.event_name == 'release' && format('org.opencontainers.image.version={0}', env.RELEASE_TAG) || '' }}
+            org.opencontainers.image.created=${{ needs.setup.outputs.created }}
+            ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && format('org.opencontainers.image.version={0}', env.RELEASE_TAG) || '' }}
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=${{ github.event_name == 'pull_request' && 'min' || 'max' }},scope=${{ matrix.arch }}
 


### PR DESCRIPTION
### Context

The four container build-push workflows (api, ui, mcp, sdk) already share the same five-job skeleton — `setup`, `notify-release-started`, `container-build-push`, `create-manifest`, `notify-release-completed` — the same per-arch build plus `imagetools create` manifest and `regctl` cleanup. They had drifted apart on a few small points that had no reason to differ.

### Description

Closes three divergences between the workflows:

1. **Harden Runner policy on UI's `setup` job.** UI ran a step named "Harden the runner (Audit all outbound calls)" with `egress-policy: audit`, while api, mcp and sdk all use `Harden Runner` with `egress-policy: block`. UI now matches. Safe: the job only computes a short SHA, and the other three already run blocked with no allowed endpoints on that job.

2. **OCI image labels.** Only mcp stamped OCI labels (`title`, `description`, `vendor`, `source`, `revision`, `created`, `version`) on its image. api, ui and sdk published to Docker Hub with nothing but the Dockerfile `maintainer` label. The same label block is now applied to all three, using each component's own wording: "Prowler's API (Django/DRF)" (from `api/pyproject.toml`), "Prowler's web UI (Next.js)", and a trimmed form of the SDK's `pyproject.toml` description. sdk's version label reads `needs.setup.outputs.prowler_version` because that workflow has no workflow-level `RELEASE_TAG`.

3. **`allowed-endpoints` ordering.** These lists were in arbitrary order across the four workflows. All are now sorted alphabetically. The sets still differ per component and legitimately so — api needs the Debian/PowerShell mirrors, ui needs npm/alpine/fonts, sdk needs ECR/STS — but a future addition now shows as a single added line instead of a reshuffle.

**Legitimate remaining differences** (flagging so reviewers don't read them as inconsistencies): api's `prowler/**` path trigger and its SDK-pin refresh step; ui's `NEXT_PUBLIC_PROWLER_RELEASE_VERSION` build-arg; the per-component endpoint sets; the label text; and sdk's ECR plus `toniblyx` mirroring path.

**Known follow-up, not addressed here:** mcp's build job allows `ghcr.io` and `pkg-containers.githubusercontent.com` even though the workflow only pushes to Docker Hub. It looks vestigial, but pruning egress could break a container-based action, so it was left alone pending confirmation.

No functional/build behavior changes — this is workflow metadata and ordering only.

### Steps to review

- Diff each workflow pair (api/ui/mcp/sdk) on the `container-build-push` job and confirm the label blocks and endpoint lists are the only intended changes, aside from the UI Harden Runner policy switch.
- Confirm the label wording is accurate per component.
- `zizmor --persona=regular`: no findings.
- `actionlint`: reports the same 40 pre-existing shellcheck SC2086 info-level findings as `origin/master` — none new.

No changelog fragment: `pr-check-changelog.yml` only monitors the `api`, `ui`, `prowler`, `mcp_server` folders, and this diff touches `.github/workflows/` exclusively.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. (not applicable — see above)

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
</content>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container images now include standardized metadata such as title, description, source, version, revision, vendor, and creation time.
  * Release and manually triggered builds can include version metadata.
* **Chores**
  * Improved build and publishing workflows by refining permitted network access and registry handling.
  * Strengthened controls for the UI container build environment by blocking unauthorized outbound connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->