### PR TITLE
fix(ui): prevent timezone mismatch in scan findings links

### DIFF
--- a/ui/changelog.d/scan-findings-timezone.fixed.md
+++ b/ui/changelog.d/scan-findings-timezone.fixed.md
@@ -1,0 +1,1 @@
+`View Findings` from completed scans no longer returns empty results near local midnight in non-UTC timezones

--- a/ui/components/scans/table/scan-jobs-row-actions.test.tsx
+++ b/ui/components/scans/table/scan-jobs-row-actions.test.tsx
@@ -44,11 +44,6 @@ vi.mock("@/lib/helper", () => ({
   downloadScanZip: downloadScanZipMock,
 }));
 
-vi.mock("@/lib/date-utils", () => ({
-  toLocalDateString: (value: string | null | undefined) =>
-    value ? "2026-01-01" : undefined,
-}));
-
 vi.mock("@/components/scans/edit-alias-modal", () => ({
   EditAliasModal: ({
     open,
@@ -314,14 +309,14 @@ describe("ScanJobsRowActions", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("links completed scans to filtered findings", async () => {
+  it("delegates scan date resolution when opening findings", async () => {
     // Given
     const user = userEvent.setup();
     render(
       <ScanJobsRowActions
         scan={makeScan({
           state: "completed",
-          completed_at: "2026-01-01T10:05:00Z",
+          completed_at: "2026-08-01T14:30:00Z",
         })}
         tab="completed"
       />,
@@ -335,7 +330,7 @@ describe("ScanJobsRowActions", () => {
 
     // Then
     expect(pushMock).toHaveBeenCalledWith(
-      "/findings?filter[scan__in]=scan-1&filter[inserted_at]=2026-01-01&filter[status__in]=FAIL",
+      "/findings?filter[scan__in]=scan-1&filter[status__in]=FAIL",
     );
   });
 

--- a/ui/components/scans/table/scan-jobs-row-actions.tsx
+++ b/ui/components/scans/table/scan-jobs-row-actions.tsx
@@ -30,7 +30,6 @@ import {
   ActionDropdownItem,
 } from "@/components/shadcn/dropdown";
 import { buildPerScanComplianceHref } from "@/lib/compliance/compliance-tab-url";
-import { toLocalDateString } from "@/lib/date-utils";
 import { downloadScanZip } from "@/lib/helper";
 import { getScanScheduleCapability } from "@/lib/schedules";
 import { isCloud } from "@/lib/shared/env";
@@ -80,7 +79,7 @@ export function ScanJobsRowActions({
   const isCompleted = scanState === "completed";
   const isFailed = scanState === "failed";
   const taskId = scan.relationships.task.data?.id;
-  const scanDate = toLocalDateString(scan.attributes.completed_at);
+  const canViewFindings = isCompleted && Boolean(scan.attributes.completed_at);
   const providerId = scan.relationships.provider.data?.id;
   const scheduleProvider: ScanScheduleProvider | undefined = providerId
     ? {
@@ -92,9 +91,9 @@ export function ScanJobsRowActions({
     : undefined;
 
   const openFindings = () => {
-    if (!isCompleted || !scanDate) return;
+    if (!canViewFindings) return;
     router.push(
-      `/findings?filter[scan__in]=${scan.id}&filter[inserted_at]=${scanDate}&filter[status__in]=FAIL`,
+      `/findings?filter[scan__in]=${scan.id}&filter[status__in]=FAIL`,
     );
   };
 
@@ -202,7 +201,7 @@ export function ScanJobsRowActions({
               icon={<Eye />}
               label="View Findings"
               onSelect={openFindings}
-              disabled={!isCompleted || !scanDate}
+              disabled={!canViewFindings}
             />
             <ActionDropdownItem
               icon={<ShieldCheck />}


### PR DESCRIPTION
### Context

Completed scans can return an empty **View Findings** result when the browser-local completion date differs from the UTC date used by the findings API.

The scan row action added the browser-local date as `filter[inserted_at]`. The API interpreted that value as a UTC day and combined it with the scan ID, which could exclude every finding for scans completing near local midnight.

### Description

- Remove the browser-local `inserted_at` value from completed-scan findings links
- Let the existing Findings page resolver derive the UTC date from the scan completion timestamp
- Preserve the existing API request, UTC partition filtering, and database performance
- Add regression coverage using a timestamp that crosses the Canberra local-date boundary

### Steps to review

1. Run linter and tests.
2. Open the actions menu for a completed scan and select **View Findings**.
3. Confirm that the URL contains `filter[scan__in]` and `filter[status__in]=FAIL`, without `filter[inserted_at]`.
4. Confirm that the Findings page displays the selected scan’s findings.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### UI

- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where viewing findings from completed scans could return empty results near local midnight in non-UTC time zones.
  - Improved findings navigation by consistently using the scan completion status and timestamp.
  - Updated the findings action to remain unavailable until a scan has completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->