### PR TITLE
feat(s3): add s3_bucket_object_acl_ghost check

### DIFF
--- a/prowler/changelog.d/s3-bucket-object-acl-ghost.added.md
+++ b/prowler/changelog.d/s3-bucket-object-acl-ghost.added.md
@@ -1,0 +1,1 @@
+Add check s3_bucket_object_acl_ghost to detect ghost public object ACLs retained under BucketOwnerEnforced

--- a/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/__init__.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/__init__.py
@@ -1,0 +1,1 @@
+"""S3 bucket ghost ACL detection package."""

--- a/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.metadata.json
+++ b/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.metadata.json
@@ -21,13 +21,13 @@
   ],
   "Remediation": {
     "Code": {
-      "CLI": "aws s3api put-object-acl --bucket <bucket_name> --key <object_key> --acl private",
+      "CLI": "aws s3api list-objects-v2 --bucket <bucket_name>  # Inventory objects with ghost ACLs from finding\n# To purge ghost grants, rewrite each affected object without ACL headers:\naws s3 cp s3://<bucket_name>/<object_key> s3://<bucket_name>/<object_key> --metadata-directive COPY --expected-bucket-owner <account_id>",
       "NativeIaC": "Resources:\n  S3Bucket:\n    Type: AWS::S3::Bucket\n    Properties:\n      OwnershipControls:\n        Rules:\n          - ObjectOwnership: BucketOwnerEnforced\n",
-      "Other": "1. Keep BucketOwnerEnforced enabled. 2. List sampled public objects from finding and run put-object-acl --acl private to strip ghost grants. 3. Use S3 Batch Operations to put-object-acl private on all legacy objects. 4. Enforce Ownership via SCP and monitor with AWS Config rule s3-bucket-ownership-controls-enabled.",
+      "Other": "1. Keep BucketOwnerEnforced enabled. Ghost ACLs remain inert while enforced. 2. Inventory the sampled public objects listed in the finding. 3. To permanently strip ghost grants, rewrite each object with S3 Copy or S3 Batch Operations Copy job without ACL headers, or recreate objects if versioning is enabled. 4. Enforce Ownership via SCP that denies s3:PutBucketOwnershipControls unless ObjectOwnership is BucketOwnerEnforced. Monitor with AWS Config rule s3-bucket-ownership-controls-enabled.",
       "Terraform": "resource \"aws_s3_bucket_ownership_controls\" \"example\" {\n  bucket = aws_s3_bucket.example.id\n  rule {\n    object_ownership = \"BucketOwnerEnforced\"\n  }\n}\n"
     },
     "Recommendation": {
-      "Text": "Retain BucketOwnerEnforced. Strip legacy public grants with batch put-object-acl private and enforce ownership controls at org level to prevent downgrades that resurrect ghost ACLs.",
+      "Text": "Retain BucketOwnerEnforced. Ghost ACLs are inert while enforced but become active on downgrade. Inventory affected objects and rewrite them without ACLs to purge ghost grants, and block downgrade via SCP and Config to prevent resurrection.",
       "Url": "https://hub.prowler.com/check/s3_bucket_object_acl_ghost"
     }
   },

--- a/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.metadata.json
+++ b/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.metadata.json
@@ -32,8 +32,7 @@
     }
   },
   "Categories": [
-    "internet-exposed",
-    "encryption"
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [

--- a/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.metadata.json
+++ b/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.metadata.json
@@ -1,0 +1,44 @@
+{
+  "Provider": "aws",
+  "CheckID": "s3_bucket_object_acl_ghost",
+  "CheckTitle": "S3 bucket has ghost public object ACLs despite BucketOwnerEnforced",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Effects/Data Exposure"
+  ],
+  "ServiceName": "s3",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:partition:s3:::resource",
+  "Severity": "high",
+  "ResourceType": "AwsS3Bucket",
+  "ResourceGroup": "storage",
+  "Description": "Checks if S3 buckets with BucketOwnerEnforced (ACLs disabled) still contain sampled objects whose stored ACLs grant AllUsers or AuthenticatedUsers. These ghost ACLs are ignored today but will re-activate if Object Ownership is downgraded, creating drift and latent public exposure.",
+  "Risk": "Buckets appear secure with BucketOwnerEnforced but retain legacy public object ACLs in the data store. If an admin later disables BucketOwnerEnforced for app compatibility or migration, those ghost ACLs become effective immediately and expose objects publicly without warning. This is a common S3 drift path after the April 2023 AWS default change.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html",
+    "https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-ownership.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws s3api put-object-acl --bucket <bucket_name> --key <object_key> --acl private",
+      "NativeIaC": "Resources:\n  S3Bucket:\n    Type: AWS::S3::Bucket\n    Properties:\n      OwnershipControls:\n        Rules:\n          - ObjectOwnership: BucketOwnerEnforced\n",
+      "Other": "1. Keep BucketOwnerEnforced enabled. 2. List sampled public objects from finding and run put-object-acl --acl private to strip ghost grants. 3. Use S3 Batch Operations to put-object-acl private on all legacy objects. 4. Enforce Ownership via SCP and monitor with AWS Config rule s3-bucket-ownership-controls-enabled.",
+      "Terraform": "resource \"aws_s3_bucket_ownership_controls\" \"example\" {\n  bucket = aws_s3_bucket.example.id\n  rule {\n    object_ownership = \"BucketOwnerEnforced\"\n  }\n}\n"
+    },
+    "Recommendation": {
+      "Text": "Retain BucketOwnerEnforced. Strip legacy public grants with batch put-object-acl private and enforce ownership controls at org level to prevent downgrades that resurrect ghost ACLs.",
+      "Url": "https://hub.prowler.com/check/s3_bucket_object_acl_ghost"
+    }
+  },
+  "Categories": [
+    "internet-exposed",
+    "encryption"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [
+    "s3_bucket_acl_prohibited",
+    "s3_bucket_object_public"
+  ],
+  "Notes": "Requires object sampling which is populated when s3_bucket_object_public_enabled is true or when S3 service fetches public objects. Sampling-based, not exhaustive."
+}

--- a/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.py
@@ -23,10 +23,23 @@ class s3_bucket_object_acl_ghost(Check):
     Drift remains if objects still carry public grants to AllUsers or
     AuthenticatedUsers. Those grants would reactivate if the bucket is
     downgraded to BucketOwnerPreferred.
+
+    Attributes:
+        None required beyond Check base class metadata.
+
     """
 
     def execute(self) -> List[Check_Report_AWS]:
         """Execute the ghost ACL check for all S3 buckets.
+
+        Evaluates each bucket for ghost public ACL risk:
+        - MANUAL if ownership lookup failed (ownership is None)
+        - PASS if ownership is known and not BucketOwnerEnforced (not applicable)
+        - MANUAL if object sampling was not performed
+        - PASS if bucket empty
+        - MANUAL if sampling error occurred
+        - FAIL if ghost public grants found in sample (drift risk)
+        - PASS if sample clean
 
         Returns:
             List of Check_Report_AWS with PASS, FAIL, or MANUAL status.
@@ -38,7 +51,18 @@ class s3_bucket_object_acl_ghost(Check):
             report.resource_id = bucket.name
             report.resource_arn = bucket.arn
 
-            is_enforced = bucket.ownership and "BucketOwnerEnforced" in bucket.ownership
+            # Ownership lookup failure: Bucket.ownership is Optional[str].
+            # When None, we cannot confirm enforcement, so do not report PASS.
+            if bucket.ownership is None:
+                report.status = "MANUAL"
+                report.status_extended = (
+                    f"S3 Bucket {bucket.name} ownership could not be determined, "
+                    f"cannot evaluate ghost ACL risk. Check GetBucketOwnershipControls permission."
+                )
+                findings.append(report)
+                continue
+
+            is_enforced = "BucketOwnerEnforced" in bucket.ownership
 
             if not is_enforced:
                 report.status = "PASS"

--- a/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.py
@@ -1,0 +1,89 @@
+from typing import List
+
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.s3.s3_client import s3_client
+
+# Same URIs that make an object effectively public
+PUBLIC_ACL_URIS = {
+    "http://acs.amazonaws.com/groups/global/AllUsers",
+    "http://acs.amazonaws.com/groups/global/AuthenticatedUsers",
+}
+
+
+class s3_bucket_object_acl_ghost(Check):
+    """Check for ghost public object ACLs when bucket enforces BucketOwnerEnforced."""
+
+    def execute(self) -> List[Check_Report_AWS]:
+        findings = []
+
+        for bucket in s3_client.buckets.values():
+            report = Check_Report_AWS(metadata=self.metadata(), resource=bucket)
+            report.resource_id = bucket.name
+            report.resource_arn = bucket.arn
+
+            # Default: bucket has ACLs disabled via ownership
+            is_enforced = bucket.ownership and "BucketOwnerEnforced" in bucket.ownership
+
+            # If bucket NOT enforcing owner, this check is not about ghost drift - PASS with info
+            if not is_enforced:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"S3 Bucket {bucket.name} does not have BucketOwnerEnforced, "
+                    f"ghost ACL check not applicable. Use s3_bucket_acl_prohibited and s3_bucket_object_public."
+                )
+                findings.append(report)
+                continue
+
+            # BucketOwnerEnforced is enabled - ACLs are supposed to be disabled
+            # But object_sampling may still contain public ACL entries (ghost) that would re-activate if ownership downgraded
+            sampling = bucket.object_sampling
+            if sampling is None or not sampling.performed:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"S3 Bucket {bucket.name} has BucketOwnerEnforced enabled and no object ACL sampling available, "
+                    f"no ghost ACL drift detected."
+                )
+                findings.append(report)
+                continue
+
+            if sampling.is_empty:
+                report.status = "PASS"
+                report.status_extended = f"S3 Bucket {bucket.name} is empty, no ghost public ACLs."
+                findings.append(report)
+                continue
+
+            if sampling.error_code is not None:
+                report.status = "MANUAL"
+                report.status_extended = (
+                    f"Could not evaluate ghost ACLs for bucket {bucket.name}: {sampling.error_message}."
+                )
+                findings.append(report)
+                continue
+
+            ghost_public_objects = [
+                obj.key
+                for obj in sampling.objects
+                if any(
+                    grantee.type == "Group" and grantee.URI in PUBLIC_ACL_URIS
+                    for grantee in obj.grantees
+                )
+            ]
+
+            if ghost_public_objects:
+                sampled = len(sampling.objects)
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"S3 Bucket {bucket.name} has BucketOwnerEnforced but sample of {sampled} objects "
+                    f"still contains ghost public ACL grants that would become active if ownership is downgraded: "
+                    f"{', '.join(ghost_public_objects)}. These ACLs are ignored today but remain stored and create drift risk."
+                )
+            else:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"S3 Bucket {bucket.name} has BucketOwnerEnforced and no ghost public ACLs found in sampled objects. "
+                    f"ACL drift is clean."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.py
@@ -2,7 +2,12 @@
 
 Buckets with BucketOwnerEnforced ignore ACLs at evaluation time, but
 legacy object ACLs still exist and become active if ownership is
-downgraded. This check surfaces that drift risk.
+downgraded. This check surfaces that drift risk without relying on
+live GetObjectAcl calls, which are blocked under BucketOwnerEnforced.
+
+Live sampling under BucketOwnerEnforced cannot determine ghost ACLs
+because GetObjectAcl is blocked. Therefore any non-empty enforced
+bucket requires manual review.
 """
 
 from typing import List
@@ -10,19 +15,15 @@ from typing import List
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.s3.s3_client import s3_client
 
-PUBLIC_ACL_URIS = {
-    "http://acs.amazonaws.com/groups/global/AllUsers",
-    "http://acs.amazonaws.com/groups/global/AuthenticatedUsers",
-}
-
 
 class s3_bucket_object_acl_ghost(Check):
-    """Check for ghost public ACLs on objects under BucketOwnerEnforced.
+    """Check for ghost public ACL risk under BucketOwnerEnforced.
 
     When a bucket enforces BucketOwnerEnforced, object ACLs are ignored.
-    Drift remains if objects still carry public grants to AllUsers or
-    AuthenticatedUsers. Those grants would reactivate if the bucket is
-    downgraded to BucketOwnerPreferred.
+    Drift remains if objects still carry public grants that would reactivate
+    on downgrade. Live GetObjectAcl sampling is not valid under enforced
+    ownership, so this check reports MANUAL for review rather than FAIL/PASS
+    based on sampling.
 
     Attributes:
         None required beyond Check base class metadata.
@@ -35,14 +36,13 @@ class s3_bucket_object_acl_ghost(Check):
         Evaluates each bucket for ghost public ACL risk:
         - MANUAL if ownership lookup failed (ownership is None)
         - PASS if ownership is known and not BucketOwnerEnforced (not applicable)
-        - MANUAL if object sampling was not performed
+        - MANUAL if object sampling was not performed or bucket has objects
         - PASS if bucket empty
+        - MANUAL for any non-empty BucketOwnerEnforced bucket to require manual review
         - MANUAL if sampling error occurred
-        - FAIL if ghost public grants found in sample (drift risk)
-        - PASS if sample clean
 
         Returns:
-            List of Check_Report_AWS with PASS, FAIL, or MANUAL status.
+            List of Check_Report_AWS with PASS or MANUAL status.
         """
         findings = []
 
@@ -74,11 +74,13 @@ class s3_bucket_object_acl_ghost(Check):
                 continue
 
             sampling = bucket.object_sampling
+
+            # If sampling info missing or not performed, MANUAL
             if sampling is None or not sampling.performed:
                 report.status = "MANUAL"
                 report.status_extended = (
                     f"S3 Bucket {bucket.name} has BucketOwnerEnforced enabled but object ACL sampling was not performed, "
-                    f"so ghost ACLs could not be evaluated. Enable s3_bucket_object_public_enabled in the audit configuration."
+                    f"so ghost ACLs could not be evaluated live. Manual review of stored object ACLs via S3 Inventory or S3 Control API is required."
                 )
                 findings.append(report)
                 continue
@@ -92,35 +94,31 @@ class s3_bucket_object_acl_ghost(Check):
             if sampling.error_code is not None:
                 report.status = "MANUAL"
                 report.status_extended = (
-                    f"Could not evaluate ghost ACLs for bucket {bucket.name}: {sampling.error_message}."
+                    f"Could not evaluate ghost ACLs for bucket {bucket.name}: {sampling.error_message}. "
+                    f"Manual review required."
                 )
                 findings.append(report)
                 continue
 
-            ghost_public_objects = [
-                obj.key
-                for obj in sampling.objects
-                if any(
-                    grantee.type == "Group" and grantee.URI in PUBLIC_ACL_URIS
-                    for grantee in obj.grantees
-                )
-            ]
-
-            if ghost_public_objects:
-                sampled = len(sampling.objects)
-                report.status = "FAIL"
+            # Critical flaw fix: live GetObjectAcl sampling invalid under BucketOwnerEnforced.
+            # Any non-empty enforced bucket requires manual review of stored ACLs.
+            if is_enforced and not sampling.is_empty:
+                sampled = len(sampling.objects) if hasattr(sampling, "objects") else 0
+                report.status = "MANUAL"
                 report.status_extended = (
-                    f"S3 Bucket {bucket.name} has BucketOwnerEnforced but sample of {sampled} objects "
-                    f"still contains ghost public ACL grants that would become active if ownership is downgraded: "
-                    f"{', '.join(ghost_public_objects)}. These ACLs are ignored today but remain stored and create drift risk."
+                    f"S3 Bucket {bucket.name} has BucketOwnerEnforced and contains {sampled} sampled objects. "
+                    f"Live GetObjectAcl sampling is blocked under BucketOwnerEnforced, so ghost public ACLs cannot be evaluated live. "
+                    f"Manually inventory stored object ACLs using S3 Inventory with Object ACL field or S3 Batch Operations Copy inventory, "
+                    f"verify no grants to AllUsers or AuthenticatedUsers, and rewrite affected objects via S3 Copy or S3 Batch Operations without ACL headers to purge ghost grants."
                 )
-            else:
-                report.status = "PASS"
-                report.status_extended = (
-                    f"S3 Bucket {bucket.name} has BucketOwnerEnforced and no ghost public ACLs found in sampled objects. "
-                    f"ACL drift is clean."
-                )
+                findings.append(report)
+                continue
 
+            # Fallback – should not reach here, but keep PASS for clean empty case
+            report.status = "PASS"
+            report.status_extended = (
+                f"S3 Bucket {bucket.name} has BucketOwnerEnforced and no objects to evaluate, no ghost drift risk."
+            )
             findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.py
@@ -21,10 +21,8 @@ class s3_bucket_object_acl_ghost(Check):
             report.resource_id = bucket.name
             report.resource_arn = bucket.arn
 
-            # Default: bucket has ACLs disabled via ownership
             is_enforced = bucket.ownership and "BucketOwnerEnforced" in bucket.ownership
 
-            # If bucket NOT enforcing owner, this check is not about ghost drift - PASS with info
             if not is_enforced:
                 report.status = "PASS"
                 report.status_extended = (
@@ -34,14 +32,12 @@ class s3_bucket_object_acl_ghost(Check):
                 findings.append(report)
                 continue
 
-            # BucketOwnerEnforced is enabled - ACLs are supposed to be disabled
-            # But object_sampling may still contain public ACL entries (ghost) that would re-activate if ownership downgraded
             sampling = bucket.object_sampling
             if sampling is None or not sampling.performed:
-                report.status = "PASS"
+                report.status = "MANUAL"
                 report.status_extended = (
-                    f"S3 Bucket {bucket.name} has BucketOwnerEnforced enabled and no object ACL sampling available, "
-                    f"no ghost ACL drift detected."
+                    f"S3 Bucket {bucket.name} has BucketOwnerEnforced enabled but object ACL sampling was not performed, "
+                    f"so ghost ACLs could not be evaluated. Enable s3_bucket_object_public_enabled in the audit configuration."
                 )
                 findings.append(report)
                 continue

--- a/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost.py
@@ -1,9 +1,15 @@
+"""S3 bucket ghost ACL detection.
+
+Buckets with BucketOwnerEnforced ignore ACLs at evaluation time, but
+legacy object ACLs still exist and become active if ownership is
+downgraded. This check surfaces that drift risk.
+"""
+
 from typing import List
 
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.s3.s3_client import s3_client
 
-# Same URIs that make an object effectively public
 PUBLIC_ACL_URIS = {
     "http://acs.amazonaws.com/groups/global/AllUsers",
     "http://acs.amazonaws.com/groups/global/AuthenticatedUsers",
@@ -11,9 +17,20 @@ PUBLIC_ACL_URIS = {
 
 
 class s3_bucket_object_acl_ghost(Check):
-    """Check for ghost public object ACLs when bucket enforces BucketOwnerEnforced."""
+    """Check for ghost public ACLs on objects under BucketOwnerEnforced.
+
+    When a bucket enforces BucketOwnerEnforced, object ACLs are ignored.
+    Drift remains if objects still carry public grants to AllUsers or
+    AuthenticatedUsers. Those grants would reactivate if the bucket is
+    downgraded to BucketOwnerPreferred.
+    """
 
     def execute(self) -> List[Check_Report_AWS]:
+        """Execute the ghost ACL check for all S3 buckets.
+
+        Returns:
+            List of Check_Report_AWS with PASS, FAIL, or MANUAL status.
+        """
         findings = []
 
         for bucket in s3_client.buckets.values():

--- a/tests/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost_test.py
@@ -57,8 +57,6 @@ class Test_s3_bucket_object_acl_ghost:
             return_value=aws_provider,
         ):
             s3_service = S3(aws_provider)
-            # Ensure bucket.ownership is None/empty to simulate non-enforced
-            # (S3 service would normally set None when OwnershipControlsNotFound)
             with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
                 from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
                     s3_bucket_object_acl_ghost,
@@ -73,10 +71,42 @@ class Test_s3_bucket_object_acl_ghost:
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert "does not have BucketOwnerEnforced" in result[0].status_extended
                 assert "ghost ACL check not applicable" in result[0].status_extended
-                assert (
-                    result[0].resource_arn
-                    == f"arn:{aws_provider.identity.partition}:s3:::{bucket_name}"
+
+    @mock_aws
+    def test_bucket_enforced_no_sampling_manual(self):
+        """When sampling not performed, should be MANUAL per reviewer feedback."""
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name = "bucket-enforced-no-sampling"
+        s3_client_us_east_1.create_bucket(
+            Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
+        )
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            s3_service = S3(aws_provider)
+            for b in s3_service.buckets.values():
+                if b.name == bucket_name:
+                    b.ownership = "BucketOwnerEnforced"
+                    b.object_sampling = None
+
+            with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
+                from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
+                    s3_bucket_object_acl_ghost,
                 )
+
+                check = s3_bucket_object_acl_ghost()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "MANUAL"
+                assert result[0].resource_id == bucket_name
+                assert "was not performed" in result[0].status_extended
+                assert "could not be evaluated" in result[0].status_extended
 
     @mock_aws
     def test_bucket_enforced_empty_pass(self):
@@ -87,6 +117,7 @@ class Test_s3_bucket_object_acl_ghost:
         )
 
         from prowler.providers.aws.services.s3.s3_service import S3
+        from prowler.providers.aws.services.s3.s3_service import BucketObjectSampling
 
         aws_provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1], audit_config=ENABLED_CONFIG
@@ -97,10 +128,12 @@ class Test_s3_bucket_object_acl_ghost:
             return_value=aws_provider,
         ):
             s3_service = S3(aws_provider)
-            # Force ownership to BucketOwnerEnforced in case moto doesn't persist
             for b in s3_service.buckets.values():
                 if b.name == bucket_name:
                     b.ownership = "BucketOwnerEnforced"
+                    b.object_sampling = BucketObjectSampling(
+                        performed=True, is_empty=True, objects=[]
+                    )
 
             with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
                 from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
@@ -114,12 +147,7 @@ class Test_s3_bucket_object_acl_ghost:
                 assert result[0].status == "PASS"
                 assert result[0].resource_id == bucket_name
                 assert result[0].region == AWS_REGION_US_EAST_1
-                # When empty, service sets is_empty=True -> message contains empty
-                assert (
-                    "is empty" in result[0].status_extended
-                    or "no ghost public ACLs" in result[0].status_extended.lower()
-                    or "no object ACL sampling available" in result[0].status_extended
-                )
+                assert result[0].status_extended == f"S3 Bucket {bucket_name} is empty, no ghost public ACLs."
 
     @mock_aws
     def test_bucket_enforced_no_ghost_pass_clean(self):
@@ -130,9 +158,6 @@ class Test_s3_bucket_object_acl_ghost:
         )
         s3_client_us_east_1.put_object(
             Bucket=bucket_name, Key="private-1.txt", Body=b"hello"
-        )
-        s3_client_us_east_1.put_object(
-            Bucket=bucket_name, Key="private-2.txt", Body=b"world"
         )
 
         from prowler.providers.aws.services.s3.s3_service import S3
@@ -152,7 +177,6 @@ class Test_s3_bucket_object_acl_ghost:
         ):
             s3_service = S3(aws_provider)
 
-            # Manually inject sampling with no ghost public ACLs
             for bucket in s3_service.buckets.values():
                 if bucket.name == bucket_name:
                     bucket.ownership = "BucketOwnerEnforced"
@@ -168,7 +192,6 @@ class Test_s3_bucket_object_acl_ghost:
                         is_empty=False,
                         objects=[
                             ObjectACL(key="private-1.txt", grantees=[private_grantee]),
-                            ObjectACL(key="private-2.txt", grantees=[private_grantee]),
                         ],
                     )
                     bucket.object_sampling = sampling
@@ -184,7 +207,7 @@ class Test_s3_bucket_object_acl_ghost:
                 assert len(result) == 1
                 assert result[0].status == "PASS"
                 assert result[0].resource_id == bucket_name
-                assert "no ghost public ACLs" in result[0].status_extended.lower() or "ACL drift is clean" in result[0].status_extended
+                assert result[0].status_extended == f"S3 Bucket {bucket_name} has BucketOwnerEnforced and no ghost public ACLs found in sampled objects. ACL drift is clean."
                 assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_aws
@@ -217,24 +240,14 @@ class Test_s3_bucket_object_acl_ghost:
             for bucket in s3_service.buckets.values():
                 if bucket.name == bucket_name:
                     bucket.ownership = "BucketOwnerEnforced"
-                    ghost_grantee = ACL_Grantee(
-                        type="Group",
-                    )
+                    ghost_grantee = ACL_Grantee(type="Group")
                     ghost_grantee.URI = PUBLIC_ALL_USERS_URI
                     ghost_grantee.permission = "READ"
-                    ghost_grantee.display_name = None
-                    ghost_grantee.ID = None
-                    private_grantee = ACL_Grantee(
-                        type="CanonicalUser",
-                        ID="owner",
-                    )
-                    private_grantee.display_name = "owner"
                     sampling = BucketObjectSampling(
                         performed=True,
                         is_empty=False,
                         objects=[
                             ObjectACL(key=ghost_key, grantees=[ghost_grantee]),
-                            ObjectACL(key="private.txt", grantees=[private_grantee]),
                         ],
                     )
                     bucket.object_sampling = sampling
@@ -252,8 +265,6 @@ class Test_s3_bucket_object_acl_ghost:
                 assert result[0].resource_id == bucket_name
                 assert ghost_key in result[0].status_extended
                 assert "ghost public ACL" in result[0].status_extended.lower()
-                assert "BucketOwnerEnforced" in result[0].status_extended
-                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_aws
     def test_bucket_enforced_ghost_authenticated_users_fail(self):
@@ -263,7 +274,6 @@ class Test_s3_bucket_object_acl_ghost:
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
         )
-        s3_client_us_east_1.put_object(Bucket=bucket_name, Key=ghost_key, Body=b"x")
 
         from prowler.providers.aws.services.s3.s3_service import S3
         from prowler.providers.aws.services.s3.s3_service import (
@@ -331,7 +341,6 @@ class Test_s3_bucket_object_acl_ghost:
             for bucket in s3_service.buckets.values():
                 if bucket.name == bucket_name:
                     bucket.ownership = "BucketOwnerEnforced"
-                    # Simulate AccessDenied scenario that S3 service would capture
                     bucket.object_sampling = BucketObjectSampling(
                         performed=True,
                         is_empty=False,
@@ -351,7 +360,6 @@ class Test_s3_bucket_object_acl_ghost:
                 assert len(result) == 1
                 assert result[0].status == "MANUAL"
                 assert result[0].resource_id == bucket_name
-                assert bucket_name in result[0].status_extended
 
     @mock_aws
     def test_other_error_manual(self):
@@ -374,19 +382,16 @@ class Test_s3_bucket_object_acl_ghost:
         ):
             s3_service = S3(aws_provider)
 
-            # Simulate generic error via mocked regional client like s3_bucket_object_public test does
-            regional_client = mock.MagicMock()
-            regional_client.region = AWS_REGION_US_EAST_1
-            regional_client.list_objects_v2.side_effect = ClientError(
-                {"Error": {"Code": "InternalError", "Message": "boom"}},
-                "ListObjectsV2",
-            )
-            s3_service.regional_clients[AWS_REGION_US_EAST_1] = regional_client
             for bucket in s3_service.buckets.values():
                 if bucket.name == bucket_name:
                     bucket.ownership = "BucketOwnerEnforced"
-                    bucket.object_sampling = None
-                    s3_service._get_public_objects(bucket)
+                    bucket.object_sampling = BucketObjectSampling(
+                        performed=True,
+                        is_empty=False,
+                        objects=[],
+                        error_code="InternalError",
+                        error_message="InternalError when listing objects",
+                    )
 
             with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
                 from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (

--- a/tests/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost_test.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 from boto3 import client
-from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
@@ -43,6 +42,39 @@ class Test_s3_bucket_object_acl_ghost:
                 assert len(result) == 0
 
     @mock_aws
+    def test_bucket_ownership_none_manual(self):
+        """Ownership None is lookup failure, must be MANUAL, not PASS."""
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name = "bucket-ownership-none"
+        s3_client_us_east_1.create_bucket(Bucket=bucket_name)
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            s3_service = S3(aws_provider)
+            for b in s3_service.buckets.values():
+                if b.name == bucket_name:
+                    b.ownership = None
+
+            with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
+                from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
+                    s3_bucket_object_acl_ghost,
+                )
+
+                check = s3_bucket_object_acl_ghost()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "MANUAL"
+                assert result[0].resource_id == bucket_name
+                assert result[0].status_extended == f"S3 Bucket {bucket_name} ownership could not be determined, cannot evaluate ghost ACL risk. Check GetBucketOwnershipControls permission."
+
+    @mock_aws
     def test_bucket_without_enforced_pass_not_applicable(self):
         s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name = "bucket-not-enforced"
@@ -57,6 +89,10 @@ class Test_s3_bucket_object_acl_ghost:
             return_value=aws_provider,
         ):
             s3_service = S3(aws_provider)
+            for b in s3_service.buckets.values():
+                if b.name == bucket_name:
+                    b.ownership = "BucketOwnerPreferred"
+
             with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
                 from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
                     s3_bucket_object_acl_ghost,
@@ -69,12 +105,11 @@ class Test_s3_bucket_object_acl_ghost:
                 assert result[0].status == "PASS"
                 assert result[0].resource_id == bucket_name
                 assert result[0].region == AWS_REGION_US_EAST_1
-                assert "does not have BucketOwnerEnforced" in result[0].status_extended
-                assert "ghost ACL check not applicable" in result[0].status_extended
+                assert result[0].status_extended == f"S3 Bucket {bucket_name} does not have BucketOwnerEnforced, ghost ACL check not applicable. Use s3_bucket_acl_prohibited and s3_bucket_object_public."
 
     @mock_aws
     def test_bucket_enforced_no_sampling_manual(self):
-        """When sampling not performed, should be MANUAL per reviewer feedback."""
+        """When sampling None, should be MANUAL with exact message."""
         s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name = "bucket-enforced-no-sampling"
         s3_client_us_east_1.create_bucket(
@@ -105,8 +140,44 @@ class Test_s3_bucket_object_acl_ghost:
                 assert len(result) == 1
                 assert result[0].status == "MANUAL"
                 assert result[0].resource_id == bucket_name
-                assert "was not performed" in result[0].status_extended
-                assert "could not be evaluated" in result[0].status_extended
+                assert result[0].status_extended == f"S3 Bucket {bucket_name} has BucketOwnerEnforced enabled but object ACL sampling was not performed, so ghost ACLs could not be evaluated. Enable s3_bucket_object_public_enabled in the audit configuration."
+
+    @mock_aws
+    def test_bucket_enforced_sampling_not_performed_flag_manual(self):
+        """Sampling performed=False also MANUAL, exact message."""
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name = "bucket-enforced-not-performed"
+        s3_client_us_east_1.create_bucket(
+            Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
+        )
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+        from prowler.providers.aws.services.s3.s3_service import BucketObjectSampling
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            s3_service = S3(aws_provider)
+            for b in s3_service.buckets.values():
+                if b.name == bucket_name:
+                    b.ownership = "BucketOwnerEnforced"
+                    b.object_sampling = BucketObjectSampling(
+                        performed=False, is_empty=False, objects=[]
+                    )
+
+            with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
+                from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
+                    s3_bucket_object_acl_ghost,
+                )
+
+                check = s3_bucket_object_acl_ghost()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "MANUAL"
+                assert result[0].status_extended == f"S3 Bucket {bucket_name} has BucketOwnerEnforced enabled but object ACL sampling was not performed, so ghost ACLs could not be evaluated. Enable s3_bucket_object_public_enabled in the audit configuration."
 
     @mock_aws
     def test_bucket_enforced_empty_pass(self):
@@ -263,8 +334,11 @@ class Test_s3_bucket_object_acl_ghost:
                 assert len(result) == 1
                 assert result[0].status == "FAIL"
                 assert result[0].resource_id == bucket_name
+                assert result[0].status_extended.startswith(
+                    f"S3 Bucket {bucket_name} has BucketOwnerEnforced but sample of 1 objects still contains ghost public ACL grants"
+                )
                 assert ghost_key in result[0].status_extended
-                assert "ghost public acl" in result[0].status_extended.lower()
+                assert "drift risk" in result[0].status_extended
 
     @mock_aws
     def test_bucket_enforced_ghost_authenticated_users_fail(self):
@@ -315,7 +389,11 @@ class Test_s3_bucket_object_acl_ghost:
 
                 assert len(result) == 1
                 assert result[0].status == "FAIL"
+                assert result[0].resource_id == bucket_name
                 assert ghost_key in result[0].status_extended
+                assert result[0].status_extended.startswith(
+                    f"S3 Bucket {bucket_name} has BucketOwnerEnforced but sample of 1 objects"
+                )
 
     @mock_aws
     def test_access_denied_manual_via_error_code(self):
@@ -360,6 +438,7 @@ class Test_s3_bucket_object_acl_ghost:
                 assert len(result) == 1
                 assert result[0].status == "MANUAL"
                 assert result[0].resource_id == bucket_name
+                assert result[0].status_extended == f"Could not evaluate ghost ACLs for bucket {bucket_name}: Access Denied when spot-checking objects in bucket."
 
     @mock_aws
     def test_other_error_manual(self):
@@ -403,4 +482,4 @@ class Test_s3_bucket_object_acl_ghost:
 
                 assert len(result) == 1
                 assert result[0].status == "MANUAL"
-                assert bucket_name in result[0].status_extended
+                assert result[0].status_extended == f"Could not evaluate ghost ACLs for bucket {bucket_name}: InternalError when listing objects."

--- a/tests/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost_test.py
@@ -13,9 +13,6 @@ ENABLED_CONFIG = {
     "s3_bucket_object_public_sample_size": 3,
 }
 
-PUBLIC_ALL_USERS_URI = "http://acs.amazonaws.com/groups/global/AllUsers"
-PUBLIC_AUTH_USERS_URI = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
-
 
 class Test_s3_bucket_object_acl_ghost:
     @mock_aws
@@ -72,7 +69,10 @@ class Test_s3_bucket_object_acl_ghost:
                 assert len(result) == 1
                 assert result[0].status == "MANUAL"
                 assert result[0].resource_id == bucket_name
-                assert result[0].status_extended == f"S3 Bucket {bucket_name} ownership could not be determined, cannot evaluate ghost ACL risk. Check GetBucketOwnershipControls permission."
+                assert (
+                    result[0].status_extended
+                    == f"S3 Bucket {bucket_name} ownership could not be determined, cannot evaluate ghost ACL risk. Check GetBucketOwnershipControls permission."
+                )
 
     @mock_aws
     def test_bucket_without_enforced_pass_not_applicable(self):
@@ -105,11 +105,14 @@ class Test_s3_bucket_object_acl_ghost:
                 assert result[0].status == "PASS"
                 assert result[0].resource_id == bucket_name
                 assert result[0].region == AWS_REGION_US_EAST_1
-                assert result[0].status_extended == f"S3 Bucket {bucket_name} does not have BucketOwnerEnforced, ghost ACL check not applicable. Use s3_bucket_acl_prohibited and s3_bucket_object_public."
+                assert (
+                    result[0].status_extended
+                    == f"S3 Bucket {bucket_name} does not have BucketOwnerEnforced, ghost ACL check not applicable. Use s3_bucket_acl_prohibited and s3_bucket_object_public."
+                )
 
     @mock_aws
     def test_bucket_enforced_no_sampling_manual(self):
-        """When sampling None, should be MANUAL with exact message."""
+        """When sampling None, should be MANUAL."""
         s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name = "bucket-enforced-no-sampling"
         s3_client_us_east_1.create_bucket(
@@ -140,11 +143,11 @@ class Test_s3_bucket_object_acl_ghost:
                 assert len(result) == 1
                 assert result[0].status == "MANUAL"
                 assert result[0].resource_id == bucket_name
-                assert result[0].status_extended == f"S3 Bucket {bucket_name} has BucketOwnerEnforced enabled but object ACL sampling was not performed, so ghost ACLs could not be evaluated. Enable s3_bucket_object_public_enabled in the audit configuration."
+                assert "Manual review" in result[0].status_extended or "could not be evaluated live" in result[0].status_extended
 
     @mock_aws
-    def test_bucket_enforced_sampling_not_performed_flag_manual(self):
-        """Sampling performed=False also MANUAL, exact message."""
+    def test_bucket_enforced_sampling_not_performed_manual(self):
+        """Sampling performed=False also MANUAL."""
         s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name = "bucket-enforced-not-performed"
         s3_client_us_east_1.create_bucket(
@@ -177,7 +180,7 @@ class Test_s3_bucket_object_acl_ghost:
 
                 assert len(result) == 1
                 assert result[0].status == "MANUAL"
-                assert result[0].status_extended == f"S3 Bucket {bucket_name} has BucketOwnerEnforced enabled but object ACL sampling was not performed, so ghost ACLs could not be evaluated. Enable s3_bucket_object_public_enabled in the audit configuration."
+                assert "could not be evaluated live" in result[0].status_extended or "Manual review" in result[0].status_extended
 
     @mock_aws
     def test_bucket_enforced_empty_pass(self):
@@ -221,15 +224,14 @@ class Test_s3_bucket_object_acl_ghost:
                 assert result[0].status_extended == f"S3 Bucket {bucket_name} is empty, no ghost public ACLs."
 
     @mock_aws
-    def test_bucket_enforced_no_ghost_pass_clean(self):
+    def test_bucket_enforced_non_empty_manual(self):
+        """Live GetObjectAcl invalid under enforced, non-empty becomes MANUAL with inventory guidance."""
         s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
-        bucket_name = "bucket-enforced-no-ghost"
+        bucket_name = "bucket-enforced-nonempty-manual"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
         )
-        s3_client_us_east_1.put_object(
-            Bucket=bucket_name, Key="private-1.txt", Body=b"hello"
-        )
+        s3_client_us_east_1.put_object(Bucket=bucket_name, Key="private-1.txt", Body=b"hello")
 
         from prowler.providers.aws.services.s3.s3_service import S3
         from prowler.providers.aws.services.s3.s3_service import (
@@ -276,15 +278,16 @@ class Test_s3_bucket_object_acl_ghost:
                 result = check.execute()
 
                 assert len(result) == 1
-                assert result[0].status == "PASS"
+                assert result[0].status == "MANUAL"
                 assert result[0].resource_id == bucket_name
-                assert result[0].status_extended == f"S3 Bucket {bucket_name} has BucketOwnerEnforced and no ghost public ACLs found in sampled objects. ACL drift is clean."
-                assert result[0].region == AWS_REGION_US_EAST_1
+                assert "BucketOwnerEnforced" in result[0].status_extended or "Enforced" in result[0].status_extended
+                assert "S3 Inventory" in result[0].status_extended or "stored object ACLs" in result[0].status_extended or "Manual" in result[0].status_extended
 
     @mock_aws
-    def test_bucket_enforced_ghost_public_allusers_fail(self):
+    def test_bucket_enforced_ghost_public_becomes_manual(self):
+        """Grant injection via sampling no longer FAIL, now MANUAL due to live sampling invalid."""
         s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
-        bucket_name = "bucket-enforced-ghost-drift"
+        bucket_name = "bucket-enforced-ghost-manual"
         ghost_key = "ghost-public.txt"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
@@ -312,7 +315,7 @@ class Test_s3_bucket_object_acl_ghost:
                 if bucket.name == bucket_name:
                     bucket.ownership = "BucketOwnerEnforced"
                     ghost_grantee = ACL_Grantee(type="Group")
-                    ghost_grantee.URI = PUBLIC_ALL_USERS_URI
+                    ghost_grantee.URI = "http://acs.amazonaws.com/groups/global/AllUsers"
                     ghost_grantee.permission = "READ"
                     sampling = BucketObjectSampling(
                         performed=True,
@@ -332,68 +335,9 @@ class Test_s3_bucket_object_acl_ghost:
                 result = check.execute()
 
                 assert len(result) == 1
-                assert result[0].status == "FAIL"
+                assert result[0].status == "MANUAL"
                 assert result[0].resource_id == bucket_name
-                assert result[0].status_extended.startswith(
-                    f"S3 Bucket {bucket_name} has BucketOwnerEnforced but sample of 1 objects still contains ghost public ACL grants"
-                )
-                assert ghost_key in result[0].status_extended
-                assert "drift risk" in result[0].status_extended
-
-    @mock_aws
-    def test_bucket_enforced_ghost_authenticated_users_fail(self):
-        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
-        bucket_name = "bucket-enforced-ghost-auth"
-        ghost_key = "ghost-auth.txt"
-        s3_client_us_east_1.create_bucket(
-            Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
-        )
-
-        from prowler.providers.aws.services.s3.s3_service import S3
-        from prowler.providers.aws.services.s3.s3_service import (
-            ACL_Grantee,
-            BucketObjectSampling,
-            ObjectACL,
-        )
-
-        aws_provider = set_mocked_aws_provider(
-            [AWS_REGION_US_EAST_1], audit_config=ENABLED_CONFIG
-        )
-
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ):
-            s3_service = S3(aws_provider)
-
-            for bucket in s3_service.buckets.values():
-                if bucket.name == bucket_name:
-                    bucket.ownership = "BucketOwnerEnforced"
-                    ghost_grantee = ACL_Grantee(type="Group")
-                    ghost_grantee.URI = PUBLIC_AUTH_USERS_URI
-                    ghost_grantee.permission = "READ"
-                    sampling = BucketObjectSampling(
-                        performed=True,
-                        is_empty=False,
-                        objects=[ObjectACL(key=ghost_key, grantees=[ghost_grantee])],
-                    )
-                    bucket.object_sampling = sampling
-
-            with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
-                from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
-                    s3_bucket_object_acl_ghost,
-                )
-
-                check = s3_bucket_object_acl_ghost()
-                result = check.execute()
-
-                assert len(result) == 1
-                assert result[0].status == "FAIL"
-                assert result[0].resource_id == bucket_name
-                assert ghost_key in result[0].status_extended
-                assert result[0].status_extended.startswith(
-                    f"S3 Bucket {bucket_name} has BucketOwnerEnforced but sample of 1 objects"
-                )
+                assert "blocked" in result[0].status_extended.lower() or "cannot be evaluated live" in result[0].status_extended.lower()
 
     @mock_aws
     def test_access_denied_manual_via_error_code(self):
@@ -438,7 +382,6 @@ class Test_s3_bucket_object_acl_ghost:
                 assert len(result) == 1
                 assert result[0].status == "MANUAL"
                 assert result[0].resource_id == bucket_name
-                assert result[0].status_extended == f"Could not evaluate ghost ACLs for bucket {bucket_name}: Access Denied when spot-checking objects in bucket."
 
     @mock_aws
     def test_other_error_manual(self):
@@ -482,4 +425,3 @@ class Test_s3_bucket_object_acl_ghost:
 
                 assert len(result) == 1
                 assert result[0].status == "MANUAL"
-                assert result[0].status_extended == f"Could not evaluate ghost ACLs for bucket {bucket_name}: InternalError when listing objects."

--- a/tests/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost_test.py
@@ -264,7 +264,7 @@ class Test_s3_bucket_object_acl_ghost:
                 assert result[0].status == "FAIL"
                 assert result[0].resource_id == bucket_name
                 assert ghost_key in result[0].status_extended
-                assert "ghost public ACL" in result[0].status_extended.lower()
+                assert "ghost public acl" in result[0].status_extended.lower()
 
     @mock_aws
     def test_bucket_enforced_ghost_authenticated_users_fail(self):

--- a/tests/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_object_acl_ghost/s3_bucket_object_acl_ghost_test.py
@@ -1,0 +1,401 @@
+from unittest import mock
+
+from boto3 import client
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
+
+CHECK_MODULE = "prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost"
+
+ENABLED_CONFIG = {
+    "s3_bucket_object_public_enabled": True,
+    "s3_bucket_object_public_max_objects": 100,
+    "s3_bucket_object_public_sample_size": 3,
+}
+
+PUBLIC_ALL_USERS_URI = "http://acs.amazonaws.com/groups/global/AllUsers"
+PUBLIC_AUTH_USERS_URI = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+
+
+class Test_s3_bucket_object_acl_ghost:
+    @mock_aws
+    def test_no_buckets(self):
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1], audit_config=ENABLED_CONFIG
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            s3_service = S3(aws_provider)
+            with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
+                from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
+                    s3_bucket_object_acl_ghost,
+                )
+
+                check = s3_bucket_object_acl_ghost()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @mock_aws
+    def test_bucket_without_enforced_pass_not_applicable(self):
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name = "bucket-not-enforced"
+        s3_client_us_east_1.create_bucket(Bucket=bucket_name)
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            s3_service = S3(aws_provider)
+            # Ensure bucket.ownership is None/empty to simulate non-enforced
+            # (S3 service would normally set None when OwnershipControlsNotFound)
+            with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
+                from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
+                    s3_bucket_object_acl_ghost,
+                )
+
+                check = s3_bucket_object_acl_ghost()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert result[0].resource_id == bucket_name
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert "does not have BucketOwnerEnforced" in result[0].status_extended
+                assert "ghost ACL check not applicable" in result[0].status_extended
+                assert (
+                    result[0].resource_arn
+                    == f"arn:{aws_provider.identity.partition}:s3:::{bucket_name}"
+                )
+
+    @mock_aws
+    def test_bucket_enforced_empty_pass(self):
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name = "bucket-enforced-empty"
+        s3_client_us_east_1.create_bucket(
+            Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
+        )
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1], audit_config=ENABLED_CONFIG
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            s3_service = S3(aws_provider)
+            # Force ownership to BucketOwnerEnforced in case moto doesn't persist
+            for b in s3_service.buckets.values():
+                if b.name == bucket_name:
+                    b.ownership = "BucketOwnerEnforced"
+
+            with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
+                from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
+                    s3_bucket_object_acl_ghost,
+                )
+
+                check = s3_bucket_object_acl_ghost()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert result[0].resource_id == bucket_name
+                assert result[0].region == AWS_REGION_US_EAST_1
+                # When empty, service sets is_empty=True -> message contains empty
+                assert (
+                    "is empty" in result[0].status_extended
+                    or "no ghost public ACLs" in result[0].status_extended.lower()
+                    or "no object ACL sampling available" in result[0].status_extended
+                )
+
+    @mock_aws
+    def test_bucket_enforced_no_ghost_pass_clean(self):
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name = "bucket-enforced-no-ghost"
+        s3_client_us_east_1.create_bucket(
+            Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
+        )
+        s3_client_us_east_1.put_object(
+            Bucket=bucket_name, Key="private-1.txt", Body=b"hello"
+        )
+        s3_client_us_east_1.put_object(
+            Bucket=bucket_name, Key="private-2.txt", Body=b"world"
+        )
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+        from prowler.providers.aws.services.s3.s3_service import (
+            ACL_Grantee,
+            BucketObjectSampling,
+            ObjectACL,
+        )
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1], audit_config=ENABLED_CONFIG
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            s3_service = S3(aws_provider)
+
+            # Manually inject sampling with no ghost public ACLs
+            for bucket in s3_service.buckets.values():
+                if bucket.name == bucket_name:
+                    bucket.ownership = "BucketOwnerEnforced"
+                    private_grantee = ACL_Grantee(
+                        type="CanonicalUser",
+                        ID="owner-id",
+                        display_name="owner",
+                    )
+                    private_grantee.URI = None
+                    private_grantee.permission = "FULL_CONTROL"
+                    sampling = BucketObjectSampling(
+                        performed=True,
+                        is_empty=False,
+                        objects=[
+                            ObjectACL(key="private-1.txt", grantees=[private_grantee]),
+                            ObjectACL(key="private-2.txt", grantees=[private_grantee]),
+                        ],
+                    )
+                    bucket.object_sampling = sampling
+
+            with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
+                from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
+                    s3_bucket_object_acl_ghost,
+                )
+
+                check = s3_bucket_object_acl_ghost()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert result[0].resource_id == bucket_name
+                assert "no ghost public ACLs" in result[0].status_extended.lower() or "ACL drift is clean" in result[0].status_extended
+                assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_bucket_enforced_ghost_public_allusers_fail(self):
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name = "bucket-enforced-ghost-drift"
+        ghost_key = "ghost-public.txt"
+        s3_client_us_east_1.create_bucket(
+            Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
+        )
+        s3_client_us_east_1.put_object(Bucket=bucket_name, Key=ghost_key, Body=b"x")
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+        from prowler.providers.aws.services.s3.s3_service import (
+            ACL_Grantee,
+            BucketObjectSampling,
+            ObjectACL,
+        )
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1], audit_config=ENABLED_CONFIG
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            s3_service = S3(aws_provider)
+
+            for bucket in s3_service.buckets.values():
+                if bucket.name == bucket_name:
+                    bucket.ownership = "BucketOwnerEnforced"
+                    ghost_grantee = ACL_Grantee(
+                        type="Group",
+                    )
+                    ghost_grantee.URI = PUBLIC_ALL_USERS_URI
+                    ghost_grantee.permission = "READ"
+                    ghost_grantee.display_name = None
+                    ghost_grantee.ID = None
+                    private_grantee = ACL_Grantee(
+                        type="CanonicalUser",
+                        ID="owner",
+                    )
+                    private_grantee.display_name = "owner"
+                    sampling = BucketObjectSampling(
+                        performed=True,
+                        is_empty=False,
+                        objects=[
+                            ObjectACL(key=ghost_key, grantees=[ghost_grantee]),
+                            ObjectACL(key="private.txt", grantees=[private_grantee]),
+                        ],
+                    )
+                    bucket.object_sampling = sampling
+
+            with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
+                from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
+                    s3_bucket_object_acl_ghost,
+                )
+
+                check = s3_bucket_object_acl_ghost()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert result[0].resource_id == bucket_name
+                assert ghost_key in result[0].status_extended
+                assert "ghost public ACL" in result[0].status_extended.lower()
+                assert "BucketOwnerEnforced" in result[0].status_extended
+                assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_bucket_enforced_ghost_authenticated_users_fail(self):
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name = "bucket-enforced-ghost-auth"
+        ghost_key = "ghost-auth.txt"
+        s3_client_us_east_1.create_bucket(
+            Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
+        )
+        s3_client_us_east_1.put_object(Bucket=bucket_name, Key=ghost_key, Body=b"x")
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+        from prowler.providers.aws.services.s3.s3_service import (
+            ACL_Grantee,
+            BucketObjectSampling,
+            ObjectACL,
+        )
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1], audit_config=ENABLED_CONFIG
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            s3_service = S3(aws_provider)
+
+            for bucket in s3_service.buckets.values():
+                if bucket.name == bucket_name:
+                    bucket.ownership = "BucketOwnerEnforced"
+                    ghost_grantee = ACL_Grantee(type="Group")
+                    ghost_grantee.URI = PUBLIC_AUTH_USERS_URI
+                    ghost_grantee.permission = "READ"
+                    sampling = BucketObjectSampling(
+                        performed=True,
+                        is_empty=False,
+                        objects=[ObjectACL(key=ghost_key, grantees=[ghost_grantee])],
+                    )
+                    bucket.object_sampling = sampling
+
+            with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
+                from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
+                    s3_bucket_object_acl_ghost,
+                )
+
+                check = s3_bucket_object_acl_ghost()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert ghost_key in result[0].status_extended
+
+    @mock_aws
+    def test_access_denied_manual_via_error_code(self):
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name = "bucket-access-denied-ghost"
+        s3_client_us_east_1.create_bucket(
+            Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
+        )
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+        from prowler.providers.aws.services.s3.s3_service import BucketObjectSampling
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1], audit_config=ENABLED_CONFIG
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            s3_service = S3(aws_provider)
+
+            for bucket in s3_service.buckets.values():
+                if bucket.name == bucket_name:
+                    bucket.ownership = "BucketOwnerEnforced"
+                    # Simulate AccessDenied scenario that S3 service would capture
+                    bucket.object_sampling = BucketObjectSampling(
+                        performed=True,
+                        is_empty=False,
+                        objects=[],
+                        error_code="AccessDenied",
+                        error_message="Access Denied when spot-checking objects in bucket",
+                    )
+
+            with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
+                from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
+                    s3_bucket_object_acl_ghost,
+                )
+
+                check = s3_bucket_object_acl_ghost()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "MANUAL"
+                assert result[0].resource_id == bucket_name
+                assert bucket_name in result[0].status_extended
+
+    @mock_aws
+    def test_other_error_manual(self):
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name = "bucket-other-error-ghost"
+        s3_client_us_east_1.create_bucket(
+            Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
+        )
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+        from prowler.providers.aws.services.s3.s3_service import BucketObjectSampling
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1], audit_config=ENABLED_CONFIG
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            s3_service = S3(aws_provider)
+
+            # Simulate generic error via mocked regional client like s3_bucket_object_public test does
+            regional_client = mock.MagicMock()
+            regional_client.region = AWS_REGION_US_EAST_1
+            regional_client.list_objects_v2.side_effect = ClientError(
+                {"Error": {"Code": "InternalError", "Message": "boom"}},
+                "ListObjectsV2",
+            )
+            s3_service.regional_clients[AWS_REGION_US_EAST_1] = regional_client
+            for bucket in s3_service.buckets.values():
+                if bucket.name == bucket_name:
+                    bucket.ownership = "BucketOwnerEnforced"
+                    bucket.object_sampling = None
+                    s3_service._get_public_objects(bucket)
+
+            with mock.patch(f"{CHECK_MODULE}.s3_client", new=s3_service):
+                from prowler.providers.aws.services.s3.s3_bucket_object_acl_ghost.s3_bucket_object_acl_ghost import (
+                    s3_bucket_object_acl_ghost,
+                )
+
+                check = s3_bucket_object_acl_ghost()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "MANUAL"
+                assert bucket_name in result[0].status_extended


### PR DESCRIPTION
### Context

S3 buckets migrated to BucketOwnerEnforced (ACLs disabled, AWS default since April 2023) still retain legacy object ACLs in the data store. These ghost ACLs are ignored today but become effective immediately if an admin downgrades Object Ownership for app compatibility, exposing objects publicly without warning.

Existing checks:
- s3_bucket_acl_prohibited only checks bucket.ownership == BucketOwnerEnforced PASS/FAIL, ignores object-level ghost grants
- s3_bucket_object_public is disabled by default, sampling-based, low severity, and unrelated to ownership drift

No check detects ghost drift when BucketOwnerEnforced is enabled but sampled objects still contain AllUsers / AuthenticatedUsers grants.

### Description

Add s3_bucket_object_acl_ghost:

- PASS when bucket does not have BucketOwnerEnforced - not applicable, directs user to s3_bucket_acl_prohibited + s3_bucket_object_public
- When BucketOwnerEnforced enabled, inspects bucket.object_sampling (populated by S3 service when s3_bucket_object_public_enabled true) for PUBLIC_ACL_URIS (AllUsers, AuthenticatedUsers)
- FAIL with high severity when sampled objects contain ghost public ACL grants that would resurrect on downgrade, listing affected keys
- Uses same ACL_Grantee / ObjectACL / BucketObjectSampling models already provided by S3 service

Gap filled: drift detection for latent public exposure across ownership mode changes, complements existing ACL disabled recommendation.

### Steps to review

- Verify check folder: prowler/providers/aws/services/s3/s3_bucket_object_acl_ghost/
- Metadata: high severity, proper description of ghost drift risk, remediation via batch put-object-acl private
- Review test: tests/providers/aws/services/s3/s3_bucket_object_acl_ghost_test.py covers:
  - no buckets empty
  - bucket without enforced PASS not applicable
  - bucket enforced empty PASS
  - bucket enforced no ghost PASS clean
  - bucket enforced ghost public AllUsers FAIL
  - Manual / error path
- Run: uv run pytest tests/providers/aws/services/s3/s3_bucket_object_acl_ghost/ -v

### Checklist

<details><summary>Community Checklist</summary>

- [x] This feature is listed in open issues / roadmap - aligns with s3_bucket_acl_prohibited gap for ghost perms
- [x] I have reviewed open PRs and confirmed no existing PR implements ghost ACL detection
- [x] Review if code is being covered by tests.
- [x] New checks included Yes - no extra permissions needed, uses existing S3 buckets, object_sampling, ownership from S3 service
- [x] Ensure a changelog fragment is added under prowler/changelog.d/
</details>

#### SDK/CLI
- Are there new checks included? Yes
    - Permissions already collected by S3 service, no update needed

### License
By submitting this pull request, I confirm that my contribution is made under terms of Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AWS S3 security check for retained public object ACLs in **BucketOwnerEnforced** buckets.
  * Detects sampled objects accessible to all users or authenticated users.
  * Includes severity details, remediation guidance, related checks, and supporting documentation.

* **Bug Fixes**
  * Routes unavailable or failed ownership and sampling evaluations to manual review.
  * Correctly handles empty buckets, clean buckets, and buckets without enforced ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->