### PR TITLE
feat(api): identify active membership in current user response

### DIFF
--- a/api/changelog.d/users-me-active-membership.changed.md
+++ b/api/changelog.d/users-me-active-membership.changed.md
@@ -1,0 +1,1 @@
+`GET /api/v1/users/me` membership relationships identify the active tenant with `meta.active` for JWT and API key authentication

--- a/api/src/backend/api/tests/integration/test_authentication.py
+++ b/api/src/backend/api/tests/integration/test_authentication.py
@@ -1590,8 +1590,8 @@ class TestAPIKeyMultiTenantWorkflows:
         tenant1 = tenants_fixture[0]
         tenant2 = tenants_fixture[1]
 
-        Membership.objects.create(user=user, tenant=tenant1)
-        Membership.objects.create(user=user, tenant=tenant2)
+        membership1 = Membership.objects.create(user=user, tenant=tenant1)
+        membership2 = Membership.objects.create(user=user, tenant=tenant2)
 
         role1 = Role.objects.create(
             tenant_id=tenant1.id,
@@ -1645,6 +1645,27 @@ class TestAPIKeyMultiTenantWorkflows:
 
         assert me_response1.json()["data"]["id"] == str(user.id)
         assert me_response2.json()["data"]["id"] == str(user.id)
+
+        memberships1 = {
+            item["id"]: item["meta"]["active"]
+            for item in me_response1.json()["data"]["relationships"]["memberships"][
+                "data"
+            ]
+        }
+        memberships2 = {
+            item["id"]: item["meta"]["active"]
+            for item in me_response2.json()["data"]["relationships"]["memberships"][
+                "data"
+            ]
+        }
+        assert memberships1 == {
+            str(membership1.id): True,
+            str(membership2.id): False,
+        }
+        assert memberships2 == {
+            str(membership1.id): False,
+            str(membership2.id): True,
+        }
 
     def test_api_key_cannot_access_different_tenant_resources(
         self, tenants_fixture, aws_provider

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -329,6 +329,15 @@ class TokenSwitchTenantSerializer(BaseSerializerV1):
 # Users
 
 
+class ActiveMembershipRelatedField(SerializerMethodResourceRelatedField):
+    def to_representation(self, value):
+        representation = super().to_representation(value)
+        representation["meta"] = {
+            "active": str(value.tenant_id) == str(self.context["request"].tenant_id),
+        }
+        return representation
+
+
 class UserSerializer(BaseModelSerializerV1):
     """
     Serializer for the User model.
@@ -388,6 +397,12 @@ class UserSerializer(BaseModelSerializerV1):
             if self._can_view_relationships(instance)
             else Membership.objects.none()
         )
+
+
+class UserMeSerializer(UserSerializer):
+    memberships = ActiveMembershipRelatedField(
+        many=True, read_only=True, source="memberships", method_name="get_memberships"
+    )
 
 
 class UserIncludeSerializer(UserSerializer):

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -238,6 +238,7 @@ from api.v1.serializers import (
     TokenSocialLoginSerializer,
     TokenSwitchTenantSerializer,
     UserCreateSerializer,
+    UserMeSerializer,
     UserRoleRelationshipSerializer,
     UserSerializer,
     UserUpdateSerializer,
@@ -1113,6 +1114,8 @@ class UserViewSet(BaseUserViewset):
             return UserCreateSerializer
         elif self.action == "partial_update":
             return UserUpdateSerializer
+        elif self.action == "me":
+            return UserMeSerializer
         else:
             return UserSerializer
 
@@ -1130,7 +1133,7 @@ class UserViewSet(BaseUserViewset):
     @action(detail=False, methods=["get"], url_name="me")
     def me(self, request):
         user = self.request.user
-        serializer = UserSerializer(user, context=self.get_serializer_context())
+        serializer = self.get_serializer(user)
         return Response(
             data=serializer.data,
             status=status.HTTP_200_OK,


### PR DESCRIPTION
### Context

The active tenant is part of the authentication context, but `GET /api/v1/users/me` returned all membership identifiers without indicating which membership matched that tenant. API clients, especially those using API keys, could not determine the active membership from the response.

### Description

- Add `meta.active` to each membership resource identifier returned by `GET /api/v1/users/me`
- Set `active` by comparing the membership tenant with `request.tenant_id`
- Support both JWT and API key authentication
- Keep other user endpoints unchanged through an action-specific serializer
- Update the existing multi-tenant API key integration test

Example relationship output:

```json
{
  "memberships": {
    "data": [
      {
        "type": "memberships",
        "id": "membership-1",
        "meta": {
          "active": true
        }
      },
      {
        "type": "memberships",
        "id": "membership-2",
        "meta": {
          "active": false
        }
      }
    ],
    "meta": {
      "count": 2
    }
  }
}
```

### Steps to review

1. Authenticate with an API key for a user who belongs to multiple tenants.
2. Request `GET /api/v1/users/me`.
3. Confirm the membership associated with the API key tenant has `meta.active: true`.
4. Confirm the other memberships have `meta.active: false`.
5. Repeat with an API key for another tenant and confirm the active membership changes.
6. Execute test suite.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### API

- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected membership status reporting when accessing the API through different tenant API keys.
  * The membership for the current tenant is now marked active, while memberships for other tenants are marked inactive.
  * Updated the current-user endpoint to return accurate membership information for both API key and JWT authentication.

* **Documentation**
  * Documented how to identify the active tenant membership in the current-user response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->