### PR TITLE
feat(ui): support multiple SAML domains in Cloud

### DIFF
--- a/ui/actions/integrations/saml.test.ts
+++ b/ui/actions/integrations/saml.test.ts
@@ -1,12 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fetchMock, getAuthHeadersMock, handleApiResponseMock } = vi.hoisted(
-  () => ({
-    fetchMock: vi.fn(),
-    getAuthHeadersMock: vi.fn(),
-    handleApiResponseMock: vi.fn(),
-  }),
-);
+const {
+  fetchMock,
+  getAuthHeadersMock,
+  handleApiResponseMock,
+  revalidatePathMock,
+} = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  getAuthHeadersMock: vi.fn(),
+  handleApiResponseMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
 
 vi.mock("@/lib/helper", () => ({
   apiBaseUrl: "https://api.example.com/api/v1",
@@ -17,7 +25,7 @@ vi.mock("@/lib/server-actions-helper", () => ({
   handleApiResponse: handleApiResponseMock,
 }));
 
-import { createSamlConfig, updateSamlConfig } from "./saml";
+import { createSamlConfig, deleteSamlConfig, updateSamlConfig } from "./saml";
 
 const buildFormData = ({
   additionalEmailDomains = [],
@@ -178,5 +186,19 @@ describe("SAML configuration actions", () => {
     expect(result).toEqual({
       errors: { additional_email_domains: "Domain is already in use." },
     });
+  });
+
+  it("revalidates the profile after deleting a SAML configuration", async () => {
+    // Given
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    // When
+    const result = await deleteSamlConfig("saml-1");
+
+    // Then
+    expect(result).toEqual({
+      success: "SAML configuration deleted successfully!",
+    });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/profile");
   });
 });

--- a/ui/actions/integrations/saml.test.ts
+++ b/ui/actions/integrations/saml.test.ts
@@ -116,6 +116,25 @@ describe("SAML configuration actions", () => {
     });
   });
 
+  it("rejects updates without a SAML configuration ID", async () => {
+    // Given
+    const formData = buildFormData({
+      additionalEmailDomains: ["alias.example.com"],
+    });
+
+    // When
+    const result = await updateSamlConfig(null, formData);
+
+    // Then
+    expect(result).toEqual({
+      errors: {
+        general: "SAML configuration ID is required for update.",
+      },
+    });
+    expect(getAuthHeadersMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("omits additional domains in OSS while preserving the SAML configuration flow", async () => {
     // Given
     vi.stubEnv("UI_CLOUD_ENABLED", "false");

--- a/ui/actions/integrations/saml.test.ts
+++ b/ui/actions/integrations/saml.test.ts
@@ -22,13 +22,15 @@ import { createSamlConfig, updateSamlConfig } from "./saml";
 const buildFormData = ({
   additionalEmailDomains = [],
   id,
+  metadataXml = " <EntityDescriptor /> ",
 }: {
   additionalEmailDomains?: string[];
   id?: string;
+  metadataXml?: string;
 }) => {
   const formData = new FormData();
   formData.set("email_domain", " Primary.Example.com ");
-  formData.set("metadata_xml", " <EntityDescriptor /> ");
+  formData.set("metadata_xml", metadataXml);
   if (id) formData.set("id", id);
   additionalEmailDomains.forEach((domain) =>
     formData.append("additional_email_domains", domain),
@@ -93,12 +95,34 @@ describe("SAML configuration actions", () => {
     );
   });
 
+  it("updates Cloud aliases without requiring unchanged metadata XML", async () => {
+    // Given
+    const formData = buildFormData({
+      additionalEmailDomains: ["alias.example.com"],
+      id: "saml-1",
+      metadataXml: "",
+    });
+
+    // When
+    const result = await updateSamlConfig(null, formData);
+
+    // Then
+    expect(result).toEqual({
+      success: "SAML configuration updated successfully!",
+    });
+    expect(getRequestBody().data.attributes).toEqual({
+      email_domain: "primary.example.com",
+      additional_email_domains: ["alias.example.com"],
+    });
+  });
+
   it("omits additional domains in OSS while preserving the SAML configuration flow", async () => {
     // Given
     vi.stubEnv("UI_CLOUD_ENABLED", "false");
     const formData = buildFormData({
       additionalEmailDomains: ["alias.example.com"],
       id: "saml-1",
+      metadataXml: "",
     });
 
     // When
@@ -107,7 +131,6 @@ describe("SAML configuration actions", () => {
     // Then
     expect(getRequestBody().data.attributes).toEqual({
       email_domain: "primary.example.com",
-      metadata_xml: "<EntityDescriptor />",
     });
   });
 

--- a/ui/actions/integrations/saml.test.ts
+++ b/ui/actions/integrations/saml.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchMock, getAuthHeadersMock, handleApiResponseMock } = vi.hoisted(
+  () => ({
+    fetchMock: vi.fn(),
+    getAuthHeadersMock: vi.fn(),
+    handleApiResponseMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/helper", () => ({
+  apiBaseUrl: "https://api.example.com/api/v1",
+  getAuthHeaders: getAuthHeadersMock,
+}));
+
+vi.mock("@/lib/server-actions-helper", () => ({
+  handleApiResponse: handleApiResponseMock,
+}));
+
+import { createSamlConfig, updateSamlConfig } from "./saml";
+
+const buildFormData = ({
+  additionalEmailDomains = [],
+  id,
+}: {
+  additionalEmailDomains?: string[];
+  id?: string;
+}) => {
+  const formData = new FormData();
+  formData.set("email_domain", " Primary.Example.com ");
+  formData.set("metadata_xml", " <EntityDescriptor /> ");
+  if (id) formData.set("id", id);
+  additionalEmailDomains.forEach((domain) =>
+    formData.append("additional_email_domains", domain),
+  );
+  return formData;
+};
+
+const getRequestBody = () => {
+  const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+  return JSON.parse(String(request.body));
+};
+
+describe("SAML configuration actions", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    getAuthHeadersMock.mockResolvedValue({ Authorization: "Bearer token" });
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    handleApiResponseMock.mockResolvedValue({
+      data: { id: "saml-1", type: "saml-configurations" },
+    });
+  });
+
+  it("sends every normalized additional domain when Cloud creates a configuration", async () => {
+    // Given
+    const formData = buildFormData({
+      additionalEmailDomains: [
+        " Subsidiary.Example.com ",
+        "Division.Example.com",
+      ],
+    });
+
+    // When
+    await createSamlConfig(null, formData);
+
+    // Then
+    expect(getRequestBody()).toEqual({
+      data: {
+        type: "saml-configurations",
+        attributes: {
+          email_domain: "primary.example.com",
+          additional_email_domains: [
+            "subsidiary.example.com",
+            "division.example.com",
+          ],
+          metadata_xml: "<EntityDescriptor />",
+        },
+      },
+    });
+  });
+
+  it("sends an empty additional-domain list when Cloud removes every alias", async () => {
+    // Given
+    const formData = buildFormData({ id: "saml-1" });
+
+    // When
+    await updateSamlConfig(null, formData);
+
+    // Then
+    expect(getRequestBody().data.attributes.additional_email_domains).toEqual(
+      [],
+    );
+  });
+
+  it("omits additional domains in OSS while preserving the SAML configuration flow", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+    const formData = buildFormData({
+      additionalEmailDomains: ["alias.example.com"],
+      id: "saml-1",
+    });
+
+    // When
+    await updateSamlConfig(null, formData);
+
+    // Then
+    expect(getRequestBody().data.attributes).toEqual({
+      email_domain: "primary.example.com",
+      metadata_xml: "<EntityDescriptor />",
+    });
+  });
+
+  it("maps API validation failures to the additional-domains field", async () => {
+    // Given
+    handleApiResponseMock.mockResolvedValue({
+      error: "Domain is already in use.",
+      errors: [
+        {
+          detail: "Domain is already in use.",
+          source: {
+            pointer: "/data/attributes/additional_email_domains/0",
+          },
+        },
+      ],
+      status: 400,
+    });
+    const formData = buildFormData({
+      additionalEmailDomains: ["alias.example.com"],
+    });
+
+    // When
+    const result = await createSamlConfig(null, formData);
+
+    // Then
+    expect(result).toEqual({
+      errors: { additional_email_domains: "Domain is already in use." },
+    });
+  });
+});

--- a/ui/actions/integrations/saml.ts
+++ b/ui/actions/integrations/saml.ts
@@ -4,12 +4,67 @@ import { revalidatePath } from "next/cache";
 
 import { apiBaseUrl, getAuthHeaders } from "@/lib/helper";
 import { handleApiResponse } from "@/lib/server-actions-helper";
+import { isCloud } from "@/lib/shared/env";
+import type { ApiResponse } from "@/types/components";
 import { samlConfigFormSchema } from "@/types/formSchemas";
+import {
+  SAML_CONFIGURATION_RESOURCE_TYPE,
+  type SamlConfigurationActionState,
+  type SamlConfigurationErrors,
+  type SamlConfigurationRequestAttributes,
+} from "@/types/saml";
 
-export const createSamlConfig = async (_prevState: any, formData: FormData) => {
+const parseSamlFormData = (formData: FormData) =>
+  samlConfigFormSchema.safeParse({
+    email_domain: formData.get("email_domain"),
+    additional_email_domains: formData.getAll("additional_email_domains"),
+    metadata_xml: formData.get("metadata_xml"),
+  });
+
+const mapApiErrorsToFields = (
+  result: ApiResponse,
+  fallback: string,
+): SamlConfigurationErrors => {
+  const errors: SamlConfigurationErrors = {};
+
+  result.errors?.forEach((error) => {
+    const pointer = error.source?.pointer;
+    if (pointer?.includes("additional_email_domains")) {
+      errors.additional_email_domains = error.detail;
+    } else if (pointer?.includes("email_domain")) {
+      errors.email_domain = error.detail;
+    } else if (pointer?.includes("metadata_xml")) {
+      errors.metadata_xml = error.detail;
+    } else {
+      errors.general = error.detail;
+    }
+  });
+
+  if (Object.keys(errors).length === 0) {
+    errors.general = result.error || fallback;
+  }
+
+  return errors;
+};
+
+const buildRequestAttributes = (
+  emailDomain: string,
+  additionalEmailDomains: string[],
+  metadataXml: string,
+): SamlConfigurationRequestAttributes => ({
+  email_domain: emailDomain,
+  metadata_xml: metadataXml,
+  ...(isCloud() && {
+    additional_email_domains: additionalEmailDomains,
+  }),
+});
+
+export const createSamlConfig = async (
+  _prevState: SamlConfigurationActionState,
+  formData: FormData,
+): Promise<SamlConfigurationActionState> => {
   const headers = await getAuthHeaders({ contentType: true });
-  const formDataObject = Object.fromEntries(formData);
-  const validatedData = samlConfigFormSchema.safeParse(formDataObject);
+  const validatedData = parseSamlFormData(formData);
 
   if (!validatedData.success) {
     const formFieldErrors = validatedData.error.flatten().fieldErrors;
@@ -17,12 +72,15 @@ export const createSamlConfig = async (_prevState: any, formData: FormData) => {
     return {
       errors: {
         email_domain: formFieldErrors?.email_domain?.[0],
+        additional_email_domains:
+          formFieldErrors?.additional_email_domains?.[0],
         metadata_xml: formFieldErrors?.metadata_xml?.[0],
       },
     };
   }
 
-  const { email_domain, metadata_xml } = validatedData.data;
+  const { email_domain, additional_email_domains, metadata_xml } =
+    validatedData.data;
 
   try {
     const url = new URL(`${apiBaseUrl}/saml-config`);
@@ -31,24 +89,27 @@ export const createSamlConfig = async (_prevState: any, formData: FormData) => {
       headers,
       body: JSON.stringify({
         data: {
-          type: "saml-configurations",
-          attributes: {
-            email_domain: email_domain.trim(),
-            metadata_xml: metadata_xml.trim(),
-          },
+          type: SAML_CONFIGURATION_RESOURCE_TYPE,
+          attributes: buildRequestAttributes(
+            email_domain,
+            additional_email_domains,
+            metadata_xml,
+          ),
         },
       }),
     });
 
-    const result = await handleApiResponse(response, "/integrations", false);
+    const result = (await handleApiResponse(
+      response,
+      "/profile",
+      false,
+    )) as ApiResponse;
     if (result.error) {
       return {
-        errors: {
-          general:
-            result.error instanceof Error
-              ? result.error.message
-              : "Error creating SAML configuration. Please try again.",
-        },
+        errors: mapApiErrorsToFields(
+          result,
+          "Error creating SAML configuration. Please try again.",
+        ),
       };
     }
 
@@ -66,10 +127,13 @@ export const createSamlConfig = async (_prevState: any, formData: FormData) => {
   }
 };
 
-export const updateSamlConfig = async (_prevState: any, formData: FormData) => {
+export const updateSamlConfig = async (
+  _prevState: SamlConfigurationActionState,
+  formData: FormData,
+): Promise<SamlConfigurationActionState> => {
   const headers = await getAuthHeaders({ contentType: true });
-  const formDataObject = Object.fromEntries(formData);
-  const validatedData = samlConfigFormSchema.safeParse(formDataObject);
+  const id = String(formData.get("id") || "");
+  const validatedData = parseSamlFormData(formData);
 
   if (!validatedData.success) {
     const formFieldErrors = validatedData.error.flatten().fieldErrors;
@@ -77,31 +141,47 @@ export const updateSamlConfig = async (_prevState: any, formData: FormData) => {
     return {
       errors: {
         email_domain: formFieldErrors?.email_domain?.[0],
+        additional_email_domains:
+          formFieldErrors?.additional_email_domains?.[0],
         metadata_xml: formFieldErrors?.metadata_xml?.[0],
       },
     };
   }
 
-  const { email_domain, metadata_xml } = validatedData.data;
+  const { email_domain, additional_email_domains, metadata_xml } =
+    validatedData.data;
 
   try {
-    const url = new URL(`${apiBaseUrl}/saml-config/${formDataObject.id}`);
+    const url = new URL(`${apiBaseUrl}/saml-config/${id}`);
     const response = await fetch(url.toString(), {
       method: "PATCH",
       headers,
       body: JSON.stringify({
         data: {
-          type: "saml-configurations",
-          id: formDataObject.id,
-          attributes: {
-            email_domain: email_domain.trim(),
-            metadata_xml: metadata_xml.trim(),
-          },
+          type: SAML_CONFIGURATION_RESOURCE_TYPE,
+          id,
+          attributes: buildRequestAttributes(
+            email_domain,
+            additional_email_domains,
+            metadata_xml,
+          ),
         },
       }),
     });
 
-    await handleApiResponse(response, "/integrations", false);
+    const result = (await handleApiResponse(
+      response,
+      "/profile",
+      false,
+    )) as ApiResponse;
+    if (result.error) {
+      return {
+        errors: mapApiErrorsToFields(
+          result,
+          "Error updating SAML configuration. Please try again.",
+        ),
+      };
+    }
     return { success: "SAML configuration updated successfully!" };
   } catch (error) {
     console.error("Error updating SAML config:", error);
@@ -110,7 +190,7 @@ export const updateSamlConfig = async (_prevState: any, formData: FormData) => {
         general:
           error instanceof Error
             ? error.message
-            : "Error creating SAML configuration. Please try again.",
+            : "Error updating SAML configuration. Please try again.",
       },
     };
   }

--- a/ui/actions/integrations/saml.ts
+++ b/ui/actions/integrations/saml.ts
@@ -6,20 +6,29 @@ import { apiBaseUrl, getAuthHeaders } from "@/lib/helper";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 import { isCloud } from "@/lib/shared/env";
 import type { ApiResponse } from "@/types/components";
-import { samlConfigFormSchema } from "@/types/formSchemas";
+import {
+  samlConfigFormSchema,
+  samlConfigUpdateFormSchema,
+} from "@/types/formSchemas";
 import {
   SAML_CONFIGURATION_RESOURCE_TYPE,
   type SamlConfigurationActionState,
+  type SamlConfigurationCreateRequestAttributes,
   type SamlConfigurationErrors,
-  type SamlConfigurationRequestAttributes,
+  type SamlConfigurationUpdateRequestAttributes,
 } from "@/types/saml";
 
-const parseSamlFormData = (formData: FormData) =>
-  samlConfigFormSchema.safeParse({
-    email_domain: formData.get("email_domain"),
-    additional_email_domains: formData.getAll("additional_email_domains"),
-    metadata_xml: formData.get("metadata_xml"),
-  });
+const getSamlFormValues = (formData: FormData) => ({
+  email_domain: formData.get("email_domain"),
+  additional_email_domains: formData.getAll("additional_email_domains"),
+  metadata_xml: formData.get("metadata_xml"),
+});
+
+const parseSamlCreateFormData = (formData: FormData) =>
+  samlConfigFormSchema.safeParse(getSamlFormValues(formData));
+
+const parseSamlUpdateFormData = (formData: FormData) =>
+  samlConfigUpdateFormSchema.safeParse(getSamlFormValues(formData));
 
 const mapApiErrorsToFields = (
   result: ApiResponse,
@@ -47,16 +56,32 @@ const mapApiErrorsToFields = (
   return errors;
 };
 
-const buildRequestAttributes = (
+const buildSamlRequestAttributes = (
   emailDomain: string,
   additionalEmailDomains: string[],
-  metadataXml: string,
-): SamlConfigurationRequestAttributes => ({
+): SamlConfigurationUpdateRequestAttributes => ({
   email_domain: emailDomain,
-  metadata_xml: metadataXml,
   ...(isCloud() && {
     additional_email_domains: additionalEmailDomains,
   }),
+});
+
+const buildSamlCreateRequestAttributes = (
+  emailDomain: string,
+  additionalEmailDomains: string[],
+  metadataXml: string,
+): SamlConfigurationCreateRequestAttributes => ({
+  ...buildSamlRequestAttributes(emailDomain, additionalEmailDomains),
+  metadata_xml: metadataXml,
+});
+
+const buildSamlUpdateRequestAttributes = (
+  emailDomain: string,
+  additionalEmailDomains: string[],
+  metadataXml?: string,
+): SamlConfigurationUpdateRequestAttributes => ({
+  ...buildSamlRequestAttributes(emailDomain, additionalEmailDomains),
+  ...(metadataXml !== undefined && { metadata_xml: metadataXml }),
 });
 
 export const createSamlConfig = async (
@@ -64,7 +89,7 @@ export const createSamlConfig = async (
   formData: FormData,
 ): Promise<SamlConfigurationActionState> => {
   const headers = await getAuthHeaders({ contentType: true });
-  const validatedData = parseSamlFormData(formData);
+  const validatedData = parseSamlCreateFormData(formData);
 
   if (!validatedData.success) {
     const formFieldErrors = validatedData.error.flatten().fieldErrors;
@@ -90,7 +115,7 @@ export const createSamlConfig = async (
       body: JSON.stringify({
         data: {
           type: SAML_CONFIGURATION_RESOURCE_TYPE,
-          attributes: buildRequestAttributes(
+          attributes: buildSamlCreateRequestAttributes(
             email_domain,
             additional_email_domains,
             metadata_xml,
@@ -133,7 +158,7 @@ export const updateSamlConfig = async (
 ): Promise<SamlConfigurationActionState> => {
   const headers = await getAuthHeaders({ contentType: true });
   const id = String(formData.get("id") || "");
-  const validatedData = parseSamlFormData(formData);
+  const validatedData = parseSamlUpdateFormData(formData);
 
   if (!validatedData.success) {
     const formFieldErrors = validatedData.error.flatten().fieldErrors;
@@ -160,7 +185,7 @@ export const updateSamlConfig = async (
         data: {
           type: SAML_CONFIGURATION_RESOURCE_TYPE,
           id,
-          attributes: buildRequestAttributes(
+          attributes: buildSamlUpdateRequestAttributes(
             email_domain,
             additional_email_domains,
             metadata_xml,

--- a/ui/actions/integrations/saml.ts
+++ b/ui/actions/integrations/saml.ts
@@ -156,8 +156,16 @@ export const updateSamlConfig = async (
   _prevState: SamlConfigurationActionState,
   formData: FormData,
 ): Promise<SamlConfigurationActionState> => {
-  const headers = await getAuthHeaders({ contentType: true });
   const id = String(formData.get("id") || "");
+  if (!id) {
+    return {
+      errors: {
+        general: "SAML configuration ID is required for update.",
+      },
+    };
+  }
+
+  const headers = await getAuthHeaders({ contentType: true });
   const validatedData = parseSamlUpdateFormData(formData);
 
   if (!validatedData.success) {

--- a/ui/actions/integrations/saml.ts
+++ b/ui/actions/integrations/saml.ts
@@ -264,7 +264,7 @@ export const deleteSamlConfig = async (id: string) => {
       );
     }
 
-    revalidatePath("/integrations");
+    revalidatePath("/profile");
     return { success: "SAML configuration deleted successfully!" };
   } catch (error) {
     console.error("Error deleting SAML config:", error);

--- a/ui/changelog.d/saml-multiple-domains.added.md
+++ b/ui/changelog.d/saml-multiple-domains.added.md
@@ -1,0 +1,1 @@
+Multiple verified email domains in a single SAML configuration for Prowler Cloud

--- a/ui/components/integrations/saml/saml-config-form.test.tsx
+++ b/ui/components/integrations/saml/saml-config-form.test.tsx
@@ -203,6 +203,21 @@ describe("SamlConfigForm", () => {
     ).toHaveLength(0);
   });
 
+  it("shows a contextual error when an additional domain is required", async () => {
+    // Given
+    isCloudMock.mockReturnValue(true);
+    const user = userEvent.setup();
+    render(<SamlConfigForm setIsOpen={vi.fn()} />);
+
+    // When
+    await user.click(screen.getByRole("button", { name: "Add domain" }));
+
+    // Then
+    expect(
+      screen.getByText("Additional email domain is required"),
+    ).toBeVisible();
+  });
+
   it("keeps the maximum alias set inside a compact scroll region", () => {
     // Given
     isCloudMock.mockReturnValue(true);

--- a/ui/components/integrations/saml/saml-config-form.test.tsx
+++ b/ui/components/integrations/saml/saml-config-form.test.tsx
@@ -1,12 +1,23 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderToString } from "react-dom/server";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 import {
   RUNTIME_CONFIG_SCRIPT_ID,
   type RuntimePublicConfig,
 } from "@/lib/runtime-config.shared";
+import { useCloudUpgradeStore } from "@/store";
+import { CLOUD_UPGRADE_FEATURE } from "@/types/cloud-upgrade";
+import { SAML_CONFIGURATION_RESOURCE_TYPE } from "@/types/saml";
 
 import { SamlConfigForm } from "./saml-config-form";
 
@@ -18,6 +29,12 @@ vi.mock("@/actions/integrations", () => ({
 vi.mock("@/components/shadcn", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   useToast: () => ({ toast: vi.fn() }),
+}));
+
+const { isCloudMock } = vi.hoisted(() => ({ isCloudMock: vi.fn() }));
+
+vi.mock("@/lib/shared/env", () => ({
+  isCloud: isCloudMock,
 }));
 
 const runtimeConfig: RuntimePublicConfig = {
@@ -42,6 +59,11 @@ beforeAll(() => {
   runtimeConfigScript.type = "application/json";
   runtimeConfigScript.textContent = JSON.stringify(runtimeConfig);
   document.head.append(runtimeConfigScript);
+});
+
+beforeEach(() => {
+  isCloudMock.mockReturnValue(false);
+  useCloudUpgradeStore.getState().closeCloudUpgrade();
 });
 
 afterAll(() => {
@@ -71,7 +93,10 @@ describe("SamlConfigForm", () => {
     ).not.toBeInTheDocument();
 
     // When
-    await user.type(screen.getByLabelText("Email Domain*"), "example.com");
+    await user.type(
+      screen.getByLabelText("Primary Email Domain*"),
+      "example.com",
+    );
 
     // Then
     const acsUrl = screen.getByText(
@@ -80,5 +105,162 @@ describe("SamlConfigForm", () => {
 
     expect(acsUrl.parentElement).toBe(acsField);
     expect(screen.getByRole("button", { name: "Copy ACS URL" })).toBeVisible();
+  });
+
+  it("keeps single-domain SAML available in OSS and opens the Cloud upgrade for aliases", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<SamlConfigForm setIsOpen={vi.fn()} />);
+
+    // When
+    const cloudUpgradeButton = screen.getByRole("button", {
+      name: "Additional email domains are available in Prowler Cloud",
+    });
+
+    await user.click(cloudUpgradeButton);
+
+    // Then
+    expect(screen.getByLabelText("Primary Email Domain*")).toBeEnabled();
+    expect(
+      screen.queryByLabelText("Additional Email Domain"),
+    ).not.toBeInTheDocument();
+    expect(cloudUpgradeButton).toHaveClass("border-0", "bg-transparent", "p-0");
+    expect(
+      screen.getByText("Additional Email Domains").parentElement,
+    ).toContainElement(cloudUpgradeButton);
+    expect(screen.getByText("Available in Prowler Cloud")).toBeVisible();
+    expect(useCloudUpgradeStore.getState().activeFeature).toBe(
+      CLOUD_UPGRADE_FEATURE.SAML_DOMAINS,
+    );
+  });
+
+  it("loads existing aliases in Cloud and keeps the canonical ACS", () => {
+    // Given
+    isCloudMock.mockReturnValue(true);
+    const samlConfig = {
+      type: SAML_CONFIGURATION_RESOURCE_TYPE,
+      id: "saml-1",
+      attributes: {
+        email_domain: "primary.example.com",
+        additional_email_domains: [
+          "subsidiary.example.com",
+          "division.example.com",
+        ],
+        metadata_xml: "<EntityDescriptor />",
+      },
+    };
+
+    // When
+    render(<SamlConfigForm setIsOpen={vi.fn()} samlConfig={samlConfig} />);
+
+    // Then
+    expect(screen.getByText("subsidiary.example.com")).toBeVisible();
+    expect(screen.getByText("division.example.com")).toBeVisible();
+    expect(
+      screen.getByText(
+        "https://api.example.com/api/v1/accounts/saml/primary.example.com/acs/",
+      ),
+    ).toBeVisible();
+    expect(
+      screen.queryByText(/accounts\/saml\/subsidiary\.example\.com\/acs/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("adds normalized aliases and removes them in Cloud", async () => {
+    // Given
+    isCloudMock.mockReturnValue(true);
+    const user = userEvent.setup();
+    render(<SamlConfigForm setIsOpen={vi.fn()} />);
+
+    // When
+    await user.type(
+      screen.getByLabelText("Additional Email Domain"),
+      " Subsidiary.Example.com ",
+    );
+    await user.click(screen.getByRole("button", { name: "Add domain" }));
+
+    // Then
+    expect(screen.getByText("subsidiary.example.com")).toBeVisible();
+    expect(
+      document.querySelectorAll(
+        'input[name="additional_email_domains"][value="subsidiary.example.com"]',
+      ),
+    ).toHaveLength(1);
+
+    // When
+    await user.click(
+      screen.getByRole("button", {
+        name: "Remove subsidiary.example.com",
+      }),
+    );
+
+    // Then
+    expect(
+      screen.queryByText("subsidiary.example.com"),
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelectorAll('input[name="additional_email_domains"]'),
+    ).toHaveLength(0);
+  });
+
+  it("keeps the maximum alias set inside a compact scroll region", () => {
+    // Given
+    isCloudMock.mockReturnValue(true);
+    const additionalEmailDomains = Array.from(
+      { length: 19 },
+      (_, index) => `alias-${index + 1}.example.com`,
+    );
+    const samlConfig = {
+      type: SAML_CONFIGURATION_RESOURCE_TYPE,
+      id: "saml-1",
+      attributes: {
+        email_domain: "primary.example.com",
+        additional_email_domains: additionalEmailDomains,
+        metadata_xml: "<EntityDescriptor />",
+      },
+    };
+
+    // When
+    render(<SamlConfigForm setIsOpen={vi.fn()} samlConfig={samlConfig} />);
+
+    // Then
+    expect(screen.getByText("19 / 19 domains")).toBeVisible();
+    expect(
+      screen.getByRole("list", { name: "Additional email domains" }),
+    ).toHaveClass("max-h-24", "overflow-y-auto");
+    expect(screen.getByLabelText("Additional Email Domain")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add domain" })).toBeDisabled();
+    expect(
+      screen.getAllByRole("button", { name: /^Remove alias-/ }),
+    ).toHaveLength(19);
+  });
+
+  it("rejects a duplicate alias before submission", async () => {
+    // Given
+    isCloudMock.mockReturnValue(true);
+    const user = userEvent.setup();
+    const samlConfig = {
+      type: SAML_CONFIGURATION_RESOURCE_TYPE,
+      id: "saml-1",
+      attributes: {
+        email_domain: "primary.example.com",
+        additional_email_domains: ["alias.example.com"],
+        metadata_xml: "<EntityDescriptor />",
+      },
+    };
+    render(<SamlConfigForm setIsOpen={vi.fn()} samlConfig={samlConfig} />);
+
+    // When
+    await user.type(
+      screen.getByLabelText("Additional Email Domain"),
+      " ALIAS.EXAMPLE.COM ",
+    );
+    await user.click(screen.getByRole("button", { name: "Add domain" }));
+
+    // Then
+    expect(
+      screen.getByText("This domain has already been added."),
+    ).toBeVisible();
+    expect(screen.getAllByText("alias.example.com")).toHaveLength(1);
   });
 });

--- a/ui/components/integrations/saml/saml-config-form.test.tsx
+++ b/ui/components/integrations/saml/saml-config-form.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderToString } from "react-dom/server";
 import {
@@ -201,15 +201,22 @@ describe("SamlConfigForm", () => {
     const fileInput = document.getElementById(
       "metadata_xml_file",
     ) as HTMLInputElement;
+    const metadataInput = document.getElementById(
+      "metadata_xml",
+    ) as HTMLInputElement;
     const metadataFile = new File(["<EntityDescriptor />"], "metadata.xml", {
       type: "application/xml",
     });
     await user.upload(fileInput, metadataFile);
+    await waitFor(() =>
+      expect(metadataInput).toHaveValue("<EntityDescriptor />"),
+    );
 
     // When
     await user.upload(fileInput, []);
 
     // Then
+    expect(metadataInput).toHaveValue("");
     expect(
       screen.queryByText("Metadata XML is required"),
     ).not.toBeInTheDocument();

--- a/ui/components/integrations/saml/saml-config-form.test.tsx
+++ b/ui/components/integrations/saml/saml-config-form.test.tsx
@@ -185,6 +185,36 @@ describe("SamlConfigForm", () => {
     expect(screen.getByText("Metadata XML File")).not.toHaveTextContent("*");
   });
 
+  it("does not require metadata when an update file selection is cleared", async () => {
+    // Given
+    isCloudMock.mockReturnValue(true);
+    const user = userEvent.setup();
+    const samlConfig = {
+      type: SAML_CONFIGURATION_RESOURCE_TYPE,
+      id: "saml-1",
+      attributes: {
+        email_domain: "primary.example.com",
+        metadata_xml: "<EntityDescriptor />",
+      },
+    };
+    render(<SamlConfigForm setIsOpen={vi.fn()} samlConfig={samlConfig} />);
+    const fileInput = document.getElementById(
+      "metadata_xml_file",
+    ) as HTMLInputElement;
+    const metadataFile = new File(["<EntityDescriptor />"], "metadata.xml", {
+      type: "application/xml",
+    });
+    await user.upload(fileInput, metadataFile);
+
+    // When
+    await user.upload(fileInput, []);
+
+    // Then
+    expect(
+      screen.queryByText("Metadata XML is required"),
+    ).not.toBeInTheDocument();
+  });
+
   it("marks metadata XML as required when creating", () => {
     // Given
     isCloudMock.mockReturnValue(true);

--- a/ui/components/integrations/saml/saml-config-form.test.tsx
+++ b/ui/components/integrations/saml/saml-config-form.test.tsx
@@ -149,6 +149,25 @@ describe("SamlConfigForm", () => {
     expect(screen.getByRole("button", { name: "Copy ACS URL" })).toBeVisible();
   });
 
+  it("normalizes whitespace and mixed case in the ACS URL", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<SamlConfigForm setIsOpen={vi.fn()} />);
+
+    // When
+    await user.type(
+      screen.getByLabelText("Primary Email Domain*"),
+      " Example.COM ",
+    );
+
+    // Then
+    expect(
+      screen.getByText(
+        "https://api.example.com/api/v1/accounts/saml/example.com/acs/",
+      ),
+    ).toBeVisible();
+  });
+
   it("keeps single-domain SAML available in OSS and opens the Cloud upgrade for aliases", async () => {
     // Given
     const user = userEvent.setup();
@@ -295,6 +314,34 @@ describe("SamlConfigForm", () => {
     expect(screen.queryByText("earlier.xml")).not.toBeInTheDocument();
   });
 
+  it("prevents updates while the metadata file is being read", async () => {
+    // Given
+    const readers = capturePendingFileReads();
+    const user = userEvent.setup();
+    const { fileInput } = renderSamlUpdateForm();
+    const updateButton = screen.getByRole("button", { name: "Update" });
+    const metadataFile = new File(
+      ['<EntityDescriptor entityID="replacement" />'],
+      "replacement.xml",
+      { type: "application/xml" },
+    );
+
+    // When
+    await user.upload(fileInput, metadataFile);
+
+    // Then
+    expect(readers).toHaveLength(1);
+    expect(updateButton).toBeDisabled();
+
+    // When
+    act(() => {
+      finishFileRead(readers[0], '<EntityDescriptor entityID="replacement" />');
+    });
+
+    // Then
+    expect(updateButton).toBeEnabled();
+  });
+
   it("marks metadata XML as required when creating", () => {
     // Given
     isCloudMock.mockReturnValue(true);
@@ -341,6 +388,25 @@ describe("SamlConfigForm", () => {
     expect(
       document.querySelectorAll('input[name="additional_email_domains"]'),
     ).toHaveLength(0);
+  });
+
+  it("includes a pending additional domain in the submitted form data", async () => {
+    // Given
+    const user = userEvent.setup();
+    const { fileInput } = renderSamlUpdateForm();
+    const form = fileInput.form;
+    expect(form).not.toBeNull();
+
+    // When
+    await user.type(
+      screen.getByLabelText("Additional Email Domain"),
+      " Pending.Example.com ",
+    );
+
+    // Then
+    expect(new FormData(form!).getAll("additional_email_domains")).toEqual([
+      " Pending.Example.com ",
+    ]);
   });
 
   it("shows a contextual error when an additional domain is required", async () => {

--- a/ui/components/integrations/saml/saml-config-form.test.tsx
+++ b/ui/components/integrations/saml/saml-config-form.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderToString } from "react-dom/server";
 import {
   afterAll,
+  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -53,6 +54,43 @@ const runtimeConfig: RuntimePublicConfig = {
   stripePublishableKeyV2: null,
 };
 
+const capturePendingFileReads = () => {
+  const readers: FileReader[] = [];
+  vi.spyOn(FileReader.prototype, "readAsText").mockImplementation(function (
+    this: FileReader,
+  ) {
+    readers.push(this);
+  });
+  vi.spyOn(FileReader.prototype, "abort").mockImplementation(() => {});
+  return readers;
+};
+
+const finishFileRead = (reader: FileReader, content: string) => {
+  Object.defineProperty(reader, "result", {
+    configurable: true,
+    value: content,
+  });
+  reader.dispatchEvent(new ProgressEvent("load"));
+};
+
+const renderSamlUpdateForm = () => {
+  isCloudMock.mockReturnValue(true);
+  const samlConfig = {
+    type: SAML_CONFIGURATION_RESOURCE_TYPE,
+    id: "saml-1",
+    attributes: {
+      email_domain: "primary.example.com",
+      metadata_xml: "<EntityDescriptor />",
+    },
+  };
+  render(<SamlConfigForm setIsOpen={vi.fn()} samlConfig={samlConfig} />);
+
+  return {
+    fileInput: document.getElementById("metadata_xml_file") as HTMLInputElement,
+    metadataInput: document.getElementById("metadata_xml") as HTMLInputElement,
+  };
+};
+
 beforeAll(() => {
   const runtimeConfigScript = document.createElement("script");
   runtimeConfigScript.id = RUNTIME_CONFIG_SCRIPT_ID;
@@ -64,6 +102,10 @@ beforeAll(() => {
 beforeEach(() => {
   isCloudMock.mockReturnValue(false);
   useCloudUpgradeStore.getState().closeCloudUpgrade();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 afterAll(() => {
@@ -167,19 +209,10 @@ describe("SamlConfigForm", () => {
   });
 
   it("does not mark metadata XML as required when updating", () => {
-    // Given
-    isCloudMock.mockReturnValue(true);
-    const samlConfig = {
-      type: SAML_CONFIGURATION_RESOURCE_TYPE,
-      id: "saml-1",
-      attributes: {
-        email_domain: "primary.example.com",
-        metadata_xml: "<EntityDescriptor />",
-      },
-    };
+    // Given - An existing SAML configuration
 
     // When
-    render(<SamlConfigForm setIsOpen={vi.fn()} samlConfig={samlConfig} />);
+    renderSamlUpdateForm();
 
     // Then
     expect(screen.getByText("Metadata XML File")).not.toHaveTextContent("*");
@@ -187,23 +220,8 @@ describe("SamlConfigForm", () => {
 
   it("does not require metadata when an update file selection is cleared", async () => {
     // Given
-    isCloudMock.mockReturnValue(true);
     const user = userEvent.setup();
-    const samlConfig = {
-      type: SAML_CONFIGURATION_RESOURCE_TYPE,
-      id: "saml-1",
-      attributes: {
-        email_domain: "primary.example.com",
-        metadata_xml: "<EntityDescriptor />",
-      },
-    };
-    render(<SamlConfigForm setIsOpen={vi.fn()} samlConfig={samlConfig} />);
-    const fileInput = document.getElementById(
-      "metadata_xml_file",
-    ) as HTMLInputElement;
-    const metadataInput = document.getElementById(
-      "metadata_xml",
-    ) as HTMLInputElement;
+    const { fileInput, metadataInput } = renderSamlUpdateForm();
     const metadataFile = new File(["<EntityDescriptor />"], "metadata.xml", {
       type: "application/xml",
     });
@@ -220,6 +238,61 @@ describe("SamlConfigForm", () => {
     expect(
       screen.queryByText("Metadata XML is required"),
     ).not.toBeInTheDocument();
+  });
+
+  it("ignores a discarded metadata file when its read finishes", async () => {
+    // Given
+    const readers = capturePendingFileReads();
+    const user = userEvent.setup();
+    const { fileInput, metadataInput } = renderSamlUpdateForm();
+    const discardedFile = new File(
+      ['<EntityDescriptor entityID="discarded" />'],
+      "discarded.xml",
+      { type: "application/xml" },
+    );
+    await user.upload(fileInput, discardedFile);
+    expect(readers).toHaveLength(1);
+
+    // When
+    await user.upload(fileInput, []);
+    act(() => {
+      finishFileRead(readers[0], '<EntityDescriptor entityID="discarded" />');
+    });
+
+    // Then
+    expect(metadataInput).toHaveValue("");
+    expect(screen.queryByText("discarded.xml")).not.toBeInTheDocument();
+  });
+
+  it("keeps the latest metadata file when an earlier read finishes last", async () => {
+    // Given
+    const readers = capturePendingFileReads();
+    const user = userEvent.setup();
+    const { fileInput, metadataInput } = renderSamlUpdateForm();
+    const earlierFile = new File(
+      ['<EntityDescriptor entityID="earlier" />'],
+      "earlier.xml",
+      { type: "application/xml" },
+    );
+    const latestFile = new File(
+      ['<EntityDescriptor entityID="latest" />'],
+      "latest.xml",
+      { type: "application/xml" },
+    );
+    await user.upload(fileInput, earlierFile);
+    await user.upload(fileInput, latestFile);
+    expect(readers).toHaveLength(2);
+
+    // When
+    act(() => {
+      finishFileRead(readers[1], '<EntityDescriptor entityID="latest" />');
+      finishFileRead(readers[0], '<EntityDescriptor entityID="earlier" />');
+    });
+
+    // Then
+    expect(metadataInput).toHaveValue('<EntityDescriptor entityID="latest" />');
+    expect(screen.getByText("latest.xml")).toBeVisible();
+    expect(screen.queryByText("earlier.xml")).not.toBeInTheDocument();
   });
 
   it("marks metadata XML as required when creating", () => {

--- a/ui/components/integrations/saml/saml-config-form.test.tsx
+++ b/ui/components/integrations/saml/saml-config-form.test.tsx
@@ -166,6 +166,36 @@ describe("SamlConfigForm", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("does not mark metadata XML as required when updating", () => {
+    // Given
+    isCloudMock.mockReturnValue(true);
+    const samlConfig = {
+      type: SAML_CONFIGURATION_RESOURCE_TYPE,
+      id: "saml-1",
+      attributes: {
+        email_domain: "primary.example.com",
+        metadata_xml: "<EntityDescriptor />",
+      },
+    };
+
+    // When
+    render(<SamlConfigForm setIsOpen={vi.fn()} samlConfig={samlConfig} />);
+
+    // Then
+    expect(screen.getByText("Metadata XML File")).not.toHaveTextContent("*");
+  });
+
+  it("marks metadata XML as required when creating", () => {
+    // Given
+    isCloudMock.mockReturnValue(true);
+
+    // When
+    render(<SamlConfigForm setIsOpen={vi.fn()} />);
+
+    // Then
+    expect(screen.getByText("Metadata XML File")).toHaveTextContent("*");
+  });
+
   it("adds normalized aliases and removes them in Cloud", async () => {
     // Given
     isCloudMock.mockReturnValue(true);

--- a/ui/components/integrations/saml/saml-config-form.test.tsx
+++ b/ui/components/integrations/saml/saml-config-form.test.tsx
@@ -12,27 +12,34 @@ import {
   vi,
 } from "vitest";
 
+import { updateSamlConfig } from "@/actions/integrations";
 import {
   RUNTIME_CONFIG_SCRIPT_ID,
   type RuntimePublicConfig,
 } from "@/lib/runtime-config.shared";
 import { useCloudUpgradeStore } from "@/store";
 import { CLOUD_UPGRADE_FEATURE } from "@/types/cloud-upgrade";
-import { SAML_CONFIGURATION_RESOURCE_TYPE } from "@/types/saml";
+import {
+  MAX_SAML_ADDITIONAL_EMAIL_DOMAINS,
+  SAML_CONFIGURATION_RESOURCE_TYPE,
+} from "@/types/saml";
 
 import { SamlConfigForm } from "./saml-config-form";
 
+const { isCloudMock, updateSamlConfigMock } = vi.hoisted(() => ({
+  isCloudMock: vi.fn(),
+  updateSamlConfigMock: vi.fn(),
+}));
+
 vi.mock("@/actions/integrations", () => ({
   createSamlConfig: vi.fn(),
-  updateSamlConfig: vi.fn(),
+  updateSamlConfig: updateSamlConfigMock,
 }));
 
 vi.mock("@/components/shadcn", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   useToast: () => ({ toast: vi.fn() }),
 }));
-
-const { isCloudMock } = vi.hoisted(() => ({ isCloudMock: vi.fn() }));
 
 vi.mock("@/lib/shared/env", () => ({
   isCloud: isCloudMock,
@@ -101,6 +108,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   isCloudMock.mockReturnValue(false);
+  vi.mocked(updateSamlConfig).mockReset();
   useCloudUpgradeStore.getState().closeCloudUpgrade();
 });
 
@@ -409,6 +417,70 @@ describe("SamlConfigForm", () => {
     ]);
   });
 
+  it("submits a normalized pending domain through the update action", async () => {
+    // Given
+    isCloudMock.mockReturnValue(true);
+    vi.mocked(updateSamlConfig).mockResolvedValue({
+      success: "SAML configuration updated successfully!",
+    });
+    const setIsOpen = vi.fn();
+    const user = userEvent.setup();
+    const samlConfig = {
+      type: SAML_CONFIGURATION_RESOURCE_TYPE,
+      id: "saml-1",
+      attributes: {
+        email_domain: "primary.example.com",
+        additional_email_domains: ["existing.example.com"],
+        metadata_xml: "<EntityDescriptor />",
+      },
+    };
+    render(<SamlConfigForm setIsOpen={setIsOpen} samlConfig={samlConfig} />);
+    await user.type(
+      screen.getByLabelText("Additional Email Domain"),
+      " Pending.Example.com ",
+    );
+
+    // When
+    await user.click(screen.getByRole("button", { name: "Update" }));
+
+    // Then
+    await waitFor(() => expect(updateSamlConfig).toHaveBeenCalledOnce());
+    const submittedFormData = vi.mocked(updateSamlConfig).mock.calls[0][1];
+    expect(submittedFormData.get("email_domain")).toBe("primary.example.com");
+    expect(submittedFormData.getAll("additional_email_domains")).toEqual([
+      "existing.example.com",
+      "pending.example.com",
+    ]);
+    expect(setIsOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("shows an additional-domain error returned by the update action", async () => {
+    // Given
+    isCloudMock.mockReturnValue(true);
+    vi.mocked(updateSamlConfig).mockResolvedValue({
+      errors: {
+        additional_email_domains: "Domain is already in use.",
+      },
+    });
+    const user = userEvent.setup();
+    const samlConfig = {
+      type: SAML_CONFIGURATION_RESOURCE_TYPE,
+      id: "saml-1",
+      attributes: {
+        email_domain: "primary.example.com",
+        additional_email_domains: ["alias.example.com"],
+        metadata_xml: "<EntityDescriptor />",
+      },
+    };
+    render(<SamlConfigForm setIsOpen={vi.fn()} samlConfig={samlConfig} />);
+
+    // When
+    await user.click(screen.getByRole("button", { name: "Update" }));
+
+    // Then
+    expect(await screen.findByText("Domain is already in use.")).toBeVisible();
+  });
+
   it("shows a contextual error when an additional domain is required", async () => {
     // Given
     isCloudMock.mockReturnValue(true);
@@ -428,7 +500,7 @@ describe("SamlConfigForm", () => {
     // Given
     isCloudMock.mockReturnValue(true);
     const additionalEmailDomains = Array.from(
-      { length: 19 },
+      { length: MAX_SAML_ADDITIONAL_EMAIL_DOMAINS },
       (_, index) => `alias-${index + 1}.example.com`,
     );
     const samlConfig = {
@@ -445,7 +517,11 @@ describe("SamlConfigForm", () => {
     render(<SamlConfigForm setIsOpen={vi.fn()} samlConfig={samlConfig} />);
 
     // Then
-    expect(screen.getByText("19 / 19 domains")).toBeVisible();
+    expect(
+      screen.getByText(
+        `${MAX_SAML_ADDITIONAL_EMAIL_DOMAINS} / ${MAX_SAML_ADDITIONAL_EMAIL_DOMAINS} domains`,
+      ),
+    ).toBeVisible();
     expect(
       screen.getByRole("list", { name: "Additional email domains" }),
     ).toHaveClass("max-h-24", "overflow-y-auto");
@@ -453,7 +529,7 @@ describe("SamlConfigForm", () => {
     expect(screen.getByRole("button", { name: "Add domain" })).toBeDisabled();
     expect(
       screen.getAllByRole("button", { name: /^Remove alias-/ }),
-    ).toHaveLength(19);
+    ).toHaveLength(MAX_SAML_ADDITIONAL_EMAIL_DOMAINS);
   });
 
   it("rejects a duplicate alias before submission", async () => {

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { PlusIcon, XIcon } from "lucide-react";
 import {
-  Dispatch,
-  SetStateAction,
+  type Dispatch,
+  type SetStateAction,
   useActionState,
   useEffect,
   useRef,
@@ -14,9 +15,14 @@ import { createSamlConfig, updateSamlConfig } from "@/actions/integrations";
 import { AddIcon } from "@/components/icons";
 import {
   Button,
+  Badge,
   Card,
   CardContent,
   CardHeader,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
   useToast,
 } from "@/components/shadcn";
 import { CodeSnippet } from "@/components/shadcn/code-snippet/code-snippet";
@@ -24,6 +30,11 @@ import { CustomServerInput } from "@/components/shadcn/custom";
 import { CustomLink } from "@/components/shadcn/custom/custom-link";
 import { FormButtons } from "@/components/shadcn/form";
 import { useRuntimeConfig } from "@/hooks/use-runtime-config";
+import { isCloud } from "@/lib/shared/env";
+import { useCloudUpgradeStore } from "@/store";
+import { CLOUD_UPGRADE_FEATURE } from "@/types/cloud-upgrade";
+import { samlEmailDomainSchema } from "@/types/formSchemas";
+import type { SamlConfiguration } from "@/types/saml";
 
 const validateXMLContent = (
   xmlContent: string,
@@ -120,7 +131,7 @@ export const SamlConfigForm = ({
   samlConfig,
 }: {
   setIsOpen: Dispatch<SetStateAction<boolean>>;
-  samlConfig?: any;
+  samlConfig?: SamlConfiguration;
 }) => {
   const [state, formAction, isPending] = useActionState(
     samlConfig?.id ? updateSamlConfig : createSamlConfig,
@@ -129,6 +140,13 @@ export const SamlConfigForm = ({
   const [emailDomain, setEmailDomain] = useState(
     samlConfig?.attributes?.email_domain || "",
   );
+  const [additionalEmailDomains, setAdditionalEmailDomains] = useState(
+    samlConfig?.attributes?.additional_email_domains ?? [],
+  );
+  const [additionalDomainDraft, setAdditionalDomainDraft] = useState("");
+  const [additionalDomainsError, setAdditionalDomainsError] = useState<
+    string | null
+  >(null);
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const [clientErrors, setClientErrors] = useState<{
     email_domain?: string | null;
@@ -136,6 +154,49 @@ export const SamlConfigForm = ({
   }>({});
   const formRef = useRef<HTMLFormElement>(null);
   const { toast } = useToast();
+  const isCloudEnv = isCloud();
+  const openCloudUpgrade = useCloudUpgradeStore(
+    (storeState) => storeState.openCloudUpgrade,
+  );
+
+  const addAdditionalDomain = () => {
+    const validation = samlEmailDomainSchema.safeParse(additionalDomainDraft);
+    if (!validation.success) {
+      setAdditionalDomainsError(validation.error.issues[0]?.message ?? null);
+      return;
+    }
+
+    const normalizedDomain = validation.data;
+    if (normalizedDomain === emailDomain.trim().toLowerCase()) {
+      setAdditionalDomainsError(
+        "An additional domain must differ from the primary email domain.",
+      );
+      return;
+    }
+
+    if (additionalEmailDomains.includes(normalizedDomain)) {
+      setAdditionalDomainsError("This domain has already been added.");
+      return;
+    }
+
+    if (additionalEmailDomains.length >= 19) {
+      setAdditionalDomainsError(
+        "A SAML configuration supports up to 19 additional email domains.",
+      );
+      return;
+    }
+
+    setAdditionalEmailDomains([...additionalEmailDomains, normalizedDomain]);
+    setAdditionalDomainDraft("");
+    setAdditionalDomainsError(null);
+  };
+
+  const removeAdditionalDomain = (domainToRemove: string) => {
+    setAdditionalEmailDomains(
+      additionalEmailDomains.filter((domain) => domain !== domainToRemove),
+    );
+    setAdditionalDomainsError(null);
+  };
 
   // Client-side validation function
   const validateFields = (email: string, hasFile: boolean) => {
@@ -284,8 +345,8 @@ export const SamlConfigForm = ({
       <input type="hidden" name="id" value={samlConfig?.id || ""} />
       <CustomServerInput
         name="email_domain"
-        label="Email Domain"
-        placeholder="Enter your email domain (e.g., company.com)"
+        label="Primary Email Domain"
+        placeholder="Enter your primary email domain (e.g., company.com)"
         labelPlacement="outside"
         variant="bordered"
         isRequired={true}
@@ -305,6 +366,118 @@ export const SamlConfigForm = ({
           setEmailDomain(newValue);
         }}
       />
+
+      <Field>
+        <div className="flex items-center justify-between gap-2">
+          <FieldLabel
+            htmlFor={isCloudEnv ? "additional_email_domain" : undefined}
+          >
+            Additional Email Domains
+          </FieldLabel>
+          {isCloudEnv ? (
+            <span
+              aria-live="polite"
+              className="text-text-neutral-tertiary text-xs"
+            >
+              {additionalEmailDomains.length} / 19 domains
+            </span>
+          ) : (
+            <Button
+              type="button"
+              variant="bare"
+              size="link-sm"
+              aria-label="Additional email domains are available in Prowler Cloud"
+              onClick={() =>
+                openCloudUpgrade(CLOUD_UPGRADE_FEATURE.SAML_DOMAINS)
+              }
+            >
+              <Badge variant="cloud">Available in Prowler Cloud</Badge>
+            </Button>
+          )}
+        </div>
+        <p className="text-text-neutral-tertiary text-xs">
+          Allow users from other verified domains to use this same SAML
+          configuration. The ACS URL always uses the primary domain.
+        </p>
+        {isCloudEnv && (
+          <>
+            <div className="flex items-center gap-2">
+              <Input
+                id="additional_email_domain"
+                aria-label="Additional Email Domain"
+                placeholder="Enter an additional domain"
+                value={additionalDomainDraft}
+                disabled={isPending || additionalEmailDomains.length >= 19}
+                aria-invalid={
+                  Boolean(
+                    additionalDomainsError ||
+                      state?.errors?.additional_email_domains,
+                  ) || undefined
+                }
+                onChange={(event) => {
+                  setAdditionalDomainDraft(event.target.value);
+                  setAdditionalDomainsError(null);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    addAdditionalDomain();
+                  }
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isPending || additionalEmailDomains.length >= 19}
+                onClick={addAdditionalDomain}
+                aria-label="Add domain"
+              >
+                <PlusIcon aria-hidden="true" />
+                Add
+              </Button>
+            </div>
+            {(additionalDomainsError ||
+              state?.errors?.additional_email_domains) && (
+              <FieldError>
+                {additionalDomainsError ||
+                  state?.errors?.additional_email_domains}
+              </FieldError>
+            )}
+            {additionalEmailDomains.length > 0 && (
+              <ul
+                aria-label="Additional email domains"
+                className="minimal-scrollbar border-border-neutral-secondary bg-bg-neutral-secondary flex max-h-24 flex-wrap content-start gap-2 overflow-y-auto rounded-lg border p-2"
+              >
+                {additionalEmailDomains.map((domain) => (
+                  <li key={domain}>
+                    <Badge variant="tag">
+                      {domain}
+                      <Button
+                        type="button"
+                        variant="bare"
+                        size="icon-xs"
+                        disabled={isPending}
+                        aria-label={`Remove ${domain}`}
+                        onClick={() => removeAdditionalDomain(domain)}
+                      >
+                        <XIcon aria-hidden="true" />
+                      </Button>
+                    </Badge>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {additionalEmailDomains.map((domain) => (
+              <input
+                key={domain}
+                type="hidden"
+                name="additional_email_domains"
+                value={domain}
+              />
+            ))}
+          </>
+        )}
+      </Field>
 
       <Card variant="inner">
         <CardHeader className="mb-2">

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -133,8 +133,9 @@ export const SamlConfigForm = ({
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   samlConfig?: SamlConfiguration;
 }) => {
+  const isUpdate = Boolean(samlConfig?.id);
   const [state, formAction, isPending] = useActionState(
-    samlConfig?.id ? updateSamlConfig : createSamlConfig,
+    isUpdate ? updateSamlConfig : createSamlConfig,
     null,
   );
   const [emailDomain, setEmailDomain] = useState(
@@ -212,7 +213,7 @@ export const SamlConfigForm = ({
       .string()
       .trim()
       .min(1, { message: "Metadata XML is required" })
-      .safeParse(hasFile ? "dummy_xml_content" : "");
+      .safeParse(hasFile || isUpdate ? "dummy_xml_content" : "");
 
     const newErrors = {
       email_domain: emailValidation.success
@@ -549,7 +550,7 @@ export const SamlConfigForm = ({
       <div className="flex flex-col items-start gap-2">
         <span className="text-xs text-gray-700 dark:text-gray-300">
           Metadata XML File{" "}
-          {!samlConfig?.id && <span className="text-red-500">*</span>}
+          {!isUpdate && <span className="text-red-500">*</span>}
         </span>
         <Button
           type="button"

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -33,7 +33,7 @@ import { useRuntimeConfig } from "@/hooks/use-runtime-config";
 import { isCloud } from "@/lib/shared/env";
 import { useCloudUpgradeStore } from "@/store";
 import { CLOUD_UPGRADE_FEATURE } from "@/types/cloud-upgrade";
-import { samlEmailDomainSchema } from "@/types/formSchemas";
+import { samlAdditionalEmailDomainSchema } from "@/types/formSchemas";
 import type { SamlConfiguration } from "@/types/saml";
 
 const validateXMLContent = (
@@ -160,7 +160,9 @@ export const SamlConfigForm = ({
   );
 
   const addAdditionalDomain = () => {
-    const validation = samlEmailDomainSchema.safeParse(additionalDomainDraft);
+    const validation = samlAdditionalEmailDomainSchema.safeParse(
+      additionalDomainDraft,
+    );
     if (!validation.success) {
       setAdditionalDomainsError(validation.error.issues[0]?.message ?? null);
       return;

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -548,7 +548,8 @@ export const SamlConfigForm = ({
       </Card>
       <div className="flex flex-col items-start gap-2">
         <span className="text-xs text-gray-700 dark:text-gray-300">
-          Metadata XML File <span className="text-red-500">*</span>
+          Metadata XML File{" "}
+          {!samlConfig?.id && <span className="text-red-500">*</span>}
         </span>
         <Button
           type="button"

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -154,6 +154,7 @@ export const SamlConfigForm = ({
     metadata_xml?: string | null;
   }>({});
   const formRef = useRef<HTMLFormElement>(null);
+  const activeFileReaderRef = useRef<FileReader | null>(null);
   const { toast } = useToast();
   const isCloudEnv = isCloud();
   const openCloudUpgrade = useCloudUpgradeStore(
@@ -227,7 +228,14 @@ export const SamlConfigForm = ({
     setClientErrors(newErrors);
   };
 
+  const invalidateActiveFileRead = () => {
+    const activeReader = activeFileReaderRef.current;
+    activeFileReaderRef.current = null;
+    activeReader?.abort();
+  };
+
   const clearMetadataFile = (fileInput: HTMLInputElement) => {
+    invalidateActiveFileRead();
     fileInput.value = "";
     const metadataInput = formRef.current?.elements.namedItem("metadata_xml");
     if (metadataInput instanceof HTMLInputElement) {
@@ -277,8 +285,14 @@ export const SamlConfigForm = ({
       return;
     }
 
+    invalidateActiveFileRead();
     const reader = new FileReader();
+    activeFileReaderRef.current = reader;
     reader.onload = (e) => {
+      if (activeFileReaderRef.current !== reader) {
+        return;
+      }
+      activeFileReaderRef.current = null;
       const content = e.target?.result as string;
 
       // Comprehensive XML validation
@@ -309,6 +323,10 @@ export const SamlConfigForm = ({
     };
 
     reader.onerror = () => {
+      if (activeFileReaderRef.current !== reader) {
+        return;
+      }
+      activeFileReaderRef.current = null;
       toast({
         variant: "destructive",
         title: "File read error",

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -227,6 +227,16 @@ export const SamlConfigForm = ({
     setClientErrors(newErrors);
   };
 
+  const clearMetadataFile = (fileInput: HTMLInputElement) => {
+    fileInput.value = "";
+    const metadataInput = formRef.current?.elements.namedItem("metadata_xml");
+    if (metadataInput instanceof HTMLInputElement) {
+      metadataInput.value = "";
+    }
+    setUploadedFile(null);
+    validateFields(emailDomain, false);
+  };
+
   useEffect(() => {
     if (state?.success) {
       toast({
@@ -246,8 +256,7 @@ export const SamlConfigForm = ({
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) {
-      setUploadedFile(null);
-      validateFields(emailDomain, false);
+      clearMetadataFile(event.target);
       return;
     }
 
@@ -263,10 +272,7 @@ export const SamlConfigForm = ({
         title: "Invalid file type",
         description: "Please select a valid XML file (.xml extension).",
       });
-      // Clear the file input
-      event.target.value = "";
-      setUploadedFile(null);
-      validateFields(emailDomain, false);
+      clearMetadataFile(event.target);
 
       return;
     }
@@ -283,19 +289,14 @@ export const SamlConfigForm = ({
           title: "Invalid XML content",
           description: xmlValidationResult.error,
         });
-        // Clear the file input
-        event.target.value = "";
-        setUploadedFile(null);
-        validateFields(emailDomain, false);
+        clearMetadataFile(event.target);
         return;
       }
 
       // Set the XML content in a hidden input
-      const xmlInput = document.getElementById(
-        "metadata_xml",
-      ) as HTMLInputElement;
-      if (xmlInput) {
-        xmlInput.value = content;
+      const metadataInput = formRef.current?.elements.namedItem("metadata_xml");
+      if (metadataInput instanceof HTMLInputElement) {
+        metadataInput.value = content;
       }
 
       setUploadedFile(file);
@@ -313,10 +314,7 @@ export const SamlConfigForm = ({
         title: "File read error",
         description: "Failed to read the selected file.",
       });
-      // Clear the file input
-      event.target.value = "";
-      setUploadedFile(null);
-      validateFields(emailDomain, false);
+      clearMetadataFile(event.target);
     };
 
     reader.readAsText(file);

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -1,15 +1,9 @@
 "use client";
 
+import { zodResolver } from "@hookform/resolvers/zod";
 import { PlusIcon, XIcon } from "lucide-react";
-import {
-  type Dispatch,
-  type SetStateAction,
-  useActionState,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
-import { z } from "zod";
+import { type Dispatch, type SetStateAction, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
 
 import { createSamlConfig, updateSamlConfig } from "@/actions/integrations";
 import { AddIcon } from "@/components/icons";
@@ -26,18 +20,25 @@ import {
   useToast,
 } from "@/components/shadcn";
 import { CodeSnippet } from "@/components/shadcn/code-snippet/code-snippet";
-import { CustomServerInput } from "@/components/shadcn/custom";
+import { CustomInput } from "@/components/shadcn/custom";
 import { CustomLink } from "@/components/shadcn/custom/custom-link";
-import { FormButtons } from "@/components/shadcn/form";
+import { Form, FormButtons } from "@/components/shadcn/form";
 import { useRuntimeConfig } from "@/hooks/use-runtime-config";
 import { isCloud } from "@/lib/shared/env";
 import { useCloudUpgradeStore } from "@/store";
 import { CLOUD_UPGRADE_FEATURE } from "@/types/cloud-upgrade";
 import {
+  getSamlConfigFormSchema,
   samlAdditionalEmailDomainSchema,
   samlEmailDomainSchema,
+  type SamlConfigFormInput,
+  type SamlConfigFormValues,
 } from "@/types/formSchemas";
-import type { SamlConfiguration } from "@/types/saml";
+import {
+  MAX_SAML_ADDITIONAL_EMAIL_DOMAINS,
+  type SamlConfiguration,
+  type SamlConfigurationErrors,
+} from "@/types/saml";
 
 const validateXMLContent = (
   xmlContent: string,
@@ -137,41 +138,48 @@ export const SamlConfigForm = ({
   samlConfig?: SamlConfiguration;
 }) => {
   const isUpdate = Boolean(samlConfig?.id);
-  const [state, formAction, isPending] = useActionState(
-    isUpdate ? updateSamlConfig : createSamlConfig,
-    null,
-  );
-  const [emailDomain, setEmailDomain] = useState(
-    samlConfig?.attributes?.email_domain || "",
-  );
-  const [additionalEmailDomains, setAdditionalEmailDomains] = useState(
-    samlConfig?.attributes?.additional_email_domains ?? [],
-  );
+  const formSchema = getSamlConfigFormSchema(isUpdate);
+  const form = useForm<SamlConfigFormInput, unknown, SamlConfigFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      email_domain: samlConfig?.attributes?.email_domain ?? "",
+      additional_email_domains:
+        samlConfig?.attributes?.additional_email_domains ?? [],
+      metadata_xml: "",
+    },
+  });
+  const emailDomain = form.watch("email_domain");
+  const additionalEmailDomains = form.watch("additional_email_domains") ?? [];
+  const isPending = form.formState.isSubmitting;
   const [additionalDomainDraft, setAdditionalDomainDraft] = useState("");
-  const [additionalDomainsError, setAdditionalDomainsError] = useState<
-    string | null
-  >(null);
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   // Local state needed: submission must wait for the selected metadata file.
   const [isMetadataFileReading, setIsMetadataFileReading] = useState(false);
-  const [clientErrors, setClientErrors] = useState<{
-    email_domain?: string | null;
-    metadata_xml?: string | null;
-  }>({});
-  const formRef = useRef<HTMLFormElement>(null);
   const activeFileReaderRef = useRef<FileReader | null>(null);
   const { toast } = useToast();
   const isCloudEnv = isCloud();
   const openCloudUpgrade = useCloudUpgradeStore(
     (storeState) => storeState.openCloudUpgrade,
   );
+  const additionalDomainsError =
+    form.formState.errors.additional_email_domains?.message;
+
+  const setAdditionalDomainsError = (message: string) => {
+    form.setError("additional_email_domains", {
+      type: "manual",
+      message,
+    });
+  };
 
   const addAdditionalDomain = () => {
     const validation = samlAdditionalEmailDomainSchema.safeParse(
       additionalDomainDraft,
     );
     if (!validation.success) {
-      setAdditionalDomainsError(validation.error.issues[0]?.message ?? null);
+      setAdditionalDomainsError(
+        validation.error.issues[0]?.message ??
+          "Additional email domain is invalid",
+      );
       return;
     }
 
@@ -188,49 +196,29 @@ export const SamlConfigForm = ({
       return;
     }
 
-    if (additionalEmailDomains.length >= 19) {
+    if (additionalEmailDomains.length >= MAX_SAML_ADDITIONAL_EMAIL_DOMAINS) {
       setAdditionalDomainsError(
-        "A SAML configuration supports up to 19 additional email domains.",
+        `A SAML configuration supports up to ${MAX_SAML_ADDITIONAL_EMAIL_DOMAINS} additional email domains.`,
       );
       return;
     }
 
-    setAdditionalEmailDomains([...additionalEmailDomains, normalizedDomain]);
+    form.setValue(
+      "additional_email_domains",
+      [...additionalEmailDomains, normalizedDomain],
+      { shouldDirty: true },
+    );
     setAdditionalDomainDraft("");
-    setAdditionalDomainsError(null);
+    form.clearErrors("additional_email_domains");
   };
 
   const removeAdditionalDomain = (domainToRemove: string) => {
-    setAdditionalEmailDomains(
+    form.setValue(
+      "additional_email_domains",
       additionalEmailDomains.filter((domain) => domain !== domainToRemove),
+      { shouldDirty: true },
     );
-    setAdditionalDomainsError(null);
-  };
-
-  // Client-side validation function
-  const validateFields = (email: string, hasFile: boolean) => {
-    // Validar cada campo por separado para poder limpiarlos individualmente
-    const emailValidation = z
-      .string()
-      .trim()
-      .min(1, { message: "Email domain is required" })
-      .safeParse(email);
-    const metadataValidation = z
-      .string()
-      .trim()
-      .min(1, { message: "Metadata XML is required" })
-      .safeParse(hasFile || isUpdate ? "dummy_xml_content" : "");
-
-    const newErrors = {
-      email_domain: emailValidation.success
-        ? null
-        : emailValidation.error.issues[0]?.message,
-      metadata_xml: metadataValidation.success
-        ? null
-        : metadataValidation.error.issues[0]?.message,
-    };
-
-    setClientErrors(newErrors);
+    form.clearErrors("additional_email_domains");
   };
 
   const invalidateActiveFileRead = () => {
@@ -242,30 +230,13 @@ export const SamlConfigForm = ({
   const clearMetadataFile = (fileInput: HTMLInputElement) => {
     invalidateActiveFileRead();
     fileInput.value = "";
-    const metadataInput = formRef.current?.elements.namedItem("metadata_xml");
-    if (metadataInput instanceof HTMLInputElement) {
-      metadataInput.value = "";
-    }
+    form.setValue("metadata_xml", "", {
+      shouldDirty: true,
+      shouldValidate: form.formState.isSubmitted,
+    });
     setIsMetadataFileReading(false);
     setUploadedFile(null);
-    validateFields(emailDomain, false);
   };
-
-  useEffect(() => {
-    if (state?.success) {
-      toast({
-        title: "Configuration saved successfully",
-        description: state.success,
-      });
-      setIsOpen(false);
-    } else if (state?.errors?.general) {
-      toast({
-        variant: "destructive",
-        title: "Oops! Something went wrong",
-        description: state.errors.general,
-      });
-    }
-  }, [state, toast, setIsOpen]);
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -301,7 +272,8 @@ export const SamlConfigForm = ({
       }
       activeFileReaderRef.current = null;
       setIsMetadataFileReading(false);
-      const content = e.target?.result as string;
+      const content =
+        typeof e.target?.result === "string" ? e.target.result : "";
 
       // Comprehensive XML validation
       const xmlValidationResult = validateXMLContent(content);
@@ -315,14 +287,11 @@ export const SamlConfigForm = ({
         return;
       }
 
-      // Set the XML content in a hidden input
-      const metadataInput = formRef.current?.elements.namedItem("metadata_xml");
-      if (metadataInput instanceof HTMLInputElement) {
-        metadataInput.value = content;
-      }
-
+      form.setValue("metadata_xml", content, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
       setUploadedFile(file);
-      validateFields(emailDomain, true);
 
       toast({
         title: "File uploaded successfully",
@@ -346,6 +315,89 @@ export const SamlConfigForm = ({
     reader.readAsText(file);
   };
 
+  const setFieldErrors = (errors: SamlConfigurationErrors) => {
+    if (errors.email_domain) {
+      form.setError("email_domain", {
+        type: "server",
+        message: errors.email_domain,
+      });
+    }
+    if (errors.additional_email_domains) {
+      form.setError("additional_email_domains", {
+        type: "server",
+        message: errors.additional_email_domains,
+      });
+    }
+    if (errors.metadata_xml) {
+      form.setError("metadata_xml", {
+        type: "server",
+        message: errors.metadata_xml,
+      });
+    }
+  };
+
+  const onSubmit = async (values: SamlConfigFormValues) => {
+    const pendingDomains = additionalDomainDraft.trim()
+      ? [...values.additional_email_domains, additionalDomainDraft]
+      : values.additional_email_domains;
+    const validatedSubmission = formSchema.safeParse({
+      ...values,
+      additional_email_domains: pendingDomains,
+    });
+
+    if (!validatedSubmission.success) {
+      const fieldErrors = validatedSubmission.error.flatten().fieldErrors;
+      setFieldErrors({
+        email_domain: fieldErrors.email_domain?.[0],
+        additional_email_domains: fieldErrors.additional_email_domains?.[0],
+        metadata_xml: fieldErrors.metadata_xml?.[0],
+      });
+      return;
+    }
+
+    const formData = new FormData();
+    if (samlConfig?.id) {
+      formData.set("id", samlConfig.id);
+    }
+    formData.set("email_domain", validatedSubmission.data.email_domain);
+    validatedSubmission.data.additional_email_domains.forEach((domain) =>
+      formData.append("additional_email_domains", domain),
+    );
+    formData.set("metadata_xml", validatedSubmission.data.metadata_xml);
+
+    try {
+      const result = isUpdate
+        ? await updateSamlConfig(null, formData)
+        : await createSamlConfig(null, formData);
+
+      if (result?.success) {
+        toast({
+          title: "Configuration saved successfully",
+          description: result.success,
+        });
+        setIsOpen(false);
+        return;
+      }
+
+      if (result?.errors) {
+        setFieldErrors(result.errors);
+        if (result.errors.general) {
+          toast({
+            variant: "destructive",
+            title: "Oops! Something went wrong",
+            description: result.errors.general,
+          });
+        }
+      }
+    } catch {
+      toast({
+        variant: "destructive",
+        title: "Oops! Something went wrong",
+        description: "Unable to save the SAML configuration. Please try again.",
+      });
+    }
+  };
+
   const { apiBaseUrl } = useRuntimeConfig();
   const normalizedEmailDomain = samlEmailDomainSchema.safeParse(emailDomain);
   const acsEmailDomain = normalizedEmailDomain.success
@@ -357,297 +409,279 @@ export const SamlConfigForm = ({
       : "";
 
   return (
-    <form
-      ref={formRef}
-      action={formAction}
-      className="flex min-w-0 flex-col gap-2"
-    >
-      <div className="py-1 text-xs">
-        Need help configuring SAML SSO?{" "}
-        <CustomLink
-          href={
-            "https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app-sso/"
-          }
-        >
-          Read the docs
-        </CustomLink>
-      </div>
-      <input type="hidden" name="id" value={samlConfig?.id || ""} />
-      <CustomServerInput
-        name="email_domain"
-        label="Primary Email Domain"
-        placeholder="Enter your primary email domain (e.g., company.com)"
-        labelPlacement="outside"
-        variant="bordered"
-        isRequired={true}
-        isInvalid={
-          !!(clientErrors.email_domain === null
-            ? undefined
-            : clientErrors.email_domain || state?.errors?.email_domain)
-        }
-        errorMessage={
-          clientErrors.email_domain === null
-            ? undefined
-            : clientErrors.email_domain || state?.errors?.email_domain
-        }
-        value={emailDomain}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-          const newValue = e.target.value;
-          setEmailDomain(newValue);
-        }}
-      />
-
-      <Field>
-        <div className="flex items-center justify-between gap-2">
-          <FieldLabel
-            htmlFor={isCloudEnv ? "additional_email_domain" : undefined}
-          >
-            Additional Email Domains
-          </FieldLabel>
-          {isCloudEnv ? (
-            <span
-              aria-live="polite"
-              className="text-text-neutral-tertiary text-xs"
-            >
-              {additionalEmailDomains.length} / 19 domains
-            </span>
-          ) : (
-            <Button
-              type="button"
-              variant="bare"
-              size="link-sm"
-              aria-label="Additional email domains are available in Prowler Cloud"
-              onClick={() =>
-                openCloudUpgrade(CLOUD_UPGRADE_FEATURE.SAML_DOMAINS)
-              }
-            >
-              <Badge variant="cloud">Available in Prowler Cloud</Badge>
-            </Button>
-          )}
-        </div>
-        <p className="text-text-neutral-tertiary text-xs">
-          Allow users from other verified domains to use this same SAML
-          configuration. The ACS URL always uses the primary domain.
-        </p>
-        {isCloudEnv && (
-          <>
-            <div className="flex items-center gap-2">
-              <Input
-                id="additional_email_domain"
-                name={
-                  additionalDomainDraft.trim()
-                    ? "additional_email_domains"
-                    : undefined
-                }
-                aria-label="Additional Email Domain"
-                placeholder="Enter an additional domain"
-                value={additionalDomainDraft}
-                disabled={isPending || additionalEmailDomains.length >= 19}
-                aria-invalid={
-                  Boolean(
-                    additionalDomainsError ||
-                      state?.errors?.additional_email_domains,
-                  ) || undefined
-                }
-                onChange={(event) => {
-                  setAdditionalDomainDraft(event.target.value);
-                  setAdditionalDomainsError(null);
-                }}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    event.preventDefault();
-                    addAdditionalDomain();
-                  }
-                }}
-              />
-              <Button
-                type="button"
-                variant="outline"
-                disabled={isPending || additionalEmailDomains.length >= 19}
-                onClick={addAdditionalDomain}
-                aria-label="Add domain"
-              >
-                <PlusIcon aria-hidden="true" />
-                Add
-              </Button>
-            </div>
-            {(additionalDomainsError ||
-              state?.errors?.additional_email_domains) && (
-              <FieldError>
-                {additionalDomainsError ||
-                  state?.errors?.additional_email_domains}
-              </FieldError>
-            )}
-            {additionalEmailDomains.length > 0 && (
-              <ul
-                aria-label="Additional email domains"
-                className="minimal-scrollbar border-border-neutral-secondary bg-bg-neutral-secondary flex max-h-24 flex-wrap content-start gap-2 overflow-y-auto rounded-lg border p-2"
-              >
-                {additionalEmailDomains.map((domain) => (
-                  <li key={domain}>
-                    <Badge variant="tag">
-                      {domain}
-                      <Button
-                        type="button"
-                        variant="bare"
-                        size="icon-xs"
-                        disabled={isPending}
-                        aria-label={`Remove ${domain}`}
-                        onClick={() => removeAdditionalDomain(domain)}
-                      >
-                        <XIcon aria-hidden="true" />
-                      </Button>
-                    </Badge>
-                  </li>
-                ))}
-              </ul>
-            )}
-            {additionalEmailDomains.map((domain) => (
-              <input
-                key={domain}
-                type="hidden"
-                name="additional_email_domains"
-                value={domain}
-              />
-            ))}
-          </>
-        )}
-      </Field>
-
-      <Card variant="inner">
-        <CardHeader className="mb-2">
-          Identity Provider Configuration
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-col gap-4">
-            <div>
-              <span className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-                ACS URL:
-              </span>
-              <CodeSnippet
-                value={
-                  acsUrl ||
-                  "Enter your email domain above to generate the ACS URL."
-                }
-                ariaLabel="Copy ACS URL"
-                hideCopyButton={!acsUrl}
-                className="h-10 w-full"
-              />
-            </div>
-
-            <div>
-              <span className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Audience:
-              </span>
-              <CodeSnippet
-                value="urn:prowler.com:sp"
-                ariaLabel="Copy Audience"
-                className="h-10 w-full"
-              />
-            </div>
-
-            <div>
-              <span className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Name ID Format:
-              </span>
-              <span className="w-full text-sm text-gray-600 dark:text-gray-400">
-                urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
-              </span>
-            </div>
-
-            <div>
-              <span className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Supported Assertion Attributes:
-              </span>
-              <ul className="ml-4 flex flex-col gap-1 text-sm text-gray-600 dark:text-gray-400">
-                <li>• firstName</li>
-                <li>• lastName</li>
-                <li>• userType</li>
-                <li>• organization</li>
-              </ul>
-              <p className="mt-2 text-xs text-gray-600 dark:text-gray-400">
-                <strong>Note:</strong> The userType attribute will be used to
-                assign the user&apos;s role. If the role does not exist, one
-                will be created with minimal permissions. You can assign
-                permissions to roles on the{" "}
-                <CustomLink href="/roles" target="_self">
-                  <span>Roles</span>
-                </CustomLink>{" "}
-                page.
-              </p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-      <div className="flex flex-col items-start gap-2">
-        <span className="text-xs text-gray-700 dark:text-gray-300">
-          Metadata XML File{" "}
-          {!isUpdate && <span className="text-red-500">*</span>}
-        </span>
-        <Button
-          type="button"
-          variant="outline"
-          disabled={isPending}
-          onClick={() => {
-            const fileInput = document.getElementById(
-              "metadata_xml_file",
-            ) as HTMLInputElement;
-            if (fileInput) {
-              fileInput.click();
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="flex min-w-0 flex-col gap-2"
+      >
+        <div className="py-1 text-xs">
+          Need help configuring SAML SSO?{" "}
+          <CustomLink
+            href={
+              "https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app-sso/"
             }
-          }}
-          className={`justify-start gap-2 ${
-            (
-              clientErrors.metadata_xml === null
-                ? undefined
-                : clientErrors.metadata_xml || state?.errors?.metadata_xml
-            )
-              ? "border-red-500"
-              : uploadedFile
-                ? "border-green-500 bg-green-50 dark:bg-green-900/20"
-                : ""
-          }`}
-        >
-          <AddIcon size={20} />
-          <span className="text-sm">
-            {uploadedFile ? (
-              <span className="flex items-center gap-2">
-                <span className="max-w-36 truncate">{uploadedFile.name}</span>
+          >
+            Read the docs
+          </CustomLink>
+        </div>
+        <input type="hidden" name="id" value={samlConfig?.id || ""} />
+        <CustomInput
+          control={form.control}
+          name="email_domain"
+          label="Primary Email Domain"
+          placeholder="Enter your primary email domain (e.g., company.com)"
+          labelPlacement="outside"
+          variant="bordered"
+          isRequired
+          isDisabled={isPending}
+        />
+
+        <Field>
+          <div className="flex items-center justify-between gap-2">
+            <FieldLabel
+              htmlFor={isCloudEnv ? "additional_email_domain" : undefined}
+            >
+              Additional Email Domains
+            </FieldLabel>
+            {isCloudEnv ? (
+              <span
+                aria-live="polite"
+                className="text-text-neutral-tertiary text-xs"
+              >
+                {additionalEmailDomains.length} /{" "}
+                {MAX_SAML_ADDITIONAL_EMAIL_DOMAINS} domains
               </span>
             ) : (
-              "Choose File"
+              <Button
+                type="button"
+                variant="bare"
+                size="link-sm"
+                aria-label="Additional email domains are available in Prowler Cloud"
+                onClick={() =>
+                  openCloudUpgrade(CLOUD_UPGRADE_FEATURE.SAML_DOMAINS)
+                }
+              >
+                <Badge variant="cloud">Available in Prowler Cloud</Badge>
+              </Button>
             )}
-          </span>
-        </Button>
+          </div>
+          <p className="text-text-neutral-tertiary text-xs">
+            Allow users from other verified domains to use this same SAML
+            configuration. The ACS URL always uses the primary domain.
+          </p>
+          {isCloudEnv && (
+            <>
+              <div className="flex items-center gap-2">
+                <Input
+                  id="additional_email_domain"
+                  name={
+                    additionalDomainDraft.trim()
+                      ? "additional_email_domains"
+                      : undefined
+                  }
+                  aria-label="Additional Email Domain"
+                  placeholder="Enter an additional domain"
+                  value={additionalDomainDraft}
+                  disabled={
+                    isPending ||
+                    additionalEmailDomains.length >=
+                      MAX_SAML_ADDITIONAL_EMAIL_DOMAINS
+                  }
+                  aria-invalid={Boolean(additionalDomainsError) || undefined}
+                  onChange={(event) => {
+                    setAdditionalDomainDraft(event.target.value);
+                    form.clearErrors("additional_email_domains");
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      addAdditionalDomain();
+                    }
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={
+                    isPending ||
+                    additionalEmailDomains.length >=
+                      MAX_SAML_ADDITIONAL_EMAIL_DOMAINS
+                  }
+                  onClick={addAdditionalDomain}
+                  aria-label="Add domain"
+                >
+                  <PlusIcon aria-hidden="true" />
+                  Add
+                </Button>
+              </div>
+              {additionalDomainsError && (
+                <FieldError>{additionalDomainsError}</FieldError>
+              )}
+              {additionalEmailDomains.length > 0 && (
+                <ul
+                  aria-label="Additional email domains"
+                  className="minimal-scrollbar border-border-neutral-secondary bg-bg-neutral-secondary flex max-h-24 flex-wrap content-start gap-2 overflow-y-auto rounded-lg border p-2"
+                >
+                  {additionalEmailDomains.map((domain) => (
+                    <li key={domain}>
+                      <Badge variant="tag">
+                        {domain}
+                        <Button
+                          type="button"
+                          variant="bare"
+                          size="icon-xs"
+                          disabled={isPending}
+                          aria-label={`Remove ${domain}`}
+                          onClick={() => removeAdditionalDomain(domain)}
+                        >
+                          <XIcon aria-hidden="true" />
+                        </Button>
+                      </Badge>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {additionalEmailDomains.map((domain) => (
+                <input
+                  key={domain}
+                  type="hidden"
+                  name="additional_email_domains"
+                  value={domain}
+                />
+              ))}
+            </>
+          )}
+        </Field>
 
-        <input
-          type="file"
-          id="metadata_xml_file"
-          name="metadata_xml_file"
-          accept=".xml,application/xml,text/xml"
-          className="hidden"
-          disabled={isPending}
-          onChange={handleFileUpload}
+        <Card variant="inner">
+          <CardHeader className="mb-2">
+            Identity Provider Configuration
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-col gap-4">
+              <div>
+                <span className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  ACS URL:
+                </span>
+                <CodeSnippet
+                  value={
+                    acsUrl ||
+                    "Enter your email domain above to generate the ACS URL."
+                  }
+                  ariaLabel="Copy ACS URL"
+                  hideCopyButton={!acsUrl}
+                  className="h-10 w-full"
+                />
+              </div>
+
+              <div>
+                <span className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Audience:
+                </span>
+                <CodeSnippet
+                  value="urn:prowler.com:sp"
+                  ariaLabel="Copy Audience"
+                  className="h-10 w-full"
+                />
+              </div>
+
+              <div>
+                <span className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Name ID Format:
+                </span>
+                <span className="w-full text-sm text-gray-600 dark:text-gray-400">
+                  urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+                </span>
+              </div>
+
+              <div>
+                <span className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Supported Assertion Attributes:
+                </span>
+                <ul className="ml-4 flex flex-col gap-1 text-sm text-gray-600 dark:text-gray-400">
+                  <li>• firstName</li>
+                  <li>• lastName</li>
+                  <li>• userType</li>
+                  <li>• organization</li>
+                </ul>
+                <p className="mt-2 text-xs text-gray-600 dark:text-gray-400">
+                  <strong>Note:</strong> The userType attribute will be used to
+                  assign the user&apos;s role. If the role does not exist, one
+                  will be created with minimal permissions. You can assign
+                  permissions to roles on the{" "}
+                  <CustomLink href="/roles" target="_self">
+                    <span>Roles</span>
+                  </CustomLink>{" "}
+                  page.
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <div className="flex flex-col items-start gap-2">
+          <span className="text-xs text-gray-700 dark:text-gray-300">
+            Metadata XML File{" "}
+            {!isUpdate && <span className="text-red-500">*</span>}
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isPending}
+            onClick={() => {
+              const fileInput = document.getElementById(
+                "metadata_xml_file",
+              ) as HTMLInputElement;
+              if (fileInput) {
+                fileInput.click();
+              }
+            }}
+            className={`justify-start gap-2 ${
+              form.formState.errors.metadata_xml
+                ? "border-red-500"
+                : uploadedFile
+                  ? "border-green-500 bg-green-50 dark:bg-green-900/20"
+                  : ""
+            }`}
+          >
+            <AddIcon size={20} />
+            <span className="text-sm">
+              {uploadedFile ? (
+                <span className="flex items-center gap-2">
+                  <span className="max-w-36 truncate">{uploadedFile.name}</span>
+                </span>
+              ) : (
+                "Choose File"
+              )}
+            </span>
+          </Button>
+
+          <input
+            type="file"
+            id="metadata_xml_file"
+            name="metadata_xml_file"
+            accept=".xml,application/xml,text/xml"
+            className="hidden"
+            disabled={isPending}
+            onChange={handleFileUpload}
+          />
+          <input
+            type="hidden"
+            id="metadata_xml"
+            {...form.register("metadata_xml")}
+          />
+          <p className="text-xs text-gray-500">
+            Upload your Identity Provider&apos;s SAML metadata XML file
+          </p>
+          <span className="text-xs text-red-500">
+            {form.formState.errors.metadata_xml?.message}
+          </span>
+        </div>
+        <FormButtons
+          setIsOpen={setIsOpen}
+          submitText={samlConfig?.id ? "Update" : "Save"}
+          isDisabled={isPending || isMetadataFileReading}
         />
-        <input type="hidden" id="metadata_xml" name="metadata_xml" />
-        <p className="text-xs text-gray-500">
-          Upload your Identity Provider&apos;s SAML metadata XML file
-        </p>
-        <span className="text-xs text-red-500">
-          {(() => {
-            const finalError =
-              clientErrors.metadata_xml === null
-                ? undefined
-                : clientErrors.metadata_xml || state?.errors?.metadata_xml;
-            return finalError;
-          })()}
-        </span>
-      </div>
-      <FormButtons
-        setIsOpen={setIsOpen}
-        submitText={samlConfig?.id ? "Update" : "Save"}
-        isDisabled={isPending || isMetadataFileReading}
-      />
-    </form>
+      </form>
+    </Form>
   );
 };

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -33,7 +33,10 @@ import { useRuntimeConfig } from "@/hooks/use-runtime-config";
 import { isCloud } from "@/lib/shared/env";
 import { useCloudUpgradeStore } from "@/store";
 import { CLOUD_UPGRADE_FEATURE } from "@/types/cloud-upgrade";
-import { samlAdditionalEmailDomainSchema } from "@/types/formSchemas";
+import {
+  samlAdditionalEmailDomainSchema,
+  samlEmailDomainSchema,
+} from "@/types/formSchemas";
 import type { SamlConfiguration } from "@/types/saml";
 
 const validateXMLContent = (
@@ -149,6 +152,8 @@ export const SamlConfigForm = ({
     string | null
   >(null);
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+  // Local state needed: submission must wait for the selected metadata file.
+  const [isMetadataFileReading, setIsMetadataFileReading] = useState(false);
   const [clientErrors, setClientErrors] = useState<{
     email_domain?: string | null;
     metadata_xml?: string | null;
@@ -241,6 +246,7 @@ export const SamlConfigForm = ({
     if (metadataInput instanceof HTMLInputElement) {
       metadataInput.value = "";
     }
+    setIsMetadataFileReading(false);
     setUploadedFile(null);
     validateFields(emailDomain, false);
   };
@@ -288,11 +294,13 @@ export const SamlConfigForm = ({
     invalidateActiveFileRead();
     const reader = new FileReader();
     activeFileReaderRef.current = reader;
+    setIsMetadataFileReading(true);
     reader.onload = (e) => {
       if (activeFileReaderRef.current !== reader) {
         return;
       }
       activeFileReaderRef.current = null;
+      setIsMetadataFileReading(false);
       const content = e.target?.result as string;
 
       // Comprehensive XML validation
@@ -339,10 +347,13 @@ export const SamlConfigForm = ({
   };
 
   const { apiBaseUrl } = useRuntimeConfig();
-  const trimmedEmailDomain = emailDomain.trim();
+  const normalizedEmailDomain = samlEmailDomainSchema.safeParse(emailDomain);
+  const acsEmailDomain = normalizedEmailDomain.success
+    ? normalizedEmailDomain.data
+    : "";
   const acsUrl =
-    trimmedEmailDomain && apiBaseUrl
-      ? `${apiBaseUrl}/accounts/saml/${trimmedEmailDomain}/acs/`
+    acsEmailDomain && apiBaseUrl
+      ? `${apiBaseUrl}/accounts/saml/${acsEmailDomain}/acs/`
       : "";
 
   return (
@@ -423,6 +434,11 @@ export const SamlConfigForm = ({
             <div className="flex items-center gap-2">
               <Input
                 id="additional_email_domain"
+                name={
+                  additionalDomainDraft.trim()
+                    ? "additional_email_domains"
+                    : undefined
+                }
                 aria-label="Additional Email Domain"
                 placeholder="Enter an additional domain"
                 value={additionalDomainDraft}
@@ -630,6 +646,7 @@ export const SamlConfigForm = ({
       <FormButtons
         setIsOpen={setIsOpen}
         submitText={samlConfig?.id ? "Update" : "Save"}
+        isDisabled={isPending || isMetadataFileReading}
       />
     </form>
   );

--- a/ui/components/integrations/saml/saml-integration-card.tsx
+++ b/ui/components/integrations/saml/saml-integration-card.tsx
@@ -15,10 +15,15 @@ import {
 } from "@/components/shadcn";
 import { CustomLink } from "@/components/shadcn/custom/custom-link";
 import { Modal } from "@/components/shadcn/modal";
+import type { SamlConfiguration } from "@/types/saml";
 
 import { SamlConfigForm } from "./saml-config-form";
 
-export const SamlIntegrationCard = ({ samlConfig }: { samlConfig?: any }) => {
+export const SamlIntegrationCard = ({
+  samlConfig,
+}: {
+  samlConfig?: SamlConfiguration;
+}) => {
   const [isSamlModalOpen, setIsSamlModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);

--- a/ui/lib/cloud-upgrade.test.ts
+++ b/ui/lib/cloud-upgrade.test.ts
@@ -29,6 +29,7 @@ describe("cloud upgrade content", () => {
       "Use The Agent Cloud Defender",
       "Scale Prowler Without Operating It",
       "Configure Every Scan Once",
+      "Use One SAML Configuration Across Domains",
     ]);
   });
 
@@ -78,6 +79,7 @@ describe("cloud upgrade URLs", () => {
     [CLOUD_UPGRADE_FEATURE.LIGHTHOUSE_AI, "lighthouse-ai"],
     [CLOUD_UPGRADE_FEATURE.GENERAL, "general"],
     [CLOUD_UPGRADE_FEATURE.SCAN_CONFIGURATION, "scan-configuration"],
+    [CLOUD_UPGRADE_FEATURE.SAML_DOMAINS, "saml-domains"],
   ])("should use the canonical content slug for %s", (feature, contentSlug) => {
     // Given / When
     const url = new URL(getCloudUpgradePrimaryUrl(feature));

--- a/ui/lib/cloud-upgrade.ts
+++ b/ui/lib/cloud-upgrade.ts
@@ -31,6 +31,7 @@ const CLOUD_UPGRADE_UTM_CONTENT = {
   [CLOUD_UPGRADE_FEATURE.LIGHTHOUSE_AI]: "lighthouse-ai",
   [CLOUD_UPGRADE_FEATURE.GENERAL]: "general",
   [CLOUD_UPGRADE_FEATURE.SCAN_CONFIGURATION]: "scan-configuration",
+  [CLOUD_UPGRADE_FEATURE.SAML_DOMAINS]: "saml-domains",
 } as const satisfies Record<CloudUpgradeFeature, string>;
 
 export const CLOUD_UPGRADE_CONTENT = {
@@ -156,6 +157,17 @@ export const CLOUD_UPGRADE_CONTENT = {
       "Manage scan behavior from one place",
     ],
     primaryCta: "Configure Scans in Prowler Cloud",
+  },
+  [CLOUD_UPGRADE_FEATURE.SAML_DOMAINS]: {
+    title: "Use One SAML Configuration Across Domains",
+    description:
+      "Let users from multiple verified email domains share one SAML identity provider configuration.",
+    benefits: [
+      "Keep one primary domain and canonical ACS URL",
+      "Authorize up to 19 additional email domains",
+      "Manage every domain from the same SAML configuration",
+    ],
+    primaryCta: "Manage SAML Domains in Prowler Cloud",
   },
 } as const satisfies Record<CloudUpgradeFeature, CloudUpgradeContent>;
 

--- a/ui/lib/cloud-upgrade.ts
+++ b/ui/lib/cloud-upgrade.ts
@@ -2,6 +2,7 @@ import {
   CLOUD_UPGRADE_FEATURE,
   type CloudUpgradeFeature,
 } from "@/types/cloud-upgrade";
+import { MAX_SAML_ADDITIONAL_EMAIL_DOMAINS } from "@/types/saml";
 
 interface CloudUpgradeContent {
   title: string;
@@ -164,7 +165,7 @@ export const CLOUD_UPGRADE_CONTENT = {
       "Let users from multiple verified email domains share one SAML identity provider configuration.",
     benefits: [
       "Keep one primary domain and canonical ACS URL",
-      "Authorize up to 19 additional email domains",
+      `Authorize up to ${MAX_SAML_ADDITIONAL_EMAIL_DOMAINS} additional email domains`,
       "Manage every domain from the same SAML configuration",
     ],
     primaryCta: "Manage SAML Domains in Prowler Cloud",

--- a/ui/types/cloud-upgrade.ts
+++ b/ui/types/cloud-upgrade.ts
@@ -10,6 +10,7 @@ export const CLOUD_UPGRADE_FEATURE = {
   LIGHTHOUSE_AI: "lighthouse_ai",
   GENERAL: "general",
   SCAN_CONFIGURATION: "scan_configuration",
+  SAML_DOMAINS: "saml_domains",
 } as const;
 
 export type CloudUpgradeFeature =

--- a/ui/types/formSchemas.test.ts
+++ b/ui/types/formSchemas.test.ts
@@ -7,6 +7,7 @@ import {
   addCredentialsRoleFormSchema,
   addProviderFormSchema,
   KUBECONFIG_UNSUPPORTED_COMMAND_AUTHENTICATION_ERROR,
+  samlConfigFormSchema,
 } from "./formSchemas";
 
 const BASE_AWS_ROLE_VALUES = {
@@ -286,5 +287,98 @@ describe("addCredentialsFormSchema - oraclecloud", () => {
     const result = schema.safeParse(BASE_OCI_VALUES);
 
     expect(result.success).toBe(true);
+  });
+});
+
+describe("samlConfigFormSchema", () => {
+  it("normalizes the primary and additional email domains", () => {
+    // Given
+    const values = {
+      email_domain: " Primary.Example.com ",
+      additional_email_domains: [
+        " Subsidiary.Example.com ",
+        "Division.Example.com",
+      ],
+      metadata_xml: " <EntityDescriptor /> ",
+    };
+
+    // When
+    const result = samlConfigFormSchema.safeParse(values);
+
+    // Then
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual({
+      email_domain: "primary.example.com",
+      additional_email_domains: [
+        "subsidiary.example.com",
+        "division.example.com",
+      ],
+      metadata_xml: "<EntityDescriptor />",
+    });
+  });
+
+  it("defaults additional domains to an empty list for OSS submissions", () => {
+    // Given / When
+    const result = samlConfigFormSchema.safeParse({
+      email_domain: "primary.example.com",
+      metadata_xml: "<EntityDescriptor />",
+    });
+
+    // Then
+    expect(result.success && result.data.additional_email_domains).toEqual([]);
+  });
+
+  it("rejects duplicate additional domains after normalization", () => {
+    // Given / When
+    const result = samlConfigFormSchema.safeParse({
+      email_domain: "primary.example.com",
+      additional_email_domains: ["alias.example.com", " ALIAS.EXAMPLE.COM "],
+      metadata_xml: "<EntityDescriptor />",
+    });
+
+    // Then
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.flatten().fieldErrors.additional_email_domains).toEqual(
+      ["Additional email domains must be unique."],
+    );
+  });
+
+  it("rejects the primary domain when it is also added as an alias", () => {
+    // Given / When
+    const result = samlConfigFormSchema.safeParse({
+      email_domain: "primary.example.com",
+      additional_email_domains: [" PRIMARY.EXAMPLE.COM "],
+      metadata_xml: "<EntityDescriptor />",
+    });
+
+    // Then
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.flatten().fieldErrors.additional_email_domains).toEqual(
+      ["Additional email domains must differ from the primary email domain."],
+    );
+  });
+
+  it("allows at most nineteen aliases in addition to the primary domain", () => {
+    // Given
+    const aliases = Array.from(
+      { length: 20 },
+      (_, index) => `alias-${index}.example.com`,
+    );
+
+    // When
+    const result = samlConfigFormSchema.safeParse({
+      email_domain: "primary.example.com",
+      additional_email_domains: aliases,
+      metadata_xml: "<EntityDescriptor />",
+    });
+
+    // Then
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.flatten().fieldErrors.additional_email_domains).toEqual(
+      ["A SAML configuration supports up to 19 additional email domains."],
+    );
   });
 });

--- a/ui/types/formSchemas.test.ts
+++ b/ui/types/formSchemas.test.ts
@@ -328,6 +328,23 @@ describe("samlConfigFormSchema", () => {
     expect(result.success && result.data.additional_email_domains).toEqual([]);
   });
 
+  it("uses contextual required messages for SAML domains", () => {
+    // Given / When
+    const result = samlConfigFormSchema.safeParse({
+      email_domain: "",
+      additional_email_domains: [""],
+      metadata_xml: "<EntityDescriptor />",
+    });
+
+    // Then
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.flatten().fieldErrors).toMatchObject({
+      email_domain: ["Email domain is required"],
+      additional_email_domains: ["Additional email domain is required"],
+    });
+  });
+
   it("rejects duplicate additional domains after normalization", () => {
     // Given / When
     const result = samlConfigFormSchema.safeParse({

--- a/ui/types/formSchemas.test.ts
+++ b/ui/types/formSchemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { ProviderCredentialFields } from "@/lib/provider-credentials/provider-credential-fields";
+import { MAX_SAML_ADDITIONAL_EMAIL_DOMAINS } from "@/types/saml";
 
 import {
   addCredentialsFormSchema,
@@ -380,7 +381,7 @@ describe("samlConfigFormSchema", () => {
   it("accepts exactly nineteen aliases in addition to the primary domain", () => {
     // Given
     const aliases = Array.from(
-      { length: 19 },
+      { length: MAX_SAML_ADDITIONAL_EMAIL_DOMAINS },
       (_, index) => `alias-${index}.example.com`,
     );
 
@@ -401,7 +402,7 @@ describe("samlConfigFormSchema", () => {
   it("rejects more than nineteen aliases in addition to the primary domain", () => {
     // Given
     const aliases = Array.from(
-      { length: 20 },
+      { length: MAX_SAML_ADDITIONAL_EMAIL_DOMAINS + 1 },
       (_, index) => `alias-${index}.example.com`,
     );
 
@@ -416,7 +417,9 @@ describe("samlConfigFormSchema", () => {
     expect(result.success).toBe(false);
     if (result.success) return;
     expect(result.error.flatten().fieldErrors.additional_email_domains).toEqual(
-      ["A SAML configuration supports up to 19 additional email domains."],
+      [
+        `A SAML configuration supports up to ${MAX_SAML_ADDITIONAL_EMAIL_DOMAINS} additional email domains.`,
+      ],
     );
   });
 });

--- a/ui/types/formSchemas.test.ts
+++ b/ui/types/formSchemas.test.ts
@@ -360,7 +360,28 @@ describe("samlConfigFormSchema", () => {
     );
   });
 
-  it("allows at most nineteen aliases in addition to the primary domain", () => {
+  it("accepts exactly nineteen aliases in addition to the primary domain", () => {
+    // Given
+    const aliases = Array.from(
+      { length: 19 },
+      (_, index) => `alias-${index}.example.com`,
+    );
+
+    // When
+    const result = samlConfigFormSchema.safeParse({
+      email_domain: "primary.example.com",
+      additional_email_domains: aliases,
+      metadata_xml: "<EntityDescriptor />",
+    });
+
+    // Then
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.additional_email_domains).toEqual(
+      aliases,
+    );
+  });
+
+  it("rejects more than nineteen aliases in addition to the primary domain", () => {
     // Given
     const aliases = Array.from(
       { length: 20 },

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -722,16 +722,48 @@ export const editUserFormSchema = () =>
     role: z.string().optional(),
   });
 
-export const samlConfigFormSchema = z.object({
-  email_domain: z
-    .string()
-    .trim()
-    .min(1, { message: "Email domain is required" }),
-  metadata_xml: z
-    .string()
-    .trim()
-    .min(1, { message: "Metadata XML is required" }),
-});
+export const samlEmailDomainSchema = z
+  .string()
+  .trim()
+  .min(1, { message: "Email domain is required" })
+  .transform((domain) => domain.toLowerCase());
+
+export const samlConfigFormSchema = z
+  .object({
+    email_domain: samlEmailDomainSchema,
+    additional_email_domains: z
+      .array(samlEmailDomainSchema)
+      .max(19, {
+        message:
+          "A SAML configuration supports up to 19 additional email domains.",
+      })
+      .default([]),
+    metadata_xml: z
+      .string()
+      .trim()
+      .min(1, { message: "Metadata XML is required" }),
+  })
+  .superRefine((data, ctx) => {
+    if (
+      new Set(data.additional_email_domains).size !==
+      data.additional_email_domains.length
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Additional email domains must be unique.",
+        path: ["additional_email_domains"],
+      });
+    }
+
+    if (data.additional_email_domains.includes(data.email_domain)) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "Additional email domains must differ from the primary email domain.",
+        path: ["additional_email_domains"],
+      });
+    }
+  });
 
 export const mutedFindingsConfigFormSchema = z.object({
   configuration: z

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { ProviderCredentialFields } from "@/lib/provider-credentials/provider-credential-fields";
 import { validateMutelistYaml, validateYaml } from "@/lib/yaml";
+import { MAX_SAML_ADDITIONAL_EMAIL_DOMAINS } from "@/types/saml";
 
 import { PROVIDER_TYPES, ProviderType } from "./providers";
 
@@ -741,8 +742,8 @@ const samlConfigDomainSchema = z.object({
   email_domain: samlEmailDomainSchema,
   additional_email_domains: z
     .array(samlAdditionalEmailDomainSchema)
-    .max(19, {
-      error: "A SAML configuration supports up to 19 additional email domains.",
+    .max(MAX_SAML_ADDITIONAL_EMAIL_DOMAINS, {
+      error: `A SAML configuration supports up to ${MAX_SAML_ADDITIONAL_EMAIL_DOMAINS} additional email domains.`,
     })
     .default([]),
 });
@@ -751,6 +752,8 @@ const samlMetadataXmlSchema = z
   .string()
   .trim()
   .min(1, { error: "Metadata XML is required" });
+
+const samlOptionalMetadataXmlSchema = z.string().trim();
 
 const validateSamlDomains = (
   data: z.output<typeof samlConfigDomainSchema>,
@@ -784,9 +787,23 @@ const validateSamlDomains = (
   }
 };
 
-export const samlConfigFormSchema = samlConfigDomainSchema
-  .extend({ metadata_xml: samlMetadataXmlSchema })
-  .superRefine(validateSamlDomains);
+export const getSamlConfigFormSchema = (isUpdate: boolean) =>
+  samlConfigDomainSchema
+    .extend({
+      metadata_xml: isUpdate
+        ? samlOptionalMetadataXmlSchema
+        : samlMetadataXmlSchema,
+    })
+    .superRefine(validateSamlDomains);
+
+export type SamlConfigFormInput = z.input<
+  ReturnType<typeof getSamlConfigFormSchema>
+>;
+export type SamlConfigFormValues = z.output<
+  ReturnType<typeof getSamlConfigFormSchema>
+>;
+
+export const samlConfigFormSchema = getSamlConfigFormSchema(false);
 
 export const samlConfigUpdateFormSchema = samlConfigDomainSchema
   .extend({

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -726,7 +726,7 @@ const createSamlEmailDomainSchema = (requiredMessage: string) =>
   z
     .string()
     .trim()
-    .min(1, { message: requiredMessage })
+    .min(1, { error: requiredMessage })
     .transform((domain) => domain.toLowerCase());
 
 export const samlEmailDomainSchema = createSamlEmailDomainSchema(
@@ -742,8 +742,7 @@ const samlConfigDomainSchema = z.object({
   additional_email_domains: z
     .array(samlAdditionalEmailDomainSchema)
     .max(19, {
-      message:
-        "A SAML configuration supports up to 19 additional email domains.",
+      error: "A SAML configuration supports up to 19 additional email domains.",
     })
     .default([]),
 });
@@ -751,7 +750,7 @@ const samlConfigDomainSchema = z.object({
 const samlMetadataXmlSchema = z
   .string()
   .trim()
-  .min(1, { message: "Metadata XML is required" });
+  .min(1, { error: "Metadata XML is required" });
 
 const validateSamlDomains = (
   data: z.output<typeof samlConfigDomainSchema>,

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -728,42 +728,64 @@ export const samlEmailDomainSchema = z
   .min(1, { message: "Email domain is required" })
   .transform((domain) => domain.toLowerCase());
 
-export const samlConfigFormSchema = z
-  .object({
-    email_domain: samlEmailDomainSchema,
-    additional_email_domains: z
-      .array(samlEmailDomainSchema)
-      .max(19, {
-        message:
-          "A SAML configuration supports up to 19 additional email domains.",
-      })
-      .default([]),
-    metadata_xml: z
-      .string()
-      .trim()
-      .min(1, { message: "Metadata XML is required" }),
-  })
-  .superRefine((data, ctx) => {
-    if (
-      new Set(data.additional_email_domains).size !==
-      data.additional_email_domains.length
-    ) {
-      ctx.addIssue({
-        code: "custom",
-        message: "Additional email domains must be unique.",
-        path: ["additional_email_domains"],
-      });
-    }
+const samlConfigDomainSchema = z.object({
+  email_domain: samlEmailDomainSchema,
+  additional_email_domains: z
+    .array(samlEmailDomainSchema)
+    .max(19, {
+      message:
+        "A SAML configuration supports up to 19 additional email domains.",
+    })
+    .default([]),
+});
 
-    if (data.additional_email_domains.includes(data.email_domain)) {
-      ctx.addIssue({
-        code: "custom",
-        message:
-          "Additional email domains must differ from the primary email domain.",
-        path: ["additional_email_domains"],
-      });
-    }
-  });
+const samlMetadataXmlSchema = z
+  .string()
+  .trim()
+  .min(1, { message: "Metadata XML is required" });
+
+const validateSamlDomains = (
+  data: z.output<typeof samlConfigDomainSchema>,
+  ctx: z.RefinementCtx,
+) => {
+  if (
+    new Set(data.additional_email_domains).size !==
+    data.additional_email_domains.length
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Additional email domains must be unique.",
+      path: ["additional_email_domains"],
+    });
+  }
+
+  if (data.additional_email_domains.includes(data.email_domain)) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "Additional email domains must differ from the primary email domain.",
+      path: ["additional_email_domains"],
+    });
+  }
+};
+
+export const samlConfigFormSchema = samlConfigDomainSchema
+  .extend({ metadata_xml: samlMetadataXmlSchema })
+  .superRefine(validateSamlDomains);
+
+export const samlConfigUpdateFormSchema = samlConfigDomainSchema
+  .extend({
+    metadata_xml: z.preprocess(
+      (value) =>
+        value === null ||
+        value === undefined ||
+        (typeof value === "string" && value.trim() === "")
+          ? undefined
+          : value,
+      samlMetadataXmlSchema.optional(),
+    ),
+  })
+  .superRefine(validateSamlDomains);
 
 export const mutedFindingsConfigFormSchema = z.object({
   configuration: z

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -722,16 +722,25 @@ export const editUserFormSchema = () =>
     role: z.string().optional(),
   });
 
-export const samlEmailDomainSchema = z
-  .string()
-  .trim()
-  .min(1, { message: "Email domain is required" })
-  .transform((domain) => domain.toLowerCase());
+const createSamlEmailDomainSchema = (requiredMessage: string) =>
+  z
+    .string()
+    .trim()
+    .min(1, { message: requiredMessage })
+    .transform((domain) => domain.toLowerCase());
+
+export const samlEmailDomainSchema = createSamlEmailDomainSchema(
+  "Email domain is required",
+);
+
+export const samlAdditionalEmailDomainSchema = createSamlEmailDomainSchema(
+  "Additional email domain is required",
+);
 
 const samlConfigDomainSchema = z.object({
   email_domain: samlEmailDomainSchema,
   additional_email_domains: z
-    .array(samlEmailDomainSchema)
+    .array(samlAdditionalEmailDomainSchema)
     .max(19, {
       message:
         "A SAML configuration supports up to 19 additional email domains.",
@@ -748,9 +757,13 @@ const validateSamlDomains = (
   data: z.output<typeof samlConfigDomainSchema>,
   ctx: z.RefinementCtx,
 ) => {
+  const populatedAdditionalDomains = data.additional_email_domains.filter(
+    (domain) => domain.length > 0,
+  );
+
   if (
-    new Set(data.additional_email_domains).size !==
-    data.additional_email_domains.length
+    new Set(populatedAdditionalDomains).size !==
+    populatedAdditionalDomains.length
   ) {
     ctx.addIssue({
       code: "custom",
@@ -759,7 +772,10 @@ const validateSamlDomains = (
     });
   }
 
-  if (data.additional_email_domains.includes(data.email_domain)) {
+  if (
+    data.email_domain.length > 0 &&
+    populatedAdditionalDomains.includes(data.email_domain)
+  ) {
     ctx.addIssue({
       code: "custom",
       message:

--- a/ui/types/index.ts
+++ b/ui/types/index.ts
@@ -13,5 +13,6 @@ export * from "./providers-table";
 export * from "./resources";
 export * from "./scans";
 export * from "./schedules";
+export * from "./saml";
 export * from "./tasks";
 export * from "./tree";

--- a/ui/types/saml.ts
+++ b/ui/types/saml.ts
@@ -1,0 +1,33 @@
+export const SAML_CONFIGURATION_RESOURCE_TYPE = "saml-configurations" as const;
+
+export interface SamlConfigurationAttributes {
+  email_domain: string;
+  additional_email_domains?: string[];
+  metadata_xml?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface SamlConfiguration {
+  id: string;
+  type?: typeof SAML_CONFIGURATION_RESOURCE_TYPE;
+  attributes?: SamlConfigurationAttributes;
+}
+
+export interface SamlConfigurationErrors {
+  email_domain?: string;
+  additional_email_domains?: string;
+  metadata_xml?: string;
+  general?: string;
+}
+
+export type SamlConfigurationActionState = {
+  errors?: SamlConfigurationErrors;
+  success?: string;
+} | null;
+
+export interface SamlConfigurationRequestAttributes {
+  email_domain: string;
+  additional_email_domains?: string[];
+  metadata_xml: string;
+}

--- a/ui/types/saml.ts
+++ b/ui/types/saml.ts
@@ -26,8 +26,17 @@ export type SamlConfigurationActionState = {
   success?: string;
 } | null;
 
-export interface SamlConfigurationRequestAttributes {
+interface SamlConfigurationRequestAttributes {
   email_domain: string;
   additional_email_domains?: string[];
+}
+
+export interface SamlConfigurationCreateRequestAttributes
+  extends SamlConfigurationRequestAttributes {
   metadata_xml: string;
+}
+
+export interface SamlConfigurationUpdateRequestAttributes
+  extends SamlConfigurationRequestAttributes {
+  metadata_xml?: string;
 }

--- a/ui/types/saml.ts
+++ b/ui/types/saml.ts
@@ -1,4 +1,5 @@
 export const SAML_CONFIGURATION_RESOURCE_TYPE = "saml-configurations" as const;
+export const MAX_SAML_ADDITIONAL_EMAIL_DOMAINS = 19;
 
 export interface SamlConfigurationAttributes {
   email_domain: string;


### PR DESCRIPTION
### Context

[PROWLER-2304](https://prowlerpro.atlassian.net/browse/PROWLER-2304) adds UI support for managing multiple verified email domains in one SAML configuration.

Prowler Cloud needs a primary domain plus verified aliases to share one SAML identity provider. OSS must continue supporting its existing single-domain SAML configuration and authentication flow.

### Description

- Add typed support for `additional_email_domains` across the SAML form and server actions
- Normalize domains, reject duplicates, and enforce the API limit of 19 aliases
- Send complete replacement arrays from Cloud create and update actions, including an empty array when all aliases are removed
- Keep OSS SAML fully functional while omitting the Cloud-only alias field and showing a contextual upgrade option
- Keep one canonical ACS URL derived from the primary domain and render aliases in a compact scrollable list
- Map API validation errors to the form and add focused action, schema, form, and upgrade coverage
- Add the required UI changelog fragment

No new npm dependencies are included.

### Screenshots

#### Prowler Cloud

<img width="837" height="998" alt="PROWLER-2304-cloud" src="https://github.com/user-attachments/assets/e5c3340e-4294-4c5c-bb93-20416cba8128" />

#### OSS

<img width="837" height="998" alt="PROWLER-2304-oss" src="https://github.com/user-attachments/assets/25b2107a-1892-4f26-ac5d-c386e54374e9" />

#### SAML update

The metadata XML is optional when updating an existing SAML configuration because the current metadata is preserved unless a replacement file is uploaded. The required asterisk is therefore shown only during creation.

<img width="211" height="196" alt="PROWLER-2304-saml-update-optional-metadata" src="https://github.com/user-attachments/assets/25d4c36e-5ad8-4efa-947a-efcc8ea7bf4e" />

### Steps to review

1. Run the focused tests:
   `pnpm exec vitest run actions/integrations/saml.test.ts components/integrations/saml/saml-config-form.test.tsx lib/cloud-upgrade.test.ts types/formSchemas.test.ts`
2. Run `pnpm run healthcheck` from `ui/`.
3. Start the UI with `UI_CLOUD_ENABLED=true`, sign in against the dev API, and open **Profile > SAML > Update**.
4. Verify existing aliases load, additions are normalized, aliases can be removed, the counter stops at 19, and the ACS URL remains based on the primary domain.
5. Start the UI with `UI_CLOUD_ENABLED=false` and verify the primary SAML domain and metadata remain editable while **Additional Email Domains** shows the Prowler Cloud availability pill.

Validation completed locally:

- Focused Vitest coverage: 61 tests passed
- UI healthcheck: TypeScript, ESLint, and Prettier passed
- Browser verification completed in both Cloud and OSS modes against the dev API without submitting a mutation

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [x] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


[PROWLER-2304]: https://prowlerpro.atlassian.net/browse/PROWLER-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud users can configure up to 19 additional verified email domains in a single SAML configuration.
  * Added controls to add, remove, and manage domains with duplicate and conflict validation.
  * Added upgrade prompts for this capability in non-cloud environments.
* **Bug Fixes**
  * Improved SAML validation, domain normalization, and field-specific error messages.
  * SAML updates no longer require metadata XML when it is unchanged.
* **Tests**
  * Added comprehensive coverage for domain management, validation, cloud availability, upgrade messaging, and SAML configuration actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->