### PR TITLE
fix(ci): keep the cloud sync dispatch payload within the 10-property limit

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -46,6 +46,7 @@ jobs:
           token: ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}
           repository: ${{ secrets.CLOUD_DISPATCH }}
           event-type: prowler-pull-request-merged
+          # repository_dispatch caps client_payload at 10 properties; this is exactly at the cap.
           client-payload: |
             {
               "PROWLER_COMMIT_SHA": "${{ github.event.pull_request.merge_commit_sha }}",
@@ -54,10 +55,7 @@ jobs:
               "PROWLER_PR_TITLE": ${{ toJson(github.event.pull_request.title) }},
               "PROWLER_PR_LABELS": ${{ toJson(github.event.pull_request.labels.*.name) }},
               "PROWLER_PR_BODY": ${{ toJson(github.event.pull_request.body) }},
-              "PROWLER_PR_URL": ${{ toJson(github.event.pull_request.html_url) }},
               "PROWLER_PR_MERGED_BY": "${{ github.event.pull_request.merged_by.login }}",
-              "PROWLER_PR_BASE_BRANCH": ${{ toJson(github.event.pull_request.base.ref) }},
-              "PROWLER_PR_HEAD_BRANCH": ${{ toJson(github.event.pull_request.head.ref) }},
               "PROWLER_PR_STACK_NUMBER": "${{ github.event.pull_request.stack.number }}",
               "PROWLER_PR_STACK_POSITION": "${{ github.event.pull_request.stack.position }}",
               "PROWLER_PR_STACK_SIZE": "${{ github.event.pull_request.stack.size }}"


### PR DESCRIPTION
🚨 **Urgent — the cross-repo sync pipeline is currently down.** No sync PR is being opened in prowler-cloud for any merged pull request until this lands.

### Context

PR #12368 pushed the `repository_dispatch` `client_payload` from 10 to 13 properties. GitHub caps `client_payload` at 10 properties, so the API rejects the call outright:

```
No more than 10 properties are allowed; 13 were supplied
```

The `trigger-cloud-pull-request` job failed on the very merge that introduced it: https://github.com/prowler-cloud/prowler/actions/runs/31093147768

No pull request has merged to master between #12368 and this fix, so no sync was actually lost — but every merge from here on would silently fail to trigger a sync until this is fixed.

### Description

Drops `PROWLER_PR_URL`, `PROWLER_PR_BASE_BRANCH` and `PROWLER_PR_HEAD_BRANCH` from the dispatch payload. All three were dead weight: `sync-from-prowler.yml` in prowler-cloud is the only consumer of this dispatch and reads none of them. This puts the payload back at exactly 10 properties while keeping the stack metadata the receiver now expects.

Also adds a comment at the payload marking the 10-property cap so the next person adding a field doesn't trip on it again.

### Steps to review

- Confirm `sync-from-prowler.yml` in prowler-cloud does not reference `PROWLER_PR_URL`, `PROWLER_PR_BASE_BRANCH`, or `PROWLER_PR_HEAD_BRANCH`.
- Count the properties in the `client-payload` JSON block in `.github/workflows/pr-merged.yml` — should be exactly 10.
- `actionlint` and `zizmor` both run clean on the changed workflow.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation event data to comply with repository-dispatch property limits.
  * Added documentation clarifying the property limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->