### PR TITLE
fix(api): restore the API version on the release branch

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -71,7 +71,7 @@ name = "prowler-api"
 package-mode = false
 # Needed for the SDK compatibility
 requires-python = ">=3.11,<3.13"
-version = "1.39.0"
+version = "1.38.1"
 
 # Shared ruff baseline (kept in sync with mcp_server/pyproject.toml).
 # target-version tracks this project's lowest supported Python.

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "prowler-api"
-version = "1.39.0"
+version = "1.38.1"
 source = { virtual = "." }
 dependencies = [
     { name = "cartography" },


### PR DESCRIPTION
Unblocks the 5.37.1 release job.

## What broke

```
ERROR: API version mismatch in api/pyproject.toml (expected: '1.38.1', found: '1.39.0')
```

`api/pyproject.toml` on `v5.37` read `1.39.0`, which is master's next-minor version, not this branch's patch version.

## Where it came from

Mine, in the PROWLER-2291 backport (#12311). I brought `api/pyproject.toml` across from master as a whole file to pick up the dependency bumps, and the version line came with it. The release branch went `1.38.1` → `1.39.0` as a side effect.

It also disagreed with `api/CHANGELOG.md` on the same branch, which renders `## [1.38.1] (Prowler v5.37.1)` — so the branch was internally inconsistent, and the release guard is what caught it.

## The fix

Version restored to `1.38.1`, and `api/uv.lock` regenerated because it recorded the same wrong version for `prowler-api`.

**Nothing else changes.** I checked the full diff of that backport commit against this file: the only unintended line was the version. Every dependency bump it carried — `cryptography` 48.0.1, `oci` 2.183.0, `py-ocsf-models` 0.10.0, `pillow`, `pyasn1`, `pyopenssl`, `workos`, `httplib2`, `alibabacloud-tea-openapi`, `darabonba-core` — is intentional and stays.

## Lesson for the next backport

Copying a whole file across branches drags whatever else diverged. Cherry-picking the change, or diffing the file afterwards, would have caught this before it reached the branch.
