### PR TITLE
fix(ci): suppress Trivy go-git vulnerability temporarily

### DIFF
--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -111,6 +111,7 @@ jobs:
         with:
           files: |
             api/**
+            .trivyignore.yaml
             .github/actions/trivy-scan/**
             .github/actions/grype-scan/**
             .grype.yaml

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           files: |
             mcp_server/**
+            .trivyignore.yaml
             .github/actions/trivy-scan/**
             .github/actions/grype-scan/**
             .grype.yaml

--- a/.github/workflows/sdk-container-checks.yml
+++ b/.github/workflows/sdk-container-checks.yml
@@ -10,6 +10,7 @@ on:
       - 'Dockerfile*'
       - 'pyproject.toml'
       - 'uv.lock'
+      - '.trivyignore.yaml'
       - '.github/workflows/sdk-container-checks.yml'
   pull_request:
     branches:
@@ -116,6 +117,7 @@ jobs:
             Dockerfile*
             pyproject.toml
             uv.lock
+            .trivyignore.yaml
             .github/workflows/sdk-container-checks.yml
             .github/actions/trivy-scan/**
             .github/actions/grype-scan/**

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -104,6 +104,7 @@ jobs:
         with:
           files: |
             ui/**
+            .trivyignore.yaml
             .github/actions/trivy-scan/**
             .github/actions/grype-scan/**
             .grype.yaml

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -9,6 +9,14 @@ ignore:
 
   # Modules compiled into the Trivy binary we ship.
   # Only a Trivy rebuild by its vendor can change these; the version is pinned in our Dockerfile.
+  # CVE-2026-71556 is the same temporary exception documented in .trivyignore.yaml:
+  # Trivy 0.73.0 still embeds go-git 5.19.1, while the 5.19.2 fix is merged only on
+  # Trivy main. Remove this entry with the Trivy exception by 2026-09-15.
+  # https://github.com/aquasecurity/trivy/blob/v0.73.0/go.mod#L46
+  # https://github.com/aquasecurity/trivy/commit/a2edba9a03987ba0d2ebc8212c1a9a1e6979497b
+  - vulnerability: CVE-2026-71556
+    package:
+      name: github.com/go-git/go-git/v5
   - vulnerability: CVE-2026-56852
     package:
       name: golang.org/x/text

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -120,6 +120,20 @@ vulnerabilities:
 
   # Modules compiled into the Trivy binary the images ship. The binary is pinned by version
   # and verified by checksum in the Dockerfile; only a rebuild by its vendor moves these.
+  # CVE-2026-71556 affects go-git worktree operations that can follow symlinks outside a
+  # cloned repository. Trivy 0.72.0 contains go-git 5.19.1, and even the latest published
+  # Trivy release, 0.73.0, still pins that vulnerable version:
+  # https://github.com/aquasecurity/trivy/blob/v0.73.0/go.mod#L46
+  # Trivy main already contains the 5.19.2 fix, but no published release includes it yet:
+  # https://github.com/aquasecurity/trivy/commit/a2edba9a03987ba0d2ebc8212c1a9a1e6979497b
+  # Prowler invokes Trivy only with `fs` on an existing local path or with `image`; it does
+  # not ask Trivy to clone or mutate a Git worktree, so the affected path is not reachable.
+  # Remove this temporary suppression as soon as a fixed Trivy release is available.
+  - id: CVE-2026-71556
+    purls:
+      - "pkg:golang/github.com/go-git/go-git/v5"
+    expired_at: 2026-09-15
+
   - id: CVE-2026-56852
     purls:
       - "pkg:golang/golang.org/x/text"
@@ -140,4 +154,3 @@ vulnerabilities:
     purls:
       - "pkg:golang/stdlib"
     expired_at: 2026-12-31
-


### PR DESCRIPTION
### Context

PR #12154 is currently blocked by the SDK container security scan. Both Trivy and Grype report `CVE-2026-71556` in `github.com/go-git/go-git/v5@v5.19.1`, but the vulnerable dependency is compiled into `/usr/local/bin/trivy`; it does not come from the Prowler changes in that PR.

This can also block other PRs whenever their changes rebuild and scan a container that includes the affected Trivy binary. Trivy and Grype maintain independent ignore files, so the mitigation must be represented in both scanners.

The upstream state leaves two practical options:

1. Keep affected Prowler PRs blocked until Aqua Security publishes a fixed Trivy release.
2. Add narrowly scoped, temporary exceptions until that release exists.

This PR implements the second option.

#### Upstream evidence

- The fixed dependency version is `go-git v5.19.2`.
- The latest published Trivy release, [`v0.73.0`](https://github.com/aquasecurity/trivy/releases/tag/v0.73.0), still pins [`go-git v5.19.1`](https://github.com/aquasecurity/trivy/blob/v0.73.0/go.mod#L46).
- Trivy has already merged the update to `go-git v5.19.2` on its main branch in [aquasecurity/trivy@a2edba9](https://github.com/aquasecurity/trivy/commit/a2edba9a03987ba0d2ebc8212c1a9a1e6979497b).
- No published Trivy release currently contains that update, so Prowler cannot consume the fix through its normal version-and-checksum pinning process yet.

### Description

- Temporarily suppress `CVE-2026-71556` only for the `github.com/go-git/go-git/v5` package embedded in Trivy, in both `.trivyignore.yaml` and `.grype.yaml`.
- Document the vulnerability, the latest-release evidence, the merged upstream fix, and the reason the affected worktree path is not reachable through Prowler's `trivy fs` and `trivy image` invocations.
- Expire the Trivy exception on 2026-09-15 and mark the Grype exception for removal by the same date, so both must be removed once a fixed Trivy release becomes available.
- Make `.trivyignore.yaml` trigger the SDK, API, UI, and MCP container build-and-scan jobs, ensuring exception changes are validated by the affected workflows rather than silently skipping scans.

### Steps to review

1. Confirm the Trivy `v0.73.0` `go.mod` evidence still shows `go-git v5.19.1`.
2. Confirm the linked upstream commit updates Trivy main to `go-git v5.19.2`.
3. Verify both scanner exceptions match the exact CVE and go-git package and share the same removal deadline.
4. Review the container workflow results; each workflow should build its image and apply its scanner-specific ignore configuration.
5. Optional local Trivy reproduction against the failed PR report:

   ```bash
   trivy convert --format json trivy-report.json \
     | jq '[.Results[]?.Vulnerabilities[]? | select(.VulnerabilityID == \"CVE-2026-71556\")] | length'
   # 1

   trivy convert --format json --ignorefile .trivyignore.yaml trivy-report.json \
     | jq '[.Results[]?.Vulnerabilities[]? | select(.VulnerabilityID == \"CVE-2026-71556\")] | length'
   # 0
   ```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] I have reviewed the open pull requests and confirmed there is no existing PR implementing this outcome.

</details>

- [x] Review if the code is being covered by tests. Configuration behavior is covered by the container workflows and the report validation described above.
- [x] Review if code is being documented. Both suppressions contain their rationale, upstream evidence, scope, and removal deadline.
- [x] Review if backport is needed. Not currently requested.
- [x] Review if the README needs changes. No README change is needed.
- [x] Ensure a changelog fragment is added, if applicable. Not applicable to this CI-only mitigation; the PR uses `no-changelog`.

#### SDK/CLI

- Are there new checks included in this PR? No.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added temporary vulnerability scan exceptions for a known issue, including expiration dates and documented rationale.
  * Updated security scanning configuration to improve handling of the affected dependency.

* **Chores**
  * Container validation workflows now automatically rerun when vulnerability-scan configuration changes.
  * Improved consistency across API, MCP, SDK, and UI container build and security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->