### PR TITLE
fix(ui): open scan findings using the scan's UTC day

### DIFF
--- a/ui/changelog.d/scan-findings-utc-day.fixed.md
+++ b/ui/changelog.d/scan-findings-utc-day.fixed.md
@@ -1,1 +1,1 @@
-`View Findings` on the Scans page no longer opens an empty list when the scan finished on a different day in the browser's timezone, and the results now include scans whose findings span two UTC days
+`View Findings` on the Scans page no longer opens an empty list for users outside the UTC timezone

--- a/ui/changelog.d/scan-findings-utc-day.fixed.md
+++ b/ui/changelog.d/scan-findings-utc-day.fixed.md
@@ -1,0 +1,1 @@
+`View Findings` on the Scans page no longer opens an empty list when the scan finished on a different day in the browser's timezone, and the results now include scans whose findings span two UTC days

--- a/ui/components/scans/table/scan-jobs-row-actions.test.tsx
+++ b/ui/components/scans/table/scan-jobs-row-actions.test.tsx
@@ -329,14 +329,14 @@ describe("ScanJobsRowActions", () => {
     );
     await user.click(screen.getByRole("menuitem", { name: /view findings/i }));
 
-    // Then - the date is derived server-side in UTC, never in the URL.
+    // Then
     expect(pushMock).toHaveBeenCalledWith(
       "/findings?filter[scan__in]=scan-1&filter[status__in]=FAIL",
     );
   });
 
   it("disables View Findings when the completed scan has no completion timestamp", async () => {
-    // Given - without `completed_at` there is no date the server can derive.
+    // Given
     const user = userEvent.setup();
     render(
       <ScanJobsRowActions

--- a/ui/components/scans/table/scan-jobs-row-actions.test.tsx
+++ b/ui/components/scans/table/scan-jobs-row-actions.test.tsx
@@ -44,11 +44,6 @@ vi.mock("@/lib/helper", () => ({
   downloadScanZip: downloadScanZipMock,
 }));
 
-vi.mock("@/lib/date-utils", () => ({
-  toLocalDateString: (value: string | null | undefined) =>
-    value ? "2026-01-01" : undefined,
-}));
-
 vi.mock("@/components/scans/edit-alias-modal", () => ({
   EditAliasModal: ({
     open,
@@ -314,13 +309,14 @@ describe("ScanJobsRowActions", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("links completed scans to filtered findings", async () => {
+  it("links completed scans to filtered findings without a browser-local date", async () => {
     // Given
     const user = userEvent.setup();
     render(
       <ScanJobsRowActions
         scan={makeScan({
           state: "completed",
+          started_at: "2026-01-01T09:50:00Z",
           completed_at: "2026-01-01T10:05:00Z",
         })}
         tab="completed"
@@ -333,10 +329,34 @@ describe("ScanJobsRowActions", () => {
     );
     await user.click(screen.getByRole("menuitem", { name: /view findings/i }));
 
-    // Then
+    // Then - the date is derived server-side in UTC, never in the URL.
     expect(pushMock).toHaveBeenCalledWith(
-      "/findings?filter[scan__in]=scan-1&filter[inserted_at]=2026-01-01&filter[status__in]=FAIL",
+      "/findings?filter[scan__in]=scan-1&filter[status__in]=FAIL",
     );
+  });
+
+  it("disables View Findings when the completed scan has no completion timestamp", async () => {
+    // Given - without `completed_at` there is no date the server can derive.
+    const user = userEvent.setup();
+    render(
+      <ScanJobsRowActions
+        scan={makeScan({ state: "completed", completed_at: "" })}
+        tab="completed"
+      />,
+    );
+
+    // When
+    await user.click(
+      screen.getByRole("button", { name: /open actions menu/i }),
+    );
+    const viewFindings = screen.getByRole("menuitem", {
+      name: /view findings/i,
+    });
+    await user.click(viewFindings);
+
+    // Then
+    expect(viewFindings).toHaveAttribute("aria-disabled", "true");
+    expect(pushMock).not.toHaveBeenCalled();
   });
 
   it("triggers downloadScanZip with the scan id when downloading reports", async () => {

--- a/ui/components/scans/table/scan-jobs-row-actions.tsx
+++ b/ui/components/scans/table/scan-jobs-row-actions.tsx
@@ -79,9 +79,7 @@ export function ScanJobsRowActions({
   const isCompleted = scanState === "completed";
   const isFailed = scanState === "failed";
   const taskId = scan.relationships.task.data?.id;
-  // The findings page derives the UTC day range from the scan itself; without a
-  // completion timestamp there is nothing to derive and the API rejects the
-  // request for missing a date filter.
+  // Without a completion timestamp the findings page has no date to derive.
   const hasCompletedAt = Boolean(scan.attributes.completed_at);
   const providerId = scan.relationships.provider.data?.id;
   const scheduleProvider: ScanScheduleProvider | undefined = providerId

--- a/ui/components/scans/table/scan-jobs-row-actions.tsx
+++ b/ui/components/scans/table/scan-jobs-row-actions.tsx
@@ -30,7 +30,6 @@ import {
   ActionDropdownItem,
 } from "@/components/shadcn/dropdown";
 import { buildPerScanComplianceHref } from "@/lib/compliance/compliance-tab-url";
-import { toLocalDateString } from "@/lib/date-utils";
 import { downloadScanZip } from "@/lib/helper";
 import { getScanScheduleCapability } from "@/lib/schedules";
 import { isCloud } from "@/lib/shared/env";
@@ -80,7 +79,10 @@ export function ScanJobsRowActions({
   const isCompleted = scanState === "completed";
   const isFailed = scanState === "failed";
   const taskId = scan.relationships.task.data?.id;
-  const scanDate = toLocalDateString(scan.attributes.completed_at);
+  // The findings page derives the UTC day range from the scan itself; without a
+  // completion timestamp there is nothing to derive and the API rejects the
+  // request for missing a date filter.
+  const hasCompletedAt = Boolean(scan.attributes.completed_at);
   const providerId = scan.relationships.provider.data?.id;
   const scheduleProvider: ScanScheduleProvider | undefined = providerId
     ? {
@@ -92,9 +94,9 @@ export function ScanJobsRowActions({
     : undefined;
 
   const openFindings = () => {
-    if (!isCompleted || !scanDate) return;
+    if (!isCompleted || !hasCompletedAt) return;
     router.push(
-      `/findings?filter[scan__in]=${scan.id}&filter[inserted_at]=${scanDate}&filter[status__in]=FAIL`,
+      `/findings?filter[scan__in]=${scan.id}&filter[status__in]=FAIL`,
     );
   };
 
@@ -202,7 +204,7 @@ export function ScanJobsRowActions({
               icon={<Eye />}
               label="View Findings"
               onSelect={openFindings}
-              disabled={!isCompleted || !scanDate}
+              disabled={!isCompleted || !hasCompletedAt}
             />
             <ActionDropdownItem
               icon={<ShieldCheck />}

--- a/ui/components/scans/table/scan-jobs-row-actions.tsx
+++ b/ui/components/scans/table/scan-jobs-row-actions.tsx
@@ -79,7 +79,8 @@ export function ScanJobsRowActions({
   const isCompleted = scanState === "completed";
   const isFailed = scanState === "failed";
   const taskId = scan.relationships.task.data?.id;
-  // Without a completion timestamp the findings page has no date to derive.
+  // The findings page bounds the UTC day range with completed_at; without it the
+  // range collapses to the start day and can miss later findings.
   const hasCompletedAt = Boolean(scan.attributes.completed_at);
   const providerId = scan.relationships.provider.data?.id;
   const scheduleProvider: ScanScheduleProvider | undefined = providerId

--- a/ui/lib/findings-scan-filters.test.ts
+++ b/ui/lib/findings-scan-filters.test.ts
@@ -87,6 +87,120 @@ describe("resolveFindingScanDateFilters", () => {
     });
   });
 
+  it("keeps a single day when the scan starts and completes on the same UTC day", async () => {
+    const result = await resolveFindingScanDateFilters({
+      filters: {
+        "filter[scan__in]": "scan-1",
+      },
+      scans: [
+        {
+          id: "scan-1",
+          attributes: {
+            started_at: "2026-04-07T09:40:00Z",
+            completed_at: "2026-04-07T10:00:00Z",
+          },
+        },
+      ],
+      loadScan: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      "filter[scan__in]": "scan-1",
+      "filter[inserted_at]": "2026-04-07",
+    });
+  });
+
+  it("covers both UTC days for a scan that crosses midnight while inserting findings", async () => {
+    const result = await resolveFindingScanDateFilters({
+      filters: {
+        "filter[scan__in]": "scan-1",
+      },
+      scans: [
+        {
+          id: "scan-1",
+          attributes: {
+            started_at: "2026-04-06T23:40:00Z",
+            completed_at: "2026-04-07T00:15:00Z",
+          },
+        },
+      ],
+      loadScan: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      "filter[scan__in]": "scan-1",
+      "filter[inserted_at__gte]": "2026-04-06",
+      "filter[inserted_at__lte]": "2026-04-07",
+    });
+  });
+
+  it("derives the day from started_at when the scan has not completed yet", async () => {
+    const result = await resolveFindingScanDateFilters({
+      filters: {
+        "filter[scan__in]": "scan-1",
+      },
+      scans: [
+        {
+          id: "scan-1",
+          attributes: {
+            started_at: "2026-04-07T09:40:00Z",
+          },
+        },
+      ],
+      loadScan: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      "filter[scan__in]": "scan-1",
+      "filter[inserted_at]": "2026-04-07",
+    });
+  });
+
+  it("leaves the filters untouched when the scan exposes no timestamps", async () => {
+    const result = await resolveFindingScanDateFilters({
+      filters: {
+        "filter[scan__in]": "scan-1",
+      },
+      scans: [{ id: "scan-1", attributes: {} }],
+      loadScan: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      "filter[scan__in]": "scan-1",
+    });
+  });
+
+  it("spans every selected scan when several scans are filtered at once", async () => {
+    const result = await resolveFindingScanDateFilters({
+      filters: {
+        "filter[scan__in]": "scan-1,scan-2",
+      },
+      scans: [
+        {
+          id: "scan-1",
+          attributes: {
+            started_at: "2026-04-05T23:50:00Z",
+            completed_at: "2026-04-06T00:10:00Z",
+          },
+        },
+        {
+          id: "scan-2",
+          attributes: {
+            started_at: "2026-04-07T08:00:00Z",
+            completed_at: "2026-04-07T08:30:00Z",
+          },
+        },
+      ],
+      loadScan: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      "filter[scan__in]": "scan-1,scan-2",
+      "filter[inserted_at__gte]": "2026-04-05",
+      "filter[inserted_at__lte]": "2026-04-07",
+    });
+  });
+
   it("does not override an explicit inserted_at filter already chosen in the frontend", async () => {
     const result = await resolveFindingScanDateFilters({
       filters: {

--- a/ui/lib/findings-scan-filters.ts
+++ b/ui/lib/findings-scan-filters.ts
@@ -1,10 +1,11 @@
 interface ScanDateSource {
   id: string;
   attributes?: {
-    // Findings are persisted when the scan finishes, so their `inserted_at`
-    // aligns with the scan's `completed_at` — not the scan's `inserted_at`
-    // (which is when the scan row was first created and can fall on a
-    // different UTC day for scans that cross midnight).
+    // Findings are inserted progressively while the scan runs and their UUIDv7
+    // `id` is stamped on insert, so they spread over every UTC day the scan
+    // spans. The range is derived from `started_at`/`completed_at` — not from
+    // the scan's `inserted_at`, which is when the scan row was created.
+    started_at?: string;
     completed_at?: string;
   };
 }
@@ -38,10 +39,10 @@ function hasInsertedAtFilter(filters: Record<string, string>): boolean {
 }
 
 export function buildFindingScanDateFilters(
-  scanCompletedAtValues: string[],
+  scanDateTimes: string[],
 ): Record<string, string> {
   const dates = Array.from(
-    new Set(scanCompletedAtValues.map(formatScanDate).filter(Boolean)),
+    new Set(scanDateTimes.map(formatScanDate).filter(Boolean)),
   ).sort() as string[];
 
   if (dates.length === 0) {
@@ -86,11 +87,14 @@ export async function resolveFindingScanDateFilters({
     });
   }
 
-  const scanCompletedAtValues = scanIds
-    .map((scanId) => scansById.get(scanId)?.attributes?.completed_at)
-    .filter((completedAt): completedAt is string => Boolean(completedAt));
+  const scanDateTimes = scanIds
+    .flatMap((scanId) => {
+      const attributes = scansById.get(scanId)?.attributes;
+      return [attributes?.started_at, attributes?.completed_at];
+    })
+    .filter((dateTime): dateTime is string => Boolean(dateTime));
 
-  const dateFilters = buildFindingScanDateFilters(scanCompletedAtValues);
+  const dateFilters = buildFindingScanDateFilters(scanDateTimes);
 
   if (Object.keys(dateFilters).length === 0) {
     return filters;

--- a/ui/lib/findings-scan-filters.ts
+++ b/ui/lib/findings-scan-filters.ts
@@ -1,10 +1,8 @@
 interface ScanDateSource {
   id: string;
   attributes?: {
-    // Findings are inserted progressively while the scan runs and their UUIDv7
-    // `id` is stamped on insert, so they spread over every UTC day the scan
-    // spans. The range is derived from `started_at`/`completed_at` — not from
-    // the scan's `inserted_at`, which is when the scan row was created.
+    // Findings are written throughout the run, so the range spans both
+    // timestamps, not the scan's `inserted_at` (when the row was created).
     started_at?: string;
     completed_at?: string;
   };


### PR DESCRIPTION
### Context

A customer reported that **View Findings** on the Scans page opened an empty list for their scheduled scans, while the same action on their manual scans worked. Filtering the Findings page by a specific date showed the same emptiness. Nothing was failing — the scans ran fine and the findings existed.

Root cause: the link was built with a date derived in the **browser's** timezone, but the API interprets `filter[inserted_at]` as a whole **UTC** day and materialises it as a UUIDv7 `id` range (`TIME_ZONE = "UTC"`). Since `filter[scan__in]` also constrains `id`, the two ranges intersect and the result is empty rather than unfiltered.

For a viewer at UTC+10 only local hours 10:00–23:59 share the UTC date, so a scan finishing in their early morning lands on the previous UTC day. Manual scans run during business hours and matched; the nightly scheduled scan did not. Exposure is `|offset| / 24` of the day and it breaks in both directions.

Measured on the dev environment — same scan, same filters, only the date differing:

| Scan finished | UTC date | Sydney date | Sent UTC date | Sent local date |
|---|---|---|---|---|
| `2026-08-03 15:24:41Z` | Aug 3 | Aug 4 | **596** findings · 130 groups | **0** · 0 |
| `2026-07-09 14:28:05Z` | Jul 9 | Jul 10 | **92** findings · 63 groups | **0** · 0 |

This PR fixes the Scans → Findings entry point. The date picker on the Findings page is affected by the same mismatch and is **not** covered here — it needs an API change to accept timestamp precision on the grouped and metadata endpoints, and will follow separately.

### Description

**Stop deriving the date in the browser.** `openFindings` no longer puts `filter[inserted_at]` in the URL at all. `resolveFindingScanDateFilters` already derives the range server-side from the scan's own timestamps in UTC (it splits the ISO string on `"T"`), but it short-circuits when the URL already carries an `inserted_at` — so the correct code path was being overridden by the incorrect one. Removing the local date lets it run. The menu item's guard now checks the raw `completed_at` instead of a derived local date, because without a completion timestamp there is nothing to derive and the API would answer `400 "At least one date filter is required"`.

**Cover every UTC day a scan spans.** The range is now derived from `started_at` **and** `completed_at`, not `completed_at` alone. Findings are `bulk_create`d progressively while a scan runs (`api/src/backend/tasks/jobs/scan.py`) and their UUIDv7 `id` is stamped on insert, so a scan straddling UTC midnight leaves findings on both days and the previous single-day range silently dropped the earlier ones. `buildFindingScanDateFilters` already emitted `gte`/`lte` for multiple dates, so this needed no shape change. A scan with only `completed_at` behaves exactly as before.

No API changes. No new dependencies.

### Steps to review

1. On the Scans page, open the actions menu of a completed scan and choose **View Findings**. The URL should contain only `filter[scan__in]` and `filter[status__in]=FAIL` — no `filter[inserted_at]`.
2. The findings list should be populated regardless of your machine's timezone. To exercise the bug directly, set your OS timezone to `Australia/Sydney` and use a scan that finished between 14:00Z and 15:59Z: before this change the list was empty, now it is not.
3. Confirm the menu item stays disabled for a completed scan with no `completed_at`.
4. Run the unit tests:

```bash
cd ui && pnpm vitest run --project unit components/scans/table/scan-jobs-row-actions.test.tsx lib/findings-scan-filters.test.ts
```

The tests pin: the URL carries no browser-local date; the item is disabled without `completed_at`; a same-day scan yields an exact `inserted_at`; a scan crossing midnight yields a `gte`/`lte` range; `started_at`-only and no-timestamp scans degrade gracefully; multiple selected scans span the full range.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? **No**
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md — not needed.
- [x] Ensure a changelog fragment is added under `<component>/changelog.d/`, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **No** — no SDK changes.

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under `ui/changelog.d/`

> No screenshots: there is no visual change. The fix alters the query string a menu item navigates to, so the difference is a populated list where it was previously empty — the reproduction steps above show it better than a screenshot would.

#### API (if applicable)

Not applicable — no API changes in this PR.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved **View Findings** navigation across browser timezones and scans spanning two UTC days.
  * Findings now reflect scans throughout their execution period, including incomplete scans.
  * Disabled **View Findings** when a scan has not completed or lacks a completion timestamp.
* **Tests**
  * Added coverage for timezone boundaries, incomplete scans, missing timestamps, and multiple selected scans.
* **Documentation**
  * Added a changelog entry describing the corrected empty findings list behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->