### PR TITLE
feat(ui): add Manage Lighthouse AI role permission

### DIFF
--- a/ui/actions/auth/auth.test.ts
+++ b/ui/actions/auth/auth.test.ts
@@ -21,7 +21,36 @@ vi.mock("@/lib/sentry-breadcrumbs", () => ({
   addAuthEvent: vi.fn(),
 }));
 
-import { createNewUser } from "./auth";
+import { createNewUser, getUserByMe } from "./auth";
+
+const userMeResponse = (roleAttributes: Record<string, boolean>) => ({
+  data: {
+    type: "users",
+    id: "019b1234-5678-7abc-9def-0123456789ab",
+    attributes: {
+      name: "Jane Doe",
+      email: "jane@example.com",
+      company_name: "Prowler",
+      date_joined: "2026-01-01T00:00:00.000Z",
+    },
+  },
+  included: [
+    {
+      type: "roles",
+      id: "role-1",
+      attributes: { name: "Cloud admin", ...roleAttributes },
+    },
+  ],
+});
+
+const mockUserMe = (roleAttributes: Record<string, boolean>) => {
+  fetchMock.mockResolvedValue(
+    new Response(JSON.stringify(userMeResponse(roleAttributes)), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+};
 
 describe("auth actions", () => {
   beforeEach(() => {
@@ -101,5 +130,28 @@ describe("auth actions", () => {
     const requestUrl = new URL(fetchMock.mock.calls[0][0]);
     expect(requestUrl.searchParams.get("promo_code")).toBe("black-hat-2026");
     expect(requestUrl.searchParams.get("utm_source")).toBe("blackhat");
+  });
+
+  it("should carry manage_lighthouse_ai_configuration into the session permissions", async () => {
+    // Given
+    mockUserMe({ manage_lighthouse_ai_configuration: true });
+
+    // When
+    const result = await getUserByMe("access-token");
+
+    // Then
+    expect(result.permissions.manage_lighthouse_ai_configuration).toBe(true);
+  });
+
+  it("should default manage_lighthouse_ai_configuration to false when the role omits it", async () => {
+    // Given
+    mockUserMe({ manage_users: true });
+
+    // When
+    const result = await getUserByMe("access-token");
+
+    // Then
+    expect(result.permissions.manage_lighthouse_ai_configuration).toBe(false);
+    expect(result.permissions.manage_users).toBe(true);
   });
 });

--- a/ui/actions/auth/auth.ts
+++ b/ui/actions/auth/auth.ts
@@ -181,6 +181,8 @@ export const getUserByMe = async (accessToken: string) => {
       manage_integrations: userRole.attributes.manage_integrations || false,
       manage_billing: userRole.attributes.manage_billing || false,
       manage_alerts: userRole.attributes.manage_alerts || false,
+      manage_lighthouse_ai_configuration:
+        userRole.attributes.manage_lighthouse_ai_configuration || false,
       unlimited_visibility: userRole.attributes.unlimited_visibility || false,
     };
 

--- a/ui/actions/roles/roles.test.ts
+++ b/ui/actions/roles/roles.test.ts
@@ -146,4 +146,17 @@ describe("role actions", () => {
       lastRequestBody().data.attributes.manage_lighthouse_ai_configuration,
     ).toBe(true);
   });
+
+  it("omits manage_lighthouse_ai_configuration when updating a role outside Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+
+    // When
+    await updateRole(makeRoleFormData(), "role-1");
+
+    // Then
+    expect(lastRequestBody().data.attributes).not.toHaveProperty(
+      "manage_lighthouse_ai_configuration",
+    );
+  });
 });

--- a/ui/actions/roles/roles.test.ts
+++ b/ui/actions/roles/roles.test.ts
@@ -49,6 +49,7 @@ const makeRoleFormData = () => {
   formData.set("manage_integrations", "false");
   formData.set("manage_scans", "false");
   formData.set("manage_alerts", "true");
+  formData.set("manage_lighthouse_ai_configuration", "true");
   formData.set("unlimited_visibility", "false");
   return formData;
 };
@@ -105,5 +106,44 @@ describe("role actions", () => {
 
     // Then
     expect(lastRequestBody().data.attributes.manage_alerts).toBe(true);
+  });
+
+  it("includes manage_lighthouse_ai_configuration when creating a role in Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+
+    // When
+    await addRole(makeRoleFormData());
+
+    // Then
+    expect(
+      lastRequestBody().data.attributes.manage_lighthouse_ai_configuration,
+    ).toBe(true);
+  });
+
+  it("omits manage_lighthouse_ai_configuration when creating a role outside Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+
+    // When
+    await addRole(makeRoleFormData());
+
+    // Then
+    expect(lastRequestBody().data.attributes).not.toHaveProperty(
+      "manage_lighthouse_ai_configuration",
+    );
+  });
+
+  it("includes manage_lighthouse_ai_configuration when updating a role in Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+
+    // When
+    await updateRole(makeRoleFormData(), "role-1");
+
+    // Then
+    expect(
+      lastRequestBody().data.attributes.manage_lighthouse_ai_configuration,
+    ).toBe(true);
   });
 });

--- a/ui/actions/roles/roles.ts
+++ b/ui/actions/roles/roles.ts
@@ -114,6 +114,8 @@ export const addRole = async (formData: FormData) => {
       formData.get("manage_billing") === "true";
     payload.data.attributes.manage_alerts =
       formData.get("manage_alerts") === "true";
+    payload.data.attributes.manage_lighthouse_ai_configuration =
+      formData.get("manage_lighthouse_ai_configuration") === "true";
   }
 
   // Add provider groups relationships only if there are items
@@ -171,6 +173,8 @@ export const updateRole = async (formData: FormData, roleId: string) => {
       formData.get("manage_billing") === "true";
     payload.data.attributes.manage_alerts =
       formData.get("manage_alerts") === "true";
+    payload.data.attributes.manage_lighthouse_ai_configuration =
+      formData.get("manage_lighthouse_ai_configuration") === "true";
   }
 
   // Add provider groups relationships only if there are items

--- a/ui/auth.config.ts
+++ b/ui/auth.config.ts
@@ -54,6 +54,7 @@ const DEFAULT_PERMISSIONS: RolePermissionAttributes = {
   manage_integrations: false,
   manage_billing: false,
   manage_alerts: false,
+  manage_lighthouse_ai_configuration: false,
   unlimited_visibility: false,
 };
 

--- a/ui/changelog.d/lighthouse-ai-configuration-role-permission.added.md
+++ b/ui/changelog.d/lighthouse-ai-configuration-role-permission.added.md
@@ -1,0 +1,1 @@
+Manage Lighthouse AI role permission in the role forms and role details, so permission to change the Lighthouse AI configuration can be granted or restricted independently of other permissions (Prowler Cloud only)

--- a/ui/components/roles/workflow/forms/add-role-form.test.tsx
+++ b/ui/components/roles/workflow/forms/add-role-form.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
+import { addRole } from "@/actions/roles/roles";
+
 import { AddRoleForm } from "./add-role-form";
 
 const routerMocks = vi.hoisted(() => ({
@@ -94,9 +96,31 @@ beforeAll(() => {
   window.ResizeObserver = ResizeObserverMock;
 });
 
+const submitRoleForm = async (
+  user: ReturnType<typeof userEvent.setup>,
+  { grantLighthouseAi }: { grantLighthouseAi: boolean },
+) => {
+  await user.type(screen.getByPlaceholderText("Enter role name"), "New role");
+
+  if (grantLighthouseAi) {
+    await user.click(
+      screen.getByRole("checkbox", { name: "Manage Lighthouse AI" }),
+    );
+  }
+
+  await user.click(screen.getByRole("button", { name: "Add Role" }));
+};
+
+const submittedFormData = () => {
+  const formData = vi.mocked(addRole).mock.calls.at(-1)?.[0];
+  if (!formData) throw new Error("addRole was not called");
+  return formData;
+};
+
 describe("AddRoleForm", () => {
   afterEach(() => {
     routerMocks.push.mockClear();
+    vi.mocked(addRole).mockClear();
     vi.unstubAllEnvs();
   });
 
@@ -124,6 +148,51 @@ describe("AddRoleForm", () => {
     expect(screen.queryByText("Manage Alerts")).not.toBeInTheDocument();
     expect(screen.queryByText("Manage Lighthouse AI")).not.toBeInTheDocument();
     expect(screen.queryByText("Manage Billing")).not.toBeInTheDocument();
+  });
+
+  it("submits manage_lighthouse_ai_configuration when granted in Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    const user = userEvent.setup();
+    render(<AddRoleForm groups={[]} />);
+
+    // When
+    await submitRoleForm(user, { grantLighthouseAi: true });
+
+    // Then
+    expect(submittedFormData().get("manage_lighthouse_ai_configuration")).toBe(
+      "true",
+    );
+  });
+
+  it("submits manage_lighthouse_ai_configuration as false when not granted in Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    const user = userEvent.setup();
+    render(<AddRoleForm groups={[]} />);
+
+    // When
+    await submitRoleForm(user, { grantLighthouseAi: false });
+
+    // Then
+    expect(submittedFormData().get("manage_lighthouse_ai_configuration")).toBe(
+      "false",
+    );
+  });
+
+  it("omits manage_lighthouse_ai_configuration from the submission outside Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+    const user = userEvent.setup();
+    render(<AddRoleForm groups={[]} />);
+
+    // When
+    await submitRoleForm(user, { grantLighthouseAi: false });
+
+    // Then
+    expect(submittedFormData().has("manage_lighthouse_ai_configuration")).toBe(
+      false,
+    );
   });
 
   it("navigates back to roles when cancel is clicked", async () => {

--- a/ui/components/roles/workflow/forms/add-role-form.test.tsx
+++ b/ui/components/roles/workflow/forms/add-role-form.test.tsx
@@ -61,6 +61,12 @@ vi.mock("@/lib", () => ({
       description: "Allows creating and managing custom alerts",
     },
     {
+      field: "manage_lighthouse_ai_configuration",
+      label: "Manage Lighthouse AI",
+      description:
+        "Allows configuring Lighthouse AI, including its provider credentials, default model and business context",
+    },
+    {
       field: "manage_billing",
       label: "Manage Billing",
       description: "Provides access to billing settings and invoices",
@@ -103,6 +109,7 @@ describe("AddRoleForm", () => {
 
     // Then
     expect(screen.getByText("Manage Alerts")).toBeInTheDocument();
+    expect(screen.getByText("Manage Lighthouse AI")).toBeInTheDocument();
     expect(screen.getByText("Manage Billing")).toBeInTheDocument();
   });
 
@@ -115,6 +122,7 @@ describe("AddRoleForm", () => {
 
     // Then
     expect(screen.queryByText("Manage Alerts")).not.toBeInTheDocument();
+    expect(screen.queryByText("Manage Lighthouse AI")).not.toBeInTheDocument();
     expect(screen.queryByText("Manage Billing")).not.toBeInTheDocument();
   });
 

--- a/ui/components/roles/workflow/forms/add-role-form.tsx
+++ b/ui/components/roles/workflow/forms/add-role-form.tsx
@@ -27,6 +27,7 @@ export const AddRoleForm = ({ groups }: { groups: RoleGroupOption[] }) => {
     ...(isCloudEnvironment && {
       manage_billing: false,
       manage_alerts: false,
+      manage_lighthouse_ai_configuration: false,
     }),
   };
 
@@ -51,6 +52,10 @@ export const AddRoleForm = ({ groups }: { groups: RoleGroupOption[] }) => {
     if (isCloudEnvironment) {
       formData.append("manage_billing", String(values.manage_billing));
       formData.append("manage_alerts", String(values.manage_alerts));
+      formData.append(
+        "manage_lighthouse_ai_configuration",
+        String(values.manage_lighthouse_ai_configuration),
+      );
     }
 
     if (values.groups && values.groups.length > 0) {

--- a/ui/components/roles/workflow/forms/edit-role-form.test.tsx
+++ b/ui/components/roles/workflow/forms/edit-role-form.test.tsx
@@ -61,6 +61,12 @@ vi.mock("@/lib", () => ({
       description: "Allows creating and managing custom alerts",
     },
     {
+      field: "manage_lighthouse_ai_configuration",
+      label: "Manage Lighthouse AI",
+      description:
+        "Allows configuring Lighthouse AI, including its provider credentials, default model and business context",
+    },
+    {
       field: "manage_billing",
       label: "Manage Billing",
       description: "Provides access to billing settings and invoices",

--- a/ui/components/roles/workflow/forms/edit-role-form.test.tsx
+++ b/ui/components/roles/workflow/forms/edit-role-form.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
+import { updateRole } from "@/actions/roles/roles";
+
 import { EditRoleForm } from "./edit-role-form";
 
 const routerMocks = vi.hoisted(() => ({
@@ -124,10 +126,66 @@ const renderEditRoleForm = (options?: Parameters<typeof roleData>[0]) =>
     <EditRoleForm roleId="role-1" roleData={roleData(options)} groups={[]} />,
   );
 
+const submittedFormData = () => {
+  const formData = vi.mocked(updateRole).mock.calls.at(-1)?.[0];
+  if (!formData) throw new Error("updateRole was not called");
+  return formData;
+};
+
 describe("EditRoleForm", () => {
   afterEach(() => {
     routerMocks.push.mockClear();
+    vi.mocked(updateRole).mockClear();
     vi.unstubAllEnvs();
+  });
+
+  it("submits manage_lighthouse_ai_configuration when granted in Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    const user = userEvent.setup();
+    renderEditRoleForm();
+
+    // When
+    await user.click(
+      screen.getByRole("checkbox", { name: "Manage Lighthouse AI" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Update Role" }));
+
+    // Then
+    expect(submittedFormData().get("manage_lighthouse_ai_configuration")).toBe(
+      "true",
+    );
+    expect(vi.mocked(updateRole).mock.calls.at(-1)?.[1]).toBe("role-1");
+  });
+
+  it("submits manage_lighthouse_ai_configuration as false when not granted in Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    const user = userEvent.setup();
+    renderEditRoleForm();
+
+    // When
+    await user.click(screen.getByRole("button", { name: "Update Role" }));
+
+    // Then
+    expect(submittedFormData().get("manage_lighthouse_ai_configuration")).toBe(
+      "false",
+    );
+  });
+
+  it("omits manage_lighthouse_ai_configuration from the submission outside Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+    const user = userEvent.setup();
+    renderEditRoleForm();
+
+    // When
+    await user.click(screen.getByRole("button", { name: "Update Role" }));
+
+    // Then
+    expect(submittedFormData().has("manage_lighthouse_ai_configuration")).toBe(
+      false,
+    );
   });
 
   it("shows the subtle Unlimited Visibility description inside Visibility", () => {

--- a/ui/components/roles/workflow/forms/edit-role-form.tsx
+++ b/ui/components/roles/workflow/forms/edit-role-form.tsx
@@ -60,6 +60,8 @@ export const EditRoleForm = ({
       if (isCloudEnvironment) {
         updatedFields.manage_billing = values.manage_billing;
         updatedFields.manage_alerts = values.manage_alerts;
+        updatedFields.manage_lighthouse_ai_configuration =
+          values.manage_lighthouse_ai_configuration;
       }
 
       if (

--- a/ui/components/users/profile/role-item.test.tsx
+++ b/ui/components/users/profile/role-item.test.tsx
@@ -23,6 +23,7 @@ const roleDetail = {
     manage_integrations: false,
     manage_billing: false,
     manage_alerts: true,
+    manage_lighthouse_ai_configuration: true,
     unlimited_visibility: false,
   },
 } satisfies RoleDetail;
@@ -52,6 +53,28 @@ describe("RoleItem", () => {
 
     // Then
     expect(screen.queryByText("Manage Alerts")).not.toBeInTheDocument();
+  });
+
+  it("shows Manage Lighthouse AI in Prowler Cloud role details", () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+
+    // When
+    render(<RoleItem role={role} roleDetail={roleDetail} />);
+
+    // Then
+    expect(screen.getByText("Manage Lighthouse AI")).toBeInTheDocument();
+  });
+
+  it("hides Manage Lighthouse AI outside Prowler Cloud role details", () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+
+    // When
+    render(<RoleItem role={role} roleDetail={roleDetail} />);
+
+    // Then
+    expect(screen.queryByText("Manage Lighthouse AI")).not.toBeInTheDocument();
   });
 
   it("displays the permission state as a badge", () => {

--- a/ui/hooks/use-auth.ts
+++ b/ui/hooks/use-auth.ts
@@ -14,6 +14,7 @@ export function useAuth() {
     manage_integrations: false,
     manage_billing: false,
     manage_alerts: false,
+    manage_lighthouse_ai_configuration: false,
     unlimited_visibility: false,
   };
 

--- a/ui/lib/helper.ts
+++ b/ui/lib/helper.ts
@@ -469,6 +469,12 @@ export const permissionFormFields: PermissionInfo[] = [
     label: "Manage Alerts",
     description: "Allows creating and managing custom alerts",
   },
+  {
+    field: "manage_lighthouse_ai_configuration",
+    label: "Manage Lighthouse AI",
+    description:
+      "Allows configuring Lighthouse AI, including its provider credentials, default model and business context",
+  },
 
   {
     field: "manage_billing",

--- a/ui/lib/permissions.test.ts
+++ b/ui/lib/permissions.test.ts
@@ -12,6 +12,7 @@ const attributes = {
   manage_integrations: false,
   manage_billing: false,
   manage_alerts: true,
+  manage_lighthouse_ai_configuration: true,
   unlimited_visibility: false,
 } satisfies RolePermissionAttributes;
 
@@ -45,6 +46,36 @@ describe("getRolePermissions", () => {
     // Then
     expect(
       permissions.some((permission) => permission.key === "manage_alerts"),
+    ).toBe(false);
+  });
+
+  it("includes Manage Lighthouse AI in Prowler Cloud when role attributes provide it", () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+
+    // When
+    const permissions = getRolePermissions(attributes);
+
+    // Then
+    expect(permissions).toContainEqual({
+      key: "manage_lighthouse_ai_configuration",
+      label: "Manage Lighthouse AI",
+      enabled: true,
+    });
+  });
+
+  it("hides Manage Lighthouse AI outside Prowler Cloud", () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+
+    // When
+    const permissions = getRolePermissions(attributes);
+
+    // Then
+    expect(
+      permissions.some(
+        (permission) => permission.key === "manage_lighthouse_ai_configuration",
+      ),
     ).toBe(false);
   });
 });

--- a/ui/lib/permissions.ts
+++ b/ui/lib/permissions.ts
@@ -67,6 +67,11 @@ export const getRolePermissions = (attributes: RolePermissionAttributes) => {
             label: "Manage Alerts",
             enabled: attributes.manage_alerts ?? false,
           },
+          {
+            key: "manage_lighthouse_ai_configuration",
+            label: "Manage Lighthouse AI",
+            enabled: attributes.manage_lighthouse_ai_configuration ?? false,
+          },
         ]
       : []),
     {

--- a/ui/lib/role-permissions.ts
+++ b/ui/lib/role-permissions.ts
@@ -1,6 +1,10 @@
 import { permissionFormFields } from "@/lib";
 
-const hiddenOutsideCloudFields = ["manage_billing", "manage_alerts"];
+const hiddenOutsideCloudFields = [
+  "manage_billing",
+  "manage_alerts",
+  "manage_lighthouse_ai_configuration",
+];
 
 export const getVisiblePermissionFormFields = (isCloudEnvironment: boolean) =>
   permissionFormFields.filter(

--- a/ui/types/components.ts
+++ b/ui/types/components.ts
@@ -419,6 +419,7 @@ export interface InvitationProps {
         manage_integrations?: boolean;
         manage_scans?: boolean;
         manage_alerts?: boolean;
+        manage_lighthouse_ai_configuration?: boolean;
         permission_state?: PermissionState;
       };
     };
@@ -444,6 +445,7 @@ export interface Role {
     manage_integrations: boolean;
     manage_scans: boolean;
     manage_alerts?: boolean;
+    manage_lighthouse_ai_configuration?: boolean;
     unlimited_visibility: boolean;
     permission_state: PermissionState;
     inserted_at: string;

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -55,6 +55,7 @@ export const roleFormSchema = z.object({
   manage_integrations: z.boolean().default(false),
   manage_scans: z.boolean().default(false),
   manage_alerts: z.boolean().default(false),
+  manage_lighthouse_ai_configuration: z.boolean().default(false),
   unlimited_visibility: z.boolean().default(false),
   groups: z.array(z.string()).optional(),
 });

--- a/ui/types/users.ts
+++ b/ui/types/users.ts
@@ -90,6 +90,7 @@ export type PermissionKey =
   | "manage_integrations"
   | "manage_billing"
   | "manage_alerts"
+  | "manage_lighthouse_ai_configuration"
   | "unlimited_visibility";
 
 export type RolePermissionAttributes = Pick<
@@ -117,6 +118,7 @@ export interface RoleDetail {
     manage_integrations: boolean;
     manage_billing?: boolean;
     manage_alerts?: boolean;
+    manage_lighthouse_ai_configuration?: boolean;
     unlimited_visibility: boolean;
     permission_state?: string;
     inserted_at?: string;

--- a/ui/types/users.ts
+++ b/ui/types/users.ts
@@ -82,16 +82,20 @@ export interface RoleData {
   id: string;
 }
 
+export const PERMISSION_KEY = {
+  MANAGE_USERS: "manage_users",
+  MANAGE_ACCOUNT: "manage_account",
+  MANAGE_PROVIDERS: "manage_providers",
+  MANAGE_SCANS: "manage_scans",
+  MANAGE_INTEGRATIONS: "manage_integrations",
+  MANAGE_BILLING: "manage_billing",
+  MANAGE_ALERTS: "manage_alerts",
+  MANAGE_LIGHTHOUSE_AI_CONFIGURATION: "manage_lighthouse_ai_configuration",
+  UNLIMITED_VISIBILITY: "unlimited_visibility",
+} as const;
+
 export type PermissionKey =
-  | "manage_users"
-  | "manage_account"
-  | "manage_providers"
-  | "manage_scans"
-  | "manage_integrations"
-  | "manage_billing"
-  | "manage_alerts"
-  | "manage_lighthouse_ai_configuration"
-  | "unlimited_visibility";
+  (typeof PERMISSION_KEY)[keyof typeof PERMISSION_KEY];
 
 export type RolePermissionAttributes = Pick<
   RoleDetail["attributes"],


### PR DESCRIPTION
### Context

The API exposes a dedicated `manage_lighthouse_ai_configuration` RBAC permission so that managing the Lighthouse AI configuration — provider credentials, default model, business context and connection checks — can be granted or restricted independently of other capabilities.

The permission was not surfaced anywhere in the UI: it could not be granted or revoked from the role forms, it was not shown in a role's details, and it never reached the session, so the front end had no way to know whether the current user holds it.

### Description

Wires `manage_lighthouse_ai_configuration` through the UI RBAC stack, mirroring how the existing cloud-only `manage_alerts` permission is handled.

**Role create/edit forms**
- New `Manage Lighthouse AI` entry in `permissionFormFields` with a tooltip describing what it grants, placed next to `Manage Alerts`.
- Added to `hiddenOutsideCloudFields`, so the checkbox only renders in cloud-enabled environments and is left untouched otherwise.
- Cloud-gated default value and form-data submission in the add and edit forms, and cloud-gated attribute in the `addRole` / `updateRole` payloads. When the environment is not cloud-enabled the attribute is omitted from the request entirely.
- Field added to `roleFormSchema`.

**Role details and session**
- Cloud-only entry in `getRolePermissions`, so the permission appears on the profile role card.
- Mapped from `/users/me` in `getUserByMe` and added to the default permission objects in `auth.config.ts` and `useAuth`, so it reaches `session.user.permissions`.

**Types**
- `PermissionKey` and `RoleDetail` in `types/users.ts`, plus `Role` and `InvitationProps` in `types/components.ts`.

No sidebar gating or `proxy.ts` redirect was added for the Lighthouse AI settings page. The `NAVIGATION_PERMISSION` pattern is used for permissions that also gate read access; this one gates writes only, so hiding the page would restrict more than the API does.

### Steps to review

1. With `UI_CLOUD_ENABLED=true`, create a role from `/roles/new` and confirm the `Manage Lighthouse AI` checkbox renders with its tooltip, and that `Grant all admin permissions` toggles it along with the rest.
2. Save the role and confirm `manage_lighthouse_ai_configuration` is sent in the `POST /roles` payload; edit the role, toggle the permission and confirm it is sent in the `PATCH /roles/{id}` payload.
3. Open `/profile` and confirm the permission is listed in the role details for a role that has it.
4. With `UI_CLOUD_ENABLED=false`, confirm the checkbox is hidden in both forms, that it is absent from the role details, and that the attribute is not included in create/update requests.
5. Sign in with a user whose role grants the permission and confirm `session.user.permissions.manage_lighthouse_ai_configuration` is `true`; sign in with a user whose role does not grant it and confirm it is `false`.
6. Run the affected tests:
   - `pnpm vitest run lib/permissions.test.ts actions/roles/roles.test.ts components/roles/workflow/forms components/users/profile/role-item.test.tsx`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient: no dependency changes.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cloud-only **Manage Lighthouse AI** permission for role creation, editing, and details.
  * Administrators can control access to Lighthouse AI configuration, including provider credentials, default models, and business context.
  * Permission defaults to disabled and is hidden outside Prowler Cloud.

* **Bug Fixes**
  * Ensured permission settings are preserved when loading user and role information.

* **Tests**
  * Added coverage for permission visibility, defaults, and role submission behavior across cloud and non-cloud environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->