### PR TITLE
fix(container): verify the checksum of downloaded third-party binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,20 @@ ENV TRIVY_VERSION=${TRIVY_VERSION}
 ARG ZIZMOR_VERSION=1.24.1
 ENV ZIZMOR_VERSION=${ZIZMOR_VERSION}
 
+# Checksums of the third-party binaries fetched below. They are pinned here rather
+# than downloaded alongside the artefact: a compromised release would ship a matching
+# checksum file. CVE-2026-33634 was exactly that -- a malicious Trivy release published
+# with stolen credentials.
+# Trivy and PowerShell values are the vendors' published checksums. zizmor publishes
+# none, so its values were computed from the current artefacts and pin them against
+# future substitution.
+ARG TRIVY_SHA256_AMD64=bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea
+ARG TRIVY_SHA256_ARM64=2ca2c023109c2db6b2b77366b6717291452d4531167377d95c79547f0c8e3467
+ARG POWERSHELL_SHA256_AMD64=492ff26bb958336bf61e597ce19e07648b4003bd2a08659e02f0e3e0446ebfe0
+ARG POWERSHELL_SHA256_ARM64=2503b71da3e83635592b092df59a0aca4c3606b4d9b068217bb00be989cb0d56
+ARG ZIZMOR_SHA256_AMD64=a8000f3c683319a523d3b20df0e75457ba591f049cfcbfa98966631b56733c03
+ARG ZIZMOR_SHA256_ARM64=d66e37ef8a375fb07939c630ebf9709a6e0f20242bdc3faf672a7ed97e0b768d
+
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget libicu76 libunwind8 libssl3 libcurl4 ca-certificates apt-transport-https gnupg \
@@ -29,6 +43,8 @@ RUN ARCH=$(uname -m) && \
     else \
         echo "Unsupported architecture: $ARCH" && exit 1 ; \
     fi && \
+    if [ "$ARCH" = "x86_64" ]; then EXPECT="$POWERSHELL_SHA256_AMD64" ; else EXPECT="$POWERSHELL_SHA256_ARM64" ; fi && \
+    echo "$EXPECT  /tmp/powershell.tar.gz" | sha256sum -c - && \
     mkdir -p /opt/microsoft/powershell/7 && \
     tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 && \
     chmod +x /opt/microsoft/powershell/7/pwsh && \
@@ -45,6 +61,8 @@ RUN ARCH=$(uname -m) && \
         echo "Unsupported architecture for Trivy: $ARCH" && exit 1 ; \
     fi && \
     wget --progress=dot:giga "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz" -O /tmp/trivy.tar.gz && \
+    if [ "$ARCH" = "x86_64" ]; then EXPECT="$TRIVY_SHA256_AMD64" ; else EXPECT="$TRIVY_SHA256_ARM64" ; fi && \
+    echo "$EXPECT  /tmp/trivy.tar.gz" | sha256sum -c - && \
     tar zxf /tmp/trivy.tar.gz -C /tmp && \
     mv /tmp/trivy /usr/local/bin/trivy && \
     chmod +x /usr/local/bin/trivy && \
@@ -63,6 +81,8 @@ RUN ARCH=$(uname -m) && \
         echo "Unsupported architecture for zizmor: $ARCH" && exit 1 ; \
     fi && \
     wget --progress=dot:giga "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-${ZIZMOR_ARCH}.tar.gz" -O /tmp/zizmor.tar.gz && \
+    if [ "$ARCH" = "x86_64" ]; then EXPECT="$ZIZMOR_SHA256_AMD64" ; else EXPECT="$ZIZMOR_SHA256_ARM64" ; fi && \
+    echo "$EXPECT  /tmp/zizmor.tar.gz" | sha256sum -c - && \
     mkdir -p /tmp/zizmor-extract && \
     tar zxf /tmp/zizmor.tar.gz -C /tmp/zizmor-extract && \
     mv /tmp/zizmor-extract/zizmor /usr/local/bin/zizmor && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN ARCH=$(uname -m) && \
         echo "Unsupported architecture: $ARCH" && exit 1 ; \
     fi && \
     if [ "$ARCH" = "x86_64" ]; then EXPECT="$POWERSHELL_SHA256_AMD64" ; else EXPECT="$POWERSHELL_SHA256_ARM64" ; fi && \
-    echo "$EXPECT  /tmp/powershell.tar.gz" | sha256sum -c - && \
+    echo "$EXPECT  /tmp/powershell.tar.gz" > /tmp/powershell.sha256 && \
+    sha256sum -c /tmp/powershell.sha256 && rm /tmp/powershell.sha256 && \
     mkdir -p /opt/microsoft/powershell/7 && \
     tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 && \
     chmod +x /opt/microsoft/powershell/7/pwsh && \
@@ -56,7 +57,8 @@ RUN ARCH=$(uname -m) && \
     fi && \
     wget --progress=dot:giga "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz" -O /tmp/trivy.tar.gz && \
     if [ "$ARCH" = "x86_64" ]; then EXPECT="$TRIVY_SHA256_AMD64" ; else EXPECT="$TRIVY_SHA256_ARM64" ; fi && \
-    echo "$EXPECT  /tmp/trivy.tar.gz" | sha256sum -c - && \
+    echo "$EXPECT  /tmp/trivy.tar.gz" > /tmp/trivy.sha256 && \
+    sha256sum -c /tmp/trivy.sha256 && rm /tmp/trivy.sha256 && \
     tar zxf /tmp/trivy.tar.gz -C /tmp && \
     mv /tmp/trivy /usr/local/bin/trivy && \
     chmod +x /usr/local/bin/trivy && \
@@ -76,7 +78,8 @@ RUN ARCH=$(uname -m) && \
     fi && \
     wget --progress=dot:giga "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-${ZIZMOR_ARCH}.tar.gz" -O /tmp/zizmor.tar.gz && \
     if [ "$ARCH" = "x86_64" ]; then EXPECT="$ZIZMOR_SHA256_AMD64" ; else EXPECT="$ZIZMOR_SHA256_ARM64" ; fi && \
-    echo "$EXPECT  /tmp/zizmor.tar.gz" | sha256sum -c - && \
+    echo "$EXPECT  /tmp/zizmor.tar.gz" > /tmp/zizmor.sha256 && \
+    sha256sum -c /tmp/zizmor.sha256 && rm /tmp/zizmor.sha256 && \
     mkdir -p /tmp/zizmor-extract && \
     tar zxf /tmp/zizmor.tar.gz -C /tmp/zizmor-extract && \
     mv /tmp/zizmor-extract/zizmor /usr/local/bin/zizmor && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,7 @@ ENV TRIVY_VERSION=${TRIVY_VERSION}
 ARG ZIZMOR_VERSION=1.24.1
 ENV ZIZMOR_VERSION=${ZIZMOR_VERSION}
 
-# Checksums of the third-party binaries fetched below. They are pinned here rather
-# than downloaded alongside the artefact: a compromised release would ship a matching
-# checksum file. CVE-2026-33634 was exactly that -- a malicious Trivy release published
-# with stolen credentials.
-# Trivy and PowerShell values are the vendors' published checksums. zizmor publishes
-# none, so its values were computed from the current artefacts and pin them against
-# future substitution.
+# Pinned here, not fetched with the artefact: a compromised release ships its own checksum.
 ARG TRIVY_SHA256_AMD64=bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea
 ARG TRIVY_SHA256_ARM64=2ca2c023109c2db6b2b77366b6717291452d4531167377d95c79547f0c8e3467
 ARG POWERSHELL_SHA256_AMD64=492ff26bb958336bf61e597ce19e07648b4003bd2a08659e02f0e3e0446ebfe0

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -13,6 +13,20 @@ ENV TRIVY_VERSION=${TRIVY_VERSION}
 ARG ZIZMOR_VERSION=1.24.1
 ENV ZIZMOR_VERSION=${ZIZMOR_VERSION}
 
+# Checksums of the third-party binaries fetched below. They are pinned here rather
+# than downloaded alongside the artefact: a compromised release would ship a matching
+# checksum file. CVE-2026-33634 was exactly that -- a malicious Trivy release published
+# with stolen credentials.
+# Trivy and PowerShell values are the vendors' published checksums. zizmor publishes
+# none, so its values were computed from the current artefacts and pin them against
+# future substitution.
+ARG TRIVY_SHA256_AMD64=bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea
+ARG TRIVY_SHA256_ARM64=2ca2c023109c2db6b2b77366b6717291452d4531167377d95c79547f0c8e3467
+ARG POWERSHELL_SHA256_AMD64=492ff26bb958336bf61e597ce19e07648b4003bd2a08659e02f0e3e0446ebfe0
+ARG POWERSHELL_SHA256_ARM64=2503b71da3e83635592b092df59a0aca4c3606b4d9b068217bb00be989cb0d56
+ARG ZIZMOR_SHA256_AMD64=a8000f3c683319a523d3b20df0e75457ba591f049cfcbfa98966631b56733c03
+ARG ZIZMOR_SHA256_ARM64=d66e37ef8a375fb07939c630ebf9709a6e0f20242bdc3faf672a7ed97e0b768d
+
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
@@ -39,6 +53,8 @@ RUN ARCH=$(uname -m) && \
     else \
         echo "Unsupported architecture: $ARCH" && exit 1 ; \
     fi && \
+    if [ "$ARCH" = "x86_64" ]; then EXPECT="$POWERSHELL_SHA256_AMD64" ; else EXPECT="$POWERSHELL_SHA256_ARM64" ; fi && \
+    echo "$EXPECT  /tmp/powershell.tar.gz" | sha256sum -c - && \
     mkdir -p /opt/microsoft/powershell/7 && \
     tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 && \
     chmod +x /opt/microsoft/powershell/7/pwsh && \
@@ -55,6 +71,8 @@ RUN ARCH=$(uname -m) && \
         echo "Unsupported architecture for Trivy: $ARCH" && exit 1 ; \
     fi && \
     wget --progress=dot:giga "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz" -O /tmp/trivy.tar.gz && \
+    if [ "$ARCH" = "x86_64" ]; then EXPECT="$TRIVY_SHA256_AMD64" ; else EXPECT="$TRIVY_SHA256_ARM64" ; fi && \
+    echo "$EXPECT  /tmp/trivy.tar.gz" | sha256sum -c - && \
     tar zxf /tmp/trivy.tar.gz -C /tmp && \
     mv /tmp/trivy /usr/local/bin/trivy && \
     chmod +x /usr/local/bin/trivy && \
@@ -73,6 +91,8 @@ RUN ARCH=$(uname -m) && \
         echo "Unsupported architecture for zizmor: $ARCH" && exit 1 ; \
     fi && \
     wget --progress=dot:giga "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-${ZIZMOR_ARCH}.tar.gz" -O /tmp/zizmor.tar.gz && \
+    if [ "$ARCH" = "x86_64" ]; then EXPECT="$ZIZMOR_SHA256_AMD64" ; else EXPECT="$ZIZMOR_SHA256_ARM64" ; fi && \
+    echo "$EXPECT  /tmp/zizmor.tar.gz" | sha256sum -c - && \
     mkdir -p /tmp/zizmor-extract && \
     tar zxf /tmp/zizmor.tar.gz -C /tmp/zizmor-extract && \
     mv /tmp/zizmor-extract/zizmor /usr/local/bin/zizmor && \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -48,7 +48,8 @@ RUN ARCH=$(uname -m) && \
         echo "Unsupported architecture: $ARCH" && exit 1 ; \
     fi && \
     if [ "$ARCH" = "x86_64" ]; then EXPECT="$POWERSHELL_SHA256_AMD64" ; else EXPECT="$POWERSHELL_SHA256_ARM64" ; fi && \
-    echo "$EXPECT  /tmp/powershell.tar.gz" | sha256sum -c - && \
+    echo "$EXPECT  /tmp/powershell.tar.gz" > /tmp/powershell.sha256 && \
+    sha256sum -c /tmp/powershell.sha256 && rm /tmp/powershell.sha256 && \
     mkdir -p /opt/microsoft/powershell/7 && \
     tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 && \
     chmod +x /opt/microsoft/powershell/7/pwsh && \
@@ -66,7 +67,8 @@ RUN ARCH=$(uname -m) && \
     fi && \
     wget --progress=dot:giga "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz" -O /tmp/trivy.tar.gz && \
     if [ "$ARCH" = "x86_64" ]; then EXPECT="$TRIVY_SHA256_AMD64" ; else EXPECT="$TRIVY_SHA256_ARM64" ; fi && \
-    echo "$EXPECT  /tmp/trivy.tar.gz" | sha256sum -c - && \
+    echo "$EXPECT  /tmp/trivy.tar.gz" > /tmp/trivy.sha256 && \
+    sha256sum -c /tmp/trivy.sha256 && rm /tmp/trivy.sha256 && \
     tar zxf /tmp/trivy.tar.gz -C /tmp && \
     mv /tmp/trivy /usr/local/bin/trivy && \
     chmod +x /usr/local/bin/trivy && \
@@ -86,7 +88,8 @@ RUN ARCH=$(uname -m) && \
     fi && \
     wget --progress=dot:giga "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-${ZIZMOR_ARCH}.tar.gz" -O /tmp/zizmor.tar.gz && \
     if [ "$ARCH" = "x86_64" ]; then EXPECT="$ZIZMOR_SHA256_AMD64" ; else EXPECT="$ZIZMOR_SHA256_ARM64" ; fi && \
-    echo "$EXPECT  /tmp/zizmor.tar.gz" | sha256sum -c - && \
+    echo "$EXPECT  /tmp/zizmor.tar.gz" > /tmp/zizmor.sha256 && \
+    sha256sum -c /tmp/zizmor.sha256 && rm /tmp/zizmor.sha256 && \
     mkdir -p /tmp/zizmor-extract && \
     tar zxf /tmp/zizmor.tar.gz -C /tmp/zizmor-extract && \
     mv /tmp/zizmor-extract/zizmor /usr/local/bin/zizmor && \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -13,13 +13,7 @@ ENV TRIVY_VERSION=${TRIVY_VERSION}
 ARG ZIZMOR_VERSION=1.24.1
 ENV ZIZMOR_VERSION=${ZIZMOR_VERSION}
 
-# Checksums of the third-party binaries fetched below. They are pinned here rather
-# than downloaded alongside the artefact: a compromised release would ship a matching
-# checksum file. CVE-2026-33634 was exactly that -- a malicious Trivy release published
-# with stolen credentials.
-# Trivy and PowerShell values are the vendors' published checksums. zizmor publishes
-# none, so its values were computed from the current artefacts and pin them against
-# future substitution.
+# Pinned here, not fetched with the artefact: a compromised release ships its own checksum.
 ARG TRIVY_SHA256_AMD64=bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea
 ARG TRIVY_SHA256_ARM64=2ca2c023109c2db6b2b77366b6717291452d4531167377d95c79547f0c8e3467
 ARG POWERSHELL_SHA256_AMD64=492ff26bb958336bf61e597ce19e07648b4003bd2a08659e02f0e3e0446ebfe0

--- a/api/changelog.d/api-verify-downloaded-binaries.security.md
+++ b/api/changelog.d/api-verify-downloaded-binaries.security.md
@@ -1,0 +1,1 @@
+The API container image now verifies the checksum of every third-party binary it downloads (PowerShell, Trivy, zizmor) before installing it

--- a/prowler/changelog.d/verify-downloaded-binaries.security.md
+++ b/prowler/changelog.d/verify-downloaded-binaries.security.md
@@ -1,0 +1,1 @@
+The SDK container image now verifies the checksum of every third-party binary it downloads (PowerShell, Trivy, zizmor) before installing it


### PR DESCRIPTION
Both container images fetched PowerShell, Trivy and zizmor from GitHub releases and installed them **without verifying anything**.

## Why now

`CVE-2026-33634` is exactly this attack: on **19 March 2026 a threat actor used stolen credentials to publish a malicious Trivy release**. It is listed in CISA KEV, with an EPSS score in the 99th percentile.

It surfaced because a second scanner flagged it on our published API image — our own scanner does not report it.

**Our shipped binary is legitimate.** Verified by comparing the SHA-256 of `/usr/local/bin/trivy` inside the published image against the vendor's published checksum for v0.72.0:

```
in our image:  829aca12d32bc3cee0b01cbb76197e9377790c6b78eb67a703d8033bcf7b3c3d
official 0.72.0: 829aca12d32bc3cee0b01cbb76197e9377790c6b78eb67a703d8033bcf7b3c3d
```

The point is that **nothing in the build would have caught it if it had not been**.

## What changed

Each download now verifies a pinned SHA-256 before the archive is extracted.

The expected checksums live **in the Dockerfile, not fetched alongside the artefact**. Downloading a checksum file from the same compromised release would verify a malicious artefact against its own hash — the check has to be anchored somewhere the attacker does not control, which here is our reviewed, version-controlled source.

| Binary | Source of the expected value |
|---|---|
| Trivy | Vendor's published `checksums.txt` |
| PowerShell | Vendor's published `hashes.sha256` |
| zizmor | Computed from the current artefacts — the project publishes none |

The zizmor entries are trust-on-first-use: they cannot prove the current artefact is clean, but they do pin it against future substitution. Worth stating plainly rather than implying all three carry the same assurance.

## Verified in both directions

- **Correct checksums** → build succeeds, logging `trivy.tar.gz: OK`, `powershell.tar.gz: OK`, `zizmor.tar.gz: OK`
- **Wrong checksum** (`--build-arg TRIVY_SHA256_ARM64=0000…`) → build **fails at the verification step**, before anything is extracted

A control tested only in the passing case is not tested.

## Note on the CVE itself

It has **no fixed version** and its advisory range is open-ended (`>=0.69.4`), so it will keep appearing against any recent Trivy. The malicious artefact was the 0.69.4 release specifically; 0.72.0 was published months later and matches its official checksum. This PR does not make the finding disappear — it makes the claim that our binary is legitimate something the build enforces rather than something we assert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Container builds now verify downloaded Trivy, PowerShell, and zizmor binaries using architecture-specific SHA-256 checksums before installation.
  * Builds stop automatically when a downloaded binary fails verification, helping prevent corrupted or tampered tools from being included.

* **Documentation**
  * Added changelog entries describing binary verification for API and SDK container images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->