### PR TITLE
fix(ui): correct GCP organization credential labels

### DIFF
--- a/ui/changelog.d/gcp-organization-credential-labels.fixed.md
+++ b/ui/changelog.d/gcp-organization-credential-labels.fixed.md
@@ -1,0 +1,1 @@
+`Client Secret` and `Refresh Token` labels in the GCP organization authentication form

--- a/ui/components/providers/organizations/gcp-org-setup-form.test.tsx
+++ b/ui/components/providers/organizations/gcp-org-setup-form.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ORG_SETUP_PHASE } from "@/types/organizations";
+
+import { GcpOrgSetupForm } from "./gcp-org-setup-form";
+
+vi.mock("@/actions/organizations/organizations", () => ({
+  updateOrganizationName: vi.fn(),
+}));
+
+vi.mock("./hooks/use-org-setup-submission", () => ({
+  useOrgSetupSubmission: () => ({
+    apiError: null,
+    setApiError: vi.fn(),
+    submitOrganizationSetup: vi.fn(),
+    replaceSecretWarning: null,
+    confirmSecretReplace: vi.fn(),
+    cancelSecretReplace: vi.fn(),
+    discoveryTimedOut: false,
+    discoveryFailed: false,
+    isSubmissionPending: false,
+    keepWaitingForDiscovery: vi.fn(),
+    retryDiscovery: vi.fn(),
+  }),
+}));
+
+describe("GcpOrgSetupForm", () => {
+  describe("when static credentials are selected", () => {
+    it("should preserve the labels of masked credential fields", async () => {
+      // Given
+      const user = userEvent.setup();
+      render(
+        <GcpOrgSetupForm
+          onBack={vi.fn()}
+          onNext={vi.fn()}
+          onFooterChange={vi.fn()}
+          onPhaseChange={vi.fn()}
+          initialPhase={ORG_SETUP_PHASE.ACCESS}
+        />,
+      );
+
+      // When
+      await user.click(
+        screen.getByRole("radio", {
+          name: /client id, client secret and refresh token/i,
+        }),
+      );
+
+      // Then
+      expect(screen.getByLabelText("Client Secret")).toHaveAttribute(
+        "type",
+        "password",
+      );
+      expect(screen.getByLabelText("Refresh Token")).toHaveAttribute(
+        "type",
+        "password",
+      );
+    });
+  });
+});

--- a/ui/components/providers/organizations/gcp-org-setup-form.tsx
+++ b/ui/components/providers/organizations/gcp-org-setup-form.tsx
@@ -470,7 +470,7 @@ export function GcpOrgSetupForm({
                   name="clientSecret"
                   label="Client Secret"
                   labelPlacement="outside"
-                  password
+                  type="password"
                   isRequired
                 />
                 <WizardInputField
@@ -478,7 +478,7 @@ export function GcpOrgSetupForm({
                   name="refreshToken"
                   label="Refresh Token"
                   labelPlacement="outside"
-                  password
+                  type="password"
                   isRequired
                 />
               </div>


### PR DESCRIPTION
### Context

The GCP organization authentication form displayed both the Client Secret and Refresh Token fields as “Password.” The shared input component replaced custom labels when the `password` prop was used.

### Description

- Preserve the `Client Secret` and `Refresh Token` labels while keeping both fields masked
- Add a regression test for the static credential fields
- Add a UI changelog fragment

No dependencies were added or updated.

### Steps to review

1. Open the provider onboarding flow.
2. Select Google Cloud and add a GCP organization.
3. Continue to Authentication Details.
4. Select “Client ID, Client Secret and Refresh Token.”
5. Confirm that the fields are labeled:
   - `Client ID`
   - `Client Secret`
   - `Refresh Token`
6. Confirm that Client Secret and Refresh Token remain masked.

### Evidences

#### Before

<img width="2432" height="1368" alt="image" src="https://github.com/user-attachments/assets/a7e191cd-e31e-4680-8aed-3e6fafa202c0" />

#### After

<img width="2430" height="1358" alt="image" src="https://github.com/user-attachments/assets/b5d8ca3c-845a-4c61-8ca1-b779b365368f" />

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### UI

- [x] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [x] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for GCP organization authentication by masking Client Secret and Refresh Token values as password fields.
  * Preserved the existing field labels for clarity.

* **Tests**
  * Added coverage verifying credential field labels and password-style input behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->