### PR TITLE
test(m365): avoid Lob secret pattern in test name

### DIFF
--- a/tests/providers/m365/services/entra/entra_policy_default_user_cannot_create_security_groups/entra_policy_default_user_cannot_create_security_groups_test.py
+++ b/tests/providers/m365/services/entra/entra_policy_default_user_cannot_create_security_groups/entra_policy_default_user_cannot_create_security_groups_test.py
@@ -71,7 +71,7 @@ class Test_entra_policy_default_user_cannot_create_security_groups:
             assert result[0].status == "FAIL"
             assert result[0].resource_id == "authorizationPolicy"
 
-    def test_users_cannot_create_security_groups(self):
+    def test_security_group_creation_disabled(self):
         entra_client = mock.MagicMock
 
         with (


### PR DESCRIPTION
### Context

The `scan-secrets` job in [prowler-cloud/prowler-cloud#5484](https://github.com/prowler-cloud/prowler-cloud/pull/5484) reports a verified Lob secret for `test_users_cannot_create_security_groups`. The identifier accidentally matches the Lob test-key shape: `test_` followed by exactly 35 characters. It is a test name, not a credential.

### Description

Rename the test to `test_security_group_creation_disabled`. This preserves the behavior described by the test while breaking the accidental secret-detector pattern.

No runtime behavior changes.

### Steps to review

1. Confirm the diff only renames the test method.
2. Run:
   ```console
   uv run pytest tests/providers/m365/services/entra/entra_policy_default_user_cannot_create_security_groups/entra_policy_default_user_cannot_create_security_groups_test.py -v
   ```
3. Confirm pytest collects `test_security_group_creation_disabled` and no longer collects `test_users_cannot_create_security_groups`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] I have reviewed the open pull requests and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed: not required.
- [x] Review if is needed to change the README.md: not required.
- [x] Ensure a changelog fragment is added under `prowler/changelog.d/`, if applicable: not applicable; test-only CI fix.

#### SDK/CLI
- Are there new checks included in this PR? **No**

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Renamed a security group creation test for improved clarity; test behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->