### PR TITLE
fix(api): make tenant deletion cleanup atomic

### DIFF
--- a/api/changelog.d/tenant-deletion-transaction.fixed.md
+++ b/api/changelog.d/tenant-deletion-transaction.fixed.md
@@ -1,0 +1,1 @@
+Tenant deletion no longer leaves memberships partially removed when exclusive-user cleanup fails

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -78,8 +78,9 @@ from conftest import (
     today_after_n_days,
 )
 from django.conf import settings
-from django.db import close_old_connections, connection
+from django.db import close_old_connections, connection, connections
 from django.db.models import Count
+from django.db.models.signals import pre_delete
 from django.http import JsonResponse
 from django.test import RequestFactory
 from django.test.utils import CaptureQueriesContext
@@ -517,6 +518,50 @@ class TestUserViewSet:
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert error_field in response.json()["errors"][0]["source"]["pointer"]
+
+
+@pytest.mark.requires_test_admin_alias
+@pytest.mark.django_db(transaction=True, databases=["default", "admin"])
+class TestTenantDeletionTransactions:
+    @patch("api.v1.views.delete_tenant_task.apply_async")
+    def test_delete_rolls_back_memberships_when_user_cleanup_fails(
+        self,
+        delete_tenant_mock,
+        authenticated_client,
+        tenants_fixture,
+    ):
+        assert connections["default"] is not connections["admin"]
+
+        _, tenant, _ = tenants_fixture
+        exclusive_user = User.objects.create_user(
+            name="exclusive user",
+            password=TEST_PASSWORD,
+            email="exclusive-user@example.com",
+        )
+        membership = Membership.objects.create(
+            user=exclusive_user,
+            tenant=tenant,
+            role=Membership.RoleChoices.MEMBER,
+        )
+
+        def fail_user_cleanup(*, instance, **kwargs):
+            if instance.pk == exclusive_user.pk:
+                raise RuntimeError("Simulated user cleanup failure.")
+
+        pre_delete.connect(fail_user_cleanup, sender=User)
+        try:
+            with (
+                patch.object(MainRouter, "admin_db", "admin"),
+                pytest.raises(RuntimeError, match=r"Simulated user cleanup failure\."),
+            ):
+                authenticated_client.delete(
+                    reverse("tenant-detail", kwargs={"pk": tenant.id})
+                )
+        finally:
+            pre_delete.disconnect(fail_user_cleanup, sender=User)
+
+        assert Membership.objects.using("admin").filter(pk=membership.pk).exists()
+        delete_tenant_mock.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -1442,7 +1442,7 @@ class TenantViewSet(BaseTenantViewset):
         if not membership or membership.role != Membership.RoleChoices.OWNER:
             raise PermissionDenied("Only owners can delete a tenant.")
 
-        with transaction.atomic():
+        with transaction.atomic(using=MainRouter.admin_db):
             # Collect user IDs from this tenant's memberships before deleting them
             tenant_user_ids = set(
                 Membership.objects.using(MainRouter.admin_db)


### PR DESCRIPTION
### Context

Tenant deletion opened `transaction.atomic()` on the default database connection while membership and user writes were routed through `admin_db`. A failure during user cleanup could therefore leave memberships partially deleted.

This was reproduced on the latest OSS `master` with separate `default` and `admin` database connections. Cloud has a dedicated implementation, so this PR must not be synchronized automatically.

### Description

- Bind the tenant deletion transaction to `MainRouter.admin_db`.
- Add a multi-database regression test that verifies membership deletion rolls back when exclusive-user cleanup fails.
- Add an API changelog fragment.
- Apply the `skip-sync` label because Cloud has a separate tailored PR.

### Steps to review

1. Run the relevant API tests:

   ```bash
   cd api
   uv run pytest -q src/backend/api/tests/test_views.py::TestTenantDeletionTransactions src/backend/api/tests/test_views.py::TestTenantViewSet src/backend/tasks/tests/test_deletion.py::TestDeleteTenant
   ```

   Expected result: `54 passed`.

2. Run the API formatting and lint checks:

   ```bash
   uv run ruff format --check src/backend
   uv run ruff check src/backend
   ```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the open issues or roadmap.prowler.com
- [ ] It is assigned to me
- [x] I reviewed the open pull requests and found no duplicate implementation

</details>

- [x] The change is covered by tests.
- [x] No additional code documentation is required.
- [x] Backport requirements were reviewed.
- [x] No README change is required.

#### SDK/CLI

- Are there new checks included in this PR? No

#### API

- [x] Tenant deletion behavior works as expected.
- Endpoint response output: Not changed.
- EXPLAIN ANALYZE: Not applicable, no query shape or index change.
- Performance test results: Not applicable.
- [x] API specs do not need regeneration.
- [x] No version update is required.
- [x] An API changelog fragment is included.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tenant deletion reliability by ensuring membership records are preserved when exclusive-user cleanup fails.
  - Prevented asynchronous deletion tasks from being scheduled after an unsuccessful deletion attempt.
- **Tests**
  - Added coverage for transactional tenant deletion and cleanup failures.
- **Documentation**
  - Added a changelog entry describing the tenant deletion fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->