### PR TITLE
fix(docker): use stable-compatible API/UI health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       neo4j:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:${DJANGO_PORT:-8080}/health/live || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:${DJANGO_PORT:-8080}/health/v1/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 12
@@ -53,7 +53,7 @@ services:
       mcp-server:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/api/health || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/api/auth/providers || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
The docker-compose.yml from master probes /health/live (API) and /api/health (UI), but prowlercloud/*:stable images do not expose those routes yet and return 404.

That made prowler-master-api-1 and ui-1 unhealthy. Because worker and worker-beat depend on api being healthy, compose failed with:

  dependency failed to start: container prowler-master-api-1 is unhealthy

Update the healthchecks to endpoints that return 200 on the current stable images:

- API: /api/v1/
- UI: /api/auth/providers

This keeps the stack starting correctly on Linux (Kali) without requiring newer images that include the /health/* endpoints.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API and UI health checks to use the correct endpoints, improving service availability monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->