### PR TITLE
fix(ui): stabilize overview responsive layout

### DIFF
--- a/ui/app/(prowler)/_overview/threat-score/_components/threat-score.test.tsx
+++ b/ui/app/(prowler)/_overview/threat-score/_components/threat-score.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ThreatScore } from "./threat-score";
+
+describe("ThreatScore", () => {
+  it("keeps the card full width until the overview row becomes horizontal", () => {
+    render(<ThreatScore score={75} />);
+
+    const card = screen
+      .getByText("Prowler ThreatScore")
+      .closest('[data-slot="card"]');
+
+    expect(card).toHaveClass("xl:max-w-[312px]");
+    expect(card).not.toHaveClass("lg:max-w-[312px]");
+  });
+});

--- a/ui/app/(prowler)/_overview/threat-score/_components/threat-score.tsx
+++ b/ui/app/(prowler)/_overview/threat-score/_components/threat-score.tsx
@@ -115,7 +115,7 @@ export function ThreatScore({
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] w-full flex-col justify-between lg:max-w-[312px]"
+      className="flex min-h-[372px] w-full flex-col justify-between xl:max-w-[312px]"
     >
       <CardHeader>
         <CardTitle>Prowler ThreatScore</CardTitle>

--- a/ui/changelog.d/overview-threatscore-layout.fixed.md
+++ b/ui/changelog.d/overview-threatscore-layout.fixed.md
@@ -1,0 +1,1 @@
+Overview ThreatScore card no longer leaves unused horizontal space at responsive layout boundaries


### PR DESCRIPTION
### Context


https://github.com/user-attachments/assets/b24fe8c0-7502-4341-ab80-941be4eb25b5


The Overview page left a large unused area to the right of the ThreatScore card at the `lg` container boundary. This occurred around viewport widths 1304/1305 and 1558/1559 as the main content crossed the custom container-query thresholds.

### Description

- Keep the ThreatScore card full width while the Overview metrics remain stacked.
- Apply the 312px maximum width only when the metrics row becomes horizontal.
- Add a regression test and UI changelog fragment.

### Steps to review

1. Open the Overview page at widths around 1304/1305 and 1558/1559.
2. Confirm the ThreatScore card uses the available row width before the horizontal layout activates.
3. Confirm the horizontal layout still constrains ThreatScore to 312px when appropriate.
4. Run the focused Overview tests and `pnpm run typecheck` from `ui/`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the community issue tracker or roadmap.
- [ ] It is assigned to me.

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following project conventions.
- [ ] Review if backport is needed.
- [x] Review if `README.md` needs changes — not required.
- [x] Changelog fragment added under `ui/changelog.d/`.

#### UI

- [x] All issue/task requirements work as expected on the UI.
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [x] Screenshots/Video - Desktop (X > 1024px) — verified at the reported boundaries.
- [x] Changelog fragment added under `ui/changelog.d/`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Overview Threat Score card’s responsive layout to prevent unused horizontal space.
  * The card now remains full width at additional screen sizes before switching to its constrained layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->