### PR TITLE
chore(docs): sync Docker Hub repository overviews from a single source

### DIFF
--- a/.github/workflows/dockerhub-descriptions.yml
+++ b/.github/workflows/dockerhub-descriptions.yml
@@ -1,0 +1,92 @@
+name: 'Tools: Sync Docker Hub Descriptions'
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'docs/dockerhub/README.md'
+      - '.github/workflows/dockerhub-descriptions.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  OVERVIEW_FILE: docs/dockerhub/README.md
+
+permissions: {}
+
+jobs:
+  prowlercloud:
+    if: github.repository == 'prowler-cloud/prowler'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: prowlercloud/prowler
+            short_description: 'Prowler CLI: the Open Cloud Security tool for AWS, Azure, Google Cloud, Kubernetes, M365 and GitHub'
+          - repository: prowlercloud/prowler-api
+            short_description: 'This image contains the JSON API and Task Runner components for Prowler.'
+          - repository: prowlercloud/prowler-ui
+            short_description: 'This image hosts the UI component for Prowler, providing a web interface to interact with Prowler.'
+          - repository: prowlercloud/prowler-mcp
+            short_description: 'Prowler MCP Server provides AI assistants with access to the entire Prowler ecosystem'
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            hub.docker.com:443
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Update Docker Hub description for ${{ matrix.repository }}
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ matrix.repository }}
+          short-description: ${{ matrix.short_description }}
+          readme-filepath: ${{ env.OVERVIEW_FILE }}
+
+  toniblyx:
+    if: github.repository == 'prowler-cloud/prowler'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            hub.docker.com:443
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Update Docker Hub description for toniblyx/prowler
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.TONIBLYX_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.TONIBLYX_DOCKERHUB_PASSWORD }}
+          repository: toniblyx/prowler
+          short-description: 'Prowler CLI (legacy repository, mirrors prowlercloud/prowler)'
+          readme-filepath: ${{ env.OVERVIEW_FILE }}

--- a/.github/workflows/dockerhub-descriptions.yml
+++ b/.github/workflows/dockerhub-descriptions.yml
@@ -20,7 +20,7 @@ permissions: {}
 
 jobs:
   prowlercloud:
-    if: github.repository == 'prowler-cloud/prowler'
+    if: github.repository == 'prowler-cloud/prowler' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -62,7 +62,7 @@ jobs:
           readme-filepath: ${{ env.OVERVIEW_FILE }}
 
   toniblyx:
-    if: github.repository == 'prowler-cloud/prowler'
+    if: github.repository == 'prowler-cloud/prowler' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/dockerhub-descriptions.yml
+++ b/.github/workflows/dockerhub-descriptions.yml
@@ -32,11 +32,11 @@ jobs:
           - repository: prowlercloud/prowler
             short_description: 'Prowler CLI: the Open Cloud Security tool for AWS, Azure, Google Cloud, Kubernetes, M365 and GitHub'
           - repository: prowlercloud/prowler-api
-            short_description: 'This image contains the JSON API and Task Runner components for Prowler.'
+            short_description: 'Prowler Local Server - API: the JSON API and Task Runner components of Prowler'
           - repository: prowlercloud/prowler-ui
-            short_description: 'This image hosts the UI component for Prowler, providing a web interface to interact with Prowler.'
+            short_description: 'Prowler Local Server - UI: the web interface to run Prowler scans and explore findings'
           - repository: prowlercloud/prowler-mcp
-            short_description: 'Prowler MCP Server provides AI assistants with access to the entire Prowler ecosystem'
+            short_description: 'Prowler MCP: the interface for agents, including IDE plugins and agent integrations'
 
     steps:
       - name: Harden Runner

--- a/docs/dockerhub/README.md
+++ b/docs/dockerhub/README.md
@@ -1,0 +1,120 @@
+<p align="center">
+  <b>Prowler</b> is the Open Cloud Security platform trusted by thousands to automate security and compliance in any cloud environment — AWS, Azure, Google Cloud, Kubernetes, M365, GitHub and more.
+</p>
+<p align="center">
+  <b>Learn more at <a href="https://prowler.com">prowler.com</a> · <a href="https://goto.prowler.com/slack">Join our Slack community</a></b>
+</p>
+
+<p align="center">
+  <a href="https://github.com/prowler-cloud/prowler"><img alt="GitHub" src="https://img.shields.io/github/stars/prowler-cloud/prowler?style=social"></a>
+  <a href="https://github.com/prowler-cloud/prowler/releases"><img alt="Version" src="https://img.shields.io/github/v/release/prowler-cloud/prowler"></a>
+  <a href="https://pypi.org/project/prowler/"><img alt="PyPI" src="https://img.shields.io/pypi/v/prowler.svg"></a>
+  <a href="https://github.com/prowler-cloud/prowler"><img alt="License" src="https://img.shields.io/github/license/prowler-cloud/prowler"></a>
+</p>
+
+---
+
+# Prowler container images
+
+All Prowler images are built from a single repository — [github.com/prowler-cloud/prowler](https://github.com/prowler-cloud/prowler) — and published together on every release.
+
+| Image | What it is | Dockerfile |
+|---|---|---|
+| [`prowlercloud/prowler`](https://hub.docker.com/r/prowlercloud/prowler) | **Prowler CLI/SDK.** Runs scans from your terminal, a CI job, a Kubernetes Job or any container platform. | [`Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/Dockerfile) |
+| [`prowlercloud/prowler-api`](https://hub.docker.com/r/prowlercloud/prowler-api) | **Prowler App — API.** Django REST backend plus the Celery worker and scheduler that run scans and store results. | [`api/Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/api/Dockerfile) |
+| [`prowlercloud/prowler-ui`](https://hub.docker.com/r/prowlercloud/prowler-ui) | **Prowler App — UI.** Next.js web interface for launching scans and exploring findings. | [`ui/Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/ui/Dockerfile) |
+| [`prowlercloud/prowler-mcp`](https://hub.docker.com/r/prowlercloud/prowler-mcp) | **Prowler MCP Server.** Gives AI assistants access to the Prowler ecosystem over the Model Context Protocol. | [`mcp_server/Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/mcp_server/Dockerfile) |
+| [`toniblyx/prowler`](https://hub.docker.com/r/toniblyx/prowler) | **Legacy home of the Prowler CLI image.** Still mirrored on every release for backwards compatibility. New deployments should use `prowlercloud/prowler`. | [`Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/Dockerfile) |
+
+All images are published for `linux/amd64` and `linux/arm64`.
+
+## Tags
+
+| Tag | Meaning |
+|---|---|
+| `stable` | Always points to the latest stable release. **Recommended for production.** |
+| `<x.y.z>` | A specific release, e.g. `5.14.0`. Immutable. |
+| `latest` | Built from the `master` branch on every merge. Not a stable version. |
+| `<short-sha>` | A specific `master` commit (`prowler-api`, `prowler-ui` and `prowler-mcp` only). |
+
+`v3-*` and `v4-*` tags on `prowlercloud/prowler` are frozen historical artifacts of Prowler v3/v4 and no longer receive updates.
+
+## Other registries
+
+The Prowler CLI image is also available on AWS Public ECR: [`public.ecr.aws/prowler-cloud/prowler`](https://gallery.ecr.aws/prowler-cloud/prowler).
+
+---
+
+# Quick start
+
+## Prowler App (UI + API)
+
+```console
+curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/master/docker-compose.yml
+curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/master/.env
+docker compose up -d
+```
+
+Then open http://localhost:3000 and sign up with your email and password.
+
+Full guide: [Prowler App installation](https://docs.prowler.com/getting-started/installation/prowler-app)
+
+## Prowler CLI
+
+```console
+docker run -ti --rm \
+  -v /your/local/dir/prowler-output:/home/prowler/output \
+  --name prowler \
+  --env AWS_ACCESS_KEY_ID \
+  --env AWS_SECRET_ACCESS_KEY \
+  --env AWS_SESSION_TOKEN \
+  prowlercloud/prowler:stable aws
+```
+
+Swap `aws` for `azure`, `gcp`, `kubernetes`, `m365` or `github` to scan another provider. The CLI is also on PyPI: `pip install prowler`.
+
+Full guide: [Prowler CLI installation](https://docs.prowler.com/getting-started/installation/prowler-cli)
+
+## Prowler MCP Server
+
+```console
+# STDIO mode (for local MCP clients)
+docker run --rm -i prowlercloud/prowler-mcp
+
+# HTTP mode (for remote access)
+docker run --rm -p 8000:8000 prowlercloud/prowler-mcp \
+  --transport http --host 0.0.0.0 --port 8000
+```
+
+Full guide: [Prowler MCP Server installation](https://docs.prowler.com/getting-started/installation/prowler-mcp)
+
+> **Note on architecture:** if your workstation's architecture is incompatible, set `DOCKER_DEFAULT_PLATFORM=linux/amd64` or pass `--platform linux/amd64` to your Docker command.
+
+---
+
+# What Prowler covers
+
+Hundreds of built-in checks mapped to the frameworks you get audited against — CIS, NIST 800 / CSF, CISA, PCI-DSS, GDPR, HIPAA, FFIEC, SOC2, GXP, FedRAMP, RBI, AWS Well-Architected (Security Pillar), AWS FTR, ENS — plus your own custom frameworks.
+
+For live check, service, framework and category counts, see [**Prowler Hub**](https://hub.prowler.com).
+
+List what's available for any provider:
+
+```console
+prowler <provider> --list-checks
+prowler <provider> --list-services
+prowler <provider> --list-compliance
+prowler <provider> --list-categories
+```
+
+# Documentation and support
+
+- **Documentation:** [docs.prowler.com](https://docs.prowler.com/)
+- **Source:** [github.com/prowler-cloud/prowler](https://github.com/prowler-cloud/prowler)
+- **Issues:** [github.com/prowler-cloud/prowler/issues](https://github.com/prowler-cloud/prowler/issues)
+- **Community:** [Prowler Slack](https://goto.prowler.com/slack)
+- **Troubleshooting:** [docs.prowler.com/troubleshooting](https://docs.prowler.com/troubleshooting)
+
+# License
+
+Prowler is licensed under the Apache License 2.0. A copy is available at http://www.apache.org/licenses/LICENSE-2.0.

--- a/docs/dockerhub/README.md
+++ b/docs/dockerhub/README.md
@@ -20,10 +20,10 @@ All Prowler images are built from a single repository — [github.com/prowler-cl
 
 | Image | What it is | Dockerfile |
 |---|---|---|
-| [`prowlercloud/prowler`](https://hub.docker.com/r/prowlercloud/prowler) | **Prowler CLI/SDK.** Runs scans from your terminal, a CI job, a Kubernetes Job or any container platform. | [`Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/Dockerfile) |
-| [`prowlercloud/prowler-api`](https://hub.docker.com/r/prowlercloud/prowler-api) | **Prowler App — API.** Django REST backend plus the Celery worker and scheduler that run scans and store results. | [`api/Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/api/Dockerfile) |
-| [`prowlercloud/prowler-ui`](https://hub.docker.com/r/prowlercloud/prowler-ui) | **Prowler App — UI.** Next.js web interface for launching scans and exploring findings. | [`ui/Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/ui/Dockerfile) |
-| [`prowlercloud/prowler-mcp`](https://hub.docker.com/r/prowlercloud/prowler-mcp) | **Prowler MCP Server.** Gives AI assistants access to the Prowler ecosystem over the Model Context Protocol. | [`mcp_server/Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/mcp_server/Dockerfile) |
+| [`prowlercloud/prowler`](https://hub.docker.com/r/prowlercloud/prowler) | **Prowler CLI.** Runs scans from your terminal, a CI job, a Kubernetes Job or any container platform. | [`Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/Dockerfile) |
+| [`prowlercloud/prowler-api`](https://hub.docker.com/r/prowlercloud/prowler-api) | **Prowler Local Server — API.** Django REST backend plus the Celery worker and scheduler that run scans and store results. | [`api/Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/api/Dockerfile) |
+| [`prowlercloud/prowler-ui`](https://hub.docker.com/r/prowlercloud/prowler-ui) | **Prowler Local Server — UI.** Next.js web interface for launching scans and exploring findings. | [`ui/Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/ui/Dockerfile) |
+| [`prowlercloud/prowler-mcp`](https://hub.docker.com/r/prowlercloud/prowler-mcp) | **Prowler MCP.** Gives AI assistants access to the Prowler ecosystem over the Model Context Protocol. | [`mcp_server/Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/mcp_server/Dockerfile) |
 | [`toniblyx/prowler`](https://hub.docker.com/r/toniblyx/prowler) | **Legacy home of the Prowler CLI image.** Still mirrored on every release for backwards compatibility. New deployments should use `prowlercloud/prowler`. | [`Dockerfile`](https://github.com/prowler-cloud/prowler/blob/master/Dockerfile) |
 
 All images are published for `linux/amd64` and `linux/arm64`.
@@ -47,7 +47,7 @@ The Prowler CLI image is also available on AWS Public ECR: [`public.ecr.aws/prow
 
 # Quick start
 
-## Prowler App (UI + API)
+## Prowler Local Server (UI + API)
 
 ```console
 curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/master/docker-compose.yml
@@ -57,7 +57,7 @@ docker compose up -d
 
 Then open http://localhost:3000 and sign up with your email and password.
 
-Full guide: [Prowler App installation](https://docs.prowler.com/getting-started/installation/prowler-app)
+Full guide: [Prowler Local Server installation](https://docs.prowler.com/getting-started/installation/prowler-app)
 
 ## Prowler CLI
 
@@ -75,7 +75,7 @@ Swap `aws` for `azure`, `gcp`, `kubernetes`, `m365` or `github` to scan another 
 
 Full guide: [Prowler CLI installation](https://docs.prowler.com/getting-started/installation/prowler-cli)
 
-## Prowler MCP Server
+## Prowler MCP
 
 ```console
 # STDIO mode (for local MCP clients)
@@ -86,7 +86,7 @@ docker run --rm -p 8000:8000 prowlercloud/prowler-mcp \
   --transport http --host 0.0.0.0 --port 8000
 ```
 
-Full guide: [Prowler MCP Server installation](https://docs.prowler.com/getting-started/installation/prowler-mcp)
+Full guide: [Prowler MCP installation](https://docs.prowler.com/getting-started/installation/prowler-mcp)
 
 > **Note on architecture:** if your workstation's architecture is incompatible, set `DOCKER_DEFAULT_PLATFORM=linux/amd64` or pass `--platform linux/amd64` to your Docker command.
 


### PR DESCRIPTION
### Context

The Docker Hub overviews for `toniblyx/prowler` and `prowlercloud/prowler` are hand-pasted and stale:

- `toniblyx/prowler` (4.4M pulls) still shows a Prowler v3-era README: 304 AWS checks, AWS/GCP/Azure only, no Prowler App, no MCP.
- `prowlercloud/prowler` is an older README snapshot that never mentions `prowler-mcp` and still documents `v3-latest`/`v4-latest` tags, which the SDK workflow no longer produces (it hard-errors on any major other than 5).

Neither page lists the full image set, and there is no automation, so both drift further with every release.

### Description

One shared overview at `docs/dockerhub/README.md`, published to all five Docker Hub repos by a new workflow (`.github/workflows/dockerhub-descriptions.yml`) on push to `master` (plus `workflow_dispatch`). Each repo keeps its own short-description; the long overview is shared and leads with a table of all five images.

Images covered: `prowlercloud/prowler` (CLI/SDK), `prowlercloud/prowler-api`, `prowlercloud/prowler-ui`, `prowlercloud/prowler-mcp`, `toniblyx/prowler` (legacy mirror of the CLI image).

**Why a separate file instead of the root README** — pointing Docker Hub at `README.md` would break 9 images: both logos use `github.com/blob/...` URLs without `?raw=True`, which return `text/html` off GitHub (GitHub's own renderer special-cases them, Docker Hub does not), and 7 more are relative paths (`docs/img/*`, `docs/images/products/*`). The `#gh-light-mode-only` / `#gh-dark-mode-only` pair also renders both logos on Docker Hub. On top of that the README is 22,092 of the 25,000 allowed bytes, so it would start silently truncating.

### Steps to review

- Read through `docs/dockerhub/README.md` as it would render on Docker Hub (no relative links, no GitHub-only markdown extensions).
- Review `.github/workflows/dockerhub-descriptions.yml`: two jobs, `prowlercloud` (matrix of 4 repos, `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`) and `toniblyx` (`TONIBLYX_DOCKERHUB_USERNAME`/`TONIBLYX_DOCKERHUB_PASSWORD`), both gated on `github.repository == 'prowler-cloud/prowler'`.
- Trigger `workflow_dispatch` after merge to confirm the sync actually lands on Docker Hub as expected.

Notes for reviewers:

- Every URL in the overview is absolute and was verified to return 200 (badges, docs pages, Docker Hub repos, Dockerfile links, raw compose files, ECR gallery).
- No logo image is included on purpose: every Prowler wordmark asset is single-colour on a transparent background (`prowler-logo-black.png`, `prowler-logo-white.png`, and prowler.com's `og:image`), so one of Docker Hub's light/dark themes always renders it invisible. The only theme-safe brand asset in the repo is `dashboard/assets/images/icons/cloud/prowler-mark.svg` (brand green). Happy to add it if the team prefers.
- `enable-url-completion` is deliberately left off; it has documented bugs rewriting links inside code blocks.
- Requires the `DOCKERHUB_TOKEN` secret to have read/write/delete scope and the account to hold Admin on the org repos, which the Docker Hub description API needs. The existing push token may be narrower; worth confirming before merge. `TONIBLYX_DOCKERHUB_USERNAME` / `TONIBLYX_DOCKERHUB_PASSWORD` are already used by the SDK workflow's toniblyx push.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Docker image documentation covering registries, tags, architectures, quick starts, Docker Compose, MCP Server usage, supported frameworks, licensing, and support resources.

* **Chores**
  * Automated synchronization of Docker Hub repository descriptions when relevant documentation changes or updates are manually requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->