### PR TITLE
feat(container): ship an SBOM and provenance with the published images

### DIFF
--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -162,6 +162,10 @@ jobs:
         with:
           context: ${{ env.WORKING_DIRECTORY }}
           push: true
+          # Syft under the hood, the same engine Grype uses, so the document matches what the
+          # scan sees -- including components no package manifest registers.
+          sbom: true
+          provenance: mode=max
           platforms: ${{ matrix.platform }}
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ needs.setup.outputs.short-sha }}-${{ matrix.arch }}

--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -162,9 +162,8 @@ jobs:
         with:
           context: ${{ env.WORKING_DIRECTORY }}
           push: true
-          # Syft under the hood, the same engine Grype uses, so the document matches what the
-          # scan sees -- including components no package manifest registers.
           sbom: true
+          # max, not the default min: min records little beyond the build ref.
           provenance: mode=max
           platforms: ${{ matrix.platform }}
           tags: |

--- a/.github/workflows/mcp-container-build-push.yml
+++ b/.github/workflows/mcp-container-build-push.yml
@@ -144,6 +144,10 @@ jobs:
         with:
           context: ${{ env.WORKING_DIRECTORY }}
           push: true
+          # Syft under the hood, the same engine Grype uses, so the document matches what the
+          # scan sees -- including components no package manifest registers.
+          sbom: true
+          provenance: mode=max
           platforms: ${{ matrix.platform }}
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ needs.setup.outputs.short-sha }}-${{ matrix.arch }}

--- a/.github/workflows/mcp-container-build-push.yml
+++ b/.github/workflows/mcp-container-build-push.yml
@@ -144,9 +144,8 @@ jobs:
         with:
           context: ${{ env.WORKING_DIRECTORY }}
           push: true
-          # Syft under the hood, the same engine Grype uses, so the document matches what the
-          # scan sees -- including components no package manifest registers.
           sbom: true
+          # max, not the default min: min records little beyond the build ref.
           provenance: mode=max
           platforms: ${{ matrix.platform }}
           tags: |

--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -200,6 +200,10 @@ jobs:
           context: .
           file: ${{ env.DOCKERFILE_PATH }}
           push: true
+          # Syft under the hood, the same engine Grype uses, so the document matches what the
+          # scan sees -- including components no package manifest registers.
+          sbom: true
+          provenance: mode=max
           platforms: ${{ matrix.platform }}
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ needs.setup.outputs.latest_tag }}-${{ matrix.arch }}

--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -200,9 +200,8 @@ jobs:
           context: .
           file: ${{ env.DOCKERFILE_PATH }}
           push: true
-          # Syft under the hood, the same engine Grype uses, so the document matches what the
-          # scan sees -- including components no package manifest registers.
           sbom: true
+          # max, not the default min: min records little beyond the build ref.
           provenance: mode=max
           platforms: ${{ matrix.platform }}
           tags: |

--- a/.github/workflows/ui-container-build-push.yml
+++ b/.github/workflows/ui-container-build-push.yml
@@ -147,6 +147,10 @@ jobs:
           build-args: |
             NEXT_PUBLIC_PROWLER_RELEASE_VERSION=${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && format('v{0}', env.RELEASE_TAG) || needs.setup.outputs.short-sha }}
           push: true
+          # Syft under the hood, the same engine Grype uses, so the document matches what the
+          # scan sees -- including components no package manifest registers.
+          sbom: true
+          provenance: mode=max
           platforms: ${{ matrix.platform }}
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ needs.setup.outputs.short-sha }}-${{ matrix.arch }}

--- a/.github/workflows/ui-container-build-push.yml
+++ b/.github/workflows/ui-container-build-push.yml
@@ -147,9 +147,8 @@ jobs:
           build-args: |
             NEXT_PUBLIC_PROWLER_RELEASE_VERSION=${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && format('v{0}', env.RELEASE_TAG) || needs.setup.outputs.short-sha }}
           push: true
-          # Syft under the hood, the same engine Grype uses, so the document matches what the
-          # scan sees -- including components no package manifest registers.
           sbom: true
+          # max, not the default min: min records little beyond the build ref.
           provenance: mode=max
           platforms: ${{ matrix.platform }}
           tags: |

--- a/api/changelog.d/api-sbom-attestations.added.md
+++ b/api/changelog.d/api-sbom-attestations.added.md
@@ -1,0 +1,1 @@
+Container images now ship an SBOM and build provenance as OCI attestations

--- a/mcp_server/changelog.d/mcp-sbom-attestations.added.md
+++ b/mcp_server/changelog.d/mcp-sbom-attestations.added.md
@@ -1,0 +1,1 @@
+Container images now ship an SBOM and build provenance as OCI attestations

--- a/prowler/changelog.d/sbom-attestations.added.md
+++ b/prowler/changelog.d/sbom-attestations.added.md
@@ -1,0 +1,1 @@
+Container images now ship an SBOM and build provenance as OCI attestations

--- a/ui/changelog.d/ui-sbom-attestations.added.md
+++ b/ui/changelog.d/ui-sbom-attestations.added.md
@@ -1,0 +1,1 @@
+Container images now ship an SBOM and build provenance as OCI attestations


### PR DESCRIPTION
We generated **no SBOM anywhere**. Verified across all four repositories: no Syft, no CycloneDX, no SPDX output, and no `sbom:` input on any build-push step. Docker Scout reports "provenance obtained from attestation" on our published images, but that comes from buildx defaults on registry pushes — provenance only, and only in `min` mode.

An SBOM is frequently a procurement requirement rather than a nice-to-have, and we have just been through an exercise where a customer scanned our published images and we had to account for the numbers ourselves.

Closes the SBOM half of [PROWLER-2286](https://prowlerpro.atlassian.net/browse/PROWLER-2286).

## No new action for this

BuildKit generates the SBOM with **Syft** — the same engine Grype uses. Wrapping `anchore/sbom-action` would add a dependency to maintain for something two inputs already do.

## Measured before writing it

The open question was whether BuildKit's built-in scanner covers components that no package manifest registers — if it did not, the attestation would under-report exactly the class of component that motivated adding Grype in the first place.

| Question | Result |
|---|---|
| Does Syft see the CPython interpreter? | Yes — `pkg:generic/python@3.12.13` |
| Does BuildKit's attestation see it too? | **Yes** — 96 packages vs Syft's 95 on the same image, interpreter in both |
| Do attestations survive `imagetools create`? | **Yes** — 4 manifests: 2 images, 2 attestations, each bound to its image digest |
| Can it be read back from the multi-arch tag? | **Yes** — `linux/amd64` and `linux/arm64`, interpreter present in both |

The third row is the one that mattered. These workflows build **per architecture** and assemble a manifest afterwards, which is exactly the step where attestations get dropped silently. Tested against a local registry rather than assumed.

## Why `provenance: mode=max`

`min` is the buildx default and records little beyond the build ref. `max` records the full build definition, which is the point of provenance.

Only the UI passes a build argument, `NEXT_PUBLIC_PROWLER_RELEASE_VERSION` — a version string Next inlines into the client bundle by design. There is nothing `max` would expose that the public Dockerfile does not already.

## How to read it once published

```bash
docker buildx imagetools inspect <image>:<tag> --format '{{ json .SBOM }}'
docker buildx imagetools inspect <image>:<tag> --format '{{ json .Provenance }}'
```

## Not in this PR

Only the public Docker Hub images. Harbor (Private Cloud) and the `prowler-registry` / `partner-portal` images publish through different workflows — worth extending once this is proven, but they are not what external parties scan.


[PROWLER-2286]: https://prowlerpro.atlassian.net/browse/PROWLER-2286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container images now include Software Bills of Materials (SBOMs) and detailed build-provenance attestations.
  * Attestations are generated consistently across API, UI, SDK, and MCP images.

* **Documentation**
  * Added changelog entries documenting SBOM and build-provenance support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->