### PR TITLE
test(ui): preload lazy survey chunk to fix flaky feedback tests

### DIFF
--- a/ui/components/survey/feedback-survey.test.tsx
+++ b/ui/components/survey/feedback-survey.test.tsx
@@ -84,7 +84,11 @@ const provideSurveys = (surveys: Survey[]): void => {
   });
 };
 
-const renderSurvey = async () => {
+// Pre-evaluating the lazy chunk keeps findBy* queries from racing module
+// evaluation under full-suite load; guard tests that assert the chunk is never
+// touched opt out via preloadRuntime: false.
+const renderSurvey = async ({ preloadRuntime = true } = {}) => {
+  if (preloadRuntime) await import("./runtime-feedback-survey");
   const { FeedbackSurvey } = await import("./feedback-survey");
   return render(<FeedbackSurvey />);
 };
@@ -475,7 +479,7 @@ describe("FeedbackSurvey", () => {
     });
 
     // When
-    const view = await renderSurvey();
+    const view = await renderSurvey({ preloadRuntime: false });
 
     // Then - no init, no survey fetch, nothing rendered
     expect(mocks.init).not.toHaveBeenCalled();
@@ -495,7 +499,7 @@ describe("FeedbackSurvey", () => {
     });
 
     // When
-    const view = await renderSurvey();
+    const view = await renderSurvey({ preloadRuntime: false });
 
     // Then
     expect(view.container).toBeEmptyDOMElement();
@@ -515,7 +519,7 @@ describe("FeedbackSurvey", () => {
     provideSurveys([SURVEY_FIXTURE]);
 
     // When
-    const view = await renderSurvey();
+    const view = await renderSurvey({ preloadRuntime: false });
 
     // Then - no init, no trigger, no survey fetch, no capture, regardless of config
     expect(view.container).toBeEmptyDOMElement();


### PR DESCRIPTION
### Context

`ui/components/survey/feedback-survey.test.tsx` was flaky under full-suite load: the component lazy-loads `runtime-feedback-survey` via `React.lazy`, and each test's `vi.resetModules()` forces the whole chunk graph (posthog-js mock, Radix popover, lucide, zustand store) to re-evaluate inside the `findBy*` polling window. On a loaded machine that evaluation can exceed Testing Library's default 1s timeout, so the first test in the file failed intermittently during `pnpm run test` while passing in isolation.

### Description

- `renderSurvey` now pre-awaits `import("./runtime-feedback-survey")` before rendering, so the lazy chunk is already in the module registry and `React.lazy` resolves in a microtask — module evaluation no longer races the 1s `findBy*` window.
- No timeout tuning: default query timeouts are kept, so a genuine rendering regression still fails fast.
- The three guard tests that assert the PostHog surface is never touched (empty runtime config, PostHog disabled, not Cloud) opt out via `renderSurvey({ preloadRuntime: false })`, keeping their `mocks.moduleLoaded` never-called assertions meaningful — they still prove OSS never evaluates `posthog-js`.

### Steps to review

1. In `ui/components/survey/feedback-survey.test.tsx`, check the `renderSurvey` helper: the pre-import runs before `render()` and defaults to on.
2. Verify the three opt-out call sites are exactly the tests asserting `mocks.moduleLoaded` was never called.
3. Run `cd ui && pnpm run test` a few times — verified locally with three consecutive green full-suite runs (421 files / 2911 tests), plus the file in isolation (21/21).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable. (Not applicable: test-only change.)

#### API
No API changes.

#### MCP Server
No MCP Server changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved feedback survey test setup by preloading required survey resources where appropriate.
  * Preserved module-loading assertions in tests that verify analytics is not accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->