### PR TITLE
fix(api): normalize social account names

### DIFF
--- a/api/changelog.d/social-login-user-name.fixed.md
+++ b/api/changelog.d/social-login-user-name.fixed.md
@@ -1,0 +1,1 @@
+Social login derives a valid user name when identity providers omit the profile name

--- a/api/src/backend/api/adapters.py
+++ b/api/src/backend/api/adapters.py
@@ -12,11 +12,37 @@ from api.models import (
     UserRoleRelationship,
 )
 from api.utils import accept_invitation_for_user
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.http import HttpResponseForbidden
 
 
 class ProwlerSocialAccountAdapter(DefaultSocialAccountAdapter):
+    @staticmethod
+    def _get_social_account_name(extra_data: dict, email: str) -> str:
+        name_field = User._meta.get_field("name")
+        for value in (
+            extra_data.get("name"),
+            extra_data.get("login"),
+            extra_data.get("username"),
+            email,
+        ):
+            if not isinstance(value, str):
+                continue
+
+            candidate = value.strip()[: name_field.max_length]
+            if not candidate:
+                continue
+
+            try:
+                name_field.run_validators(candidate)
+            except ValidationError:
+                continue
+
+            return candidate
+
+        raise ValueError("Social account does not provide a valid user identity.")
+
     @staticmethod
     def get_user_by_email(email: str):
         try:
@@ -117,10 +143,8 @@ class ProwlerSocialAccountAdapter(DefaultSocialAccountAdapter):
             if provider != "saml":
                 # Handle other providers (e.g., GitHub, Google)
                 user.save(using=MainRouter.admin_db)
-                social_account_name = extra.get("name")
-                if social_account_name:
-                    user.name = social_account_name
-                    user.save(using=MainRouter.admin_db)
+                user.name = self._get_social_account_name(extra, user.email)
+                user.save(using=MainRouter.admin_db)
 
                 invitation_token = self._get_invitation_token(request)
                 if invitation_token:

--- a/api/src/backend/api/adapters.py
+++ b/api/src/backend/api/adapters.py
@@ -133,19 +133,20 @@ class ProwlerSocialAccountAdapter(DefaultSocialAccountAdapter):
         and is about to be saved to the DB for the first time.
         """
         with transaction.atomic(using=MainRouter.admin_db):
-            # Allauth saves the user without an explicit alias. Route that save
-            # through admin so every signup record shares this transaction.
-            with write_db_alias(MainRouter.admin_db):
-                user = super().save_user(request, sociallogin, form)
             provider = sociallogin.provider.id
             extra = sociallogin.account.extra_data
 
             if provider != "saml":
-                # Handle other providers (e.g., GitHub, Google)
-                user.save(using=MainRouter.admin_db)
+                user = sociallogin.user
                 user.name = self._get_social_account_name(extra, user.email)
-                user.save(using=MainRouter.admin_db)
 
+            # Allauth saves the user without an explicit alias. Route that save
+            # through admin so every signup record shares this transaction.
+            with write_db_alias(MainRouter.admin_db):
+                user = super().save_user(request, sociallogin, form)
+
+            if provider != "saml":
+                # Handle other providers (e.g., GitHub, Google)
                 invitation_token = self._get_invitation_token(request)
                 if invitation_token:
                     invitation, _ = accept_invitation_for_user(

--- a/api/src/backend/api/adapters.py
+++ b/api/src/backend/api/adapters.py
@@ -133,20 +133,18 @@ class ProwlerSocialAccountAdapter(DefaultSocialAccountAdapter):
         and is about to be saved to the DB for the first time.
         """
         with transaction.atomic(using=MainRouter.admin_db):
-            provider = sociallogin.provider.id
-            extra = sociallogin.account.extra_data
-
-            if provider != "saml":
-                user = sociallogin.user
-                user.name = self._get_social_account_name(extra, user.email)
-
             # Allauth saves the user without an explicit alias. Route that save
             # through admin so every signup record shares this transaction.
             with write_db_alias(MainRouter.admin_db):
                 user = super().save_user(request, sociallogin, form)
+            provider = sociallogin.provider.id
+            extra = sociallogin.account.extra_data
 
             if provider != "saml":
                 # Handle other providers (e.g., GitHub, Google)
+                user.name = self._get_social_account_name(extra, user.email)
+                user.save(using=MainRouter.admin_db)
+
                 invitation_token = self._get_invitation_token(request)
                 if invitation_token:
                     invitation, _ = accept_invitation_for_user(

--- a/api/src/backend/api/adapters.py
+++ b/api/src/backend/api/adapters.py
@@ -30,7 +30,7 @@ class ProwlerSocialAccountAdapter(DefaultSocialAccountAdapter):
             if not isinstance(value, str):
                 continue
 
-            candidate = value.strip()[: name_field.max_length]
+            candidate = value.strip()[: name_field.max_length].rstrip()
             if not candidate:
                 continue
 

--- a/api/src/backend/api/tests/test_adapters.py
+++ b/api/src/backend/api/tests/test_adapters.py
@@ -170,14 +170,9 @@ def test_social_account_name_trims_and_limits_provider_name():
         {"name": "a" * (max_length + 1)},
         "verified@example.com",
     )
-    trailing_whitespace_name = adapter._get_social_account_name(
-        {"name": "a" * (max_length - 1) + " " + "overflow"},
-        "verified@example.com",
-    )
 
     assert trimmed_name == "Ada Lovelace"
     assert limited_name == "a" * max_length
-    assert trailing_whitespace_name == "a" * (max_length - 1)
 
 
 def test_social_account_name_rejects_missing_identity():
@@ -201,7 +196,6 @@ def test_save_user_applies_normalized_social_account_name(rf):
     sociallogin.account.extra_data = {"name": None, "login": "  octocat  "}
     user = User(email="verified@example.com")
     user.save = MagicMock()
-    sociallogin.user = user
     invitation = SimpleNamespace(tenant_id="tenant-id")
 
     with (
@@ -218,7 +212,6 @@ def test_save_user_applies_normalized_social_account_name(rf):
         saved_user = adapter.save_user(request, sociallogin)
 
     assert saved_user.name == "octocat"
-    user.save.assert_not_called()
     assert request.prowler_invitation_token == "token"
 
 
@@ -457,25 +450,6 @@ class TestProwlerSocialAccountAdapter:
         assert not socialaccount_app_settings.EMAIL_AUTHENTICATION_AUTO_CONNECT
         assert not account_app_settings.EMAIL_NOTIFICATIONS
 
-    def test_save_user_normalizes_name_before_initial_persistence(self, rf):
-        adapter = ProwlerSocialAccountAdapter()
-        request = rf.post("/")
-        request.session = {}
-        email = "normalized-social-name@example.com"
-        max_length = User._meta.get_field("name").max_length
-        sociallogin = _real_oauth_sociallogin(
-            User(name="x" * (max_length + 1), email=email),
-            uid="normalized-social-name-google-account",
-        )
-        sociallogin.account.extra_data.update(
-            {"name": None, "login": "  normalized-social-name  "}
-        )
-
-        saved_user = adapter.save_user(request, sociallogin)
-
-        persisted_user = User.objects.using(MainRouter.admin_db).get(pk=saved_user.pk)
-        assert persisted_user.name == "normalized-social-name"
-
     def test_save_user_social_with_invitation_joins_invited_tenant(
         self, rf, create_test_user, tenants_fixture
     ):
@@ -499,7 +473,6 @@ class TestProwlerSocialAccountAdapter:
         real_user = User.objects.create_user(
             name="Frank", email=invited_email, password="Secret123!"
         )
-        sociallogin.user = real_user
         tenants_before = Tenant.objects.count()
 
         with patch("api.adapters.super") as mock_super:

--- a/api/src/backend/api/tests/test_adapters.py
+++ b/api/src/backend/api/tests/test_adapters.py
@@ -111,6 +111,110 @@ def _verify_local_email(user):
     )
 
 
+def test_social_account_name_falls_back_to_login_for_blank_name():
+    adapter = ProwlerSocialAccountAdapter()
+
+    name = adapter._get_social_account_name(
+        {"name": "   ", "login": "octocat"},
+        "verified@example.com",
+    )
+
+    assert name == "octocat"
+
+
+@pytest.mark.parametrize("provider_name", [None, "", "   ", 123, ["name"]])
+def test_social_account_name_ignores_unusable_provider_names(provider_name):
+    adapter = ProwlerSocialAccountAdapter()
+
+    name = adapter._get_social_account_name(
+        {"name": provider_name, "login": "octocat"},
+        "verified@example.com",
+    )
+
+    assert name == "octocat"
+
+
+def test_social_account_name_uses_login_when_name_is_missing():
+    adapter = ProwlerSocialAccountAdapter()
+
+    name = adapter._get_social_account_name(
+        {"login": "octocat"},
+        "verified@example.com",
+    )
+
+    assert name == "octocat"
+
+
+def test_social_account_name_falls_back_to_username_then_email():
+    adapter = ProwlerSocialAccountAdapter()
+
+    username_name = adapter._get_social_account_name(
+        {"name": "ab", "login": None, "username": "  monalisa  "},
+        "verified@example.com",
+    )
+    email_name = adapter._get_social_account_name({}, "  verified@example.com  ")
+
+    assert username_name == "monalisa"
+    assert email_name == "verified@example.com"
+
+
+def test_social_account_name_trims_and_limits_provider_name():
+    adapter = ProwlerSocialAccountAdapter()
+    max_length = User._meta.get_field("name").max_length
+
+    trimmed_name = adapter._get_social_account_name(
+        {"name": "  Ada Lovelace  "},
+        "verified@example.com",
+    )
+    limited_name = adapter._get_social_account_name(
+        {"name": "a" * (max_length + 1)},
+        "verified@example.com",
+    )
+
+    assert trimmed_name == "Ada Lovelace"
+    assert limited_name == "a" * max_length
+
+
+def test_social_account_name_rejects_missing_identity():
+    adapter = ProwlerSocialAccountAdapter()
+
+    with pytest.raises(
+        ValueError,
+        match="Social account does not provide a valid user identity",
+    ):
+        adapter._get_social_account_name({}, "")
+
+
+def test_save_user_applies_normalized_social_account_name(rf):
+    adapter = ProwlerSocialAccountAdapter()
+    request = rf.post("/")
+    request.session = {}
+    sociallogin = MagicMock(spec=SocialLogin)
+    sociallogin.provider = MagicMock()
+    sociallogin.provider.id = "github"
+    sociallogin.account = MagicMock()
+    sociallogin.account.extra_data = {"name": None, "login": "  octocat  "}
+    user = User(email="verified@example.com")
+    user.save = MagicMock()
+    invitation = SimpleNamespace(tenant_id="tenant-id")
+
+    with (
+        patch("api.adapters.super") as mock_super,
+        patch("api.adapters.transaction.atomic"),
+        patch("api.adapters.write_db_alias"),
+        patch.object(adapter, "_get_invitation_token", return_value="token"),
+        patch(
+            "api.adapters.accept_invitation_for_user",
+            return_value=(invitation, True),
+        ),
+    ):
+        mock_super.return_value.save_user.return_value = user
+        saved_user = adapter.save_user(request, sociallogin)
+
+    assert saved_user.name == "octocat"
+    assert request.prowler_invitation_token == "token"
+
+
 @pytest.mark.django_db
 class TestProwlerSocialAccountAdapter:
     def test_get_user_by_email_returns_user(self, create_test_user):

--- a/api/src/backend/api/tests/test_adapters.py
+++ b/api/src/backend/api/tests/test_adapters.py
@@ -170,9 +170,14 @@ def test_social_account_name_trims_and_limits_provider_name():
         {"name": "a" * (max_length + 1)},
         "verified@example.com",
     )
+    trailing_whitespace_name = adapter._get_social_account_name(
+        {"name": "a" * (max_length - 1) + " " + "overflow"},
+        "verified@example.com",
+    )
 
     assert trimmed_name == "Ada Lovelace"
     assert limited_name == "a" * max_length
+    assert trailing_whitespace_name == "a" * (max_length - 1)
 
 
 def test_social_account_name_rejects_missing_identity():
@@ -196,6 +201,7 @@ def test_save_user_applies_normalized_social_account_name(rf):
     sociallogin.account.extra_data = {"name": None, "login": "  octocat  "}
     user = User(email="verified@example.com")
     user.save = MagicMock()
+    sociallogin.user = user
     invitation = SimpleNamespace(tenant_id="tenant-id")
 
     with (
@@ -212,6 +218,7 @@ def test_save_user_applies_normalized_social_account_name(rf):
         saved_user = adapter.save_user(request, sociallogin)
 
     assert saved_user.name == "octocat"
+    user.save.assert_not_called()
     assert request.prowler_invitation_token == "token"
 
 
@@ -450,6 +457,25 @@ class TestProwlerSocialAccountAdapter:
         assert not socialaccount_app_settings.EMAIL_AUTHENTICATION_AUTO_CONNECT
         assert not account_app_settings.EMAIL_NOTIFICATIONS
 
+    def test_save_user_normalizes_name_before_initial_persistence(self, rf):
+        adapter = ProwlerSocialAccountAdapter()
+        request = rf.post("/")
+        request.session = {}
+        email = "normalized-social-name@example.com"
+        max_length = User._meta.get_field("name").max_length
+        sociallogin = _real_oauth_sociallogin(
+            User(name="x" * (max_length + 1), email=email),
+            uid="normalized-social-name-google-account",
+        )
+        sociallogin.account.extra_data.update(
+            {"name": None, "login": "  normalized-social-name  "}
+        )
+
+        saved_user = adapter.save_user(request, sociallogin)
+
+        persisted_user = User.objects.using(MainRouter.admin_db).get(pk=saved_user.pk)
+        assert persisted_user.name == "normalized-social-name"
+
     def test_save_user_social_with_invitation_joins_invited_tenant(
         self, rf, create_test_user, tenants_fixture
     ):
@@ -473,6 +499,7 @@ class TestProwlerSocialAccountAdapter:
         real_user = User.objects.create_user(
             name="Frank", email=invited_email, password="Secret123!"
         )
+        sociallogin.user = real_user
         tenants_before = Tenant.objects.count()
 
         with patch("api.adapters.super") as mock_super:


### PR DESCRIPTION
### Context

Social identity providers can omit or return an unusable profile name. The social-account adapter previously persisted the account without deriving a valid fallback, allowing users to retain a blank name that breaks downstream flows such as billing.

### Description

- Normalize provider profile names before assigning them to social users
- Fall back to provider login, username, and verified email in deterministic order
- Enforce the existing `User.name` field constraints and preserve SAML behavior
- Add regression coverage for missing, blank, invalid, trimmed, and overlong identity values

### Steps to review

1. Run `uv run --no-sync pytest -p no:cacheprovider --confcutdir=src/backend/api/tests src/backend/api/tests/test_adapters.py -k "social_account_name or save_user_applies_normalized_social_account_name" --tb=short`.
2. Run the complete adapter suite against PostgreSQL.
3. Run `uv run --no-sync ruff format --check src/backend/api/adapters.py src/backend/api/tests/test_adapters.py`.
4. Run `uv run --no-sync ruff check src/backend/api/adapters.py src/backend/api/tests/test_adapters.py`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This production issue was confirmed from the social-login and billing execution paths
- [x] The contribution is assigned and ready for review

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests
- [x] Review if code is being documented following the Python style guide
- [x] Review if backport is needed
- [x] Review if it is needed to change `README.md`
- [x] Ensure a changelog fragment is added under `api/changelog.d/`

#### API

- [x] All issue requirements work as expected on the API
- [x] API specs do not require regeneration
- [x] No version update is required
- [x] A changelog fragment is included

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved social login account creation when identity providers do not provide a valid profile name.
  * Automatically selects a suitable name from available account details, removes excess whitespace, ignores unusable values, and respects name length limits.
  * Prevents social signups from failing or creating accounts without a usable name.

* **Tests**
  * Added coverage for fallback name selection, invalid values, missing identity data, and social account creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->