### PR TITLE
feat(iam): add iam_role_chained_privilege_escalation check

### DIFF
--- a/prowler/changelog.d/iam-role-chained-privilege-escalation.added.md
+++ b/prowler/changelog.d/iam-role-chained-privilege-escalation.added.md
@@ -1,0 +1,1 @@
+Add check iam_role_chained_privilege_escalation to detect transitive IAM AssumeRole chains into privileged roles

--- a/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/__init__.py
+++ b/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/__init__.py
@@ -1,0 +1,1 @@
+"""IAM role chained privilege escalation check package."""

--- a/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation.metadata.json
+++ b/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation.metadata.json
@@ -1,0 +1,45 @@
+{
+  "Provider": "aws",
+  "CheckID": "iam_role_chained_privilege_escalation",
+  "CheckTitle": "IAM role allows chained privilege escalation via AssumeRole",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "TTPs/Privilege Escalation"
+  ],
+  "ServiceName": "iam",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "critical",
+  "ResourceType": "AwsIamRole",
+  "ResourceGroup": "IAM",
+  "Description": "Detects IAM role chains where a role can assume another role that has privilege escalation capabilities. Unlike single-policy checks, this evaluates STS AssumeRole trust and action graphs across roles to identify transitive escalation paths.",
+  "Risk": "An attacker compromising a low-privileged role can chain sts:AssumeRole into a privileged role that can escalate to admin via iam:CreatePolicyVersion, iam:AttachRolePolicy, lambda:UpdateFunctionCode, and similar actions. This breaks isolation between trust boundaries and allows persistent admin takeover through role hopping.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_permissions-to-switch.html",
+    "https://bishopfox.com/blog/privilege-escalation-in-aws",
+    "https://github.com/RhinoSecurityLabs/Security-Research/blob/master/tools/aws-pentest-tools/aws_escalate.py"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws iam update-assume-role-policy --role-name <role-name> --policy-document file://trust-policy.json",
+      "NativeIaC": "Resources:\n  MyRole:\n    Type: AWS::IAM::Role\n    Properties:\n      AssumeRolePolicyDocument:\n        Version: '2012-10-17'\n        Statement:\n          - Effect: Allow\n            Principal:\n              AWS: arn:aws:iam::ACCOUNT_ID:role/TrustedRole\n            Action: sts:AssumeRole\n",
+      "Other": "1. In IAM console, edit the role Trust relationships. 2. Remove overly permissive Principal star or AWS account root. 3. Restrict to specific role ARNs and add Condition with ExternalId or OrgID. 4. Review attached policies of the assumable role and remove privilege escalation actions.",
+      "Terraform": "resource \"aws_iam_role\" \"example\" {\n  name = \"example\"\n  assume_role_policy = jsonencode({\n    Version = \"2012-10-17\"\n    Statement = [{\n      Effect    = \"Allow\"\n      Principal = { AWS = \"arn:aws:iam::ACCOUNT_ID:role/TrustedRole\" }\n      Action    = \"sts:AssumeRole\"\n    }]\n  })\n}\n"
+    },
+    "Recommendation": {
+      "Text": "Enforce transitive least privilege. Remove sts:AssumeRole to privileged roles from low-trust roles, tighten trust policies to explicit ARNs with ExternalId and OrgID conditions, and eliminate privilege escalation actions in privileged roles. Review with IAM Access Analyzer.",
+      "Url": "https://hub.prowler.com/check/iam_role_chained_privilege_escalation"
+    }
+  },
+  "Categories": [
+    "identity-access",
+    "privilege-escalation"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [
+    "iam_policy_allows_privilege_escalation",
+    "iam_inline_policy_allows_privilege_escalation"
+  ],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation.py
@@ -5,6 +5,9 @@ into a privileged role that itself can escalate to admin. Supports multi-hop
 chains by building an assume-role graph and performing BFS.
 """
 
+import fnmatch
+import re
+from collections import deque
 from typing import Dict, List, Set
 
 from prowler.lib.check.models import Check, Check_Report_AWS
@@ -13,12 +16,33 @@ from prowler.providers.aws.services.iam.lib.privilege_escalation import (
     check_privilege_escalation,
 )
 
+_ACCOUNT_ID_RE = re.compile(r"^\d{12}$")
+_ISSUE_CONDITION_MSG = "conditional trust skipped"
+
+
+def _normalize_account_principal(principal: str) -> str:
+    """Normalize bare AWS account IDs to root ARN.
+
+    Args:
+        principal: AWS principal string, may be bare 12-digit account ID.
+
+    Returns:
+        Normalized ARN for account root if bare ID, otherwise original.
+    """
+    if _ACCOUNT_ID_RE.match(principal):
+        # Default to aws partition; partition-aware matching handles other partitions downstream
+        return f"arn:aws:iam::{principal}:root"
+    return principal
+
 
 def _parse_assume_role_principals(trust_policy: dict) -> Set[str]:
     """Extract AWS role ARNs allowed to assume this role.
 
     Parses IAM trust policy statements and returns ARNs of principals
     allowed to assume the role, plus a sentinel wildcard entry.
+
+    Handles bare 12-digit account IDs by normalizing to root ARN and skips
+    statements that contain Condition for conservative evaluation.
 
     Args:
         trust_policy: IAM trust policy document from AssumeRolePolicyDocument.
@@ -44,19 +68,21 @@ def _parse_assume_role_principals(trust_policy: dict) -> Set[str]:
             actions = [actions]
         if not any(a in ("sts:AssumeRole", "sts:*", "*") for a in actions):
             continue
+        # Conservative handling for conditional trust: if Condition present, skip
+        # because trust is not unconditionally granted. Only allow wildcard when Condition absent.
+        if "Condition" in stmt:
+            continue
         principal = stmt.get("Principal", {})
         # Handle Principal as string wildcard
         if isinstance(principal, str):
             if principal == "*":
-                if "Condition" not in stmt:
-                    principals.add("*")
+                principals.add("*")
             continue
         if not isinstance(principal, dict):
             continue
         # Handle Principal dict containing star key or wildcard value
         if "*" in principal:
-            if "Condition" not in stmt:
-                principals.add("*")
+            principals.add("*")
             continue
         aws_principals = principal.get("AWS", [])
         if isinstance(aws_principals, str):
@@ -65,12 +91,34 @@ def _parse_assume_role_principals(trust_policy: dict) -> Set[str]:
             if not isinstance(p, str):
                 continue
             if p == "*":
-                if "Condition" not in stmt:
-                    principals.add("*")
+                principals.add("*")
                 continue
-            if ":role/" in p or p.endswith(":root"):
-                principals.add(p)
+            # Normalize bare account IDs like "123456789012" to root ARN
+            normalized = _normalize_account_principal(p)
+            if ":role/" in normalized or normalized.endswith(":root") or _ACCOUNT_ID_RE.match(p):
+                # For bare account IDs we already normalized
+                principals.add(normalized)
+            elif normalized != p and _ACCOUNT_ID_RE.match(p):
+                principals.add(normalized)
     return principals
+
+
+def _is_root_trusted(trusted_set: Set[str], audited_account: str) -> bool:
+    """Check if any trusted principal is a partition-aware root ARN for the account.
+
+    Args:
+        trusted_set: Set of trusted principal ARNs.
+        audited_account: Account ID string.
+
+    Returns:
+        True if a root ARN matching the audited account exists in any partition.
+    """
+    if not audited_account:
+        return False
+    for p in trusted_set:
+        if p.endswith(":root") and audited_account in p:
+            return True
+    return False
 
 
 def _get_role_effective_documents(role) -> List[dict]:
@@ -131,6 +179,41 @@ def _get_role_effective_documents(role) -> List[dict]:
     return docs
 
 
+def _collect_deny_assume_patterns(docs: List[dict]) -> List[str]:
+    """Collect explicit Deny patterns for sts:AssumeRole actions.
+
+    Args:
+        docs: List of policy documents.
+
+    Returns:
+        List of resource pattern strings that are denied.
+    """
+    denied = []
+    for doc in docs:
+        if not doc:
+            continue
+        statements = doc.get("Statement", [])
+        if not isinstance(statements, list):
+            statements = [statements]
+        for stmt in statements:
+            if not isinstance(stmt, dict):
+                continue
+            if stmt.get("Effect") != "Deny":
+                continue
+            actions = stmt.get("Action", [])
+            if isinstance(actions, str):
+                actions = [actions]
+            if not any(a in ("sts:AssumeRole", "sts:*", "*") for a in actions):
+                continue
+            resources = stmt.get("Resource", [])
+            if isinstance(resources, str):
+                resources = [resources]
+            for res in resources:
+                if isinstance(res, str):
+                    denied.append(res)
+    return denied
+
+
 class iam_role_chained_privilege_escalation(Check):
     """Check for IAM role chains allowing privilege escalation.
 
@@ -158,8 +241,11 @@ class iam_role_chained_privilege_escalation(Check):
 
         # Cache effective documents once per role for performance
         role_docs_map: Dict[str, List[dict]] = {}
+        role_deny_map: Dict[str, List[str]] = {}
         for r in iam_client.roles:
-            role_docs_map[r.name] = _get_role_effective_documents(r)
+            docs = _get_role_effective_documents(r)
+            role_docs_map[r.name] = docs
+            role_deny_map[r.arn] = _collect_deny_assume_patterns(docs)
 
         # Cache trust principals per role
         trust_map: Dict[str, Set[str]] = {}
@@ -203,66 +289,14 @@ class iam_role_chained_privilege_escalation(Check):
                     # Fallback preserve raw string as single entry
                     role_has_privesc[role.arn] = {affected.strip()}
 
-        root_arn = f"arn:aws:iam::{iam_client.audited_account}:root"
+        audited_account = getattr(iam_client, "audited_account", "")
 
-        # Build direct assumable graph: source ARN -> set of target ARNs
-        direct_assumable: Dict[str, Set[str]] = {}
-        for role in iam_client.roles:
-            assumable = set()
-            docs = role_docs_map.get(role.name, [])
-            for doc in docs:
-                if not doc:
-                    continue
-                statements = doc.get("Statement", [])
-                if not isinstance(statements, list):
-                    statements = [statements]
-                for stmt in statements:
-                    if not isinstance(stmt, dict):
-                        continue
-                    if stmt.get("Effect") != "Allow":
-                        continue
-                    actions = stmt.get("Action", [])
-                    if isinstance(actions, str):
-                        actions = [actions]
-                    if not any(
-                        a in ("sts:AssumeRole", "sts:*", "*") for a in actions
-                    ):
-                        continue
-                    resources = stmt.get("Resource", [])
-                    if isinstance(resources, str):
-                        resources = [resources]
-                    for res in resources:
-                        if not isinstance(res, str):
-                            continue
-                        for target_arn, _ in role_has_privesc.items():
-                            # Exclude role's own ARN from assumable privileged
-                            if target_arn == role.arn:
-                                continue
-                            if not (
-                                res == "*"
-                                or res == target_arn
-                                or (res.endswith("*") and target_arn.startswith(res[:-1]))
-                            ):
-                                continue
-                            target_role = role_by_arn.get(target_arn)
-                            if not target_role:
-                                continue
-                            trusted = trust_map.get(target_arn, set())
-                            if (
-                                role.arn in trusted
-                                or root_arn in trusted
-                                or "*" in trusted
-                            ):
-                                assumable.add(target_arn)
-            if assumable:
-                direct_assumable[role.arn] = assumable
-
-        # For transitive closure, also need graph including non-privileged intermediates
-        # Build full assume graph for BFS (any role to any role)
+        # Build full assume graph for BFS (any role to any role) — single construction
         full_assumable: Dict[str, Set[str]] = {}
         for role in iam_client.roles:
             full_set = set()
             docs = role_docs_map.get(role.name, [])
+            deny_patterns = role_deny_map.get(role.arn, [])
             for doc in docs:
                 if not doc:
                     continue
@@ -290,19 +324,22 @@ class iam_role_chained_privilege_escalation(Check):
                         for target_role in iam_client.roles:
                             if target_role.arn == role.arn:
                                 continue
-                            if not (
-                                res == "*"
-                                or res == target_role.arn
-                                or (
-                                    res.endswith("*")
-                                    and target_role.arn.startswith(res[:-1])
-                                )
-                            ):
+                            # fnmatch wildcard support for ARN patterns
+                            if not fnmatch.fnmatch(target_role.arn, res) and res != target_role.arn and res != "*":
+                                # Backward compatible exact and simple star handling fallback via fnmatch already covers "*"
+                                continue
+                            # Explicit Deny handling
+                            denied = False
+                            for dpat in deny_patterns:
+                                if fnmatch.fnmatch(target_role.arn, dpat) or dpat == "*" or dpat == target_role.arn:
+                                    denied = True
+                                    break
+                            if denied:
                                 continue
                             trusted = trust_map.get(target_role.arn, set())
                             if (
                                 role.arn in trusted
-                                or root_arn in trusted
+                                or _is_root_trusted(trusted, audited_account)
                                 or "*" in trusted
                             ):
                                 full_set.add(target_role.arn)
@@ -322,10 +359,10 @@ class iam_role_chained_privilege_escalation(Check):
             # Direction 1 with transitive support: source can assume privileged via chain
             reachable_privileged: Dict[str, Set[str]] = {}
             visited = set()
-            queue = list(full_assumable.get(role.arn, []))
-            # BFS
+            queue = deque(full_assumable.get(role.arn, []))
+            # BFS using deque for performance
             while queue:
-                current_arn = queue.pop(0)
+                current_arn = queue.popleft()
                 if current_arn in visited:
                     continue
                 visited.add(current_arn)
@@ -360,6 +397,11 @@ class iam_role_chained_privilege_escalation(Check):
                         if "*" in principals and len(iam_client.roles) > 1:
                             # Treat as assumable if more than one role exists
                             in_account_assumers.append("wildcard-any-principal")
+                        # Root trust handling is already partition-aware via _is_root_trusted; include generic root
+                        if _is_root_trusted(principals, audited_account) and len(iam_client.roles) > 1:
+                            # If root is trusted, any in-account role could potentially assume via root delegation
+                            # Keep conservative: only flag when explicit role ARN trusted, wildcard case already covered
+                            pass
                         if in_account_assumers:
                             display_assumers = []
                             for a in in_account_assumers:

--- a/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation.py
@@ -1,3 +1,9 @@
+"""IAM role chained privilege escalation check.
+
+Detects transitive escalation where a low-privileged role can sts:AssumeRole
+into a privileged role that itself can escalate to admin.
+"""
+
 from typing import Dict, List, Set
 
 from prowler.lib.check.models import Check, Check_Report_AWS
@@ -8,7 +14,15 @@ from prowler.providers.aws.services.iam.lib.privilege_escalation import (
 
 
 def _parse_assume_role_principals(trust_policy: dict) -> Set[str]:
-    """Extract role ARNs allowed to assume this role from trust policy."""
+    """Extract AWS role ARNs allowed to assume this role.
+
+    Args:
+        trust_policy: IAM trust policy document from AssumeRolePolicyDocument.
+
+    Returns:
+        Set of ARN strings for principals that can assume the role,
+        including account root ARNs.
+    """
     principals = set()
     if not trust_policy:
         return principals
@@ -40,7 +54,14 @@ def _parse_assume_role_principals(trust_policy: dict) -> Set[str]:
 
 
 def _get_role_effective_document(role_name: str) -> List[dict]:
-    """Collect all effective policy documents for a role."""
+    """Collect attached policy documents for a role.
+
+    Args:
+        role_name: IAM role name to lookup.
+
+    Returns:
+        List of policy documents attached to the role.
+    """
     docs = []
     for policy_obj in iam_client.policies.values():
         if policy_obj.entity == role_name and policy_obj.attached:
@@ -50,10 +71,22 @@ def _get_role_effective_document(role_name: str) -> List[dict]:
 
 
 class iam_role_chained_privilege_escalation(Check):
-    """Detect chained escalation where a role can assume a privileged role."""
+    """Check for IAM role chains allowing privilege escalation.
+
+    Evaluates two detection directions:
+    1. Source role can assume a privileged target role.
+    2. Privileged role is assumable by in-account roles.
+
+    This fills the gap noted in the privilege escalation library where
+    transitive paths were not evaluated.
+    """
 
     def execute(self) -> List[Check_Report_AWS]:
-        """Detect two directions: source assumes privileged target, and privileged assumable by in-account role."""
+        """Execute the IAM chained escalation detection.
+
+        Returns:
+            List of Check_Report_AWS with PASS or FAIL findings per role.
+        """
         findings = []
 
         if not iam_client.roles:

--- a/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation.py
@@ -7,12 +7,8 @@ from prowler.providers.aws.services.iam.lib.privilege_escalation import (
 )
 
 
-# Re-use public ACL URIs pattern for explanation but for IAM
 def _parse_assume_role_principals(trust_policy: dict) -> Set[str]:
-    """Extract role ARNs that are allowed to assume this role.
-
-    Returns a set of principal ARNs (role ARNs) found in AssumeRole statements.
-    """
+    """Extract role ARNs allowed to assume this role from trust policy."""
     principals = set()
     if not trust_policy:
         return principals
@@ -20,6 +16,8 @@ def _parse_assume_role_principals(trust_policy: dict) -> Set[str]:
     if not isinstance(statements, list):
         statements = [statements]
     for stmt in statements:
+        if not isinstance(stmt, dict):
+            continue
         if stmt.get("Effect") != "Allow":
             continue
         actions = stmt.get("Action", [])
@@ -36,14 +34,14 @@ def _parse_assume_role_principals(trust_policy: dict) -> Set[str]:
         for p in aws_principals:
             if isinstance(p, str) and ":role/" in p:
                 principals.add(p)
-        # Also support ARN list under Principal.AWS as wildcard with root? skip
+            if isinstance(p, str) and p.endswith(":root"):
+                principals.add(p)
     return principals
 
 
 def _get_role_effective_document(role_name: str) -> List[dict]:
-    """Collect all policy documents for a role (attached + inline) from iam_client.policies."""
+    """Collect all effective policy documents for a role."""
     docs = []
-    # attached policies: policy ARN stored in role.attached_policies list of dicts with PolicyArn
     for policy_obj in iam_client.policies.values():
         if policy_obj.entity == role_name and policy_obj.attached:
             if policy_obj.document:
@@ -52,61 +50,54 @@ def _get_role_effective_document(role_name: str) -> List[dict]:
 
 
 class iam_role_chained_privilege_escalation(Check):
-    """Check if an IAM role can assume another role that allows privilege escalation."""
+    """Detect chained escalation where a role can assume a privileged role."""
 
     def execute(self) -> List[Check_Report_AWS]:
+        """Detect two directions: source assumes privileged target, and privileged assumable by in-account role."""
         findings = []
 
         if not iam_client.roles:
             return findings
 
-        # Build map role_arn -> role object for quick lookup
         role_by_arn: Dict[str, object] = {r.arn: r for r in iam_client.roles}
 
-        # Pre-compute which roles have privilege escalation
+        # Cache effective documents once per role
+        role_docs_map: Dict[str, List[dict]] = {}
+        for r in iam_client.roles:
+            role_docs_map[r.name] = _get_role_effective_document(r.name)
+
+        # Pre-compute privileged roles
         role_has_privesc: Dict[str, Set[str]] = {}
         for role in iam_client.roles:
             affected_all = set()
-            for doc in _get_role_effective_document(role.name):
+            for doc in role_docs_map.get(role.name, []):
                 affected = check_privilege_escalation(doc)
                 if affected:
-                    affected_all.update(affected)
+                    affected_all.add(affected)
             if affected_all:
                 role_has_privesc[role.arn] = affected_all
+
+        root_arn = f"arn:aws:iam::{iam_client.audited_account}:root"
 
         for role in iam_client.roles:
             report = Check_Report_AWS(metadata=self.metadata(), resource=role)
             report.resource_id = role.name
             report.resource_arn = role.arn
             report.region = iam_client.region
-
-            # Default PASS
             report.status = "PASS"
             report.status_extended = f"IAM role {role.name} does not allow chained privilege escalation."
 
-            principals = _parse_assume_role_principals(role.assume_role_policy)
-
-            # Check if this role can assume a privileged role
-            # Two directions:
-            # 1) Role A is assumable by Role B, and Role A is privileged -> Role B chain
-            # We are iterating Role A (target). Need to find who can assume it.
-            # If target role is privileged and has at least one principal role that exists in account, that principal role is the risky one.
-            # But since our report is per-role (on the privileged target), we want to also report source roles as FAIL via their ability to assume.
-            # Simpler: For each role that IS privileged, if it is assumable by another role in same account, FAIL the assumable role's assumers? That would require reporting on source role.
-            # We instead report on both sides: If current role can assume another privileged role, it is FAIL.
-
-            # Direction: current role is source, check if it is allowed to assume a privileged target via its own policies? No, AssumeRole permission comes from source role's policy, not target trust? Actually both needed: source needs sts:AssumeRole on target arn, target trust must allow source.
-            # We check target trust for efficiency and assume source has permission if in same account (common misconfig). For complete detection, we also check source policy docs for sts:AssumeRole on target arn.
-
-            # Collect target roles that current role can assume via its own policies
+            # Direction 1: source can assume privileged target via its own policies, target trust must allow source
             assumable_privileged = []
-            for doc in _get_role_effective_document(role.name):
+            for doc in role_docs_map.get(role.name, []):
                 if not doc:
                     continue
                 statements = doc.get("Statement", [])
                 if not isinstance(statements, list):
                     statements = [statements]
                 for stmt in statements:
+                    if not isinstance(stmt, dict):
+                        continue
                     if stmt.get("Effect") != "Allow":
                         continue
                     actions = stmt.get("Action", [])
@@ -118,20 +109,42 @@ class iam_role_chained_privilege_escalation(Check):
                     if isinstance(resources, str):
                         resources = [resources]
                     for res in resources:
-                        # res can be "*" or specific role ARN
                         for target_arn, priv_techniques in role_has_privesc.items():
-                            if res == "*" or res == target_arn or (res.endswith("*") and target_arn.startswith(res.rstrip("*"))):
+                            if target_arn == role.arn:
+                                continue
+                            if not (
+                                res == "*"
+                                or res == target_arn
+                                or (res.endswith("*") and target_arn.startswith(res[:-1]))
+                            ):
+                                continue
+                            target_role = role_by_arn.get(target_arn)
+                            if not target_role:
+                                continue
+                            trusted = _parse_assume_role_principals(
+                                getattr(target_role, "assume_role_policy", None)
+                            )
+                            if role.arn in trusted or root_arn in trusted:
                                 assumable_privileged.append((target_arn, priv_techniques))
 
             if assumable_privileged:
-                targets = ", ".join([f"{arn.split('/')[-1]} via {sorted(list(techs))}" for arn, techs in assumable_privileged])
+                # Deduplicate targets
+                seen = set()
+                deduped = []
+                for arn, techs in assumable_privileged:
+                    if arn not in seen:
+                        deduped.append((arn, techs))
+                        seen.add(arn)
+                targets = ", ".join(
+                    [f"{arn.split('/')[-1]} via {sorted(list(techs))}" for arn, techs in deduped]
+                )
                 report.status = "FAIL"
                 report.status_extended = f"IAM role {role.name} can assume privileged role(s) and escalate: {targets}."
             else:
-                # Also check if current role itself is privileged AND is assumable by another role in account -> still report as high risk on the privileged role having overly permissive trust
+                # Direction 2: privileged role is assumable by in-account roles
                 if role.arn in role_has_privesc:
+                    principals = _parse_assume_role_principals(role.assume_role_policy)
                     if principals:
-                        # Filter to principals that exist in our account roles
                         in_account_assumers = [p for p in principals if p in role_by_arn]
                         if in_account_assumers:
                             report.status = "FAIL"

--- a/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation.py
@@ -1,7 +1,8 @@
 """IAM role chained privilege escalation check.
 
 Detects transitive escalation where a low-privileged role can sts:AssumeRole
-into a privileged role that itself can escalate to admin.
+into a privileged role that itself can escalate to admin. Supports multi-hop
+chains by building an assume-role graph and performing BFS.
 """
 
 from typing import Dict, List, Set
@@ -16,12 +17,16 @@ from prowler.providers.aws.services.iam.lib.privilege_escalation import (
 def _parse_assume_role_principals(trust_policy: dict) -> Set[str]:
     """Extract AWS role ARNs allowed to assume this role.
 
+    Parses IAM trust policy statements and returns ARNs of principals
+    allowed to assume the role, plus a sentinel wildcard entry.
+
     Args:
         trust_policy: IAM trust policy document from AssumeRolePolicyDocument.
 
     Returns:
         Set of ARN strings for principals that can assume the role,
-        including account root ARNs.
+        including account root ARNs and a wildcard "*" when trust
+        is unconditioned and allows any principal.
     """
     principals = set()
     if not trust_policy:
@@ -40,42 +45,99 @@ def _parse_assume_role_principals(trust_policy: dict) -> Set[str]:
         if not any(a in ("sts:AssumeRole", "sts:*", "*") for a in actions):
             continue
         principal = stmt.get("Principal", {})
+        # Handle Principal as string wildcard
+        if isinstance(principal, str):
+            if principal == "*":
+                if "Condition" not in stmt:
+                    principals.add("*")
+            continue
         if not isinstance(principal, dict):
+            continue
+        # Handle Principal dict containing star key or wildcard value
+        if "*" in principal:
+            if "Condition" not in stmt:
+                principals.add("*")
             continue
         aws_principals = principal.get("AWS", [])
         if isinstance(aws_principals, str):
             aws_principals = [aws_principals]
         for p in aws_principals:
-            if isinstance(p, str) and ":role/" in p:
-                principals.add(p)
-            if isinstance(p, str) and p.endswith(":root"):
+            if not isinstance(p, str):
+                continue
+            if p == "*":
+                if "Condition" not in stmt:
+                    principals.add("*")
+                continue
+            if ":role/" in p or p.endswith(":root"):
                 principals.add(p)
     return principals
 
 
-def _get_role_effective_document(role_name: str) -> List[dict]:
-    """Collect attached policy documents for a role.
+def _get_role_effective_documents(role) -> List[dict]:
+    """Collect effective policy documents for a role including managed policies.
+
+    Looks up inline policy documents stored in iam_client.policies where
+    entity equals role name and also resolves attached managed policies
+    via role.attached_policies.
 
     Args:
-        role_name: IAM role name to lookup.
+        role: IAM Role model with name, arn, attached_policies.
 
     Returns:
         List of policy documents attached to the role.
     """
-    docs = []
+    docs: List[dict] = []
+    role_name = getattr(role, "name", None)
+    if not role_name:
+        return docs
+    # Inline policies stored in iam_client.policies with entity == role name
     for policy_obj in iam_client.policies.values():
-        if policy_obj.entity == role_name and policy_obj.attached:
-            if policy_obj.document:
-                docs.append(policy_obj.document)
+        if getattr(policy_obj, "entity", None) == role_name and getattr(
+            policy_obj, "attached", False
+        ):
+            doc = getattr(policy_obj, "document", None)
+            if doc:
+                docs.append(doc)
+    # Attached managed policies via role.attached_policies list of dicts
+    attached = getattr(role, "attached_policies", []) or []
+    for att in attached:
+        arn = None
+        name = None
+        if isinstance(att, dict):
+            arn = att.get("PolicyArn")
+            name = att.get("PolicyName")
+        else:
+            arn = getattr(att, "arn", None)
+            name = getattr(att, "name", None)
+        if arn:
+            pol = iam_client.policies.get(arn)
+            if pol and getattr(pol, "document", None):
+                docs.append(pol.document)
+            else:
+                # Fallback search by arn attribute
+                for p in iam_client.policies.values():
+                    if getattr(p, "arn", None) == arn and getattr(
+                        p, "document", None
+                    ):
+                        docs.append(p.document)
+                        break
+        elif name:
+            for p in iam_client.policies.values():
+                if getattr(p, "name", None) == name and getattr(
+                    p, "document", None
+                ):
+                    docs.append(p.document)
+                    break
     return docs
 
 
 class iam_role_chained_privilege_escalation(Check):
     """Check for IAM role chains allowing privilege escalation.
 
-    Evaluates two detection directions:
-    1. Source role can assume a privileged target role.
-    2. Privileged role is assumable by in-account roles.
+    Evaluates two detection directions plus multi-hop transitive closure:
+    1. Source role can assume a privileged target role via sts:AssumeRole.
+    2. Privileged role is assumable by in-account roles through trust.
+    3. Transitive chains where source assumes intermediate that assumes privileged.
 
     This fills the gap noted in the privilege escalation library where
     transitive paths were not evaluated.
@@ -87,42 +149,68 @@ class iam_role_chained_privilege_escalation(Check):
         Returns:
             List of Check_Report_AWS with PASS or FAIL findings per role.
         """
-        findings = []
+        findings: List[Check_Report_AWS] = []
 
         if not iam_client.roles:
             return findings
 
         role_by_arn: Dict[str, object] = {r.arn: r for r in iam_client.roles}
 
-        # Cache effective documents once per role
+        # Cache effective documents once per role for performance
         role_docs_map: Dict[str, List[dict]] = {}
         for r in iam_client.roles:
-            role_docs_map[r.name] = _get_role_effective_document(r.name)
+            role_docs_map[r.name] = _get_role_effective_documents(r)
 
-        # Pre-compute privileged roles
+        # Cache trust principals per role
+        trust_map: Dict[str, Set[str]] = {}
+        for r in iam_client.roles:
+            trust_map[r.arn] = _parse_assume_role_principals(
+                getattr(r, "assume_role_policy", None)
+            )
+
+        # Pre-compute privileged roles from combined effective permissions
         role_has_privesc: Dict[str, Set[str]] = {}
         for role in iam_client.roles:
-            affected_all = set()
-            for doc in role_docs_map.get(role.name, []):
-                affected = check_privilege_escalation(doc)
-                if affected:
-                    affected_all.add(affected)
-            if affected_all:
-                role_has_privesc[role.arn] = affected_all
+            docs = role_docs_map.get(role.name, [])
+            combined_stmts: List[dict] = []
+            for doc in docs:
+                if not doc:
+                    continue
+                statements = doc.get("Statement", [])
+                if not isinstance(statements, list):
+                    statements = [statements]
+                for stmt in statements:
+                    if not isinstance(stmt, dict):
+                        continue
+                    combined_stmts.append(stmt)
+            if not combined_stmts:
+                continue
+            combined_policy = {
+                "Version": "2012-10-17",
+                "Statement": combined_stmts,
+            }
+            affected = check_privilege_escalation(combined_policy)
+            if affected:
+                # Convert comma-separated string into set of techniques
+                techniques = set()
+                for part in affected.split(","):
+                    t = part.strip().strip("'\" ")
+                    if t:
+                        techniques.add(t)
+                if techniques:
+                    role_has_privesc[role.arn] = techniques
+                else:
+                    # Fallback preserve raw string as single entry
+                    role_has_privesc[role.arn] = {affected.strip()}
 
         root_arn = f"arn:aws:iam::{iam_client.audited_account}:root"
 
+        # Build direct assumable graph: source ARN -> set of target ARNs
+        direct_assumable: Dict[str, Set[str]] = {}
         for role in iam_client.roles:
-            report = Check_Report_AWS(metadata=self.metadata(), resource=role)
-            report.resource_id = role.name
-            report.resource_arn = role.arn
-            report.region = iam_client.region
-            report.status = "PASS"
-            report.status_extended = f"IAM role {role.name} does not allow chained privilege escalation."
-
-            # Direction 1: source can assume privileged target via its own policies, target trust must allow source
-            assumable_privileged = []
-            for doc in role_docs_map.get(role.name, []):
+            assumable = set()
+            docs = role_docs_map.get(role.name, [])
+            for doc in docs:
                 if not doc:
                     continue
                 statements = doc.get("Statement", [])
@@ -136,13 +224,18 @@ class iam_role_chained_privilege_escalation(Check):
                     actions = stmt.get("Action", [])
                     if isinstance(actions, str):
                         actions = [actions]
-                    if not any(a in ("sts:AssumeRole", "sts:*", "*") for a in actions):
+                    if not any(
+                        a in ("sts:AssumeRole", "sts:*", "*") for a in actions
+                    ):
                         continue
                     resources = stmt.get("Resource", [])
                     if isinstance(resources, str):
                         resources = [resources]
                     for res in resources:
-                        for target_arn, priv_techniques in role_has_privesc.items():
+                        if not isinstance(res, str):
+                            continue
+                        for target_arn, _ in role_has_privesc.items():
+                            # Exclude role's own ARN from assumable privileged
                             if target_arn == role.arn:
                                 continue
                             if not (
@@ -154,36 +247,130 @@ class iam_role_chained_privilege_escalation(Check):
                             target_role = role_by_arn.get(target_arn)
                             if not target_role:
                                 continue
-                            trusted = _parse_assume_role_principals(
-                                getattr(target_role, "assume_role_policy", None)
-                            )
-                            if role.arn in trusted or root_arn in trusted:
-                                assumable_privileged.append((target_arn, priv_techniques))
+                            trusted = trust_map.get(target_arn, set())
+                            if (
+                                role.arn in trusted
+                                or root_arn in trusted
+                                or "*" in trusted
+                            ):
+                                assumable.add(target_arn)
+            if assumable:
+                direct_assumable[role.arn] = assumable
 
-            if assumable_privileged:
-                # Deduplicate targets
-                seen = set()
-                deduped = []
-                for arn, techs in assumable_privileged:
-                    if arn not in seen:
-                        deduped.append((arn, techs))
-                        seen.add(arn)
+        # For transitive closure, also need graph including non-privileged intermediates
+        # Build full assume graph for BFS (any role to any role)
+        full_assumable: Dict[str, Set[str]] = {}
+        for role in iam_client.roles:
+            full_set = set()
+            docs = role_docs_map.get(role.name, [])
+            for doc in docs:
+                if not doc:
+                    continue
+                statements = doc.get("Statement", [])
+                if not isinstance(statements, list):
+                    statements = [statements]
+                for stmt in statements:
+                    if not isinstance(stmt, dict):
+                        continue
+                    if stmt.get("Effect") != "Allow":
+                        continue
+                    actions = stmt.get("Action", [])
+                    if isinstance(actions, str):
+                        actions = [actions]
+                    if not any(
+                        a in ("sts:AssumeRole", "sts:*", "*") for a in actions
+                    ):
+                        continue
+                    resources = stmt.get("Resource", [])
+                    if isinstance(resources, str):
+                        resources = [resources]
+                    for res in resources:
+                        if not isinstance(res, str):
+                            continue
+                        for target_role in iam_client.roles:
+                            if target_role.arn == role.arn:
+                                continue
+                            if not (
+                                res == "*"
+                                or res == target_role.arn
+                                or (
+                                    res.endswith("*")
+                                    and target_role.arn.startswith(res[:-1])
+                                )
+                            ):
+                                continue
+                            trusted = trust_map.get(target_role.arn, set())
+                            if (
+                                role.arn in trusted
+                                or root_arn in trusted
+                                or "*" in trusted
+                            ):
+                                full_set.add(target_role.arn)
+            if full_set:
+                full_assumable[role.arn] = full_set
+
+        for role in iam_client.roles:
+            report = Check_Report_AWS(metadata=self.metadata(), resource=role)
+            report.resource_id = role.name
+            report.resource_arn = role.arn
+            report.region = iam_client.region
+            report.status = "PASS"
+            report.status_extended = (
+                f"IAM role {role.name} does not allow chained privilege escalation."
+            )
+
+            # Direction 1 with transitive support: source can assume privileged via chain
+            reachable_privileged: Dict[str, Set[str]] = {}
+            visited = set()
+            queue = list(full_assumable.get(role.arn, []))
+            # BFS
+            while queue:
+                current_arn = queue.pop(0)
+                if current_arn in visited:
+                    continue
+                visited.add(current_arn)
+                if current_arn in role_has_privesc:
+                    reachable_privileged[current_arn] = role_has_privesc[current_arn]
+                # Continue traversing even if current is privileged to find deeper chains
+                for nxt in full_assumable.get(current_arn, []):
+                    if nxt not in visited:
+                        queue.append(nxt)
+
+            if reachable_privileged:
+                deduped = list(reachable_privileged.items())
                 targets = ", ".join(
-                    [f"{arn.split('/')[-1]} via {sorted(list(techs))}" for arn, techs in deduped]
+                    [
+                        f"{arn.split('/')[-1]} via {sorted(list(techs))}"
+                        for arn, techs in deduped
+                    ]
                 )
                 report.status = "FAIL"
-                report.status_extended = f"IAM role {role.name} can assume privileged role(s) and escalate: {targets}."
+                report.status_extended = (
+                    f"IAM role {role.name} can assume privileged role(s) and escalate: {targets}."
+                )
             else:
                 # Direction 2: privileged role is assumable by in-account roles
                 if role.arn in role_has_privesc:
-                    principals = _parse_assume_role_principals(role.assume_role_policy)
+                    principals = trust_map.get(role.arn, set())
                     if principals:
-                        in_account_assumers = [p for p in principals if p in role_by_arn]
+                        in_account_assumers = [
+                            p for p in principals if p in role_by_arn
+                        ]
+                        # Also consider wildcard trust as expanding to in-account
+                        if "*" in principals and len(iam_client.roles) > 1:
+                            # Treat as assumable if more than one role exists
+                            in_account_assumers.append("wildcard-any-principal")
                         if in_account_assumers:
+                            display_assumers = []
+                            for a in in_account_assumers:
+                                if a == "wildcard-any-principal":
+                                    display_assumers.append("any-principal-wildcard")
+                                else:
+                                    display_assumers.append(a.split("/")[-1])
                             report.status = "FAIL"
                             report.status_extended = (
                                 f"IAM role {role.name} allows privilege escalation using actions {sorted(list(role_has_privesc[role.arn]))} "
-                                f"and is assumable by in-account roles {', '.join([a.split('/')[-1] for a in in_account_assumers])}, "
+                                f"and is assumable by in-account roles {', '.join(display_assumers)}, "
                                 f"creating a chained escalation path."
                             )
 

--- a/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation.py
@@ -1,0 +1,146 @@
+from typing import Dict, List, Set
+
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.iam.iam_client import iam_client
+from prowler.providers.aws.services.iam.lib.privilege_escalation import (
+    check_privilege_escalation,
+)
+
+
+# Re-use public ACL URIs pattern for explanation but for IAM
+def _parse_assume_role_principals(trust_policy: dict) -> Set[str]:
+    """Extract role ARNs that are allowed to assume this role.
+
+    Returns a set of principal ARNs (role ARNs) found in AssumeRole statements.
+    """
+    principals = set()
+    if not trust_policy:
+        return principals
+    statements = trust_policy.get("Statement", [])
+    if not isinstance(statements, list):
+        statements = [statements]
+    for stmt in statements:
+        if stmt.get("Effect") != "Allow":
+            continue
+        actions = stmt.get("Action", [])
+        if isinstance(actions, str):
+            actions = [actions]
+        if not any(a in ("sts:AssumeRole", "sts:*", "*") for a in actions):
+            continue
+        principal = stmt.get("Principal", {})
+        if not isinstance(principal, dict):
+            continue
+        aws_principals = principal.get("AWS", [])
+        if isinstance(aws_principals, str):
+            aws_principals = [aws_principals]
+        for p in aws_principals:
+            if isinstance(p, str) and ":role/" in p:
+                principals.add(p)
+        # Also support ARN list under Principal.AWS as wildcard with root? skip
+    return principals
+
+
+def _get_role_effective_document(role_name: str) -> List[dict]:
+    """Collect all policy documents for a role (attached + inline) from iam_client.policies."""
+    docs = []
+    # attached policies: policy ARN stored in role.attached_policies list of dicts with PolicyArn
+    for policy_obj in iam_client.policies.values():
+        if policy_obj.entity == role_name and policy_obj.attached:
+            if policy_obj.document:
+                docs.append(policy_obj.document)
+    return docs
+
+
+class iam_role_chained_privilege_escalation(Check):
+    """Check if an IAM role can assume another role that allows privilege escalation."""
+
+    def execute(self) -> List[Check_Report_AWS]:
+        findings = []
+
+        if not iam_client.roles:
+            return findings
+
+        # Build map role_arn -> role object for quick lookup
+        role_by_arn: Dict[str, object] = {r.arn: r for r in iam_client.roles}
+
+        # Pre-compute which roles have privilege escalation
+        role_has_privesc: Dict[str, Set[str]] = {}
+        for role in iam_client.roles:
+            affected_all = set()
+            for doc in _get_role_effective_document(role.name):
+                affected = check_privilege_escalation(doc)
+                if affected:
+                    affected_all.update(affected)
+            if affected_all:
+                role_has_privesc[role.arn] = affected_all
+
+        for role in iam_client.roles:
+            report = Check_Report_AWS(metadata=self.metadata(), resource=role)
+            report.resource_id = role.name
+            report.resource_arn = role.arn
+            report.region = iam_client.region
+
+            # Default PASS
+            report.status = "PASS"
+            report.status_extended = f"IAM role {role.name} does not allow chained privilege escalation."
+
+            principals = _parse_assume_role_principals(role.assume_role_policy)
+
+            # Check if this role can assume a privileged role
+            # Two directions:
+            # 1) Role A is assumable by Role B, and Role A is privileged -> Role B chain
+            # We are iterating Role A (target). Need to find who can assume it.
+            # If target role is privileged and has at least one principal role that exists in account, that principal role is the risky one.
+            # But since our report is per-role (on the privileged target), we want to also report source roles as FAIL via their ability to assume.
+            # Simpler: For each role that IS privileged, if it is assumable by another role in same account, FAIL the assumable role's assumers? That would require reporting on source role.
+            # We instead report on both sides: If current role can assume another privileged role, it is FAIL.
+
+            # Direction: current role is source, check if it is allowed to assume a privileged target via its own policies? No, AssumeRole permission comes from source role's policy, not target trust? Actually both needed: source needs sts:AssumeRole on target arn, target trust must allow source.
+            # We check target trust for efficiency and assume source has permission if in same account (common misconfig). For complete detection, we also check source policy docs for sts:AssumeRole on target arn.
+
+            # Collect target roles that current role can assume via its own policies
+            assumable_privileged = []
+            for doc in _get_role_effective_document(role.name):
+                if not doc:
+                    continue
+                statements = doc.get("Statement", [])
+                if not isinstance(statements, list):
+                    statements = [statements]
+                for stmt in statements:
+                    if stmt.get("Effect") != "Allow":
+                        continue
+                    actions = stmt.get("Action", [])
+                    if isinstance(actions, str):
+                        actions = [actions]
+                    if not any(a in ("sts:AssumeRole", "sts:*", "*") for a in actions):
+                        continue
+                    resources = stmt.get("Resource", [])
+                    if isinstance(resources, str):
+                        resources = [resources]
+                    for res in resources:
+                        # res can be "*" or specific role ARN
+                        for target_arn, priv_techniques in role_has_privesc.items():
+                            if res == "*" or res == target_arn or (res.endswith("*") and target_arn.startswith(res.rstrip("*"))):
+                                assumable_privileged.append((target_arn, priv_techniques))
+
+            if assumable_privileged:
+                targets = ", ".join([f"{arn.split('/')[-1]} via {sorted(list(techs))}" for arn, techs in assumable_privileged])
+                report.status = "FAIL"
+                report.status_extended = f"IAM role {role.name} can assume privileged role(s) and escalate: {targets}."
+            else:
+                # Also check if current role itself is privileged AND is assumable by another role in account -> still report as high risk on the privileged role having overly permissive trust
+                if role.arn in role_has_privesc:
+                    if principals:
+                        # Filter to principals that exist in our account roles
+                        in_account_assumers = [p for p in principals if p in role_by_arn]
+                        if in_account_assumers:
+                            report.status = "FAIL"
+                            report.status_extended = (
+                                f"IAM role {role.name} allows privilege escalation using actions {sorted(list(role_has_privesc[role.arn]))} "
+                                f"and is assumable by in-account roles {', '.join([a.split('/')[-1] for a in in_account_assumers])}, "
+                                f"creating a chained escalation path."
+                            )
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation_test.py
@@ -1,0 +1,280 @@
+from json import dumps
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+# Common trust allowing root – safe for simple roles
+ROOT_TRUST = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {"AWS": f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"},
+            "Action": "sts:AssumeRole",
+        }
+    ],
+}
+
+
+class Test_iam_role_chained_privilege_escalation:
+    @mock_aws
+    def test_no_roles(self):
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+            assert len(result) == 0
+
+    @mock_aws
+    def test_single_role_no_escalation(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        role_name = "safe-role"
+        role_arn = iam_client.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(ROOT_TRUST),
+        )["Role"]["Arn"]
+
+        # Benign policy – no privilege escalation
+        policy_name = "read-only"
+        policy_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": ["s3:ListBucket"], "Resource": "*"}
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=role_name,
+            PolicyName=policy_name,
+            PolicyDocument=dumps(policy_doc),
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].resource_id == role_name
+            assert result[0].resource_arn == role_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].status == "PASS"
+            assert (
+                "does not allow chained privilege escalation"
+                in result[0].status_extended.lower()
+            )
+
+    @mock_aws
+    def test_role_can_assume_privileged_role(self):
+        """Source role can assume privileged role (privileged has iam:CreatePolicyVersion) -> source FAIL."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Privileged role – has privilege escalation action
+        privileged_role_name = "privileged-target"
+        privileged_arn = iam_client.create_role(
+            RoleName=privileged_role_name,
+            AssumeRolePolicyDocument=dumps(ROOT_TRUST),
+        )["Role"]["Arn"]
+
+        priv_policy_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": ["iam:CreatePolicyVersion", "iam:SetDefaultPolicyVersion"],
+                    "Resource": "*",
+                }
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=privileged_role_name,
+            PolicyName="priv-escalation",
+            PolicyDocument=dumps(priv_policy_doc),
+        )
+
+        # Source role – can AssumeRole into privileged role
+        source_role_name = "low-priv-source"
+        source_arn = iam_client.create_role(
+            RoleName=source_role_name,
+            AssumeRolePolicyDocument=dumps(ROOT_TRUST),
+        )["Role"]["Arn"]
+
+        assume_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Resource": privileged_arn,
+                }
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=source_role_name,
+            PolicyName="assume-privileged",
+            PolicyDocument=dumps(assume_doc),
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+
+            # Two roles in account – at least source must FAIL
+            assert len(result) == 2
+            result_by_id = {r.resource_id: r for r in result}
+
+            assert source_role_name in result_by_id
+            assert privileged_role_name in result_by_id
+
+            source_result = result_by_id[source_role_name]
+            assert source_result.resource_arn == source_arn
+            assert source_result.status == "FAIL"
+            # Should mention privileged role name and escalation / assume
+            assert (
+                privileged_role_name in source_result.status_extended
+                or "privileged" in source_result.status_extended.lower()
+            )
+
+            # Privileged role itself: benign trust (root), not assumable by any role ARN -> should PASS in this setup
+            privileged_result = result_by_id[privileged_role_name]
+            # It is privileged but not assumable by in-account role ARN, so it stays PASS per second branch
+            # The check only marks privileged role FAIL if trust Principal includes in-account role ARN
+            assert privileged_result.status == "PASS"
+
+    @mock_aws
+    def test_privileged_role_assumable_by_in_account_role(self):
+        """Privileged role is assumable by another role in account – privileged role FAIL via trust chain."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Low-priv role that will be trusted
+        trusted_role_name = "app-role"
+        trusted_arn = iam_client.create_role(
+            RoleName=trusted_role_name,
+            AssumeRolePolicyDocument=dumps(ROOT_TRUST),
+        )["Role"]["Arn"]
+
+        # Privileged role trusting app-role
+        trust_allowing_app_role = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": trusted_arn},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        privileged_role_name = "admin-via-broken-trust"
+        privileged_arn = iam_client.create_role(
+            RoleName=privileged_role_name,
+            AssumeRolePolicyDocument=dumps(trust_allowing_app_role),
+        )["Role"]["Arn"]
+
+        priv_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "iam:CreatePolicyVersion",
+                    "Resource": "*",
+                }
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=privileged_role_name,
+            PolicyName="priv",
+            PolicyDocument=dumps(priv_doc),
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+
+            assert len(result) == 2
+            by_id = {r.resource_id: r for r in result}
+
+            privileged_result = by_id[privileged_role_name]
+            trusted_result = by_id[trusted_role_name]
+
+            # Privileged role should be FAIL because it is assumable by in-account role
+            assert privileged_result.resource_arn == privileged_arn
+            assert privileged_result.status == "FAIL"
+            assert "assumable" in privileged_result.status_extended.lower()
+            assert trusted_role_name in privileged_result.status_extended
+
+            # App role has no escalation itself and does not assume privileged via policy – should PASS
+            assert trusted_result.resource_arn == trusted_arn
+            assert trusted_result.status == "PASS"

--- a/tests/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation_test.py
@@ -661,6 +661,347 @@ class Test_iam_role_chained_privilege_escalation:
             result = check.execute()
             by_id = {r.resource_id: r for r in result}
             role_result = by_id[role_name]
-            # Should be FAIL because combined effective permissions allow AttachRolePolicy+UpdateAssumeRolePolicy
+            # Combined statements allow escalation, trust allows in-account assume
             assert role_result.status == "FAIL"
             assert "assumable" in role_result.status_extended.lower()
+
+    @mock_aws
+    def test_bare_account_id_normalization(self):
+        """Bare 12-digit Principal should be normalized to root ARN and treated as assumable."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Privileged role trusting bare account ID "123456789012"
+        bare_account_trust = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": AWS_ACCOUNT_NUMBER},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        privileged_name = "priv-bare-account"
+        privileged_arn = iam_client.create_role(
+            RoleName=privileged_name,
+            AssumeRolePolicyDocument=dumps(bare_account_trust),
+        )["Role"]["Arn"]
+
+        priv_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "iam:CreatePolicyVersion", "Resource": "*"}
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=privileged_name,
+            PolicyName="priv",
+            PolicyDocument=dumps(priv_doc),
+        )
+
+        source_name = "source-for-bare"
+        iam_client.create_role(
+            RoleName=source_name, AssumeRolePolicyDocument=dumps(ROOT_TRUST)
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+            by_id = {r.resource_id: r for r in result}
+            # Bare account ID normalized to root should be detected as wildcard-ish root trust
+            # Privileged role should be FAIL because root trust makes it assumable in-account
+            assert by_id[privileged_name].status == "FAIL"
+
+    @mock_aws
+    def test_condition_skips_unconditional_trust(self):
+        """Trust with Condition should be skipped conservatively."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        trusted_name = "app-with-condition"
+        trusted_arn = iam_client.create_role(
+            RoleName=trusted_name, AssumeRolePolicyDocument=dumps(ROOT_TRUST)
+        )["Role"]["Arn"]
+
+        conditional_trust = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": trusted_arn},
+                    "Action": "sts:AssumeRole",
+                    "Condition": {"Bool": {"aws:MultiFactorAuthPresent": "true"}},
+                }
+            ],
+        }
+        privileged_name = "priv-conditional"
+        iam_client.create_role(
+            RoleName=privileged_name,
+            AssumeRolePolicyDocument=dumps(conditional_trust),
+        )
+        priv_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "iam:CreatePolicyVersion", "Resource": "*"}
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=privileged_name, PolicyName="priv", PolicyDocument=dumps(priv_doc)
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+            by_id = {r.resource_id: r for r in result}
+            # Conditional trust should be skipped, so privileged role stays PASS
+            assert by_id[privileged_name].status == "PASS"
+
+    @mock_aws
+    def test_explicit_deny_blocks_assume(self):
+        """Explicit Deny on sts:AssumeRole should block transitive escalation."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        privileged_name = "priv-deny-test"
+        privileged_arn = iam_client.create_role(
+            RoleName=privileged_name, AssumeRolePolicyDocument=dumps(ROOT_TRUST)
+        )["Role"]["Arn"]
+
+        priv_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "iam:CreatePolicyVersion", "Resource": "*"}
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=privileged_name, PolicyName="priv", PolicyDocument=dumps(priv_doc)
+        )
+
+        intermediate_name = "intermediate-deny"
+        intermediate_arn = iam_client.create_role(
+            RoleName=intermediate_name, AssumeRolePolicyDocument=dumps(ROOT_TRUST)
+        )["Role"]["Arn"]
+
+        source_name = "source-deny"
+        source_arn = iam_client.create_role(
+            RoleName=source_name, AssumeRolePolicyDocument=dumps(ROOT_TRUST)
+        )["Role"]["Arn"]
+
+        # Allow intermediate to assume privileged
+        intermediate_assume = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "sts:AssumeRole", "Resource": privileged_arn}],
+        }
+        iam_client.put_role_policy(
+            RoleName=intermediate_name, PolicyName="assume-priv", PolicyDocument=dumps(intermediate_assume)
+        )
+
+        # Trust assignments
+        privileged_trust_allows_intermediate = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Principal": {"AWS": intermediate_arn}, "Action": "sts:AssumeRole"}],
+        }
+        iam_client.update_assume_role_policy(
+            RoleName=privileged_name, PolicyDocument=dumps(privileged_trust_allows_intermediate)
+        )
+
+        intermediate_trust_allows_source = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Principal": {"AWS": source_arn}, "Action": "sts:AssumeRole"}],
+        }
+        iam_client.update_assume_role_policy(
+            RoleName=intermediate_name, PolicyDocument=dumps(intermediate_trust_allows_source)
+        )
+
+        # Source can Allow intermediate but also explicit Deny privileged -> should not reach privileged via direct Allow
+        source_policy_allow_intermediate = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "sts:AssumeRole", "Resource": intermediate_arn}],
+        }
+        source_policy_deny_priv = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Deny", "Action": "sts:AssumeRole", "Resource": privileged_arn}],
+        }
+        # Also Deny blocks AssumeRole via wildcard? Add Deny covering privileged to ensure chain broken if source tries direct AssumeRole to privileged via "*"
+        source_combined = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "sts:AssumeRole", "Resource": intermediate_arn},
+                {"Effect": "Allow", "Action": "sts:AssumeRole", "Resource": privileged_arn},
+                {"Effect": "Deny", "Action": "sts:AssumeRole", "Resource": privileged_arn},
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=source_name, PolicyName="assume-combined", PolicyDocument=dumps(source_combined)
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+            by_id = {r.resource_id: r for r in result}
+            # Source can still assume intermediate, and intermediate can assume privileged, so transitive chain should still FAIL
+            # But direct privileged via Deny should be blocked; transitive via intermediate should still succeed because intermediate is not denied
+            assert by_id[source_name].status == "FAIL"
+            # If we add additional Deny on intermediate, then PASS would be expected; here we only deny privileged directly
+            assert by_id[intermediate_name].status == "FAIL"
+
+    @mock_aws
+    def test_partition_aware_root_arn(self):
+        """Root ARN in other partitions should be recognized as trusted."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        cn_root_trust = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": f"arn:aws-cn:iam::{AWS_ACCOUNT_NUMBER}:root"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        privileged_name = "priv-cn-root"
+        iam_client.create_role(
+            RoleName=privileged_name, AssumeRolePolicyDocument=dumps(cn_root_trust)
+        )
+        priv_doc = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "iam:CreatePolicyVersion", "Resource": "*"}],
+        }
+        iam_client.put_role_policy(RoleName=privileged_name, PolicyName="priv", PolicyDocument=dumps(priv_doc))
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+            by_id = {r.resource_id: r for r in result}
+            # Partition-aware root should be considered assumable when account matches
+            assert by_id[privileged_name].status == "FAIL"
+
+    @mock_aws
+    def test_fnmatch_wildcard_resource(self):
+        """Wildcard pattern arn:aws:iam::*:role/Admin* should match via fnmatch."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        privileged_name = "AdminProdRole"
+        privileged_arn = iam_client.create_role(
+            RoleName=privileged_name, AssumeRolePolicyDocument=dumps(ROOT_TRUST)
+        )["Role"]["Arn"]
+
+        priv_doc = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "iam:CreatePolicyVersion", "Resource": "*"}],
+        }
+        iam_client.put_role_policy(RoleName=privileged_name, PolicyName="priv", PolicyDocument=dumps(priv_doc))
+
+        # Make privileged trust allow source
+        privileged_trust = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        iam_client.update_assume_role_policy(RoleName=privileged_name, PolicyDocument=dumps(privileged_trust))
+
+        source_name = "source-fnmatch"
+        iam_client.create_role(RoleName=source_name, AssumeRolePolicyDocument=dumps(ROOT_TRUST))
+
+        wildcard_resource = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:role/Admin*"
+        assume_doc = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "sts:AssumeRole", "Resource": wildcard_resource}],
+        }
+        iam_client.put_role_policy(RoleName=source_name, PolicyName="assume-wc", PolicyDocument=dumps(assume_doc))
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+            by_id = {r.resource_id: r for r in result}
+            assert by_id[source_name].status == "FAIL"
+            assert privileged_name in by_id[source_name].status_extended

--- a/tests/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation_test.py
@@ -185,11 +185,9 @@ class Test_iam_role_chained_privilege_escalation:
             source_result = result_by_id[source_role_name]
             assert source_result.resource_arn == source_arn
             assert source_result.status == "FAIL"
-            # Should mention privileged role name and escalation / assume
-            assert (
-                privileged_role_name in source_result.status_extended
-                or "privileged" in source_result.status_extended.lower()
-            )
+            # Must name the privileged target role and the escalation actions
+            assert privileged_role_name in source_result.status_extended
+            assert "iam:CreatePolicyVersion" in source_result.status_extended or "CreatePolicyVersion" in source_result.status_extended
 
             # Privileged role itself: benign trust (root), not assumable by any role ARN -> should PASS in this setup
             privileged_result = result_by_id[privileged_role_name]

--- a/tests/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation_test.py
@@ -24,8 +24,11 @@ ROOT_TRUST = {
 
 
 class Test_iam_role_chained_privilege_escalation:
+    """Tests for IAM role chained privilege escalation."""
+
     @mock_aws
     def test_no_roles(self):
+        """Pass when account has no IAM roles."""
         from prowler.providers.aws.services.iam.iam_service import IAM
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
@@ -50,6 +53,7 @@ class Test_iam_role_chained_privilege_escalation:
 
     @mock_aws
     def test_single_role_no_escalation(self):
+        """Pass when single role has no escalation path."""
         iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
 
         role_name = "safe-role"
@@ -371,13 +375,8 @@ class Test_iam_role_chained_privilege_escalation:
         """Three role chain: source -> intermediate -> privileged should flag source via transitive closure."""
         iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
 
-        # Privileged role with escalation, trusts intermediate
+        # source -> intermediate -> privileged topology
         intermediate_role_name = "intermediate-role"
-        # Create intermediate first to get ARN for trust? We need privileged trust intermediate,
-        # so create intermediate role initially with ROOT_TRUST, then create privileged trusting intermediate,
-        # then update intermediate trust to allow source later – order matters.
-
-        # Create privileged role trust placeholder root initially
         privileged_role_name = "privileged-final"
         privileged_arn = iam_client.create_role(
             RoleName=privileged_role_name,
@@ -579,25 +578,24 @@ class Test_iam_role_chained_privilege_escalation:
             result = check.execute()
             by_id = {r.resource_id: r for r in result}
             priv_result = by_id[privileged_role_name]
+            benign_result = by_id[benign_role_name]
             # Should be FAIL because wildcard trust makes it assumable by in-account roles
             assert priv_result.status == "FAIL"
-            assert "wildcard" in priv_result.status_extended.lower() or "assumable" in priv_result.status_extended.lower()
+            assert "wildcard" in priv_result.status_extended.lower()
+            assert benign_result.status == "PASS"
 
     @mock_aws
     def test_combined_statements_escalation(self):
         """Escalation split across two policies should be detected via combined statements."""
         iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
 
-        # Role with two incomplete policies that together form escalation
+        # split of iam:AttachRolePolicy and iam:UpdateAssumeRolePolicy
         role_name = "split-escalation-role"
         iam_client.create_role(
             RoleName=role_name,
             AssumeRolePolicyDocument=dumps(ROOT_TRUST),
         )
 
-        # First policy allows iam:CreatePolicyVersion but not enough alone? Actually single action is enough per combo table,
-        # so split test uses combo requiring two actions: PassRole+CreateLambda+AddPermission needs 3 actions split
-        # Use iam:AttachRolePolicy + iam:UpdateAssumeRolePolicy combo split across policies
         policy_one = {
             "Version": "2012-10-17",
             "Statement": [

--- a/tests/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_role_chained_privilege_escalation/iam_role_chained_privilege_escalation_test.py
@@ -187,7 +187,10 @@ class Test_iam_role_chained_privilege_escalation:
             assert source_result.status == "FAIL"
             # Must name the privileged target role and the escalation actions
             assert privileged_role_name in source_result.status_extended
-            assert "iam:CreatePolicyVersion" in source_result.status_extended or "CreatePolicyVersion" in source_result.status_extended
+            assert (
+                "iam:CreatePolicyVersion" in source_result.status_extended
+                or "CreatePolicyVersion" in source_result.status_extended
+            )
 
             # Privileged role itself: benign trust (root), not assumable by any role ARN -> should PASS in this setup
             privileged_result = result_by_id[privileged_role_name]
@@ -276,3 +279,390 @@ class Test_iam_role_chained_privilege_escalation:
             # App role has no escalation itself and does not assume privileged via policy – should PASS
             assert trusted_result.resource_arn == trusted_arn
             assert trusted_result.status == "PASS"
+
+    @mock_aws
+    def test_managed_policy_privilege_escalation(self):
+        """Regression: privilege escalation via managed policy attached to role."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Create managed policy with escalation
+        priv_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "iam:CreatePolicyVersion",
+                    "Resource": "*",
+                }
+            ],
+        }
+        managed_policy = iam_client.create_policy(
+            PolicyName="priv-managed-policy",
+            PolicyDocument=dumps(priv_doc),
+        )
+        policy_arn = managed_policy["Policy"]["Arn"]
+
+        # Privileged role trusting root, escalation via managed policy
+        privileged_role_name = "priv-managed-target"
+        privileged_arn = iam_client.create_role(
+            RoleName=privileged_role_name,
+            AssumeRolePolicyDocument=dumps(ROOT_TRUST),
+        )["Role"]["Arn"]
+        iam_client.attach_role_policy(
+            RoleName=privileged_role_name, PolicyArn=policy_arn
+        )
+
+        # Source role with managed AssumeRole policy
+        assume_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Resource": privileged_arn,
+                }
+            ],
+        }
+        assume_policy = iam_client.create_policy(
+            PolicyName="assume-managed-policy",
+            PolicyDocument=dumps(assume_doc),
+        )
+        assume_policy_arn = assume_policy["Policy"]["Arn"]
+
+        source_role_name = "source-managed"
+        source_arn = iam_client.create_role(
+            RoleName=source_role_name,
+            AssumeRolePolicyDocument=dumps(ROOT_TRUST),
+        )["Role"]["Arn"]
+        iam_client.attach_role_policy(
+            RoleName=source_role_name, PolicyArn=assume_policy_arn
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+
+            assert len(result) == 2
+            by_id = {r.resource_id: r for r in result}
+            source_result = by_id[source_role_name]
+            assert source_result.resource_arn == source_arn
+            assert source_result.status == "FAIL"
+            assert privileged_role_name in source_result.status_extended
+
+    @mock_aws
+    def test_three_role_chain(self):
+        """Three role chain: source -> intermediate -> privileged should flag source via transitive closure."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Privileged role with escalation, trusts intermediate
+        intermediate_role_name = "intermediate-role"
+        # Create intermediate first to get ARN for trust? We need privileged trust intermediate,
+        # so create intermediate role initially with ROOT_TRUST, then create privileged trusting intermediate,
+        # then update intermediate trust to allow source later – order matters.
+
+        # Create privileged role trust placeholder root initially
+        privileged_role_name = "privileged-final"
+        privileged_arn = iam_client.create_role(
+            RoleName=privileged_role_name,
+            AssumeRolePolicyDocument=dumps(ROOT_TRUST),
+        )["Role"]["Arn"]
+
+        priv_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "iam:CreatePolicyVersion",
+                    "Resource": "*",
+                }
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=privileged_role_name,
+            PolicyName="priv",
+            PolicyDocument=dumps(priv_doc),
+        )
+
+        # Intermediate role trusting source will be created after source, but needs ARN of privileged for assume
+        # To simplify: create source, intermediate, privileged with dynamic trust updates via update_assume_role_policy
+
+        source_role_name = "source-chain"
+        source_arn = iam_client.create_role(
+            RoleName=source_role_name,
+            AssumeRolePolicyDocument=dumps(ROOT_TRUST),
+        )["Role"]["Arn"]
+
+        intermediate_trust_allows_source = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": source_arn},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        intermediate_arn = iam_client.create_role(
+            RoleName=intermediate_role_name,
+            AssumeRolePolicyDocument=dumps(intermediate_trust_allows_source),
+        )["Role"]["Arn"]
+
+        # Update privileged trust to allow intermediate
+        privileged_trust_allows_intermediate = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": intermediate_arn},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        iam_client.update_assume_role_policy(
+            RoleName=privileged_role_name,
+            PolicyDocument=dumps(privileged_trust_allows_intermediate),
+        )
+
+        # Source can assume intermediate
+        source_assume_intermediate = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Resource": intermediate_arn,
+                }
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=source_role_name,
+            PolicyName="assume-intermediate",
+            PolicyDocument=dumps(source_assume_intermediate),
+        )
+
+        # Intermediate can assume privileged
+        intermediate_assume_priv = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Resource": privileged_arn,
+                }
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=intermediate_role_name,
+            PolicyName="assume-privileged",
+            PolicyDocument=dumps(intermediate_assume_priv),
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+
+            assert len(result) == 3
+            by_id = {r.resource_id: r for r in result}
+
+            source_result = by_id[source_role_name]
+            intermediate_result = by_id[intermediate_role_name]
+            privileged_result = by_id[privileged_role_name]
+
+            # Source should FAIL via transitive chain to privileged
+            assert source_result.status == "FAIL"
+            assert privileged_role_name in source_result.status_extended
+
+            # Intermediate should FAIL direct assume privileged
+            assert intermediate_result.status == "FAIL"
+            assert privileged_role_name in intermediate_result.status_extended
+
+            # Privileged should FAIL because assumable by intermediate (in-account)
+            assert privileged_result.status == "FAIL"
+            assert intermediate_role_name in privileged_result.status_extended
+
+    @mock_aws
+    def test_wildcard_trust_unconditioned(self):
+        """Wildcard trust Principal star should be treated as assumable when unconditioned."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        wildcard_trust = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": "*",
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        privileged_role_name = "wildcard-priv"
+        privileged_arn = iam_client.create_role(
+            RoleName=privileged_role_name,
+            AssumeRolePolicyDocument=dumps(wildcard_trust),
+        )["Role"]["Arn"]
+
+        priv_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "iam:CreatePolicyVersion",
+                    "Resource": "*",
+                }
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=privileged_role_name,
+            PolicyName="priv",
+            PolicyDocument=dumps(priv_doc),
+        )
+
+        benign_role_name = "benign-other"
+        iam_client.create_role(
+            RoleName=benign_role_name,
+            AssumeRolePolicyDocument=dumps(ROOT_TRUST),
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+            by_id = {r.resource_id: r for r in result}
+            priv_result = by_id[privileged_role_name]
+            # Should be FAIL because wildcard trust makes it assumable by in-account roles
+            assert priv_result.status == "FAIL"
+            assert "wildcard" in priv_result.status_extended.lower() or "assumable" in priv_result.status_extended.lower()
+
+    @mock_aws
+    def test_combined_statements_escalation(self):
+        """Escalation split across two policies should be detected via combined statements."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Role with two incomplete policies that together form escalation
+        role_name = "split-escalation-role"
+        iam_client.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(ROOT_TRUST),
+        )
+
+        # First policy allows iam:CreatePolicyVersion but not enough alone? Actually single action is enough per combo table,
+        # so split test uses combo requiring two actions: PassRole+CreateLambda+AddPermission needs 3 actions split
+        # Use iam:AttachRolePolicy + iam:UpdateAssumeRolePolicy combo split across policies
+        policy_one = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "iam:AttachRolePolicy", "Resource": "*"}
+            ],
+        }
+        policy_two = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "iam:UpdateAssumeRolePolicy", "Resource": "*"}
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=role_name,
+            PolicyName="part-one",
+            PolicyDocument=dumps(policy_one),
+        )
+        iam_client.put_role_policy(
+            RoleName=role_name,
+            PolicyName="part-two",
+            PolicyDocument=dumps(policy_two),
+        )
+
+        trusted_name = "trusted-for-split"
+        trusted_arn = iam_client.create_role(
+            RoleName=trusted_name,
+            AssumeRolePolicyDocument=dumps(ROOT_TRUST),
+        )["Role"]["Arn"]
+
+        trust_allowing = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": trusted_arn},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        iam_client.update_assume_role_policy(
+            RoleName=role_name, PolicyDocument=dumps(trust_allowing)
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_role_chained_privilege_escalation.iam_role_chained_privilege_escalation import (
+                iam_role_chained_privilege_escalation,
+            )
+
+            check = iam_role_chained_privilege_escalation()
+            result = check.execute()
+            by_id = {r.resource_id: r for r in result}
+            role_result = by_id[role_name]
+            # Should be FAIL because combined effective permissions allow AttachRolePolicy+UpdateAssumeRolePolicy
+            assert role_result.status == "FAIL"
+            assert "assumable" in role_result.status_extended.lower()


### PR DESCRIPTION
### Context

Existing privilege escalation checks (iam_policy_allows_privilege_escalation, iam_inline_policy_allows_privilege_escalation) evaluate single policies in isolation. They do not detect transitive attack chains where a low-privileged role can sts:AssumeRole into a privileged role that itself can escalate to admin.

This gap is noted in priv escalation lib comments: Does the tool handle transitive privesc paths (i.e., attack chains)? --> Not yet.

### Description

Add new check `iam_role_chained_privilege_escalation`:

- Builds role-by-ARN map and pre-computes which roles have privilege escalation via existing `check_privilege_escalation` lib (covers 17+ techniques from iam:CreatePolicyVersion to lambda:UpdateFunctionCode and ec2:RunInstances+PassRole)
- For each role, parses its own policies for sts:AssumeRole on target ARNs. If source role can assume a privileged target, FAIL source role with chain detail.
- Also detects privileged roles with overly permissive trust: if privileged role is assumable by in-account role ARNs (Principal.AWS contains role ARN), FAIL privileged role and list in-account assumers.
- Uses same pattern as other IAM checks: IAM service already provides roles, trust policies, attached/inline policies.

Fills distinct gap vs existing checks: role-chain graph, not single-policy static analysis.

### Steps to review

- Verify check folder: prowler/providers/aws/services/iam/iam_role_chained_privilege_escalation/
- Check metadata: critical severity, ResourceType AwsIamRole, proper remediation.
- Review test: tests/providers/aws/services/iam/iam_role_chained_privilege_escalation_test.py covers:
  - no roles empty
  - single safe role PASS
  - source role can assume privileged target FAIL
  - privileged role assumable by in-account role FAIL via trust chain
- Run locally: uv run pytest tests/providers/aws/services/iam/iam_role_chained_privilege_escalation/ -v

### Checklist

<details><summary>Community Checklist</summary>

- [x] This feature is listed in open issues / roadmap - gap documented in lib comments
- [x] I have reviewed open PRs and confirmed no existing PR implements chained escalation
- [x] Review if code is being covered by tests.
- [x] Review if code is documented
- [x] New checks included Yes
    - No extra permissions needed beyond iam:ListRoles GetRole ListRolePolicies GetRolePolicy ListAttachedRolePolicies - already collected by IAM service
- [x] Ensure a changelog fragment is added under prowler/changelog.d/
</details>

#### SDK/CLI
- Are there new checks included? Yes
    - No permission update needed, uses existing IAM service data

### License
By submitting this pull request, I confirm that my contribution is made under terms of Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AWS IAM security check to detect direct and chained privilege-escalation paths between roles.
  * Identifies escalation through inline or managed policies, trusted in-account roles, and unrestricted wildcard trusts.
  * Provides severity, risk details, remediation guidance, references, and clear pass/fail findings.

* **Tests**
  * Added coverage for empty accounts, safe roles, policy-based escalation, multi-hop chains, wildcard trusts, and combined permissions.

* **Documentation**
  * Added release documentation and metadata for the new IAM security check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->