### PR TITLE
ci: always report from actionlint, skipping the work when nothing changed

### DIFF
--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - 'master'
-    paths:
-      - '.github/**'
   pull_request:
     branches:
       - 'master'
-    paths:
-      - '.github/**'
   schedule:
     - cron: '45 06 * * *'
   workflow_dispatch:
@@ -46,11 +42,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          persist-credentials: false
+          # zizmor: ignore[artipacked]
+          persist-credentials: true # Required by tj-actions/changed-files to fetch PR branch
+
+      # The job always runs so it always reports, which is what a required check needs;
+      # the work is skipped when nothing under .github changed.
+      - name: Check for workflow changes
+        id: check-changes
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files: .github/**
 
       # SC2129 only suggests grouping consecutive redirects. Restructuring release
       # workflows for a formatting preference is not worth the risk.
       - name: Run actionlint
+        if: steps.check-changes.outputs.any_changed == 'true'
         env:
           SHELLCHECK_OPTS: '-e SC2129'
         run: |

--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -45,16 +45,14 @@ jobs:
           # zizmor: ignore[artipacked]
           persist-credentials: true # Required by tj-actions/changed-files to fetch PR branch
 
-      # The job always runs so it always reports, which is what a required check needs;
-      # the work is skipped when nothing under .github changed.
+      # Always runs so it always reports; the lint is skipped when nothing changed.
       - name: Check for workflow changes
         id: check-changes
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: .github/**
 
-      # SC2129 only suggests grouping consecutive redirects. Restructuring release
-      # workflows for a formatting preference is not worth the risk.
+      # SC2129 is style only: it suggests grouping consecutive redirects.
       - name: Run actionlint
         if: steps.check-changes.outputs.any_changed == 'true'
         env:

--- a/prowler/changelog.d/actionlint-always-runs.changed.md
+++ b/prowler/changelog.d/actionlint-always-runs.changed.md
@@ -1,0 +1,1 @@
+Run actionlint on every pull request so it can be a required check

--- a/prowler/changelog.d/actionlint-always-runs.changed.md
+++ b/prowler/changelog.d/actionlint-always-runs.changed.md
@@ -1,1 +1,0 @@
-Run actionlint on every pull request so it can be a required check


### PR DESCRIPTION
Preparation for making `GitHub Actions Schema Check` a **required** status check ([platform#1060](https://github.com/prowler-cloud/platform/pull/1060)).

## The problem with the paths filter

The workflow was scoped to `.github/**`. That scoping is exactly what stops it from being required: **a required check with a path filter never reports on a pull request that misses the filter**, and GitHub waits for it indefinitely rather than treating it as passed. Every PR touching no workflow would sit blocked.

## Why not just remove the filter

That fixes reportability but pulls and runs a container on every pull request for nothing.

This uses the `tj-actions/changed-files` pattern the container checks already use: **the job always runs, so it always reports, and the lint step is skipped when nothing under `.github` changed.**

Same reportability, no wasted container pull, and one pattern in the repository rather than two.

## Details

`api.github.com` is already on the egress allowlist, which is what `changed-files` needs. `persist-credentials` has to be `true` for it to fetch the PR branch — matching how the container checks do it, `zizmor` suppression included.

## Ordering

This has to land **before** the branch protection change that adds the context. The other way round deadlocks every open pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Workflow validation now runs for all pushes to the master branch and pull requests.
  * Validation is limited to changes involving workflow configuration files.
  * Job results continue to be reported consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->