### PR TITLE
fix(api): enforce POST on SAML ACS endpoint

### DIFF
--- a/api/changelog.d/saml-acs-post-only.fixed.md
+++ b/api/changelog.d/saml-acs-post-only.fixed.md
@@ -1,0 +1,1 @@
+`/api/v1/accounts/saml/{organization_slug}/acs/` rejects non-POST requests before SAML response processing

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -14684,6 +14684,7 @@ class TestSAMLACSView:
         )
 
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+        assert response.headers["Allow"] == "POST"
         assert "saml-acs-session" not in response.cookies
 
     def test_post_is_forwarded_to_allauth(self, client, saml_setup):

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -14674,6 +14674,36 @@ class TestSAMLConfigurationViewSet:
 
 
 @pytest.mark.django_db
+class TestSAMLACSView:
+    def test_get_is_not_allowed(self, client, saml_setup):
+        response = client.get(
+            reverse(
+                "saml_acs",
+                kwargs={"organization_slug": saml_setup["domain"]},
+            )
+        )
+
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+        assert "saml-acs-session" not in response.cookies
+
+    def test_post_is_forwarded_to_allauth(self, client, saml_setup):
+        response = client.post(
+            reverse(
+                "saml_acs",
+                kwargs={"organization_slug": saml_setup["domain"]},
+            ),
+            data={"SAMLResponse": "test-saml-response"},
+        )
+
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response.url == reverse(
+            "saml_finish_acs",
+            kwargs={"organization_slug": saml_setup["domain"]},
+        )
+        assert "saml-acs-session" in response.cookies
+
+
+@pytest.mark.django_db
 class TestTenantFinishACSView:
     def test_dispatch_skips_if_user_not_authenticated(self, monkeypatch):
         monkeypatch.setenv("AUTH_URL", "http://localhost")

--- a/api/src/backend/api/v1/urls.py
+++ b/api/src/backend/api/v1/urls.py
@@ -46,6 +46,7 @@ from api.v1.views import (
 from django.http import JsonResponse
 from django.urls import include, path
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 from drf_spectacular.views import SpectacularRedocView
 from rest_framework_nested import routers
 
@@ -194,7 +195,7 @@ urlpatterns = [
     ),
     path(
         "accounts/saml/<organization_slug>/acs/",
-        ACSView.as_view(),
+        require_POST(ACSView.as_view()),
         name="saml_acs",
     ),
     path(


### PR DESCRIPTION
### Context

Public SAML ACS endpoints can be requested by link-preview clients and other crawlers using GET. Allauth currently serializes that request and redirects it to the finish endpoint, where SAML processing reports a missing `SAMLResponse`.

The SAML ACS binding uses HTTP-POST, so non-POST methods should be rejected at the initial endpoint before an ACS session is created.

### Description

- Enforce POST on the initial SAML ACS route with Django's native `require_POST` decorator.
- Add regression coverage confirming GET returns 405 without an Allauth ACS cookie.
- Confirm POST continues to redirect to the finish endpoint and creates the temporary ACS cookie.
- Add an API changelog fragment.

### Steps to review

1. Run:
   `cd api && uv run pytest src/backend/api/tests/test_views.py::TestSAMLACSView src/backend/api/tests/test_views.py::TestTenantFinishACSView -q`
2. Start the API with `make dev`.
3. Request `GET /api/v1/accounts/saml/example.com/acs/` and verify:
   - `405 Method Not Allowed`
   - `Allow: POST`
   - no `saml-acs-session` cookie
4. Submit a form POST containing `SAMLResponse` and verify it returns `302` to `/api/v1/accounts/saml/example.com/acs/finish/` with the temporary cookie.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) (no README change required).
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable (not applicable; API-only change).

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Not applicable.

#### UI

Not applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (GET returns 405 with `Allow: POST`; POST retains the 302 ACS handoff)
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (not applicable; no query or index changes)
- [x] Performance test results (not applicable; request method validation only)
- [x] Any other relevant evidence of the implementation (18 focused SAML tests pass; Ruff and diff checks pass)
- [x] Verify if API specs need to be regenerated (not required; the route is not represented in the generated API schema)
- [x] Check if version updates are required (not required)
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server

Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted the SAML assertion consumer endpoint to POST requests.
  * Non-POST requests, including GET requests, now receive an HTTP 405 response before SAML response processing.
  * Preserved expected redirects and session-cookie behavior for valid POST requests.
  * Improved protection against unintended or unsupported requests to the SAML endpoint.

* **Documentation**
  * Documented the SAML endpoint’s POST-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->