### PR TITLE
fix(ui): align overview metric cards

### DIFF
--- a/ui/app/(prowler)/_overview/risk-severity/_components/risk-severity-chart.skeleton.tsx
+++ b/ui/app/(prowler)/_overview/risk-severity/_components/risk-severity-chart.skeleton.tsx
@@ -4,7 +4,7 @@ export function RiskSeverityChartSkeleton() {
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] min-w-[312px] flex-1 flex-col md:min-w-[380px]"
+      className="flex min-h-[372px] w-full min-w-0 flex-1 flex-col lg:w-auto lg:min-w-[485px]"
     >
       <CardHeader>
         <Skeleton className="h-7 w-[260px] rounded-xl" />

--- a/ui/app/(prowler)/_overview/risk-severity/_components/risk-severity-chart.tsx
+++ b/ui/app/(prowler)/_overview/risk-severity/_components/risk-severity-chart.tsx
@@ -79,7 +79,7 @@ export const RiskSeverityChart = ({
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] w-full flex-1 flex-col min-[485px]:w-auto min-[485px]:min-w-[485px]"
+      className="flex min-h-[372px] w-full min-w-0 flex-1 flex-col lg:w-auto lg:min-w-[485px]"
     >
       <CardHeader>
         <CardTitle>Risk Severity</CardTitle>

--- a/ui/app/(prowler)/_overview/risk-severity/_components/risk-severity-chart.tsx
+++ b/ui/app/(prowler)/_overview/risk-severity/_components/risk-severity-chart.tsx
@@ -79,7 +79,7 @@ export const RiskSeverityChart = ({
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] min-w-[485px] flex-1 flex-col"
+      className="flex min-h-[372px] w-full flex-1 flex-col min-[485px]:w-auto min-[485px]:min-w-[485px]"
     >
       <CardHeader>
         <CardTitle>Risk Severity</CardTitle>

--- a/ui/app/(prowler)/_overview/risk-severity/_components/risk-severity-chart.tsx
+++ b/ui/app/(prowler)/_overview/risk-severity/_components/risk-severity-chart.tsx
@@ -79,7 +79,7 @@ export const RiskSeverityChart = ({
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] min-w-[312px] flex-1 flex-col md:min-w-[380px]"
+      className="flex min-h-[372px] min-w-[485px] flex-1 flex-col"
     >
       <CardHeader>
         <CardTitle>Risk Severity</CardTitle>

--- a/ui/app/(prowler)/_overview/status-chart/_components/status-chart.skeleton.tsx
+++ b/ui/app/(prowler)/_overview/status-chart/_components/status-chart.skeleton.tsx
@@ -4,7 +4,7 @@ export function StatusChartSkeleton() {
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] min-w-[312px] flex-1 flex-col justify-between md:min-w-[380px]"
+      className="flex min-h-[372px] w-full min-w-0 flex-1 flex-col justify-between lg:w-auto lg:min-w-[485px]"
     >
       <CardHeader>
         <Skeleton className="h-7 w-[260px] rounded-xl" />

--- a/ui/app/(prowler)/_overview/status-chart/_components/status-chart.tsx
+++ b/ui/app/(prowler)/_overview/status-chart/_components/status-chart.tsx
@@ -93,7 +93,7 @@ export const StatusChart = ({
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] min-w-[485px] flex-1 flex-col justify-between"
+      className="flex min-h-[372px] w-full flex-1 flex-col justify-between min-[485px]:w-auto min-[485px]:min-w-[485px]"
     >
       <CardHeader>
         <CardTitle>Check Findings</CardTitle>

--- a/ui/app/(prowler)/_overview/status-chart/_components/status-chart.tsx
+++ b/ui/app/(prowler)/_overview/status-chart/_components/status-chart.tsx
@@ -93,7 +93,7 @@ export const StatusChart = ({
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] w-full flex-1 flex-col justify-between min-[485px]:w-auto min-[485px]:min-w-[485px]"
+      className="flex min-h-[372px] w-full min-w-0 flex-1 flex-col justify-between lg:w-auto lg:min-w-[485px]"
     >
       <CardHeader>
         <CardTitle>Check Findings</CardTitle>

--- a/ui/app/(prowler)/_overview/status-chart/_components/status-chart.tsx
+++ b/ui/app/(prowler)/_overview/status-chart/_components/status-chart.tsx
@@ -93,7 +93,7 @@ export const StatusChart = ({
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] min-w-[312px] flex-1 flex-col justify-between md:min-w-[380px]"
+      className="flex min-h-[372px] min-w-[485px] flex-1 flex-col justify-between"
     >
       <CardHeader>
         <CardTitle>Check Findings</CardTitle>

--- a/ui/app/(prowler)/_overview/threat-score/_components/threat-score.skeleton.tsx
+++ b/ui/app/(prowler)/_overview/threat-score/_components/threat-score.skeleton.tsx
@@ -4,7 +4,7 @@ export function ThreatScoreSkeleton() {
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] w-full flex-col justify-between lg:max-w-[312px]"
+      className="flex min-h-[372px] w-full min-w-0 flex-col justify-between lg:max-w-[312px]"
     >
       <CardHeader>
         <Skeleton className="h-7 w-36 rounded-xl" />

--- a/ui/app/(prowler)/_overview/threat-score/_components/threat-score.test.tsx
+++ b/ui/app/(prowler)/_overview/threat-score/_components/threat-score.test.tsx
@@ -11,6 +11,7 @@ describe("ThreatScore", () => {
       .getByText("Prowler ThreatScore")
       .closest('[data-slot="card"]');
 
-    expect(card).toHaveClass("min-[1304px]:max-w-[312px]");
+    expect(card).toHaveClass("min-w-0", "flex-1", "min-[485px]:min-w-[312px]");
+    expect(card).not.toHaveClass("max-w-[312px]");
   });
 });

--- a/ui/app/(prowler)/_overview/threat-score/_components/threat-score.test.tsx
+++ b/ui/app/(prowler)/_overview/threat-score/_components/threat-score.test.tsx
@@ -11,6 +11,6 @@ describe("ThreatScore", () => {
       .getByText("Prowler ThreatScore")
       .closest('[data-slot="card"]');
 
-    expect(card).toHaveClass("lg:max-w-[312px]");
+    expect(card).toHaveClass("min-[1304px]:max-w-[312px]");
   });
 });

--- a/ui/app/(prowler)/_overview/threat-score/_components/threat-score.test.tsx
+++ b/ui/app/(prowler)/_overview/threat-score/_components/threat-score.test.tsx
@@ -2,16 +2,40 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { ThreatScore } from "./threat-score";
+import { ThreatScoreSkeleton } from "./threat-score.skeleton";
 
 describe("ThreatScore", () => {
   it("keeps the card compact when the overview row is horizontal", () => {
+    // Given / When
     render(<ThreatScore score={75} />);
 
     const card = screen
       .getByText("Prowler ThreatScore")
       .closest('[data-slot="card"]');
 
-    expect(card).toHaveClass("min-w-0", "flex-1", "min-[485px]:min-w-[312px]");
-    expect(card).not.toHaveClass("max-w-[312px]");
+    // Then
+    expect(card).toHaveClass("w-full", "min-w-0", "lg:max-w-[312px]");
+    ["max-w-[312px]", "xl:max-w-[312px]", "min-[485px]:min-w-[312px]"].forEach(
+      (className) => expect(card).not.toHaveClass(className),
+    );
+  });
+
+  it("keeps the skeleton width aligned with the loaded card", () => {
+    // Given
+    const { container, rerender } = render(<ThreatScoreSkeleton />);
+    const skeletonCard = container.querySelector('[data-slot="card"]');
+    const skeletonClassName = skeletonCard?.className;
+
+    // When
+    rerender(<ThreatScore score={75} />);
+    const loadedCard = screen
+      .getByText("Prowler ThreatScore")
+      .closest('[data-slot="card"]');
+
+    // Then
+    expect(skeletonClassName).toBeDefined();
+    expect(loadedCard?.className.split(" ").sort()).toEqual(
+      skeletonClassName?.split(" ").sort(),
+    );
   });
 });

--- a/ui/app/(prowler)/_overview/threat-score/_components/threat-score.test.tsx
+++ b/ui/app/(prowler)/_overview/threat-score/_components/threat-score.test.tsx
@@ -4,14 +4,13 @@ import { describe, expect, it } from "vitest";
 import { ThreatScore } from "./threat-score";
 
 describe("ThreatScore", () => {
-  it("keeps the card full width until the overview row becomes horizontal", () => {
+  it("keeps the card compact when the overview row is horizontal", () => {
     render(<ThreatScore score={75} />);
 
     const card = screen
       .getByText("Prowler ThreatScore")
       .closest('[data-slot="card"]');
 
-    expect(card).toHaveClass("xl:max-w-[312px]");
-    expect(card).not.toHaveClass("lg:max-w-[312px]");
+    expect(card).toHaveClass("lg:max-w-[312px]");
   });
 });

--- a/ui/app/(prowler)/_overview/threat-score/_components/threat-score.tsx
+++ b/ui/app/(prowler)/_overview/threat-score/_components/threat-score.tsx
@@ -115,7 +115,7 @@ export function ThreatScore({
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] w-full min-w-0 flex-1 flex-col justify-between min-[485px]:min-w-[312px]"
+      className="flex min-h-[372px] w-full min-w-0 flex-col justify-between lg:max-w-[312px]"
     >
       <CardHeader>
         <CardTitle>Prowler ThreatScore</CardTitle>

--- a/ui/app/(prowler)/_overview/threat-score/_components/threat-score.tsx
+++ b/ui/app/(prowler)/_overview/threat-score/_components/threat-score.tsx
@@ -115,7 +115,7 @@ export function ThreatScore({
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] w-full flex-col justify-between lg:max-w-[312px]"
+      className="flex min-h-[372px] w-full flex-col justify-between min-[1304px]:max-w-[312px]"
     >
       <CardHeader>
         <CardTitle>Prowler ThreatScore</CardTitle>

--- a/ui/app/(prowler)/_overview/threat-score/_components/threat-score.tsx
+++ b/ui/app/(prowler)/_overview/threat-score/_components/threat-score.tsx
@@ -115,7 +115,7 @@ export function ThreatScore({
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] w-full flex-col justify-between min-[1304px]:max-w-[312px]"
+      className="flex min-h-[372px] w-full min-w-0 flex-1 flex-col justify-between min-[485px]:min-w-[312px]"
     >
       <CardHeader>
         <CardTitle>Prowler ThreatScore</CardTitle>

--- a/ui/app/(prowler)/_overview/threat-score/_components/threat-score.tsx
+++ b/ui/app/(prowler)/_overview/threat-score/_components/threat-score.tsx
@@ -115,7 +115,7 @@ export function ThreatScore({
   return (
     <Card
       variant="base"
-      className="flex min-h-[372px] w-full flex-col justify-between xl:max-w-[312px]"
+      className="flex min-h-[372px] w-full flex-col justify-between lg:max-w-[312px]"
     >
       <CardHeader>
         <CardTitle>Prowler ThreatScore</CardTitle>

--- a/ui/app/(prowler)/page.test.tsx
+++ b/ui/app/(prowler)/page.test.tsx
@@ -9,6 +9,16 @@ describe("Overview page", () => {
   const filePath = path.join(currentDir, "page.tsx");
   const source = readFileSync(filePath, "utf8");
 
+  const getBaseCardClasses = (componentSource: string) => {
+    const className = componentSource.match(
+      /<Card\s+variant="base"\s+className="([^"]+)"/,
+    )?.[1];
+
+    expect(className).toBeDefined();
+
+    return className?.split(" ") ?? [];
+  };
+
   it("renders the overview banners before the provider filters", () => {
     // Given
     const firstBannerPosition = source.indexOf("<OverviewBanner");
@@ -26,17 +36,42 @@ describe("Overview page", () => {
     expect(bannersRenderBeforeFilters).toBe(true);
   });
 
-  it("keeps the primary metric row horizontal and wrapping at every width", () => {
-    expect(source).toMatch(
-      /className="flex flex-col gap-6 min-\[485px\]:flex-row min-\[485px\]:flex-wrap min-\[485px\]:items-stretch"/,
+  it("uses the responsive container breakpoint for the primary metric row", () => {
+    // Given
+    const metricRowClassName = source.match(
+      /<div className="([^"]+)">\s*<Suspense fallback={<ThreatScoreSkeleton \/>}>/,
+    )?.[1];
+
+    // When
+    const metricRowClasses = metricRowClassName?.split(" ") ?? [];
+
+    // Then
+    expect(metricRowClassName).toBeDefined();
+    expect(metricRowClasses.sort()).toEqual(
+      [
+        "flex",
+        "flex-col",
+        "gap-6",
+        "lg:flex-row",
+        "lg:flex-wrap",
+        "lg:items-stretch",
+      ].sort(),
     );
   });
 
-  it("keeps findings metric cards at their minimum readable width", () => {
+  it("keeps findings cards fluid below the desktop row breakpoint", () => {
+    // Given
     const statusChartSource = readFileSync(
       path.join(
         currentDir,
         "_overview/status-chart/_components/status-chart.tsx",
+      ),
+      "utf8",
+    );
+    const statusChartSkeletonSource = readFileSync(
+      path.join(
+        currentDir,
+        "_overview/status-chart/_components/status-chart.skeleton.tsx",
       ),
       "utf8",
     );
@@ -47,10 +82,69 @@ describe("Overview page", () => {
       ),
       "utf8",
     );
+    const riskSeveritySkeletonSource = readFileSync(
+      path.join(
+        currentDir,
+        "_overview/risk-severity/_components/risk-severity-chart.skeleton.tsx",
+      ),
+      "utf8",
+    );
 
-    expect(statusChartSource).toMatch(/min-\[485px\]:min-w-\[485px\]/);
-    expect(riskSeveritySource).toMatch(/min-\[485px\]:min-w-\[485px\]/);
-    expect(statusChartSource).toMatch(/min-\[485px\]:w-auto/);
-    expect(riskSeveritySource).toMatch(/min-\[485px\]:w-auto/);
+    // When
+    const cardClassLists = [
+      getBaseCardClasses(statusChartSource),
+      getBaseCardClasses(statusChartSkeletonSource),
+      getBaseCardClasses(riskSeveritySource),
+      getBaseCardClasses(riskSeveritySkeletonSource),
+    ];
+
+    // Then
+    cardClassLists.forEach((cardClasses) => {
+      expect(cardClasses).toEqual(
+        expect.arrayContaining([
+          "w-full",
+          "min-w-0",
+          "flex-1",
+          "lg:w-auto",
+          "lg:min-w-[485px]",
+        ]),
+      );
+      const widthClasses = cardClasses.filter((className) =>
+        className.includes("w-"),
+      );
+
+      expect(widthClasses.sort()).toEqual(
+        ["w-full", "min-w-0", "lg:w-auto", "lg:min-w-[485px]"].sort(),
+      );
+      expect(
+        cardClasses.some((className) => className.startsWith("min-[")),
+      ).toBe(false);
+    });
+  });
+
+  it("keeps findings skeletons aligned with their loaded cards", () => {
+    // Given
+    const sourcePairs = [
+      [
+        "_overview/status-chart/_components/status-chart.tsx",
+        "_overview/status-chart/_components/status-chart.skeleton.tsx",
+      ],
+      [
+        "_overview/risk-severity/_components/risk-severity-chart.tsx",
+        "_overview/risk-severity/_components/risk-severity-chart.skeleton.tsx",
+      ],
+    ];
+
+    // When / Then
+    sourcePairs.forEach(([componentPath, skeletonPath]) => {
+      const componentClasses = getBaseCardClasses(
+        readFileSync(path.join(currentDir, componentPath), "utf8"),
+      );
+      const skeletonClasses = getBaseCardClasses(
+        readFileSync(path.join(currentDir, skeletonPath), "utf8"),
+      );
+
+      expect(skeletonClasses).toEqual(componentClasses);
+    });
   });
 });

--- a/ui/app/(prowler)/page.test.tsx
+++ b/ui/app/(prowler)/page.test.tsx
@@ -25,4 +25,13 @@ describe("Overview page", () => {
     expect(firstProviderFilterPosition).toBeGreaterThan(-1);
     expect(bannersRenderBeforeFilters).toBe(true);
   });
+
+  it("keeps the primary metric row horizontal at the lg container breakpoint", () => {
+    expect(source).toMatch(
+      /className="flex flex-row flex-wrap items-stretch gap-6"/,
+    );
+    expect(source).not.toMatch(
+      /className="flex flex-col gap-6 xl:flex-row xl:flex-wrap xl:items-stretch"/,
+    );
+  });
 });

--- a/ui/app/(prowler)/page.test.tsx
+++ b/ui/app/(prowler)/page.test.tsx
@@ -26,9 +26,9 @@ describe("Overview page", () => {
     expect(bannersRenderBeforeFilters).toBe(true);
   });
 
-  it("keeps the primary metric row horizontal at the lg container breakpoint", () => {
+  it("keeps the primary metric row horizontal and wrapping at every width", () => {
     expect(source).toMatch(
-      /className="flex flex-col gap-6 min-\[1304px\]:flex-row min-\[1304px\]:flex-wrap min-\[1304px\]:items-stretch"/,
+      /className="flex flex-col gap-6 min-\[485px\]:flex-row min-\[485px\]:flex-wrap min-\[485px\]:items-stretch"/,
     );
   });
 
@@ -48,7 +48,9 @@ describe("Overview page", () => {
       "utf8",
     );
 
-    expect(statusChartSource).toMatch(/min-w-\[485px\]/);
-    expect(riskSeveritySource).toMatch(/min-w-\[485px\]/);
+    expect(statusChartSource).toMatch(/min-\[485px\]:min-w-\[485px\]/);
+    expect(riskSeveritySource).toMatch(/min-\[485px\]:min-w-\[485px\]/);
+    expect(statusChartSource).toMatch(/min-\[485px\]:w-auto/);
+    expect(riskSeveritySource).toMatch(/min-\[485px\]:w-auto/);
   });
 });

--- a/ui/app/(prowler)/page.test.tsx
+++ b/ui/app/(prowler)/page.test.tsx
@@ -28,10 +28,27 @@ describe("Overview page", () => {
 
   it("keeps the primary metric row horizontal at the lg container breakpoint", () => {
     expect(source).toMatch(
-      /className="flex flex-row flex-wrap items-stretch gap-6"/,
+      /className="flex flex-col gap-6 min-\[1304px\]:flex-row min-\[1304px\]:flex-wrap min-\[1304px\]:items-stretch"/,
     );
-    expect(source).not.toMatch(
-      /className="flex flex-col gap-6 xl:flex-row xl:flex-wrap xl:items-stretch"/,
+  });
+
+  it("keeps findings metric cards at their minimum readable width", () => {
+    const statusChartSource = readFileSync(
+      path.join(
+        currentDir,
+        "_overview/status-chart/_components/status-chart.tsx",
+      ),
+      "utf8",
     );
+    const riskSeveritySource = readFileSync(
+      path.join(
+        currentDir,
+        "_overview/risk-severity/_components/risk-severity-chart.tsx",
+      ),
+      "utf8",
+    );
+
+    expect(statusChartSource).toMatch(/min-w-\[485px\]/);
+    expect(riskSeveritySource).toMatch(/min-w-\[485px\]/);
   });
 });

--- a/ui/app/(prowler)/page.tsx
+++ b/ui/app/(prowler)/page.tsx
@@ -90,7 +90,7 @@ export default async function Home({
         <ProviderGroupSelector groups={providerGroupsData?.data ?? []} />
       </div>
 
-      <div className="flex flex-col gap-6 min-[485px]:flex-row min-[485px]:flex-wrap min-[485px]:items-stretch">
+      <div className="flex flex-col gap-6 lg:flex-row lg:flex-wrap lg:items-stretch">
         <Suspense fallback={<ThreatScoreSkeleton />}>
           <ThreatScoreSSR searchParams={resolvedSearchParams} />
         </Suspense>

--- a/ui/app/(prowler)/page.tsx
+++ b/ui/app/(prowler)/page.tsx
@@ -90,7 +90,7 @@ export default async function Home({
         <ProviderGroupSelector groups={providerGroupsData?.data ?? []} />
       </div>
 
-      <div className="flex flex-row flex-wrap items-stretch gap-6">
+      <div className="flex flex-col gap-6 min-[1304px]:flex-row min-[1304px]:flex-wrap min-[1304px]:items-stretch">
         <Suspense fallback={<ThreatScoreSkeleton />}>
           <ThreatScoreSSR searchParams={resolvedSearchParams} />
         </Suspense>

--- a/ui/app/(prowler)/page.tsx
+++ b/ui/app/(prowler)/page.tsx
@@ -90,7 +90,7 @@ export default async function Home({
         <ProviderGroupSelector groups={providerGroupsData?.data ?? []} />
       </div>
 
-      <div className="flex flex-col gap-6 min-[1304px]:flex-row min-[1304px]:flex-wrap min-[1304px]:items-stretch">
+      <div className="flex flex-col gap-6 min-[485px]:flex-row min-[485px]:flex-wrap min-[485px]:items-stretch">
         <Suspense fallback={<ThreatScoreSkeleton />}>
           <ThreatScoreSSR searchParams={resolvedSearchParams} />
         </Suspense>

--- a/ui/app/(prowler)/page.tsx
+++ b/ui/app/(prowler)/page.tsx
@@ -90,7 +90,7 @@ export default async function Home({
         <ProviderGroupSelector groups={providerGroupsData?.data ?? []} />
       </div>
 
-      <div className="flex flex-col gap-6 xl:flex-row xl:flex-wrap xl:items-stretch">
+      <div className="flex flex-row flex-wrap items-stretch gap-6">
         <Suspense fallback={<ThreatScoreSkeleton />}>
           <ThreatScoreSSR searchParams={resolvedSearchParams} />
         </Suspense>

--- a/ui/changelog.d/overview-metric-breakpoint.fixed.md
+++ b/ui/changelog.d/overview-metric-breakpoint.fixed.md
@@ -1,0 +1,1 @@
+Overview metric cards stack below the desktop layout threshold and preserve readable widths when aligned

--- a/ui/changelog.d/overview-metric-row.fixed.md
+++ b/ui/changelog.d/overview-metric-row.fixed.md
@@ -1,0 +1,1 @@
+Overview metric cards now align horizontally at medium desktop widths


### PR DESCRIPTION
### Context

After the previous Overview breakpoint fix, the primary metric row remained vertical at 1512px even though the cards should be side by side. The row only switched to horizontal at the `xl` container threshold.

### Description

- Keep the primary Overview metric row horizontal from the `lg` container breakpoint.
- Restore the compact ThreatScore width for the horizontal row.
- Add regression coverage for the row contract and update the UI changelog.

### Steps to review

1. Open Overview at approximately 1304px and 1512px content widths.
2. Confirm ThreatScore and Check Findings align side by side at 1512px.
3. Confirm the row wraps naturally when the available width is insufficient.
4. Run the focused Overview tests and `pnpm run typecheck` from `ui/`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the community issue tracker or roadmap.
- [ ] It is assigned to me.

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following project conventions.
- [ ] Review if backport is needed.
- [x] Review if `README.md` needs changes — not required.
- [x] Changelog fragment added under `ui/changelog.d/`.

#### UI

- [x] All issue/task requirements work as expected on the UI.
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [x] Screenshots/Video - Desktop (X > 1024px) — validated at the reported width.
- [x] Changelog fragment added under `ui/changelog.d/`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overview dashboard responsiveness by aligning metric cards horizontally at medium desktop widths.
  * Updated metric cards to maintain readable widths when displayed side by side.
  * Improved Threat Score, risk severity, and status chart sizing across desktop breakpoints.
  * Ensured metric cards stack appropriately below the desktop layout breakpoint.
  * Kept loaded cards and their loading placeholders visually consistent.
* **Documentation**
  * Added changelog entries describing the updated overview metric layout and responsive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->