### PR TITLE
fix(ci): make the YAML Trivy suppressions actually apply

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -64,8 +64,10 @@ runs:
         scanners: 'vuln'
         timeout: '5m'
         version: 'v0.71.2'
-        # Explicit: Trivy only auto-loads the classic .trivyignore, never the YAML one.
-        trivyignores: '.trivyignore.yaml'
+      # trivyignores: concatenates into a file Trivy parses as the classic format,
+      # which silently drops YAML suppressions. TRIVY_IGNOREFILE keeps the extension.
+      env:
+        TRIVY_IGNOREFILE: '.trivyignore.yaml'
 
     - name: Run Trivy vulnerability scan (SARIF)
       if: inputs.upload-sarif == 'true' && github.event_name == 'push'
@@ -79,8 +81,10 @@ runs:
         scanners: 'vuln'
         timeout: '5m'
         version: 'v0.71.2'
-        # Explicit: Trivy only auto-loads the classic .trivyignore, never the YAML one.
-        trivyignores: '.trivyignore.yaml'
+      # trivyignores: concatenates into a file Trivy parses as the classic format,
+      # which silently drops YAML suppressions. TRIVY_IGNOREFILE keeps the extension.
+      env:
+        TRIVY_IGNOREFILE: '.trivyignore.yaml'
 
     - name: Upload Trivy results to GitHub Security tab
       if: inputs.upload-sarif == 'true' && github.event_name == 'push'

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -64,8 +64,7 @@ runs:
         scanners: 'vuln'
         timeout: '5m'
         version: 'v0.71.2'
-      # trivyignores: concatenates into a file Trivy parses as the classic format,
-      # which silently drops YAML suppressions. TRIVY_IGNOREFILE keeps the extension.
+      # Not trivyignores: that input drops the .yaml extension Trivy parses by.
       env:
         TRIVY_IGNOREFILE: '.trivyignore.yaml'
 
@@ -81,8 +80,7 @@ runs:
         scanners: 'vuln'
         timeout: '5m'
         version: 'v0.71.2'
-      # trivyignores: concatenates into a file Trivy parses as the classic format,
-      # which silently drops YAML suppressions. TRIVY_IGNOREFILE keeps the extension.
+      # Not trivyignores: that input drops the .yaml extension Trivy parses by.
       env:
         TRIVY_IGNOREFILE: '.trivyignore.yaml'
 


### PR DESCRIPTION
Fixes container checks, which have been failing on every PR since PROWLER-2327 merged.

## What broke

PROWLER-2327 moved the suppressions from `.trivyignore` to `.trivyignore.yaml` and told the scan action about it through trivy-action's `trivyignores` input.

That input **concatenates** the listed files into one of its own, and **Trivy selects its parser from the file extension**. The YAML was therefore read as the classic format, where none of the lines look like a CVE id, so every suppression was silently dropped.

Result: `Found 4 critical vulnerabilities` — the four `perl-base` entries that are supposed to be suppressed — on any PR that builds the API or SDK image.

## Why it was not obvious

The action logs

```
Found ignorefile '.trivyignore.yaml':
# Trivy suppressions for the prowler-cloud SDK and API container images.
...
```

and prints the whole file. It looks like it loaded and applied it. The file *is* found; it is simply parsed with the wrong reader.

## Proof

Against `debian:trixie-slim`, which carries the same four `perl-base` CVEs, with identical YAML content in both cases:

| how the file is passed | criticals reported |
|---|---:|
| `--ignorefile` on a file ending `.yaml` | **0** |
| `--ignorefile` on the same content in a file **not** ending `.yaml` | **4** |
| `TRIVY_IGNOREFILE` env var pointing at the `.yaml` | **0** |

## The fix

Replace the `trivyignores` input with the `TRIVY_IGNOREFILE` environment variable on both scan steps. Trivy reads it directly, so the path — and therefore the extension — reaches it intact.

This is mine: I introduced it in #5372 and the check that should have caught it passed, because that PR did not itself rebuild an image carrying suppressed findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to consistently apply the project’s vulnerability ignore rules.
  * Removed outdated scan configuration and comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->