### PR TITLE
ci: fix the remaining shellcheck findings and enable the check

### DIFF
--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -48,10 +48,12 @@ jobs:
         with:
           persist-credentials: false
 
-      # -shellcheck= because the shell-quality findings are a separate backlog; this
-      # check is here for the schema, and mixing the two would make it unactionable.
+      # SC2129 only suggests grouping consecutive redirects. Restructuring release
+      # workflows for a formatting preference is not worth the risk.
       - name: Run actionlint
+        env:
+          SHELLCHECK_OPTS: '-e SC2129'
         run: |
-          docker run --rm -v "$PWD:/repo" --workdir /repo \
+          docker run --rm -v "$PWD:/repo" --workdir /repo -e SHELLCHECK_OPTS \
             rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
-            -color -shellcheck=
+            -color

--- a/.github/workflows/comment-label-update.yml
+++ b/.github/workflows/comment-label-update.yml
@@ -32,7 +32,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           echo "Removing 'status/awaiting-response' label from #$ISSUE_NUMBER"
-          gh api /repos/${{ github.repository }}/issues/$ISSUE_NUMBER/labels/status%2Fawaiting-response \
+          gh api "/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/labels/status%2Fawaiting-response" \
             -X DELETE
 
       - name: Add 'status/waiting-for-revision' label
@@ -41,6 +41,6 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           echo "Adding 'status/waiting-for-revision' label to #$ISSUE_NUMBER"
-          gh api /repos/${{ github.repository }}/issues/$ISSUE_NUMBER/labels \
+          gh api "/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/labels" \
             -X POST \
             -f labels[]='status/waiting-for-revision'

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -50,7 +50,7 @@ jobs:
           GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
       - name: Update chart dependencies
         run: helm dependency update ${{ env.CHART_PATH }}

--- a/.github/workflows/pr-check-changelog.yml
+++ b/.github/workflows/pr-check-changelog.yml
@@ -129,7 +129,6 @@ jobs:
           handwritten_changelogs=""
 
           all_changed=$(echo "${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}" | tr ' ' '\n')
-          added=$(echo "${STEPS_CHANGED_FILES_OUTPUTS_ADDED_FILES}" | tr ' ' '\n')
           added_or_renamed=$(printf '%s\n%s' "${STEPS_CHANGED_FILES_OUTPUTS_ADDED_FILES}" "${STEPS_CHANGED_FILES_OUTPUTS_RENAMED_FILES}" | tr ' ' '\n')
           added_modified_or_renamed=$(printf '%s\n%s\n%s' "${STEPS_CHANGED_FILES_OUTPUTS_ADDED_FILES}" "${STEPS_CHANGED_FILES_OUTPUTS_MODIFIED_FILES}" "${STEPS_CHANGED_FILES_OUTPUTS_RENAMED_FILES}" | tr ' ' '\n')
 

--- a/.github/workflows/pr-check-compliance-mapping.yml
+++ b/.github/workflows/pr-check-compliance-mapping.yml
@@ -111,7 +111,7 @@ jobs:
             done
 
             if [ -n "$found_in" ]; then
-              found_in=$(echo "$found_in" | sed 's/, $//')
+              found_in="${found_in%, }"
               MAPPED="${MAPPED}- \`${check_id}\` (\`${provider}\`): ${found_in}"$'\n'
             else
               UNMAPPED="${UNMAPPED}- \`${check_id}\` (\`${provider}\`)"$'\n'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -77,7 +77,7 @@ jobs:
 
           echo "Prowler version: $PROWLER_VERSION"
           echo "Branch name: $BRANCH_NAME"
-          echo "Is minor release: $([ $PATCH_VERSION -eq 0 ] && echo 'true' || echo 'false')"
+          echo "Is minor release: $([ "$PATCH_VERSION" -eq 0 ] && echo 'true' || echo 'false')"
         else
           echo "Invalid version syntax: '$PROWLER_VERSION' (must be N.N.N)" >&2
           exit 1
@@ -107,7 +107,8 @@ jobs:
           if [ -f "$changelog_file" ]; then
             # Extract version that matches this Prowler release
             # Format: ## [version] (Prowler X.Y.Z) or ## [vversion] (Prowler vX.Y.Z)
-            local version=$(grep '^## \[' "$changelog_file" | grep "(Prowler v\?${prowler_version})" | head -1 | sed 's/^## \[\(.*\)\].*/\1/' | sed 's/^v//' | tr -d '[:space:]')
+            local version
+            version=$(grep '^## \[' "$changelog_file" | grep "(Prowler v\?${prowler_version})" | head -1 | sed 's/^## \[\(.*\)\].*/\1/' | sed 's/^v//' | tr -d '[:space:]')
             echo "$version"
           else
             echo ""
@@ -226,7 +227,7 @@ jobs:
         fi
 
         # Combine changelogs in order: UI, API, SDK, MCP
-        > combined_changelog.md
+        : > combined_changelog.md
 
         if [ "$HAS_UI_CHANGES" = "true" ] && [ -s "ui_changelog.md" ]; then
           echo "## UI" >> combined_changelog.md

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -216,7 +216,8 @@ jobs:
           elif [ -z "${STEPS_AWS_SERVICES_OUTPUTS_SERVICE_PATHS}" ]; then
             echo "No AWS service paths detected; skipping AWS tests."
           else
-            uv run pytest -n auto --cov=./prowler/providers/aws --cov-report=xml:aws_coverage.xml ${STEPS_AWS_SERVICES_OUTPUTS_SERVICE_PATHS}
+            read -ra service_paths <<< "${STEPS_AWS_SERVICES_OUTPUTS_SERVICE_PATHS}"
+            uv run pytest -n auto --cov=./prowler/providers/aws --cov-report=xml:aws_coverage.xml "${service_paths[@]}"
           fi
         env:
           STEPS_AWS_SERVICES_OUTPUTS_RUN_ALL: ${{ steps.aws-services.outputs.run_all }}

--- a/.github/workflows/test-impact-analysis.yml
+++ b/.github/workflows/test-impact-analysis.yml
@@ -84,7 +84,8 @@ jobs:
           echo "Changed files:"
           echo "${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}" | tr ' ' '\n'
           echo ""
-          python .github/scripts/test-impact.py ${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}
+          read -ra changed <<< "${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}"
+          python .github/scripts/test-impact.py "${changed[@]}"
         env:
           STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 

--- a/.github/workflows/ui-e2e-tests-v2.yml
+++ b/.github/workflows/ui-e2e-tests-v2.yml
@@ -233,7 +233,7 @@ jobs:
           yq -i '.services.worker.networks = ["kind","default"]' docker-compose.yml
 
       - name: Fix API data directory permissions
-        run: docker run --rm -v $(pwd)/_data/api:/data alpine chown -R 1000:1000 /data
+        run: docker run --rm -v "$(pwd)/_data/api:/data" alpine chown -R 1000:1000 /data
 
       - name: Add AWS credentials for testing
         run: |
@@ -267,7 +267,7 @@ jobs:
           timeout=150
           elapsed=0
           while [ $elapsed -lt $timeout ]; do
-            if curl -s ${UI_API_BASE_URL}/docs >/dev/null 2>&1; then
+            if curl -s "${UI_API_BASE_URL}/docs" >/dev/null 2>&1; then
               echo "Prowler API is ready!"
               exit 0
             fi
@@ -387,7 +387,8 @@ jobs:
             fi
             TEST_PATHS=$(echo "$VALID_PATHS" | tr '\n' ' ')
             echo "Resolved test paths: $TEST_PATHS"
-            pnpm exec playwright test $TEST_PATHS
+            read -ra test_paths <<< "$TEST_PATHS"
+            pnpm exec playwright test "${test_paths[@]}"
           fi
 
       - name: Upload test reports

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -157,7 +157,8 @@ jobs:
           echo "${STEPS_CHANGED_SOURCE_OUTPUTS_ALL_CHANGED_FILES}"
           # Convert space-separated to vitest related format (remove ui/ prefix for relative paths)
           CHANGED_FILES=$(echo "${STEPS_CHANGED_SOURCE_OUTPUTS_ALL_CHANGED_FILES}" | tr ' ' '\n' | sed 's|^ui/||' | tr '\n' ' ')
-          pnpm exec vitest related $CHANGED_FILES --run --project unit
+          read -ra changed <<< "$CHANGED_FILES"
+          pnpm exec vitest related "${changed[@]}" --run --project unit
         env:
           STEPS_CHANGED_SOURCE_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-source.outputs.all_changed_files }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,8 +51,8 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
-        # Shell-quality findings are a separate backlog; this hook is here for the schema.
-        args: ['-shellcheck=']
+        # SC2129 only suggests grouping consecutive redirects; not worth restructuring for.
+        args: ['-shellcheck=-e SC2129']
         priority: 30
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit

--- a/prowler/changelog.d/shellcheck-workflows-complete.changed.md
+++ b/prowler/changelog.d/shellcheck-workflows-complete.changed.md
@@ -1,0 +1,1 @@
+Fix the remaining shellcheck findings in workflows and enable the check


### PR DESCRIPTION
Completes [PROWLER-2368](https://prowlerpro.atlassian.net/browse/PROWLER-2368) for this repository. [#12365](https://github.com/prowler-cloud/prowler/pull/12365) cleared the mechanical 82; these are the ones that needed reading.

## Two were not style at all

**`prepare-release.yml`** declared and assigned in one statement:

```bash
local version=$(grep ... | sed ...)
```

That discards the command's exit status, so under `set -e` a failing pipeline goes unnoticed and the function returns an empty version. Split into declaration and assignment.

**`pr-check-changelog.yml`** computed `added` and never used it. The two variables beside it, `added_or_renamed` and `added_modified_or_renamed`, are used five times between them — so this was dead code rather than a typo for one of those. Removed.

## Four relied on word splitting

`pytest` service paths, `playwright` test paths, `vitest` changed files, and the file list passed to `test-impact.py`. Each took a space-separated string and depended on the shell splitting it into separate arguments.

Quoting those alone would have collapsed each list into **one** argument — the check would have gone green while the step started running against a single nonexistent path. The split is now explicit with `read -ra`, which says what it means and satisfies the rule for the right reason.

## The rest

Quoting, plus one `sed 's/, $//'` replaced by `${found_in%, }` after checking both produce the same output.

## SC2129 is excluded, not fixed

It only suggests grouping consecutive redirects into `{ ...; } >> file`. Restructuring release workflows for a formatting preference is not worth the risk, so it is excluded via `SHELLCHECK_OPTS` with the reasoning recorded next to it in the workflow and the hook.

## Result

`-shellcheck=` comes out of both. **actionlint now runs in full here**, as it already does in [prowler-registry#193](https://github.com/prowler-cloud/prowler-registry/pull/193) and [partner-portal#526](https://github.com/prowler-cloud/partner-portal/pull/526).

Verified through the pinned Docker image the workflow uses, not just locally. `zizmor` clean.

## Remaining

`prowler-cloud`, with 188. It is the last one.


[PROWLER-2368]: https://prowlerpro.atlassian.net/browse/PROWLER-2368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow reliability by safely handling command arguments, paths, URLs, and environment values.
  * Corrected test and release automation behavior when processing multiple files or generated content.
  * Preserved ShellCheck validation while addressing remaining workflow warnings.

* **Documentation**
  * Added a changelog entry covering workflow ShellCheck improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->