### PR TITLE
fix(alibabacloud): retry STS connection failures

### DIFF
--- a/prowler/changelog.d/alibabacloud-sts-connection-retries.fixed.md
+++ b/prowler/changelog.d/alibabacloud-sts-connection-retries.fixed.md
@@ -1,0 +1,1 @@
+Alibaba Cloud STS credential validation retries transient connection failures and reports exhausted attempts as connection errors instead of invalid credentials

--- a/prowler/providers/alibabacloud/alibabacloud_provider.py
+++ b/prowler/providers/alibabacloud/alibabacloud_provider.py
@@ -1,11 +1,17 @@
 import os
 import pathlib
+import socket
 
 from alibabacloud_credentials.client import Client as CredClient
 from alibabacloud_credentials.models import Config as CredConfig
 from alibabacloud_sts20150401.client import Client as StsClient
 from alibabacloud_tea_openapi import models as open_api_models
+from alibabacloud_tea_openapi.exceptions import ClientException
 from colorama import Fore, Style
+from darabonba.exceptions import RetryError
+from darabonba.policy.retry import RetryCondition, RetryOptions
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import Timeout as RequestsTimeout
 
 from prowler.config.config import (
     default_config_file_path,
@@ -17,9 +23,11 @@ from prowler.lib.utils.utils import print_boxes
 from prowler.providers.alibabacloud.config import (
     ALIBABACLOUD_DEFAULT_REGION,
     ALIBABACLOUD_REGIONS,
+    ALIBABACLOUD_STS_MAX_ATTEMPTS,
     ROLE_SESSION_NAME,
 )
 from prowler.providers.alibabacloud.exceptions.exceptions import (
+    AlibabaCloudConnectionError,
     AlibabaCloudInvalidCredentialsError,
     AlibabaCloudNoCredentialsError,
     AlibabaCloudSetUpSessionError,
@@ -32,6 +40,61 @@ from prowler.providers.alibabacloud.models import (
 )
 from prowler.providers.common.models import Audit_Metadata, Connection
 from prowler.providers.common.provider import Provider
+
+
+def _exception_chain(error: Exception):
+    """Yield structured exceptions wrapped by SDK and Python exception chains."""
+    pending = [error]
+    seen = set()
+
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        yield current
+
+        for attribute in ("inner_exception", "__cause__", "__context__"):
+            nested = getattr(current, attribute, None)
+            if isinstance(nested, BaseException):
+                pending.append(nested)
+        pending.extend(arg for arg in current.args if isinstance(arg, BaseException))
+
+
+def _is_connection_error(error: Exception) -> bool:
+    """Return whether an SDK exception chain contains a transport failure."""
+    connection_errors = (
+        ConnectionError,
+        TimeoutError,
+        socket.gaierror,
+        RetryError,
+        RequestsConnectionError,
+        RequestsTimeout,
+    )
+    return any(
+        isinstance(exception, connection_errors)
+        for exception in _exception_chain(error)
+    )
+
+
+def _is_authentication_error(error: Exception) -> bool:
+    """Return whether an SDK exception chain contains an authentication failure."""
+    authentication_code_prefixes = (
+        "InvalidAccessKeyId",
+        "InvalidSecurityToken",
+        "MissingSecurityToken",
+        "SecurityTokenExpired",
+        "SignatureDoesNotMatch",
+    )
+    for exception in _exception_chain(error):
+        if not isinstance(exception, ClientException):
+            continue
+        code = exception.code or ""
+        if exception.status_code == 401 or code == "InvalidCredentials":
+            return True
+        if code.startswith(authentication_code_prefixes):
+            return True
+    return False
 
 
 class AlibabacloudProvider(Provider):
@@ -435,6 +498,7 @@ class AlibabacloudProvider(Provider):
             AlibabaCloudCallerIdentity: An object containing the caller identity information.
 
         Raises:
+            AlibabaCloudConnectionError: If STS cannot be reached after retries.
             AlibabaCloudInvalidCredentialsError: If credentials are invalid.
         """
         try:
@@ -445,6 +509,15 @@ class AlibabacloudProvider(Provider):
             sts_config = open_api_models.Config(
                 access_key_id=cred.access_key_id,
                 access_key_secret=cred.access_key_secret,
+                retry_options=RetryOptions(
+                    retryCondition=[
+                        RetryCondition(
+                            maxAttempts=ALIBABACLOUD_STS_MAX_ATTEMPTS,
+                            exception=["RetryError"],
+                            backoff={"policy": "Fixed", "period": 0},
+                        )
+                    ]
+                ),
             )
             if cred.security_token:
                 sts_config.security_token = cred.security_token
@@ -477,10 +550,17 @@ class AlibabacloudProvider(Provider):
 
         except Exception as sts_error:
             logger.error(f"Could not get caller identity from STS: {sts_error}. ")
-            raise AlibabaCloudInvalidCredentialsError(
-                file=pathlib.Path(__file__).name,
-                original_exception=sts_error,
-            )
+            if _is_connection_error(sts_error):
+                raise AlibabaCloudConnectionError(
+                    file=pathlib.Path(__file__).name,
+                    original_exception=sts_error,
+                ) from sts_error
+            if _is_authentication_error(sts_error):
+                raise AlibabaCloudInvalidCredentialsError(
+                    file=pathlib.Path(__file__).name,
+                    original_exception=sts_error,
+                ) from sts_error
+            raise
 
     @staticmethod
     def get_profile_region() -> str:
@@ -742,6 +822,7 @@ class AlibabacloudProvider(Provider):
 
         Raises:
             AlibabaCloudSetUpSessionError: If there is an error setting up the session.
+            AlibabaCloudConnectionError: If STS cannot be reached after retries.
             AlibabaCloudInvalidCredentialsError: If there is an authentication error.
             Exception: If there is an unexpected error.
 

--- a/prowler/providers/alibabacloud/alibabacloud_provider.py
+++ b/prowler/providers/alibabacloud/alibabacloud_provider.py
@@ -554,13 +554,13 @@ class AlibabacloudProvider(Provider):
 
         except Exception as sts_error:
             logger.error(f"Could not get caller identity from STS: {sts_error}. ")
-            if _is_connection_error(sts_error):
-                raise AlibabaCloudConnectionError(
+            if _is_authentication_error(sts_error):
+                raise AlibabaCloudInvalidCredentialsError(
                     file=pathlib.Path(__file__).name,
                     original_exception=sts_error,
                 ) from sts_error
-            if _is_authentication_error(sts_error):
-                raise AlibabaCloudInvalidCredentialsError(
+            if _is_connection_error(sts_error):
+                raise AlibabaCloudConnectionError(
                     file=pathlib.Path(__file__).name,
                     original_exception=sts_error,
                 ) from sts_error
@@ -893,6 +893,14 @@ class AlibabacloudProvider(Provider):
             if raise_on_exception:
                 raise auth_error
             return Connection(error=auth_error)
+
+        except AlibabaCloudConnectionError as connection_error:
+            logger.error(
+                f"{connection_error.__class__.__name__}[{connection_error.__traceback__.tb_lineno}]: {connection_error}"
+            )
+            if raise_on_exception:
+                raise connection_error
+            return Connection(error=connection_error)
 
         except Exception as error:
             logger.critical(

--- a/prowler/providers/alibabacloud/alibabacloud_provider.py
+++ b/prowler/providers/alibabacloud/alibabacloud_provider.py
@@ -24,6 +24,7 @@ from prowler.providers.alibabacloud.config import (
     ALIBABACLOUD_DEFAULT_REGION,
     ALIBABACLOUD_REGIONS,
     ALIBABACLOUD_STS_MAX_ATTEMPTS,
+    ALIBABACLOUD_STS_RETRY_DELAY_MS,
     ROLE_SESSION_NAME,
 )
 from prowler.providers.alibabacloud.exceptions.exceptions import (
@@ -514,7 +515,10 @@ class AlibabacloudProvider(Provider):
                         RetryCondition(
                             maxAttempts=ALIBABACLOUD_STS_MAX_ATTEMPTS,
                             exception=["RetryError"],
-                            backoff={"policy": "Fixed", "period": 0},
+                            backoff={
+                                "policy": "Fixed",
+                                "period": ALIBABACLOUD_STS_RETRY_DELAY_MS,
+                            },
                         )
                     ]
                 ),

--- a/prowler/providers/alibabacloud/config.py
+++ b/prowler/providers/alibabacloud/config.py
@@ -6,6 +6,7 @@ ROLE_SESSION_NAME = "ProwlerAssessmentSession"
 # Alibaba Cloud SDK Configuration
 ALIBABACLOUD_SDK_READ_TIMEOUT = 60  # seconds
 ALIBABACLOUD_SDK_CONNECT_TIMEOUT = 10  # seconds
+ALIBABACLOUD_STS_MAX_ATTEMPTS = 3
 
 # Alibaba Cloud Regions - Only publicly accessible regions
 # Note: Some regions may require special approval or are not globally available

--- a/prowler/providers/alibabacloud/config.py
+++ b/prowler/providers/alibabacloud/config.py
@@ -7,7 +7,7 @@ ROLE_SESSION_NAME = "ProwlerAssessmentSession"
 ALIBABACLOUD_SDK_READ_TIMEOUT = 60  # seconds
 ALIBABACLOUD_SDK_CONNECT_TIMEOUT = 10  # seconds
 ALIBABACLOUD_STS_MAX_ATTEMPTS = 3
-# Avoid immediate retry bursts while bounding validation latency to two seconds:
+# Avoid immediate retry bursts while bounding added retry delay to two seconds:
 # three total attempts introduce at most two fixed one-second waits.
 ALIBABACLOUD_STS_RETRY_DELAY_MS = 1000
 

--- a/prowler/providers/alibabacloud/config.py
+++ b/prowler/providers/alibabacloud/config.py
@@ -7,6 +7,9 @@ ROLE_SESSION_NAME = "ProwlerAssessmentSession"
 ALIBABACLOUD_SDK_READ_TIMEOUT = 60  # seconds
 ALIBABACLOUD_SDK_CONNECT_TIMEOUT = 10  # seconds
 ALIBABACLOUD_STS_MAX_ATTEMPTS = 3
+# Avoid immediate retry bursts while bounding validation latency to two seconds:
+# three total attempts introduce at most two fixed one-second waits.
+ALIBABACLOUD_STS_RETRY_DELAY_MS = 1000
 
 # Alibaba Cloud Regions - Only publicly accessible regions
 # Note: Some regions may require special approval or are not globally available

--- a/prowler/providers/alibabacloud/exceptions/exceptions.py
+++ b/prowler/providers/alibabacloud/exceptions/exceptions.py
@@ -38,6 +38,10 @@ class AlibabaCloudBaseException(ProwlerException):
             "message": "Alibaba Cloud HTTP/API error",
             "remediation": "Check the Alibaba Cloud API request and response, and ensure the service is accessible.",
         },
+        (10008, "AlibabaCloudConnectionError"): {
+            "message": "Could not connect to Alibaba Cloud",
+            "remediation": "Check network connectivity and ensure the Alibaba Cloud service endpoint is accessible.",
+        },
     }
 
     def __init__(self, code, file=None, original_exception=None, message=None):
@@ -113,4 +117,11 @@ class AlibabaCloudHTTPError(AlibabaCloudBaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             10007, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AlibabaCloudConnectionError(AlibabaCloudBaseException):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            10008, file=file, original_exception=original_exception, message=message
         )

--- a/prowler/providers/alibabacloud/exceptions/exceptions.py
+++ b/prowler/providers/alibabacloud/exceptions/exceptions.py
@@ -121,6 +121,8 @@ class AlibabaCloudHTTPError(AlibabaCloudBaseException):
 
 
 class AlibabaCloudConnectionError(AlibabaCloudBaseException):
+    """Raised when Alibaba Cloud cannot be reached after retry attempts."""
+
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             10008, file=file, original_exception=original_exception, message=message

--- a/tests/providers/alibabacloud/alibabacloud_provider_test.py
+++ b/tests/providers/alibabacloud/alibabacloud_provider_test.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from alibabacloud_tea_openapi.exceptions import ClientException
@@ -59,15 +59,19 @@ def test_validate_credentials_retries_transport_failure_then_succeeds():
         b'"IdentityType":"RamUser"}'
     )
 
-    with patch.object(
-        DaraCore,
-        "do_action",
-        side_effect=[RetryError("connection reset"), response],
-    ) as do_action:
+    with (
+        patch.object(
+            DaraCore,
+            "do_action",
+            side_effect=[RetryError("connection reset"), response],
+        ) as do_action,
+        patch.object(DaraCore, "sleep") as sleep,
+    ):
         caller_identity = AlibabacloudProvider.validate_credentials(session)
 
     assert caller_identity.account_id == "1234567890"
     assert do_action.call_count == 2
+    sleep.assert_called_once_with(1000)
 
 
 def test_validate_credentials_connection_failure_is_not_invalid_credentials():
@@ -85,12 +89,16 @@ def test_validate_credentials_connection_failure_is_not_invalid_credentials():
         retry_error.__cause__ = connection_reset
         retry_errors.append(retry_error)
 
-    with patch.object(DaraCore, "do_action", side_effect=retry_errors) as do_action:
+    with (
+        patch.object(DaraCore, "do_action", side_effect=retry_errors) as do_action,
+        patch.object(DaraCore, "sleep") as sleep,
+    ):
         with pytest.raises(AlibabaCloudConnectionError) as exception:
             AlibabacloudProvider.validate_credentials(session)
 
     assert not isinstance(exception.value, AlibabaCloudInvalidCredentialsError)
     assert do_action.call_count == 3
+    assert sleep.call_args_list == [call(1000), call(1000)]
     assert isinstance(exception.value.original_exception, UnretryableException)
     assert exception.value.original_exception.inner_exception is retry_errors[-1]
     assert exception.value.__cause__ is exception.value.original_exception

--- a/tests/providers/alibabacloud/alibabacloud_provider_test.py
+++ b/tests/providers/alibabacloud/alibabacloud_provider_test.py
@@ -5,6 +5,7 @@ import pytest
 from alibabacloud_tea_openapi.exceptions import ClientException
 from darabonba.core import DaraCore
 from darabonba.exceptions import RetryError, UnretryableException
+from Tea.exceptions import UnretryableException as TeaUnretryableException
 from Tea.response import TeaResponse
 
 from prowler.providers.alibabacloud.alibabacloud_provider import AlibabacloudProvider
@@ -30,16 +31,19 @@ def test_validate_credentials_non_authentication_api_error_is_not_invalid_creden
         message="The caller is not authorized",
         status_code=403,
     )
+    wrapped_api_error = TeaUnretryableException(request=None, ex=api_error)
 
-    with patch(
-        "prowler.providers.alibabacloud.alibabacloud_provider.StsClient"
-    ) as sts_client:
-        sts_client.return_value.get_caller_identity.side_effect = api_error
-
-        with pytest.raises(ClientException) as exception:
+    with (
+        patch.object(DaraCore, "do_action", side_effect=wrapped_api_error),
+        patch.object(DaraCore, "sleep") as sleep,
+    ):
+        with pytest.raises(UnretryableException) as exception:
             AlibabacloudProvider.validate_credentials(session)
 
-    assert exception.value is api_error
+    assert not isinstance(exception.value, AlibabaCloudInvalidCredentialsError)
+    assert exception.value.inner_exception is wrapped_api_error
+    assert exception.value.inner_exception.inner_exception is api_error
+    sleep.assert_not_called()
 
 
 def test_validate_credentials_retries_transport_failure_then_succeeds():
@@ -117,17 +121,60 @@ def test_validate_credentials_genuine_invalid_credentials():
         message="The AccessKey ID does not exist",
         status_code=400,
     )
+    wrapped_authentication_error = TeaUnretryableException(
+        request=None, ex=authentication_error
+    )
 
-    with patch(
-        "prowler.providers.alibabacloud.alibabacloud_provider.StsClient"
-    ) as sts_client:
-        sts_client.return_value.get_caller_identity.side_effect = authentication_error
-
+    with (
+        patch.object(DaraCore, "do_action", side_effect=wrapped_authentication_error),
+        patch.object(DaraCore, "sleep") as sleep,
+    ):
         with pytest.raises(AlibabaCloudInvalidCredentialsError) as exception:
             AlibabacloudProvider.validate_credentials(session)
 
-    assert exception.value.original_exception is authentication_error
-    assert exception.value.__cause__ is authentication_error
+    assert isinstance(exception.value.original_exception, UnretryableException)
+    assert (
+        exception.value.original_exception.inner_exception
+        is wrapped_authentication_error
+    )
+    assert (
+        exception.value.original_exception.inner_exception.inner_exception
+        is authentication_error
+    )
+    assert exception.value.__cause__ is exception.value.original_exception
+    sleep.assert_not_called()
+
+
+def test_validate_credentials_authentication_error_wins_over_transport_error():
+    """Test a definitive nested authentication error takes precedence over transport."""
+    session = MagicMock()
+    session.get_credentials.return_value = MagicMock(
+        access_key_id="LTAI-invalid",
+        access_key_secret="invalid-secret",
+        security_token=None,
+    )
+    authentication_error = ClientException(
+        code="InvalidAccessKeyId.NotFound",
+        message="The AccessKey ID does not exist",
+        status_code=400,
+    )
+    retry_errors = []
+    for _ in range(3):
+        retry_error = RetryError("connection reset")
+        retry_error.__cause__ = authentication_error
+        retry_errors.append(retry_error)
+
+    with (
+        patch.object(DaraCore, "do_action", side_effect=retry_errors),
+        patch.object(DaraCore, "sleep") as sleep,
+    ):
+        with pytest.raises(AlibabaCloudInvalidCredentialsError) as exception:
+            AlibabacloudProvider.validate_credentials(session)
+
+    assert isinstance(exception.value.original_exception, UnretryableException)
+    assert exception.value.original_exception.inner_exception is retry_errors[-1]
+    assert exception.value.__cause__ is exception.value.original_exception
+    assert sleep.call_args_list == [call(1000), call(1000)]
 
 
 class TestAlibabacloudProviderTestConnection:
@@ -152,6 +199,12 @@ class TestAlibabacloudProviderTestConnection:
                 "validate_credentials",
                 side_effect=connection_error,
             ),
+            patch(
+                "prowler.providers.alibabacloud.alibabacloud_provider.logger.error"
+            ) as logger_error,
+            patch(
+                "prowler.providers.alibabacloud.alibabacloud_provider.logger.critical"
+            ) as logger_critical,
         ):
             result = AlibabacloudProvider.test_connection(
                 access_key_id="LTAI1234567890",
@@ -162,6 +215,45 @@ class TestAlibabacloudProviderTestConnection:
         assert result.is_connected is False
         assert result.error is connection_error
         assert result.error.code == 10008
+        logger_error.assert_called_once()
+        logger_critical.assert_not_called()
+
+    def test_test_connection_connection_error_raises(self):
+        """Test connection failures retain raise-on-exception behavior."""
+        mock_session = MagicMock()
+        connection_error = AlibabaCloudConnectionError(
+            file="test_file",
+            original_exception=RetryError("connection reset"),
+        )
+
+        with (
+            patch.object(
+                AlibabacloudProvider,
+                "setup_session",
+                return_value=mock_session,
+            ),
+            patch.object(
+                AlibabacloudProvider,
+                "validate_credentials",
+                side_effect=connection_error,
+            ),
+            patch(
+                "prowler.providers.alibabacloud.alibabacloud_provider.logger.error"
+            ) as logger_error,
+            patch(
+                "prowler.providers.alibabacloud.alibabacloud_provider.logger.critical"
+            ) as logger_critical,
+        ):
+            with pytest.raises(AlibabaCloudConnectionError) as exception:
+                AlibabacloudProvider.test_connection(
+                    access_key_id="LTAI1234567890",
+                    access_key_secret="test-secret-key",
+                    raise_on_exception=True,
+                )
+
+        assert exception.value is connection_error
+        logger_error.assert_called_once()
+        logger_critical.assert_not_called()
 
     def test_test_connection_with_static_credentials_success(self):
         """Test successful connection with static access key credentials."""

--- a/tests/providers/alibabacloud/alibabacloud_provider_test.py
+++ b/tests/providers/alibabacloud/alibabacloud_provider_test.py
@@ -2,9 +2,14 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from alibabacloud_tea_openapi.exceptions import ClientException
+from darabonba.core import DaraCore
+from darabonba.exceptions import RetryError, UnretryableException
+from Tea.response import TeaResponse
 
 from prowler.providers.alibabacloud.alibabacloud_provider import AlibabacloudProvider
 from prowler.providers.alibabacloud.exceptions.exceptions import (
+    AlibabaCloudConnectionError,
     AlibabaCloudInvalidCredentialsError,
     AlibabaCloudSetUpSessionError,
 )
@@ -12,8 +17,143 @@ from prowler.providers.alibabacloud.models import AlibabaCloudCallerIdentity
 from prowler.providers.common.models import Connection
 
 
+def test_validate_credentials_non_authentication_api_error_is_not_invalid_credentials():
+    """Test non-authentication STS API errors are not relabeled as credentials."""
+    session = MagicMock()
+    session.get_credentials.return_value = MagicMock(
+        access_key_id="LTAI1234567890",
+        access_key_secret="test-secret-key",
+        security_token=None,
+    )
+    api_error = ClientException(
+        code="Forbidden",
+        message="The caller is not authorized",
+        status_code=403,
+    )
+
+    with patch(
+        "prowler.providers.alibabacloud.alibabacloud_provider.StsClient"
+    ) as sts_client:
+        sts_client.return_value.get_caller_identity.side_effect = api_error
+
+        with pytest.raises(ClientException) as exception:
+            AlibabacloudProvider.validate_credentials(session)
+
+    assert exception.value is api_error
+
+
+def test_validate_credentials_retries_transport_failure_then_succeeds():
+    """Test STS caller identity retries a transient transport failure."""
+    session = MagicMock()
+    session.get_credentials.return_value = MagicMock(
+        access_key_id="LTAI1234567890",
+        access_key_secret="test-secret-key",
+        security_token=None,
+    )
+    response = TeaResponse()
+    response.status_code = 200
+    response.headers = {"content-type": "application/json"}
+    response.body = (
+        b'{"AccountId":"1234567890","PrincipalId":"123456",'
+        b'"Arn":"acs:ram::1234567890:user/test-user",'
+        b'"IdentityType":"RamUser"}'
+    )
+
+    with patch.object(
+        DaraCore,
+        "do_action",
+        side_effect=[RetryError("connection reset"), response],
+    ) as do_action:
+        caller_identity = AlibabacloudProvider.validate_credentials(session)
+
+    assert caller_identity.account_id == "1234567890"
+    assert do_action.call_count == 2
+
+
+def test_validate_credentials_connection_failure_is_not_invalid_credentials():
+    """Test exhausted STS transport retries raise a connection-specific error."""
+    session = MagicMock()
+    session.get_credentials.return_value = MagicMock(
+        access_key_id="LTAI1234567890",
+        access_key_secret="test-secret-key",
+        security_token=None,
+    )
+    retry_errors = []
+    for _ in range(3):
+        connection_reset = ConnectionResetError(104, "Connection reset by peer")
+        retry_error = RetryError(str(connection_reset))
+        retry_error.__cause__ = connection_reset
+        retry_errors.append(retry_error)
+
+    with patch.object(DaraCore, "do_action", side_effect=retry_errors) as do_action:
+        with pytest.raises(AlibabaCloudConnectionError) as exception:
+            AlibabacloudProvider.validate_credentials(session)
+
+    assert not isinstance(exception.value, AlibabaCloudInvalidCredentialsError)
+    assert do_action.call_count == 3
+    assert isinstance(exception.value.original_exception, UnretryableException)
+    assert exception.value.original_exception.inner_exception is retry_errors[-1]
+    assert exception.value.__cause__ is exception.value.original_exception
+
+
+def test_validate_credentials_genuine_invalid_credentials():
+    """Test an explicit STS authentication failure remains a credentials error."""
+    session = MagicMock()
+    session.get_credentials.return_value = MagicMock(
+        access_key_id="LTAI-invalid",
+        access_key_secret="invalid-secret",
+        security_token=None,
+    )
+    authentication_error = ClientException(
+        code="InvalidAccessKeyId.NotFound",
+        message="The AccessKey ID does not exist",
+        status_code=400,
+    )
+
+    with patch(
+        "prowler.providers.alibabacloud.alibabacloud_provider.StsClient"
+    ) as sts_client:
+        sts_client.return_value.get_caller_identity.side_effect = authentication_error
+
+        with pytest.raises(AlibabaCloudInvalidCredentialsError) as exception:
+            AlibabacloudProvider.validate_credentials(session)
+
+    assert exception.value.original_exception is authentication_error
+    assert exception.value.__cause__ is authentication_error
+
+
 class TestAlibabacloudProviderTestConnection:
     """Tests for the AlibabacloudProvider.test_connection method."""
+
+    def test_test_connection_connection_error_no_raise(self):
+        """Test connection failures are returned with their dedicated type."""
+        mock_session = MagicMock()
+        connection_error = AlibabaCloudConnectionError(
+            file="test_file",
+            original_exception=RetryError("connection reset"),
+        )
+
+        with (
+            patch.object(
+                AlibabacloudProvider,
+                "setup_session",
+                return_value=mock_session,
+            ),
+            patch.object(
+                AlibabacloudProvider,
+                "validate_credentials",
+                side_effect=connection_error,
+            ),
+        ):
+            result = AlibabacloudProvider.test_connection(
+                access_key_id="LTAI1234567890",
+                access_key_secret="test-secret-key",
+                raise_on_exception=False,
+            )
+
+        assert result.is_connected is False
+        assert result.error is connection_error
+        assert result.error.code == 10008
 
     def test_test_connection_with_static_credentials_success(self):
         """Test successful connection with static access key credentials."""

--- a/tests/providers/alibabacloud/conftest.py
+++ b/tests/providers/alibabacloud/conftest.py
@@ -5,6 +5,7 @@ Mocks Alibaba Cloud SDK modules to avoid import issues when the real
 dependencies are not installed in the test environment.
 """
 
+import importlib
 import sys
 from unittest.mock import MagicMock
 
@@ -38,4 +39,7 @@ MOCKED_MODULES = [
 ]
 
 for module_name in MOCKED_MODULES:
-    sys.modules.setdefault(module_name, MagicMock())
+    try:
+        importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        sys.modules.setdefault(module_name, MagicMock())


### PR DESCRIPTION
### Context

Alibaba Cloud STS credential validation can fail with a transient `UnretryableException` wrapping `RetryError` and `ConnectionResetError`. The provider previously classified every STS failure as invalid credentials, causing report generation to fail with a misleading error.

Sentry event: https://prowler.sentry.io/issues/7416692876/?alert_rule_id=15789335&alert_type=issue&notification_uuid=c0604d17-5c62-4ea2-b98e-b16c43edf02b&project=4508777908535296&referrer=slack

### Description

- Configure three bounded SDK-managed attempts for STS `GetCallerIdentity`
- Wait one fixed second between attempts, limiting added validation latency to two seconds
- Add `AlibabaCloudConnectionError` for exhausted transport failures
- Preserve explicit authentication failures as `AlibabaCloudInvalidCredentialsError`
- Keep unrelated API failures from being mislabeled as credential failures
- Add separate regression coverage for retry success, retry exhaustion, authentication failure, connection-test behavior, and retry delays

### Steps to review

1. Review the STS retry configuration and exception-chain classification in `alibabacloud_provider.py`
2. Confirm three total attempts use two fixed one-second waits on exhaustion
3. Confirm transport and authentication failures map to their dedicated exceptions
4. Run:
   ```bash
   uv run pytest tests/providers/alibabacloud/ -v
   ```
5. Expected result: 151 tests pass

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the Prowler issue tracker or roadmap
- [ ] It is assigned to me

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests
- [x] Review if code is being documented following the Python style guide
- [x] Review if backport is needed
- [x] Review if it is needed to change `README.md`
- [x] Ensure a changelog fragment is added under `prowler/changelog.d/`

#### SDK/CLI

- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Alibaba Cloud STS credential validation now retries temporary connection failures.
* Connection failures that persist after retries are reported as connection errors rather than invalid credentials.
* Genuine authentication failures continue to be identified correctly.
* Added a default limit of three connection attempts with a one-second delay between retries.
* Connection status checks now handle persistent connectivity failures consistently, with optional error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->