### PR TITLE
ci: forward stacked PR metadata in the cloud sync dispatch

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -57,5 +57,8 @@ jobs:
               "PROWLER_PR_URL": ${{ toJson(github.event.pull_request.html_url) }},
               "PROWLER_PR_MERGED_BY": "${{ github.event.pull_request.merged_by.login }}",
               "PROWLER_PR_BASE_BRANCH": ${{ toJson(github.event.pull_request.base.ref) }},
-              "PROWLER_PR_HEAD_BRANCH": ${{ toJson(github.event.pull_request.head.ref) }}
+              "PROWLER_PR_HEAD_BRANCH": ${{ toJson(github.event.pull_request.head.ref) }},
+              "PROWLER_PR_STACK_NUMBER": "${{ github.event.pull_request.stack.number }}",
+              "PROWLER_PR_STACK_POSITION": "${{ github.event.pull_request.stack.position }}",
+              "PROWLER_PR_STACK_SIZE": "${{ github.event.pull_request.stack.size }}"
             }


### PR DESCRIPTION
### Context

GitHub stacked pull requests are in public preview. Each PR in a stack fires its own `pull_request_target: closed` event with its own `merge_commit_sha`, so prowler-cloud receives one sync dispatch per stacked PR. Those commits are dependent on each other, so the receiving workflow needs to know the stack and the position to chain them instead of cherry-picking each one onto master independently.

### Description

Adds `PROWLER_PR_STACK_NUMBER`, `PROWLER_PR_STACK_POSITION`, and `PROWLER_PR_STACK_SIZE` to the `repository_dispatch` client-payload, read from `github.event.pull_request.stack`. Fields are empty strings for non-stacked PRs, so behaviour is unchanged outside stacks.

Pairs with the prowler-cloud PR: https://github.com/prowler-cloud/prowler-cloud/pull/5449

### Steps to review

Confirm the four new/changed lines only add fields to the JSON payload sent to `repository_dispatch` — no other step in `pr-merged.yml` is touched. `actionlint` and `zizmor` are clean on the workflow.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. — Not needed; this only affects future stacked-PR dispatches.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. — N/A, CI-only change.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merged pull request notifications now include stack metadata, including stack number, position, and size, alongside the head branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->