### PR TITLE
fix(compose): bump DozerDB to 5.26.27.0 (PROWLER-2308)

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -104,7 +104,7 @@ services:
       retries: 3
 
   neo4j:
-    image: graphstack/dozerdb:5.26.3.0@sha256:a77526ea3918fdc46d1fff70c4aea7d71d3874a26ecec059179d6775845b1247
+    image: graphstack/dozerdb:5.26.27.0@sha256:9b54d6b3a98a76c00bd23e8e78d8c82081ff168162aebd47b25c234e092cb0a0
     hostname: "neo4j"
     volumes:
       - ./_data/neo4j:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
       retries: 3
 
   neo4j:
-    image: graphstack/dozerdb:5.26.3.0@sha256:a77526ea3918fdc46d1fff70c4aea7d71d3874a26ecec059179d6775845b1247
+    image: graphstack/dozerdb:5.26.27.0@sha256:9b54d6b3a98a76c00bd23e8e78d8c82081ff168162aebd47b25c234e092cb0a0
     hostname: "neo4j"
     volumes:
       - ./_data/neo4j:/data

--- a/prowler/changelog.d/dozerdb-5-26-27.security.md
+++ b/prowler/changelog.d/dozerdb-5-26-27.security.md
@@ -1,0 +1,1 @@
+Bumped the Compose DozerDB image from 5.26.3.0 to 5.26.27.0, which moves it off Debian 11 and onto Debian 13


### PR DESCRIPTION
Closes the Compose half of PROWLER-2308. The production half is tracked separately — see below.

## Why, and why the headline numbers mislead

`5.26.3.0` runs on **Debian 11.11**, which is out of standard support. `5.26.27.0` runs on **Debian 13.5**.

Scanned side by side with Trivy 0.71.2, the raw counts argue *against* the bump:

| version | Debian | CRITICAL | HIGH |
|---|---|---:|---:|
| 5.26.3.0 | 11.11 | 9 | 90 |
| 5.26.27.0 | 13.5 | 6 | **214** |

**182 of those 214 are `linux-libc-dev`** — the kernel *header* package. It executes nothing, and its CVEs belong to the host kernel, not the container. Excluding it:

| version | CRITICAL | HIGH |
|---|---:|---:|
| 5.26.3.0 | 9 | 90 |
| **5.26.27.0** | **4** | **34** |

So the bump is a substantial improvement, and anyone reading only the totals would reject it.

## Verified, not assumed

A database version bump is exactly the kind of change that builds fine and fails at runtime, so the new image was started and exercised:

- `Neo4j Kernel 5.26.27`, reporting `enterprise` edition — DozerDB's patch is intact
- **APOC 5.26.28** loads (`apoc.version()`)
- **Multi-database works** — this is the whole reason for DozerDB over Neo4j Community, since the API creates one database per tenant
- The **exact statement the API issues** succeeds, parameterised as in `sink/neo4j.py` and `ingest/driver.py`:
  ```
  CREATE DATABASE $database IF NOT EXISTS
  ```
  and is idempotent when repeated
- Wrote a node into a tenant database and read it back

One limitation found: **`CREATE DATABASE ... WAIT` is not supported** in this build. Nothing in the codebase uses it — checked both call sites — but it is worth recording before someone adds it and it fails only in production.

## Production is not covered by this PR

Prowler Cloud does **not** run this image. It installs DozerDB on EC2 via `platform/terraform/stacks/aws/saas/database`, with the versions pinned separately:

```
neo4j_version   = "5.26.3-1"
dozerdb_version = "5.26.3.0"
apoc_version    = "5.26.3"
```

All three workspaces are on those values. Upgrading them is an in-place upgrade of a stateful database on a persistent EBS volume, which needs a maintenance window, a volume snapshot, and a check that the 5.26.3 → 5.26.27 store opens without migration. That is its own change, not something to slip into a Compose tag bump.

Worth noting for that work: this image ships **APOC 5.26.28**, not 5.26.27. Terraform pins `apoc_version` independently, so the version has to be chosen deliberately rather than assumed to follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled DozerDB service to version 5.26.27.0.
  * Updated the service image to use its corresponding pinned digest.

* **Security**
  * Upgraded the DozerDB base operating system from Debian 11 to Debian 13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->