### PR TITLE
ci(container): pin Trivy to v0.72.0 across the estate

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -64,7 +64,7 @@ runs:
         scanners: 'vuln'
         ignore-unfixed: 'true' # A finding with no available fix is not actionable, so it must not gate
         timeout: '5m'
-        version: 'v0.71.2'
+        version: 'v0.72.0'
       # Not trivyignores: that input drops the .yaml extension Trivy parses by.
       env:
         TRIVY_IGNOREFILE: '.trivyignore.yaml'
@@ -81,7 +81,7 @@ runs:
         scanners: 'vuln'
         ignore-unfixed: 'true' # A finding with no available fix is not actionable, so it must not gate
         timeout: '5m'
-        version: 'v0.71.2'
+        version: 'v0.72.0'
       # Not trivyignores: that input drops the .yaml extension Trivy parses by.
       env:
         TRIVY_IGNOREFILE: '.trivyignore.yaml'

--- a/api/changelog.d/api-trivy-0720-pin.changed.md
+++ b/api/changelog.d/api-trivy-0720-pin.changed.md
@@ -1,0 +1,1 @@
+Pin the container vulnerability scanner to Trivy v0.72.0, matching prowler-registry and partner-portal

--- a/prowler/changelog.d/trivy-0720-pin.changed.md
+++ b/prowler/changelog.d/trivy-0720-pin.changed.md
@@ -1,0 +1,1 @@
+Pin the container vulnerability scanner to Trivy v0.72.0, matching prowler-registry and partner-portal


### PR DESCRIPTION
The four repositories had drifted across three Trivy versions:

| Repository | Was | Now |
|---|---|---|
| prowler | v0.71.2 | **v0.72.0** |
| prowler-cloud | v0.71.2 | v0.72.0 (follows this) |
| prowler-registry | v0.72.0 | unchanged |
| partner-portal | v0.69.2 | v0.72.0 ([#521](https://github.com/prowler-cloud/partner-portal/pull/521)) |

The same image could be reported differently depending on which repository scanned it. That makes the ignore files incomparable across repositories and any number we quote arguable — which matters now that all four gate on critical **and** high, and each keeps its own curated exclusion list.

## Why v0.72.0 and not v0.73.0

v0.73.0 was published **two days ago**. v0.72.0 has been out five weeks and is already running in prowler-registry.

Adopting a freshly published Trivy release in the same week we added checksum verification for `CVE-2026-33634` — a malicious Trivy release published with stolen credentials — would not be consistent. The cooldown reasoning we apply to dependencies applies to our own tooling too.

## Grype

No equivalent change needed: all four repositories are on `v0.116.1`, which is the current release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container vulnerability scanning to Trivy v0.72.0 across supported projects.

* **Documentation**
  * Added changelog entries documenting the Trivy version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->