### PR TITLE
fix(ui): preserve local dates in scan findings

### DIFF
--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -25,7 +25,11 @@ import {
   hasDateOrScanFilter,
 } from "@/lib";
 import { getFindingGroupFilterOptions } from "@/lib/finding-group-filter-options";
-import { resolveFindingScanDateFilters } from "@/lib/findings-scan-filters";
+import {
+  FINDING_SCAN_DATE_SOURCE_PARAM,
+  parseFindingScanDateSource,
+  resolveFindingScanDateFilters,
+} from "@/lib/findings-scan-filters";
 import { isCloud } from "@/lib/shared/env";
 import { ScanEntity, ScanProps } from "@/types";
 import { SearchParamsProps } from "@/types/components";
@@ -52,6 +56,9 @@ export default async function Findings({
       const response = await getScan(scanId);
       return response?.data;
     },
+    dateSource: parseFindingScanDateSource(
+      resolvedSearchParams[FINDING_SCAN_DATE_SOURCE_PARAM],
+    ),
   });
   const resolvedFilters = applyDefaultMutedFilter(filtersWithScanDates);
   const hasHistoricalData = hasDateOrScanFilter(filtersWithScanDates);

--- a/ui/changelog.d/scan-findings-utc-date.fixed.md
+++ b/ui/changelog.d/scan-findings-utc-date.fixed.md
@@ -1,0 +1,1 @@
+Scan `View Findings` navigation now preserves the user's local date while querying findings with the scan's UTC completion date

--- a/ui/components/findings/findings-filters.tsx
+++ b/ui/components/findings/findings-filters.tsx
@@ -20,6 +20,10 @@ import { ExpandableSection } from "@/components/shadcn/expandable-section";
 import { DataTableFilterCustom } from "@/components/shadcn/table/data-table-filter-custom";
 import { useFilterBatch } from "@/hooks/use-filter-batch";
 import { getCategoryLabel, getGroupLabel } from "@/lib/categories";
+import {
+  FINDING_SCAN_DATE_PROVENANCE_FILTER_KEYS,
+  FINDING_SCAN_DATE_SOURCE_PARAM,
+} from "@/lib/findings-scan-filters";
 import { FILTER_FIELD, ScanEntity } from "@/types";
 import { ProviderGroup } from "@/types/components";
 import { DATA_TABLE_FILTER_MODE } from "@/types/filters";
@@ -369,6 +373,12 @@ export const FindingsFilters = (props: FindingsFiltersProps) => {
   } = useFilterBatch({
     defaultParams: { "filter[muted]": "false" },
     exclusiveFilterGroups: [FINDING_GROUP_FILTER_KEYS],
+    urlParamInvalidationRules: [
+      {
+        param: FINDING_SCAN_DATE_SOURCE_PARAM,
+        filterKeys: FINDING_SCAN_DATE_PROVENANCE_FILTER_KEYS,
+      },
+    ],
   });
 
   return (

--- a/ui/components/scans/table/scan-jobs-row-actions.test.tsx
+++ b/ui/components/scans/table/scan-jobs-row-actions.test.tsx
@@ -314,7 +314,7 @@ describe("ScanJobsRowActions", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("links completed scans to filtered findings", async () => {
+  it("links completed scans to findings with a local display date", async () => {
     // Given
     const user = userEvent.setup();
     render(
@@ -334,9 +334,11 @@ describe("ScanJobsRowActions", () => {
     await user.click(screen.getByRole("menuitem", { name: /view findings/i }));
 
     // Then
-    expect(pushMock).toHaveBeenCalledWith(
-      "/findings?filter[scan__in]=scan-1&filter[inserted_at]=2026-01-01&filter[status__in]=FAIL",
-    );
+    const findingsHref = pushMock.mock.calls[0]?.[0] as string;
+    expect(findingsHref).toContain("filter[scan__in]=scan-1");
+    expect(findingsHref).toContain("filter[inserted_at]=2026-01-01");
+    expect(findingsHref).toContain("filter[status__in]=FAIL");
+    expect(findingsHref).toContain("scanDateSource=scan-action:2026-01-01");
   });
 
   it("triggers downloadScanZip with the scan id when downloading reports", async () => {

--- a/ui/components/scans/table/scan-jobs-row-actions.tsx
+++ b/ui/components/scans/table/scan-jobs-row-actions.tsx
@@ -31,6 +31,10 @@ import {
 } from "@/components/shadcn/dropdown";
 import { buildPerScanComplianceHref } from "@/lib/compliance/compliance-tab-url";
 import { toLocalDateString } from "@/lib/date-utils";
+import {
+  buildFindingScanDateSource,
+  FINDING_SCAN_DATE_SOURCE_PARAM,
+} from "@/lib/findings-scan-filters";
 import { downloadScanZip } from "@/lib/helper";
 import { getScanScheduleCapability } from "@/lib/schedules";
 import { isCloud } from "@/lib/shared/env";
@@ -93,8 +97,9 @@ export function ScanJobsRowActions({
 
   const openFindings = () => {
     if (!isCompleted || !scanDate) return;
+
     router.push(
-      `/findings?filter[scan__in]=${scan.id}&filter[inserted_at]=${scanDate}&filter[status__in]=FAIL`,
+      `/findings?filter[scan__in]=${scan.id}&filter[inserted_at]=${scanDate}&filter[status__in]=FAIL&${FINDING_SCAN_DATE_SOURCE_PARAM}=${buildFindingScanDateSource(scanDate)}`,
     );
   };
 

--- a/ui/hooks/use-filter-batch.test.ts
+++ b/ui/hooks/use-filter-batch.test.ts
@@ -1,6 +1,12 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  buildFindingScanDateSource,
+  FINDING_SCAN_DATE_PROVENANCE_FILTER_KEYS,
+  FINDING_SCAN_DATE_SOURCE_PARAM,
+} from "@/lib/findings-scan-filters";
+
 // --- Mock next/navigation ---
 const mockPush = vi.fn();
 let mockSearchParamsValue = new URLSearchParams();
@@ -432,6 +438,84 @@ describe("useFilterBatch", () => {
       expect(calledUrl).toContain("filter%5Bsearch%5D=my-search");
       expect(calledUrl).toContain("filter%5Bmuted%5D=false");
     });
+
+    it("should clear scan-date provenance when the displayed date changes", () => {
+      // Given
+      setSearchParams({
+        "filter[scan__in]": "scan-1",
+        "filter[inserted_at]": "2026-04-06",
+        [FINDING_SCAN_DATE_SOURCE_PARAM]:
+          buildFindingScanDateSource("2026-04-06"),
+        expandedCheckId: "check-1",
+      });
+      const { result } = renderHook(() =>
+        useFilterBatch({
+          urlParamInvalidationRules: [
+            {
+              param: FINDING_SCAN_DATE_SOURCE_PARAM,
+              filterKeys: FINDING_SCAN_DATE_PROVENANCE_FILTER_KEYS,
+            },
+          ],
+        }),
+      );
+
+      act(() => {
+        result.current.setPending("filter[inserted_at]", ["2026-04-05"]);
+      });
+
+      // When
+      act(() => {
+        result.current.applyAll();
+      });
+
+      // Then
+      const calledUrl = new URL(
+        mockPush.mock.calls[0][0],
+        "https://example.com",
+      );
+      expect(calledUrl.searchParams.has(FINDING_SCAN_DATE_SOURCE_PARAM)).toBe(
+        false,
+      );
+      expect(calledUrl.searchParams.get("expandedCheckId")).toBe("check-1");
+    });
+
+    it("should preserve scan-date provenance for unrelated filter changes", () => {
+      // Given
+      const dateSource = buildFindingScanDateSource("2026-04-06");
+      setSearchParams({
+        "filter[scan__in]": "scan-1",
+        "filter[inserted_at]": "2026-04-06",
+        [FINDING_SCAN_DATE_SOURCE_PARAM]: dateSource,
+      });
+      const { result } = renderHook(() =>
+        useFilterBatch({
+          urlParamInvalidationRules: [
+            {
+              param: FINDING_SCAN_DATE_SOURCE_PARAM,
+              filterKeys: FINDING_SCAN_DATE_PROVENANCE_FILTER_KEYS,
+            },
+          ],
+        }),
+      );
+
+      act(() => {
+        result.current.setPending("filter[severity__in]", ["critical"]);
+      });
+
+      // When
+      act(() => {
+        result.current.applyAll();
+      });
+
+      // Then
+      const calledUrl = new URL(
+        mockPush.mock.calls[0][0],
+        "https://example.com",
+      );
+      expect(calledUrl.searchParams.get(FINDING_SCAN_DATE_SOURCE_PARAM)).toBe(
+        dateSource,
+      );
+    });
   });
 
   // ── discardAll ─────────────────────────────────────────────────────────────
@@ -634,6 +718,42 @@ describe("useFilterBatch", () => {
       expect(mockPush).toHaveBeenCalledTimes(1);
       const calledUrl: string = mockPush.mock.calls[0][0];
       expect(calledUrl).toContain("page=1");
+    });
+
+    it("should clear scan-date provenance without deleting unrelated URL params", () => {
+      // Given
+      setSearchParams({
+        "filter[scan__in]": "scan-1",
+        "filter[inserted_at]": "2026-04-06",
+        [FINDING_SCAN_DATE_SOURCE_PARAM]:
+          buildFindingScanDateSource("2026-04-06"),
+        expandedCheckId: "check-1",
+      });
+      const { result } = renderHook(() =>
+        useFilterBatch({
+          urlParamInvalidationRules: [
+            {
+              param: FINDING_SCAN_DATE_SOURCE_PARAM,
+              filterKeys: FINDING_SCAN_DATE_PROVENANCE_FILTER_KEYS,
+            },
+          ],
+        }),
+      );
+
+      // When
+      act(() => {
+        result.current.clearAndApply();
+      });
+
+      // Then
+      const calledUrl = new URL(
+        mockPush.mock.calls[0][0],
+        "https://example.com",
+      );
+      expect(calledUrl.searchParams.has(FINDING_SCAN_DATE_SOURCE_PARAM)).toBe(
+        false,
+      );
+      expect(calledUrl.searchParams.get("expandedCheckId")).toBe("check-1");
     });
   });
 });

--- a/ui/hooks/use-filter-batch.ts
+++ b/ui/hooks/use-filter-batch.ts
@@ -157,6 +157,16 @@ export interface UseFilterBatchOptions {
    * applied together.
    */
   exclusiveFilterGroups?: string[][];
+  /**
+   * Non-filter URL params whose provenance becomes invalid when specific
+   * URL-backed filters change.
+   */
+  urlParamInvalidationRules?: UrlParamInvalidationRule[];
+}
+
+export interface UrlParamInvalidationRule {
+  param: string;
+  filterKeys: readonly string[];
 }
 
 function normalizeFilterKey(key: string): string {
@@ -233,9 +243,26 @@ export const useFilterBatch = (
   };
 
   /** Private helper — builds URLSearchParams from a pending state and pushes. */
-  const buildAndPush = (nextPending: PendingFilters) => {
+  const buildAndPush = (
+    nextPending: PendingFilters,
+    clearInvalidatedParams = false,
+  ) => {
     setAppliedFilters(nextPending);
     const params = new URLSearchParams(searchParams.toString());
+
+    options?.urlParamInvalidationRules?.forEach(({ param, filterKeys }) => {
+      const isInvalidated =
+        clearInvalidatedParams ||
+        filterKeys.some((filterKey) => {
+          const currentValue = searchParams.get(filterKey) || "";
+          const nextValue = (nextPending[filterKey] ?? [])
+            .filter(Boolean)
+            .join(",");
+          return currentValue !== nextValue;
+        });
+
+      if (isInvalidated) params.delete(param);
+    });
 
     // Remove all batch-managed filter params
     Array.from(params.keys()).forEach((key) => {
@@ -290,7 +317,7 @@ export const useFilterBatch = (
    */
   const clearAndApply = () => {
     setPendingFilters({});
-    buildAndPush({});
+    buildAndPush({}, true);
   };
 
   const removeAppliedAndApply = (key: string, value?: string) => {

--- a/ui/lib/findings-scan-filters.test.ts
+++ b/ui/lib/findings-scan-filters.test.ts
@@ -109,4 +109,56 @@ describe("resolveFindingScanDateFilters", () => {
       "filter[inserted_at__gte]": "2026-04-01",
     });
   });
+
+  it("replaces a scan-action local date with the scan UTC completion date", async () => {
+    const result = await resolveFindingScanDateFilters({
+      filters: {
+        "filter[muted]": "false",
+        "filter[scan__in]": "scan-1",
+        "filter[inserted_at]": "2026-04-06",
+        "filter[status__in]": "FAIL",
+      },
+      scans: [
+        {
+          id: "scan-1",
+          attributes: {
+            completed_at: "2026-04-07T00:30:00Z",
+          },
+        },
+      ],
+      loadScan: vi.fn(),
+      dateSource: "scan-action:2026-04-06",
+    });
+
+    expect(result).toEqual({
+      "filter[muted]": "false",
+      "filter[scan__in]": "scan-1",
+      "filter[inserted_at]": "2026-04-07",
+      "filter[status__in]": "FAIL",
+    });
+  });
+
+  it("preserves a manually changed date when the scan-action marker is stale", async () => {
+    const result = await resolveFindingScanDateFilters({
+      filters: {
+        "filter[scan__in]": "scan-1",
+        "filter[inserted_at]": "2026-04-05",
+      },
+      scans: [
+        {
+          id: "scan-1",
+          attributes: {
+            completed_at: "2026-04-07T00:30:00Z",
+          },
+        },
+      ],
+      loadScan: vi.fn(),
+      dateSource: "scan-action:2026-04-06",
+    });
+
+    expect(result).toEqual({
+      "filter[scan__in]": "scan-1",
+      "filter[inserted_at]": "2026-04-05",
+    });
+  });
 });

--- a/ui/lib/findings-scan-filters.ts
+++ b/ui/lib/findings-scan-filters.ts
@@ -13,6 +13,36 @@ interface ResolveFindingScanDateFiltersOptions {
   filters: Record<string, string>;
   scans: ScanDateSource[];
   loadScan: (scanId: string) => Promise<ScanDateSource | null | undefined>;
+  dateSource?: FindingScanDateSource;
+}
+
+export const FINDING_SCAN_DATE_SOURCE_PARAM = "scanDateSource";
+
+export const FINDING_SCAN_DATE_SOURCE = {
+  SCAN_ACTION: "scan-action",
+} as const;
+
+type FindingScanDateSource =
+  `${typeof FINDING_SCAN_DATE_SOURCE.SCAN_ACTION}:${string}`;
+
+const SCAN_ACTION_DATE_PREFIX =
+  `${FINDING_SCAN_DATE_SOURCE.SCAN_ACTION}:` as const;
+
+export function buildFindingScanDateSource(
+  displayDate: string,
+): FindingScanDateSource {
+  return `${SCAN_ACTION_DATE_PREFIX}${displayDate}`;
+}
+
+export function parseFindingScanDateSource(
+  value: string | string[] | undefined,
+): FindingScanDateSource | undefined {
+  const candidate = Array.isArray(value) ? value[0] : value;
+
+  return candidate?.startsWith(SCAN_ACTION_DATE_PREFIX) &&
+    candidate.length > SCAN_ACTION_DATE_PREFIX.length
+    ? (candidate as FindingScanDateSource)
+    : undefined;
 }
 
 const INSERTED_AT_FILTER_KEYS = [
@@ -20,6 +50,12 @@ const INSERTED_AT_FILTER_KEYS = [
   "filter[inserted_at__date]",
   "filter[inserted_at__gte]",
   "filter[inserted_at__lte]",
+] as const;
+
+export const FINDING_SCAN_DATE_PROVENANCE_FILTER_KEYS = [
+  "filter[scan__in]",
+  "filter[scan]",
+  ...INSERTED_AT_FILTER_KEYS,
 ] as const;
 
 function getScanFilterIds(filters: Record<string, string>): string[] {
@@ -64,10 +100,20 @@ export async function resolveFindingScanDateFilters({
   filters,
   scans,
   loadScan,
+  dateSource,
 }: ResolveFindingScanDateFiltersOptions): Promise<Record<string, string>> {
   const scanIds = getScanFilterIds(filters);
+  const scanActionDisplayDate = dateSource?.slice(
+    SCAN_ACTION_DATE_PREFIX.length,
+  );
+  const isScanActionDate =
+    Boolean(scanActionDisplayDate) &&
+    filters["filter[inserted_at]"] === scanActionDisplayDate;
 
-  if (scanIds.length === 0 || hasInsertedAtFilter(filters)) {
+  if (
+    scanIds.length === 0 ||
+    (hasInsertedAtFilter(filters) && !isScanActionDate)
+  ) {
     return filters;
   }
 
@@ -96,8 +142,16 @@ export async function resolveFindingScanDateFilters({
     return filters;
   }
 
+  const apiFilters = isScanActionDate
+    ? Object.fromEntries(
+        Object.entries(filters).filter(([key]) =>
+          INSERTED_AT_FILTER_KEYS.every((dateKey) => dateKey !== key),
+        ),
+      )
+    : filters;
+
   return {
-    ...filters,
+    ...apiFilters,
     ...dateFilters,
   };
 }


### PR DESCRIPTION
### Context

**View Findings** from a completed scan could open an empty Findings page.

The scan action derived `filter[inserted_at]` in the browser timezone, while the findings API interprets date buckets in UTC. For scans completed near UTC midnight, combining the scan ID with the local calendar day produced an empty intersection.

### Description

- Preserve the user's browser-local date in the Findings URL and filter UI.
- Convert only scan-action dates to the scan's UTC completion day before calling findings APIs.
- Keep manually selected dates unchanged.
- Invalidate scan-date provenance when scan/date filters change or are cleared.

The `scanDateSource` parameter records that the visible date came from the scan action. This provenance is necessary because the server must distinguish an automatically generated local date from a date selected manually by the user. It is cleared with the related filters because retaining stale provenance could incorrectly convert a later manual date to the scan's UTC completion date.

### Steps to review

1. Open the scans table in a timezone where a scan's local completion day differs from UTC.
2. Select **View Findings** for the completed scan.
3. Confirm the URL and filter chip retain the local calendar date.
4. Confirm the findings request uses the UTC completion date and returns the scan findings.
5. Change or clear the date/scan filters and confirm `scanDateSource` is removed.

Automated verification:

```bash
cd ui
pnpm exec vitest run components/scans/table/scan-jobs-row-actions.test.tsx lib/findings-scan-filters.test.ts hooks/use-filter-batch.test.ts
pnpm exec eslint "app/(prowler)/findings/page.tsx" components/findings/findings-filters.tsx components/scans/table/scan-jobs-row-actions.tsx components/scans/table/scan-jobs-row-actions.test.tsx hooks/use-filter-batch.ts hooks/use-filter-batch.test.ts lib/findings-scan-filters.ts lib/findings-scan-filters.test.ts --max-warnings 0
pnpm exec tsc --noEmit --incremental false
```

Results: 59 tests passed; Prettier, ESLint, TypeScript, and commit hooks passed.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] The customer report is documented in PRWLRHELP-2500.
- [x] The change is assigned and scoped by PRWLRHELP-2500.

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented where needed.
- [x] Review if backport is needed.
- [x] Review if it is needed to change `README.md`.
- [x] Ensure a changelog fragment is added under the component's `changelog.d/`, if applicable.

#### UI

- [x] All issue/task requirements work as expected on the UI.
- [x] No visual layout change; screenshots are not applicable.
- [x] A changelog fragment is included under `ui/changelog.d/`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Findings opened from a completed scan now display the scan’s local date while querying results using the correct UTC completion date.
  * Changing or clearing related filters now removes outdated scan-date metadata, preventing stale results.
  * Manually selected finding dates are preserved when appropriate.
* **Tests**
  * Added coverage for scan-date navigation, filter updates, and date-source handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
