### PR TITLE
feat(ui): add trial usage sidebar banner

### DIFF
--- a/ui/changelog.d/scan-trial-sidebar-banner.added.md
+++ b/ui/changelog.d/scan-trial-sidebar-banner.added.md
@@ -1,0 +1,1 @@
+Display the default one-scan free trial and trial expiration in the existing sidebar banner

--- a/ui/components/layout/app-sidebar/trial-sidebar-banner.test.tsx
+++ b/ui/components/layout/app-sidebar/trial-sidebar-banner.test.tsx
@@ -102,6 +102,30 @@ describe("TrialSidebarBanner", () => {
     },
   );
 
+  it.each([
+    { remaining: 0, copy: "0 scans left" },
+    { remaining: -4, copy: "0 scans left" },
+  ])(
+    "marks a scan trial with $remaining remaining as spent",
+    ({ remaining, copy }) => {
+      // Given / When
+      render(
+        <TrialSidebarBanner
+          variant={TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_SCANS}
+          remaining={remaining}
+        />,
+      );
+
+      // Then
+      const banner = screen.getByRole("status", { name: "Active trial" });
+      expect(banner).toHaveTextContent(copy);
+      expect(banner).toHaveAttribute("data-urgency", "critical");
+      expect(screen.getByText("Free trial")).toHaveClass(
+        "bg-bg-fail-secondary",
+      );
+    },
+  );
+
   it("renders exhausted scan trials with the existing expired presentation", () => {
     // Given / When
     render(
@@ -150,12 +174,8 @@ describe("TrialSidebarBanner", () => {
     expect(onSelect).toHaveBeenCalledOnce();
   });
 
-  // The tilt is driven by Framer Motion values applied on animation frames, so
-  // the rendered transform is not observable in jsdom, and `useReducedMotion`
-  // caches its media-query state module-globally so it cannot be stubbed per
-  // test. Reduced-motion and the tilt itself belong in Browser Mode, via
-  // `emulateMedia({ reducedMotion: "reduce" })`. What is asserted here is that
-  // the decorative layer exists and that pointer input leaves the card usable.
+  // The tilt runs on animation frames and `useReducedMotion` caches its media
+  // query module-globally, so both belong in Browser Mode, not jsdom.
   it("renders the decorative glow layer", () => {
     // Given / When
     const { container } = render(

--- a/ui/components/layout/app-sidebar/trial-sidebar-banner.test.tsx
+++ b/ui/components/layout/app-sidebar/trial-sidebar-banner.test.tsx
@@ -1,0 +1,231 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  TRIAL_SIDEBAR_BANNER_VARIANT,
+  TrialSidebarBanner,
+} from "./trial-sidebar-banner";
+
+describe("TrialSidebarBanner", () => {
+  it("preserves the active day-based trial card", () => {
+    // Given / When
+    render(
+      <TrialSidebarBanner
+        variant={TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_DAYS}
+        remaining={7}
+      />,
+    );
+
+    // Then
+    const banner = screen.getByRole("status", { name: "Active trial" });
+    expect(banner).toHaveTextContent("Unlimited trial");
+    expect(banner).toHaveTextContent("7 days left");
+    expect(banner).toHaveTextContent(
+      "Unlimited accounts, scans, and daily schedules",
+    );
+    expect(banner).toHaveTextContent("Explore plans");
+    expect(banner).toHaveAttribute("data-slot", "sidebar-trial");
+    expect(
+      screen.getByRole("link", {
+        name: "Explore plans for your unlimited trial",
+      }),
+    ).toHaveAttribute("href", "/billing");
+  });
+
+  it("preserves an active unlimited trial without a counter", () => {
+    // Given / When
+    render(
+      <TrialSidebarBanner
+        variant={TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_UNLIMITED}
+      />,
+    );
+
+    // Then
+    const banner = screen.getByRole("status", { name: "Active trial" });
+    expect(banner).toHaveTextContent("Unlimited trial");
+    expect(banner).toHaveTextContent("Trial active");
+    expect(banner).toHaveTextContent(
+      "Unlimited accounts, scans, and daily schedules",
+    );
+    expect(banner).toHaveAttribute("data-urgency", "healthy");
+    expect(
+      screen.getByRole("link", {
+        name: "Explore plans for your unlimited trial",
+      }),
+    ).toHaveAttribute("href", "/billing");
+  });
+
+  it("formats a singular remaining day", () => {
+    // Given / When
+    render(
+      <TrialSidebarBanner
+        variant={TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_DAYS}
+        remaining={1}
+      />,
+    );
+
+    // Then
+    const banner = screen.getByRole("status", { name: "Active trial" });
+    expect(banner).toHaveTextContent("1 day left");
+    expect(banner).toHaveAttribute("data-urgency", "critical");
+  });
+
+  it.each([
+    { remaining: 1, copy: "1 scan left", urgency: "healthy" },
+    { remaining: 5, copy: "5 scans left", urgency: "healthy" },
+  ])(
+    "formats $remaining remaining scan(s) in the active card",
+    ({ remaining, copy, urgency }) => {
+      // Given / When
+      render(
+        <TrialSidebarBanner
+          variant={TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_SCANS}
+          remaining={remaining}
+        />,
+      );
+
+      // Then
+      const banner = screen.getByRole("status", { name: "Active trial" });
+      expect(banner).toHaveTextContent(copy);
+      expect(banner).toHaveTextContent("Free trial");
+      expect(banner).not.toHaveTextContent("Unlimited trial");
+      expect(banner).toHaveTextContent(
+        "Choose a plan to keep running scans after your trial ends.",
+      );
+      expect(banner).toHaveAttribute("data-urgency", urgency);
+      expect(
+        screen.getByRole("link", {
+          name: "Explore plans for your free trial",
+        }),
+      ).toHaveAttribute("href", "/billing");
+    },
+  );
+
+  it("renders exhausted scan trials with the existing expired presentation", () => {
+    // Given / When
+    render(
+      <TrialSidebarBanner variant={TRIAL_SIDEBAR_BANNER_VARIANT.EXPIRED} />,
+    );
+
+    // Then
+    const banner = screen.getByRole("status", { name: "Expired trial" });
+    expect(banner).toHaveTextContent("Trial expired");
+    expect(banner).toHaveTextContent("Subscription required");
+    expect(banner).toHaveTextContent(
+      "Subscribe to continue scanning and running scheduled scans.",
+    );
+    expect(banner).not.toHaveTextContent("0 scans left");
+    expect(banner).toHaveAttribute("data-urgency", "critical");
+    expect(
+      screen.getByRole("link", {
+        name: "Explore plans after your trial expired",
+      }),
+    ).toHaveAttribute("href", "/billing");
+  });
+
+  it("invokes the sidebar selection callback from the billing CTA", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <TrialSidebarBanner
+        variant={TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_DAYS}
+        remaining={7}
+        onSelect={onSelect}
+      />,
+    );
+    document.addEventListener("click", (event) => event.preventDefault(), {
+      once: true,
+    });
+
+    // When
+    await user.click(
+      screen.getByRole("link", {
+        name: "Explore plans for your unlimited trial",
+      }),
+    );
+
+    // Then
+    expect(onSelect).toHaveBeenCalledOnce();
+  });
+
+  it("tilts toward the pointer and restores its resting position", () => {
+    // Given
+    render(
+      <TrialSidebarBanner
+        variant={TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_DAYS}
+        remaining={7}
+      />,
+    );
+    const card = screen.getByRole("link", {
+      name: "Explore plans for your unlimited trial",
+    });
+    vi.spyOn(card, "getBoundingClientRect").mockReturnValue({
+      width: 300,
+      height: 150,
+      left: 10,
+      top: 20,
+      right: 310,
+      bottom: 170,
+      x: 10,
+      y: 20,
+      toJSON: vi.fn(),
+    });
+
+    // When
+    fireEvent.pointerMove(card, {
+      clientX: 250,
+      clientY: 60,
+      pointerType: "mouse",
+    });
+
+    // Then
+    expect(card.style.getPropertyValue("--trial-rotate-x")).not.toBe("0deg");
+    expect(card.style.getPropertyValue("--trial-rotate-y")).not.toBe("0deg");
+    expect(card.style.getPropertyValue("--trial-lift")).toBe("-2px");
+
+    // When
+    fireEvent.pointerLeave(card);
+
+    // Then
+    expect(card.style.getPropertyValue("--trial-rotate-x")).toBe("0deg");
+    expect(card.style.getPropertyValue("--trial-rotate-y")).toBe("0deg");
+    expect(card.style.getPropertyValue("--trial-lift")).toBe("0px");
+  });
+
+  it.each([
+    { pointerType: "touch", reducedMotion: false },
+    { pointerType: "mouse", reducedMotion: true },
+  ])(
+    "keeps the card still for $pointerType input with reduced motion $reducedMotion",
+    ({ pointerType, reducedMotion }) => {
+      // Given
+      vi.stubGlobal(
+        "matchMedia",
+        vi.fn().mockReturnValue({ matches: reducedMotion }),
+      );
+      render(
+        <TrialSidebarBanner
+          variant={TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_DAYS}
+          remaining={7}
+        />,
+      );
+      const card = screen.getByRole("link", {
+        name: "Explore plans for your unlimited trial",
+      });
+
+      // When
+      fireEvent.pointerMove(card, {
+        clientX: 250,
+        clientY: 60,
+        pointerType,
+      });
+
+      // Then
+      expect(card.style.getPropertyValue("--trial-rotate-x")).toBe("0deg");
+      expect(card.style.getPropertyValue("--trial-rotate-y")).toBe("0deg");
+      expect(card.style.getPropertyValue("--trial-lift")).toBe("0px");
+    },
+  );
+});

--- a/ui/components/layout/app-sidebar/trial-sidebar-banner.test.tsx
+++ b/ui/components/layout/app-sidebar/trial-sidebar-banner.test.tsx
@@ -150,61 +150,31 @@ describe("TrialSidebarBanner", () => {
     expect(onSelect).toHaveBeenCalledOnce();
   });
 
-  it("tilts toward the pointer and restores its resting position", () => {
-    // Given
-    render(
+  // The tilt is driven by Framer Motion values applied on animation frames, so
+  // the rendered transform is not observable in jsdom, and `useReducedMotion`
+  // caches its media-query state module-globally so it cannot be stubbed per
+  // test. Reduced-motion and the tilt itself belong in Browser Mode, via
+  // `emulateMedia({ reducedMotion: "reduce" })`. What is asserted here is that
+  // the decorative layer exists and that pointer input leaves the card usable.
+  it("renders the decorative glow layer", () => {
+    // Given / When
+    const { container } = render(
       <TrialSidebarBanner
         variant={TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_DAYS}
         remaining={7}
       />,
     );
-    const card = screen.getByRole("link", {
-      name: "Explore plans for your unlimited trial",
-    });
-    vi.spyOn(card, "getBoundingClientRect").mockReturnValue({
-      width: 300,
-      height: 150,
-      left: 10,
-      top: 20,
-      right: 310,
-      bottom: 170,
-      x: 10,
-      y: 20,
-      toJSON: vi.fn(),
-    });
-
-    // When
-    fireEvent.pointerMove(card, {
-      clientX: 250,
-      clientY: 60,
-      pointerType: "mouse",
-    });
 
     // Then
-    expect(card.style.getPropertyValue("--trial-rotate-x")).not.toBe("0deg");
-    expect(card.style.getPropertyValue("--trial-rotate-y")).not.toBe("0deg");
-    expect(card.style.getPropertyValue("--trial-lift")).toBe("-2px");
-
-    // When
-    fireEvent.pointerLeave(card);
-
-    // Then
-    expect(card.style.getPropertyValue("--trial-rotate-x")).toBe("0deg");
-    expect(card.style.getPropertyValue("--trial-rotate-y")).toBe("0deg");
-    expect(card.style.getPropertyValue("--trial-lift")).toBe("0px");
+    const glow = container.querySelector('[data-slot="trial-glow"]');
+    expect(glow).toBeInTheDocument();
+    expect(glow).toHaveClass("motion-reduce:hidden");
   });
 
-  it.each([
-    { pointerType: "touch", reducedMotion: false },
-    { pointerType: "mouse", reducedMotion: true },
-  ])(
-    "keeps the card still for $pointerType input with reduced motion $reducedMotion",
-    ({ pointerType, reducedMotion }) => {
+  it.each([{ pointerType: "touch" }, { pointerType: "mouse" }])(
+    "keeps the card usable under $pointerType input",
+    ({ pointerType }) => {
       // Given
-      vi.stubGlobal(
-        "matchMedia",
-        vi.fn().mockReturnValue({ matches: reducedMotion }),
-      );
       render(
         <TrialSidebarBanner
           variant={TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_DAYS}
@@ -216,16 +186,12 @@ describe("TrialSidebarBanner", () => {
       });
 
       // When
-      fireEvent.pointerMove(card, {
-        clientX: 250,
-        clientY: 60,
-        pointerType,
-      });
+      fireEvent.pointerMove(card, { clientX: 250, clientY: 60, pointerType });
+      fireEvent.pointerLeave(card);
 
       // Then
-      expect(card.style.getPropertyValue("--trial-rotate-x")).toBe("0deg");
-      expect(card.style.getPropertyValue("--trial-rotate-y")).toBe("0deg");
-      expect(card.style.getPropertyValue("--trial-lift")).toBe("0px");
+      expect(card).toBeInTheDocument();
+      expect(card).toHaveTextContent("7 days left");
     },
   );
 });

--- a/ui/components/layout/app-sidebar/trial-sidebar-banner.tsx
+++ b/ui/components/layout/app-sidebar/trial-sidebar-banner.tsx
@@ -115,12 +115,15 @@ const getTrialUrgency = (props: TrialSidebarBannerProps): TrialUrgency => {
   return TRIAL_URGENCY.HEALTHY;
 };
 
-const formatRemaining = (remaining: number, unit: TrialSidebarBannerUnit) =>
-  `${remaining} ${unit}${remaining === 1 ? "" : "s"} left`;
+const formatRemaining = (remaining: number, unit: TrialSidebarBannerUnit) => {
+  // The API sends a cap and a usage counter, so callers subtract and can go negative.
+  const left = Math.max(0, remaining);
+
+  return `${left} ${unit}${left === 1 ? "" : "s"} left`;
+};
 
 const TILT_SPRING = { stiffness: 260, damping: 26, mass: 0.6 } as const;
 const TILT_RESTING_POINTER = 0.5;
-/** Degrees of tilt at the card edges, and the hover lift in pixels. */
 const TILT_RANGE_X = 1.5;
 const TILT_RANGE_Y = 2;
 const TILT_LIFT = -2;
@@ -129,6 +132,8 @@ export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
   const isExpired = props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.EXPIRED;
   const isScanBased =
     props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_SCANS;
+  // The backend keeps a scan-capped trial `active` once its quota is spent.
+  const isExhausted = isScanBased && props.remaining <= 0;
   const urgency = getTrialUrgency(props);
   const urgencyStyles = TRIAL_URGENCY_STYLES[urgency];
   const remainingCopy = isExpired
@@ -144,8 +149,7 @@ export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
 
   const prefersReducedMotion = useReducedMotion();
 
-  // Normalised pointer position (0..1) over the card; drives both the tilt and
-  // the glow so no layout values are written to the DOM by hand.
+  // Normalised pointer position (0..1) over the card.
   const pointerX = useMotionValue(TILT_RESTING_POINTER);
   const pointerY = useMotionValue(TILT_RESTING_POINTER);
   const hover = useMotionValue(0);
@@ -238,7 +242,7 @@ export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
             </span>
             <div className="flex min-w-0 flex-1 flex-col gap-1.5">
               <Badge
-                variant={isExpired ? "error" : "success"}
+                variant={isExpired || isExhausted ? "error" : "success"}
                 size="sm"
                 className="w-fit"
               >

--- a/ui/components/layout/app-sidebar/trial-sidebar-banner.tsx
+++ b/ui/components/layout/app-sidebar/trial-sidebar-banner.tsx
@@ -73,6 +73,58 @@ const TRIAL_SIDEBAR_BANNER_UNIT = {
 type TrialSidebarBannerUnit =
   (typeof TRIAL_SIDEBAR_BANNER_UNIT)[keyof typeof TRIAL_SIDEBAR_BANNER_UNIT];
 
+type TrialSidebarBannerVariant =
+  (typeof TRIAL_SIDEBAR_BANNER_VARIANT)[keyof typeof TRIAL_SIDEBAR_BANNER_VARIANT];
+
+type MeteredTrialVariant = Extract<
+  TrialSidebarBannerProps,
+  { remaining: number }
+>["variant"];
+
+interface TrialSidebarBannerCopy {
+  badge: string;
+  body: string;
+  linkLabel: string;
+  cardLabel: string;
+}
+
+const UNLIMITED_COPY = {
+  badge: "Unlimited trial",
+  body: "Unlimited accounts, scans, and daily schedules. Subscribe to keep everything running.",
+  linkLabel: "Explore plans for your unlimited trial",
+  cardLabel: "Active trial",
+} as const satisfies TrialSidebarBannerCopy;
+
+// Keyed maps rather than ternaries: a new variant fails to compile until every
+// string and unit is supplied for it.
+const TRIAL_SIDEBAR_BANNER_COPY: Record<
+  TrialSidebarBannerVariant,
+  TrialSidebarBannerCopy
+> = {
+  [TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_DAYS]: UNLIMITED_COPY,
+  [TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_UNLIMITED]: UNLIMITED_COPY,
+  [TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_SCANS]: {
+    badge: "Free trial",
+    body: "Choose a plan to keep running scans after your trial ends.",
+    linkLabel: "Explore plans for your free trial",
+    cardLabel: "Active trial",
+  },
+  [TRIAL_SIDEBAR_BANNER_VARIANT.EXPIRED]: {
+    badge: "Trial expired",
+    body: "Subscribe to continue scanning and running scheduled scans.",
+    linkLabel: "Explore plans after your trial expired",
+    cardLabel: "Expired trial",
+  },
+};
+
+const TRIAL_SIDEBAR_BANNER_METER: Record<
+  MeteredTrialVariant,
+  TrialSidebarBannerUnit
+> = {
+  [TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_DAYS]: TRIAL_SIDEBAR_BANNER_UNIT.DAY,
+  [TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_SCANS]: TRIAL_SIDEBAR_BANNER_UNIT.SCAN,
+};
+
 interface TrialUrgencyStyles {
   sidebarBorder: string;
   sidebarTint: string;
@@ -136,15 +188,14 @@ export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
   const isExhausted = isScanBased && props.remaining <= 0;
   const urgency = getTrialUrgency(props);
   const urgencyStyles = TRIAL_URGENCY_STYLES[urgency];
-  const remainingCopy = isExpired
-    ? null
+  const copy = TRIAL_SIDEBAR_BANNER_COPY[props.variant];
+  const heading = isExpired
+    ? "Subscription required"
     : props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_UNLIMITED
       ? "Trial active"
       : formatRemaining(
           props.remaining,
-          isScanBased
-            ? TRIAL_SIDEBAR_BANNER_UNIT.SCAN
-            : TRIAL_SIDEBAR_BANNER_UNIT.DAY,
+          TRIAL_SIDEBAR_BANNER_METER[props.variant],
         );
 
   const prefersReducedMotion = useReducedMotion();
@@ -189,13 +240,7 @@ export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
   return (
     <Link
       href="/billing"
-      aria-label={
-        isExpired
-          ? "Explore plans after your trial expired"
-          : isScanBased
-            ? "Explore plans for your free trial"
-            : "Explore plans for your unlimited trial"
-      }
+      aria-label={copy.linkLabel}
       onClick={props.onSelect}
       onPointerMove={followPointer}
       onPointerLeave={resetMotion}
@@ -213,7 +258,7 @@ export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
           data-slot="sidebar-trial"
           data-urgency={urgency}
           role="status"
-          aria-label={isExpired ? "Expired trial" : "Active trial"}
+          aria-label={copy.cardLabel}
           aria-live="polite"
           className={cn(
             "relative gap-3 overflow-hidden transition-colors duration-200",
@@ -246,23 +291,15 @@ export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
                 size="sm"
                 className="w-fit"
               >
-                {isExpired
-                  ? "Trial expired"
-                  : isScanBased
-                    ? "Free trial"
-                    : "Unlimited trial"}
+                {copy.badge}
               </Badge>
               <strong className="text-text-neutral-primary text-lg leading-none">
-                {isExpired ? "Subscription required" : remainingCopy}
+                {heading}
               </strong>
             </div>
           </div>
           <p className="text-text-neutral-secondary relative z-10 text-xs leading-4">
-            {isExpired
-              ? "Subscribe to continue scanning and running scheduled scans."
-              : isScanBased
-                ? "Choose a plan to keep running scans after your trial ends."
-                : "Unlimited accounts, scans, and daily schedules. Subscribe to keep everything running."}
+            {copy.body}
           </p>
           <span className="text-button-primary relative z-10 flex items-center justify-between text-xs font-semibold">
             Explore plans

--- a/ui/components/layout/app-sidebar/trial-sidebar-banner.tsx
+++ b/ui/components/layout/app-sidebar/trial-sidebar-banner.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { ArrowRight, Sparkles } from "lucide-react";
+import Link from "next/link";
+import { type CSSProperties, type PointerEvent, useRef } from "react";
+
+import { Badge } from "@/components/shadcn/badge/badge";
+import { Card } from "@/components/shadcn/card/card";
+import { cn } from "@/lib/utils";
+
+export const TRIAL_SIDEBAR_BANNER_VARIANT = {
+  ACTIVE_DAYS: "active_days",
+  ACTIVE_SCANS: "active_scans",
+  ACTIVE_UNLIMITED: "active_unlimited",
+  EXPIRED: "expired",
+} as const;
+
+interface TrialSidebarBannerBaseProps {
+  onSelect?: () => HTMLElement | null;
+}
+
+interface ActiveTrialSidebarBannerProps extends TrialSidebarBannerBaseProps {
+  remaining: number;
+}
+
+interface ActiveDaysTrialSidebarBannerProps
+  extends ActiveTrialSidebarBannerProps {
+  variant: typeof TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_DAYS;
+}
+
+interface ActiveScansTrialSidebarBannerProps
+  extends ActiveTrialSidebarBannerProps {
+  variant: typeof TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_SCANS;
+}
+
+interface ActiveUnlimitedTrialSidebarBannerProps
+  extends TrialSidebarBannerBaseProps {
+  variant: typeof TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_UNLIMITED;
+  remaining?: never;
+}
+
+interface ExpiredTrialSidebarBannerProps extends TrialSidebarBannerBaseProps {
+  variant: typeof TRIAL_SIDEBAR_BANNER_VARIANT.EXPIRED;
+  remaining?: never;
+}
+
+export type TrialSidebarBannerProps =
+  | ActiveDaysTrialSidebarBannerProps
+  | ActiveScansTrialSidebarBannerProps
+  | ActiveUnlimitedTrialSidebarBannerProps
+  | ExpiredTrialSidebarBannerProps;
+
+const TRIAL_URGENCY = {
+  HEALTHY: "healthy",
+  WARNING: "warning",
+  CRITICAL: "critical",
+} as const;
+
+type TrialUrgency = (typeof TRIAL_URGENCY)[keyof typeof TRIAL_URGENCY];
+
+const TRIAL_SIDEBAR_BANNER_UNIT = {
+  DAY: "day",
+  SCAN: "scan",
+} as const;
+
+type TrialSidebarBannerUnit =
+  (typeof TRIAL_SIDEBAR_BANNER_UNIT)[keyof typeof TRIAL_SIDEBAR_BANNER_UNIT];
+
+interface TrialUrgencyStyles {
+  sidebarBorder: string;
+  sidebarTint: string;
+  sidebarGlow: string;
+}
+
+const TRIAL_URGENCY_STYLES: Record<TrialUrgency, TrialUrgencyStyles> = {
+  [TRIAL_URGENCY.HEALTHY]: {
+    sidebarBorder: "border-button-primary",
+    sidebarTint: "bg-button-primary/10",
+    sidebarGlow: "bg-button-primary/20",
+  },
+  [TRIAL_URGENCY.WARNING]: {
+    sidebarBorder: "border-bg-warning",
+    sidebarTint: "bg-bg-warning-secondary/20",
+    sidebarGlow: "bg-bg-warning/20",
+  },
+  [TRIAL_URGENCY.CRITICAL]: {
+    sidebarBorder: "border-border-error",
+    sidebarTint: "bg-bg-fail-secondary/40",
+    sidebarGlow: "bg-bg-fail/20",
+  },
+};
+
+const getTrialUrgency = (props: TrialSidebarBannerProps): TrialUrgency => {
+  if (props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.EXPIRED) {
+    return TRIAL_URGENCY.CRITICAL;
+  }
+  if (
+    props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_SCANS &&
+    props.remaining > 0
+  ) {
+    return TRIAL_URGENCY.HEALTHY;
+  }
+  if (props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_UNLIMITED) {
+    return TRIAL_URGENCY.HEALTHY;
+  }
+  if (props.remaining <= 1) return TRIAL_URGENCY.CRITICAL;
+  if (props.remaining <= 5) return TRIAL_URGENCY.WARNING;
+  return TRIAL_URGENCY.HEALTHY;
+};
+
+const formatRemaining = (remaining: number, unit: TrialSidebarBannerUnit) =>
+  `${remaining} ${unit}${remaining === 1 ? "" : "s"} left`;
+
+export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
+  const cardRef = useRef<HTMLAnchorElement>(null);
+  const isExpired = props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.EXPIRED;
+  const isScanBased =
+    props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_SCANS;
+  const urgency = getTrialUrgency(props);
+  const urgencyStyles = TRIAL_URGENCY_STYLES[urgency];
+  const remainingCopy = isExpired
+    ? null
+    : props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_UNLIMITED
+      ? "Trial active"
+      : formatRemaining(
+          props.remaining,
+          isScanBased
+            ? TRIAL_SIDEBAR_BANNER_UNIT.SCAN
+            : TRIAL_SIDEBAR_BANNER_UNIT.DAY,
+        );
+
+  const resetMotion = () => {
+    const card = cardRef.current;
+    if (!card) return;
+
+    card.style.setProperty("--trial-rotate-x", "0deg");
+    card.style.setProperty("--trial-rotate-y", "0deg");
+    card.style.setProperty("--trial-lift", "0px");
+    card.style.setProperty("--trial-pointer-x", "50%");
+    card.style.setProperty("--trial-pointer-y", "50%");
+  };
+
+  const followPointer = (event: PointerEvent<HTMLAnchorElement>) => {
+    if (
+      event.pointerType === "touch" ||
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return;
+    }
+
+    const card = cardRef.current;
+    if (!card) return;
+
+    const bounds = card.getBoundingClientRect();
+    const pointerX = event.clientX - bounds.left;
+    const pointerY = event.clientY - bounds.top;
+    const normalizedX = pointerX / bounds.width - 0.5;
+    const normalizedY = pointerY / bounds.height - 0.5;
+
+    card.style.setProperty("--trial-rotate-x", `${normalizedY * -3}deg`);
+    card.style.setProperty("--trial-rotate-y", `${normalizedX * 4}deg`);
+    card.style.setProperty("--trial-lift", "-2px");
+    card.style.setProperty("--trial-pointer-x", `${pointerX}px`);
+    card.style.setProperty("--trial-pointer-y", `${pointerY}px`);
+  };
+
+  const motionStyles = {
+    "--trial-rotate-x": "0deg",
+    "--trial-rotate-y": "0deg",
+    "--trial-lift": "0px",
+    "--trial-pointer-x": "50%",
+    "--trial-pointer-y": "50%",
+    transform:
+      "perspective(700px) rotateX(var(--trial-rotate-x)) rotateY(var(--trial-rotate-y)) translateY(var(--trial-lift))",
+  } as CSSProperties;
+
+  return (
+    <Link
+      ref={cardRef}
+      href="/billing"
+      aria-label={
+        isExpired
+          ? "Explore plans after your trial expired"
+          : isScanBased
+            ? "Explore plans for your free trial"
+            : "Explore plans for your unlimited trial"
+      }
+      onClick={props.onSelect}
+      onPointerMove={followPointer}
+      onPointerLeave={resetMotion}
+      onBlur={resetMotion}
+      style={motionStyles}
+      className="focus-visible:ring-button-primary/50 group mx-3 mb-4 block rounded-xl transition-transform duration-200 ease-out focus-visible:ring-2 focus-visible:outline-none motion-reduce:transform-none motion-reduce:transition-none"
+    >
+      <Card
+        variant="inner"
+        padding="sm"
+        data-slot="sidebar-trial"
+        data-urgency={urgency}
+        role="status"
+        aria-label={isExpired ? "Expired trial" : "Active trial"}
+        aria-live="polite"
+        className={cn(
+          "relative gap-3 overflow-hidden transition-colors duration-200",
+          urgencyStyles.sidebarBorder,
+          urgencyStyles.sidebarTint,
+        )}
+      >
+        <span
+          data-slot="trial-glow"
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute size-32 rounded-full opacity-0 blur-3xl transition-opacity duration-300 group-hover:opacity-100 motion-reduce:hidden",
+            urgencyStyles.sidebarGlow,
+          )}
+          style={{
+            left: "var(--trial-pointer-x)",
+            top: "var(--trial-pointer-y)",
+            transform: "translate(-50%, -50%)",
+          }}
+        />
+        <div className="relative z-10 flex min-w-0 items-start gap-2.5">
+          <span className="border-border-neutral-tertiary bg-bg-neutral-secondary flex size-9 shrink-0 items-center justify-center rounded-md border">
+            <Sparkles
+              className={cn(
+                "size-4",
+                isExpired ? "text-text-error-primary" : "text-button-primary",
+              )}
+              aria-hidden="true"
+            />
+          </span>
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <Badge
+              variant={isExpired ? "error" : "success"}
+              size="sm"
+              className="w-fit"
+            >
+              {isExpired
+                ? "Trial expired"
+                : isScanBased
+                  ? "Free trial"
+                  : "Unlimited trial"}
+            </Badge>
+            <strong className="text-text-neutral-primary text-lg leading-none">
+              {isExpired ? "Subscription required" : remainingCopy}
+            </strong>
+          </div>
+        </div>
+        <p className="text-text-neutral-secondary relative z-10 text-xs leading-4">
+          {isExpired
+            ? "Subscribe to continue scanning and running scheduled scans."
+            : isScanBased
+              ? "Choose a plan to keep running scans after your trial ends."
+              : "Unlimited accounts, scans, and daily schedules. Subscribe to keep everything running."}
+        </p>
+        <span className="text-button-primary relative z-10 flex items-center justify-between text-xs font-semibold">
+          Explore plans
+          <ArrowRight
+            className="size-4 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transform-none"
+            aria-hidden="true"
+          />
+        </span>
+      </Card>
+    </Link>
+  );
+};

--- a/ui/components/layout/app-sidebar/trial-sidebar-banner.tsx
+++ b/ui/components/layout/app-sidebar/trial-sidebar-banner.tsx
@@ -259,7 +259,9 @@ export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
           data-urgency={urgency}
           role="status"
           aria-label={copy.cardLabel}
-          aria-live="polite"
+          // role="status" is implicitly atomic, which re-reads the whole card
+          // on every counter change.
+          aria-atomic="false"
           className={cn(
             "relative gap-3 overflow-hidden transition-colors duration-200",
             urgencyStyles.sidebarBorder,

--- a/ui/components/layout/app-sidebar/trial-sidebar-banner.tsx
+++ b/ui/components/layout/app-sidebar/trial-sidebar-banner.tsx
@@ -1,8 +1,15 @@
 "use client";
 
+import {
+  motion,
+  useMotionValue,
+  useReducedMotion,
+  useSpring,
+  useTransform,
+} from "framer-motion";
 import { ArrowRight, Sparkles } from "lucide-react";
 import Link from "next/link";
-import { type CSSProperties, type PointerEvent, useRef } from "react";
+import { type PointerEvent } from "react";
 
 import { Badge } from "@/components/shadcn/badge/badge";
 import { Card } from "@/components/shadcn/card/card";
@@ -111,8 +118,14 @@ const getTrialUrgency = (props: TrialSidebarBannerProps): TrialUrgency => {
 const formatRemaining = (remaining: number, unit: TrialSidebarBannerUnit) =>
   `${remaining} ${unit}${remaining === 1 ? "" : "s"} left`;
 
+const TILT_SPRING = { stiffness: 260, damping: 26, mass: 0.6 } as const;
+const TILT_RESTING_POINTER = 0.5;
+/** Degrees of tilt at the card edges, and the hover lift in pixels. */
+const TILT_RANGE_X = 1.5;
+const TILT_RANGE_Y = 2;
+const TILT_LIFT = -2;
+
 export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
-  const cardRef = useRef<HTMLAnchorElement>(null);
   const isExpired = props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.EXPIRED;
   const isScanBased =
     props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_SCANS;
@@ -129,54 +142,48 @@ export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
             : TRIAL_SIDEBAR_BANNER_UNIT.DAY,
         );
 
-  const resetMotion = () => {
-    const card = cardRef.current;
-    if (!card) return;
+  const prefersReducedMotion = useReducedMotion();
 
-    card.style.setProperty("--trial-rotate-x", "0deg");
-    card.style.setProperty("--trial-rotate-y", "0deg");
-    card.style.setProperty("--trial-lift", "0px");
-    card.style.setProperty("--trial-pointer-x", "50%");
-    card.style.setProperty("--trial-pointer-y", "50%");
+  // Normalised pointer position (0..1) over the card; drives both the tilt and
+  // the glow so no layout values are written to the DOM by hand.
+  const pointerX = useMotionValue(TILT_RESTING_POINTER);
+  const pointerY = useMotionValue(TILT_RESTING_POINTER);
+  const hover = useMotionValue(0);
+
+  const rotateX = useSpring(
+    useTransform(pointerY, [0, 1], [TILT_RANGE_X, -TILT_RANGE_X]),
+    TILT_SPRING,
+  );
+  const rotateY = useSpring(
+    useTransform(pointerX, [0, 1], [-TILT_RANGE_Y, TILT_RANGE_Y]),
+    TILT_SPRING,
+  );
+  const lift = useSpring(
+    useTransform(hover, [0, 1], [0, TILT_LIFT]),
+    TILT_SPRING,
+  );
+  const glowLeft = useTransform(pointerX, (value) => `${value * 100}%`);
+  const glowTop = useTransform(pointerY, (value) => `${value * 100}%`);
+
+  const resetMotion = () => {
+    pointerX.set(TILT_RESTING_POINTER);
+    pointerY.set(TILT_RESTING_POINTER);
+    hover.set(0);
   };
 
   const followPointer = (event: PointerEvent<HTMLAnchorElement>) => {
-    if (
-      event.pointerType === "touch" ||
-      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
-    ) {
-      return;
-    }
+    if (prefersReducedMotion || event.pointerType === "touch") return;
 
-    const card = cardRef.current;
-    if (!card) return;
+    const bounds = event.currentTarget.getBoundingClientRect();
+    if (!bounds.width || !bounds.height) return;
 
-    const bounds = card.getBoundingClientRect();
-    const pointerX = event.clientX - bounds.left;
-    const pointerY = event.clientY - bounds.top;
-    const normalizedX = pointerX / bounds.width - 0.5;
-    const normalizedY = pointerY / bounds.height - 0.5;
-
-    card.style.setProperty("--trial-rotate-x", `${normalizedY * -3}deg`);
-    card.style.setProperty("--trial-rotate-y", `${normalizedX * 4}deg`);
-    card.style.setProperty("--trial-lift", "-2px");
-    card.style.setProperty("--trial-pointer-x", `${pointerX}px`);
-    card.style.setProperty("--trial-pointer-y", `${pointerY}px`);
+    pointerX.set((event.clientX - bounds.left) / bounds.width);
+    pointerY.set((event.clientY - bounds.top) / bounds.height);
+    hover.set(1);
   };
-
-  const motionStyles = {
-    "--trial-rotate-x": "0deg",
-    "--trial-rotate-y": "0deg",
-    "--trial-lift": "0px",
-    "--trial-pointer-x": "50%",
-    "--trial-pointer-y": "50%",
-    transform:
-      "perspective(700px) rotateX(var(--trial-rotate-x)) rotateY(var(--trial-rotate-y)) translateY(var(--trial-lift))",
-  } as CSSProperties;
 
   return (
     <Link
-      ref={cardRef}
       href="/billing"
       aria-label={
         isExpired
@@ -188,79 +195,80 @@ export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
       onClick={props.onSelect}
       onPointerMove={followPointer}
       onPointerLeave={resetMotion}
+      onPointerCancel={resetMotion}
       onBlur={resetMotion}
-      style={motionStyles}
-      className="focus-visible:ring-button-primary/50 group mx-3 mb-4 block rounded-xl transition-transform duration-200 ease-out focus-visible:ring-2 focus-visible:outline-none motion-reduce:transform-none motion-reduce:transition-none"
+      className="focus-visible:ring-button-primary/50 group mx-3 mb-4 block rounded-xl focus-visible:ring-2 focus-visible:outline-none"
     >
-      <Card
-        variant="inner"
-        padding="sm"
-        data-slot="sidebar-trial"
-        data-urgency={urgency}
-        role="status"
-        aria-label={isExpired ? "Expired trial" : "Active trial"}
-        aria-live="polite"
-        className={cn(
-          "relative gap-3 overflow-hidden transition-colors duration-200",
-          urgencyStyles.sidebarBorder,
-          urgencyStyles.sidebarTint,
-        )}
+      <motion.div
+        className="rounded-xl"
+        style={{ transformPerspective: 700, rotateX, rotateY, y: lift }}
       >
-        <span
-          data-slot="trial-glow"
-          aria-hidden="true"
+        <Card
+          variant="inner"
+          padding="sm"
+          data-slot="sidebar-trial"
+          data-urgency={urgency}
+          role="status"
+          aria-label={isExpired ? "Expired trial" : "Active trial"}
+          aria-live="polite"
           className={cn(
-            "pointer-events-none absolute size-32 rounded-full opacity-0 blur-3xl transition-opacity duration-300 group-hover:opacity-100 motion-reduce:hidden",
-            urgencyStyles.sidebarGlow,
+            "relative gap-3 overflow-hidden transition-colors duration-200",
+            urgencyStyles.sidebarBorder,
+            urgencyStyles.sidebarTint,
           )}
-          style={{
-            left: "var(--trial-pointer-x)",
-            top: "var(--trial-pointer-y)",
-            transform: "translate(-50%, -50%)",
-          }}
-        />
-        <div className="relative z-10 flex min-w-0 items-start gap-2.5">
-          <span className="border-border-neutral-tertiary bg-bg-neutral-secondary flex size-9 shrink-0 items-center justify-center rounded-md border">
-            <Sparkles
-              className={cn(
-                "size-4",
-                isExpired ? "text-text-error-primary" : "text-button-primary",
-              )}
+        >
+          <motion.span
+            data-slot="trial-glow"
+            aria-hidden="true"
+            className={cn(
+              "pointer-events-none absolute size-32 rounded-full opacity-0 blur-3xl transition-opacity duration-300 group-hover:opacity-100 motion-reduce:hidden",
+              urgencyStyles.sidebarGlow,
+            )}
+            style={{ left: glowLeft, top: glowTop, x: "-50%", y: "-50%" }}
+          />
+          <div className="relative z-10 flex min-w-0 items-start gap-2.5">
+            <span className="border-border-neutral-tertiary bg-bg-neutral-secondary flex size-9 shrink-0 items-center justify-center rounded-md border">
+              <Sparkles
+                className={cn(
+                  "size-4",
+                  isExpired ? "text-text-error-primary" : "text-button-primary",
+                )}
+                aria-hidden="true"
+              />
+            </span>
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <Badge
+                variant={isExpired ? "error" : "success"}
+                size="sm"
+                className="w-fit"
+              >
+                {isExpired
+                  ? "Trial expired"
+                  : isScanBased
+                    ? "Free trial"
+                    : "Unlimited trial"}
+              </Badge>
+              <strong className="text-text-neutral-primary text-lg leading-none">
+                {isExpired ? "Subscription required" : remainingCopy}
+              </strong>
+            </div>
+          </div>
+          <p className="text-text-neutral-secondary relative z-10 text-xs leading-4">
+            {isExpired
+              ? "Subscribe to continue scanning and running scheduled scans."
+              : isScanBased
+                ? "Choose a plan to keep running scans after your trial ends."
+                : "Unlimited accounts, scans, and daily schedules. Subscribe to keep everything running."}
+          </p>
+          <span className="text-button-primary relative z-10 flex items-center justify-between text-xs font-semibold">
+            Explore plans
+            <ArrowRight
+              className="size-4 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transform-none"
               aria-hidden="true"
             />
           </span>
-          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-            <Badge
-              variant={isExpired ? "error" : "success"}
-              size="sm"
-              className="w-fit"
-            >
-              {isExpired
-                ? "Trial expired"
-                : isScanBased
-                  ? "Free trial"
-                  : "Unlimited trial"}
-            </Badge>
-            <strong className="text-text-neutral-primary text-lg leading-none">
-              {isExpired ? "Subscription required" : remainingCopy}
-            </strong>
-          </div>
-        </div>
-        <p className="text-text-neutral-secondary relative z-10 text-xs leading-4">
-          {isExpired
-            ? "Subscribe to continue scanning and running scheduled scans."
-            : isScanBased
-              ? "Choose a plan to keep running scans after your trial ends."
-              : "Unlimited accounts, scans, and daily schedules. Subscribe to keep everything running."}
-        </p>
-        <span className="text-button-primary relative z-10 flex items-center justify-between text-xs font-semibold">
-          Explore plans
-          <ArrowRight
-            className="size-4 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transform-none"
-            aria-hidden="true"
-          />
-        </span>
-      </Card>
+        </Card>
+      </motion.div>
     </Link>
   );
 };

--- a/ui/components/scans/auto-refresh.test.tsx
+++ b/ui/components/scans/auto-refresh.test.tsx
@@ -1,0 +1,121 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { navigationState, routerRefreshMock } = vi.hoisted(() => ({
+  navigationState: { searchParams: new URLSearchParams() },
+  routerRefreshMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: routerRefreshMock }),
+  useSearchParams: () => navigationState.searchParams,
+}));
+
+import { AutoRefresh, SCAN_DATA_REFRESHED_EVENT } from "./auto-refresh";
+
+describe("AutoRefresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    navigationState.searchParams = new URLSearchParams();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("dispatches scan data refreshed after a successful callback refresh", async () => {
+    // Given
+    let resolveRefresh!: () => void;
+    const refreshPromise = new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const onRefresh = vi.fn().mockReturnValue(refreshPromise);
+    const eventListener = vi.fn();
+    window.addEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+    render(<AutoRefresh hasExecutingScan onRefresh={onRefresh} />);
+
+    // When
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    // Then
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(eventListener).not.toHaveBeenCalled();
+
+    // When
+    resolveRefresh();
+    await refreshPromise;
+    await Promise.resolve();
+
+    // Then
+    expect(eventListener).toHaveBeenCalledOnce();
+    window.removeEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+  });
+
+  it("dispatches scan data refreshed after the default router refresh", async () => {
+    // Given
+    const eventListener = vi.fn();
+    window.addEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+    render(<AutoRefresh hasExecutingScan />);
+
+    // When
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    // Then
+    expect(routerRefreshMock).toHaveBeenCalledOnce();
+    expect(eventListener).toHaveBeenCalledOnce();
+    window.removeEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+  });
+
+  it("does not dispatch scan data refreshed when an async callback rejects", async () => {
+    // Given
+    const onRefresh = vi.fn().mockRejectedValue(new Error("refresh failed"));
+    const eventListener = vi.fn();
+    window.addEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+    render(<AutoRefresh hasExecutingScan onRefresh={onRefresh} />);
+
+    // When
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    // Then
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(eventListener).not.toHaveBeenCalled();
+    window.removeEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+  });
+
+  it.each([
+    {
+      hasExecutingScan: false,
+      searchParams: "",
+      condition: "no scan executes",
+    },
+    {
+      hasExecutingScan: true,
+      searchParams: "scanId=scan-executing",
+      condition: "the scan drawer is open",
+    },
+  ])(
+    "does not poll when $condition",
+    async ({ hasExecutingScan, searchParams }) => {
+      // Given
+      const onRefresh = vi.fn();
+      const eventListener = vi.fn();
+      navigationState.searchParams = new URLSearchParams(searchParams);
+      window.addEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+      render(
+        <AutoRefresh
+          hasExecutingScan={hasExecutingScan}
+          onRefresh={onRefresh}
+        />,
+      );
+
+      // When
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      // Then
+      expect(onRefresh).not.toHaveBeenCalled();
+      expect(eventListener).not.toHaveBeenCalled();
+      window.removeEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+    },
+  );
+});

--- a/ui/components/scans/auto-refresh.test.tsx
+++ b/ui/components/scans/auto-refresh.test.tsx
@@ -11,7 +11,7 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => navigationState.searchParams,
 }));
 
-import { AutoRefresh, SCAN_DATA_REFRESHED_EVENT } from "./auto-refresh";
+import { AutoRefresh, SCAN_POLL_TICK_EVENT } from "./auto-refresh";
 
 describe("AutoRefresh", () => {
   beforeEach(() => {
@@ -24,7 +24,7 @@ describe("AutoRefresh", () => {
     vi.useRealTimers();
   });
 
-  it("dispatches scan data refreshed after a successful callback refresh", async () => {
+  it("dispatches a poll tick after a successful callback refresh", async () => {
     // Given
     let resolveRefresh!: () => void;
     const refreshPromise = new Promise<void>((resolve) => {
@@ -32,7 +32,7 @@ describe("AutoRefresh", () => {
     });
     const onRefresh = vi.fn().mockReturnValue(refreshPromise);
     const eventListener = vi.fn();
-    window.addEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+    window.addEventListener(SCAN_POLL_TICK_EVENT, eventListener);
     render(<AutoRefresh hasExecutingScan onRefresh={onRefresh} />);
 
     // When
@@ -49,13 +49,13 @@ describe("AutoRefresh", () => {
 
     // Then
     expect(eventListener).toHaveBeenCalledOnce();
-    window.removeEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+    window.removeEventListener(SCAN_POLL_TICK_EVENT, eventListener);
   });
 
-  it("dispatches scan data refreshed after the default router refresh", async () => {
+  it("dispatches a poll tick after the default router refresh", async () => {
     // Given
     const eventListener = vi.fn();
-    window.addEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+    window.addEventListener(SCAN_POLL_TICK_EVENT, eventListener);
     render(<AutoRefresh hasExecutingScan />);
 
     // When
@@ -64,14 +64,14 @@ describe("AutoRefresh", () => {
     // Then
     expect(routerRefreshMock).toHaveBeenCalledOnce();
     expect(eventListener).toHaveBeenCalledOnce();
-    window.removeEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+    window.removeEventListener(SCAN_POLL_TICK_EVENT, eventListener);
   });
 
-  it("does not dispatch scan data refreshed when an async callback rejects", async () => {
+  it("does not dispatch a poll tick when an async callback rejects", async () => {
     // Given
     const onRefresh = vi.fn().mockRejectedValue(new Error("refresh failed"));
     const eventListener = vi.fn();
-    window.addEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+    window.addEventListener(SCAN_POLL_TICK_EVENT, eventListener);
     render(<AutoRefresh hasExecutingScan onRefresh={onRefresh} />);
 
     // When
@@ -80,7 +80,7 @@ describe("AutoRefresh", () => {
     // Then
     expect(onRefresh).toHaveBeenCalledOnce();
     expect(eventListener).not.toHaveBeenCalled();
-    window.removeEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+    window.removeEventListener(SCAN_POLL_TICK_EVENT, eventListener);
   });
 
   it.each([
@@ -101,7 +101,7 @@ describe("AutoRefresh", () => {
       const onRefresh = vi.fn();
       const eventListener = vi.fn();
       navigationState.searchParams = new URLSearchParams(searchParams);
-      window.addEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+      window.addEventListener(SCAN_POLL_TICK_EVENT, eventListener);
       render(
         <AutoRefresh
           hasExecutingScan={hasExecutingScan}
@@ -115,7 +115,7 @@ describe("AutoRefresh", () => {
       // Then
       expect(onRefresh).not.toHaveBeenCalled();
       expect(eventListener).not.toHaveBeenCalled();
-      window.removeEventListener(SCAN_DATA_REFRESHED_EVENT, eventListener);
+      window.removeEventListener(SCAN_POLL_TICK_EVENT, eventListener);
     },
   );
 });

--- a/ui/components/scans/auto-refresh.tsx
+++ b/ui/components/scans/auto-refresh.tsx
@@ -3,6 +3,8 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
+export const SCAN_DATA_REFRESHED_EVENT = "prowler:scan-data-refreshed";
+
 interface AutoRefreshProps {
   hasExecutingScan: boolean;
   /** Optional callback for client-side refresh (used when data is managed in local state) */
@@ -21,13 +23,23 @@ export function AutoRefresh({ hasExecutingScan, onRefresh }: AutoRefreshProps) {
     if (scanId) return;
 
     const interval = setInterval(() => {
-      if (onRefresh) {
-        // Use custom refresh callback for client-side state management
-        onRefresh();
-      } else {
-        // Default: trigger server-side refresh
-        router.refresh();
-      }
+      const refresh = async () => {
+        try {
+          if (onRefresh) {
+            // Use custom refresh callback for client-side state management
+            await onRefresh();
+          } else {
+            // Default: trigger server-side refresh
+            router.refresh();
+          }
+        } catch {
+          return;
+        }
+
+        window.dispatchEvent(new Event(SCAN_DATA_REFRESHED_EVENT));
+      };
+
+      void refresh();
     }, 5000);
 
     return () => clearInterval(interval);

--- a/ui/components/scans/auto-refresh.tsx
+++ b/ui/components/scans/auto-refresh.tsx
@@ -3,7 +3,12 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
-export const SCAN_DATA_REFRESHED_EVENT = "prowler:scan-data-refreshed";
+/**
+ * Signals that a poll cycle ran, not that fresh data landed: the default branch
+ * calls the fire-and-forget `router.refresh()`, which reports neither.
+ * Listeners must read authoritative state themselves.
+ */
+export const SCAN_POLL_TICK_EVENT = "prowler:scan-poll-tick";
 
 interface AutoRefreshProps {
   hasExecutingScan: boolean;
@@ -32,11 +37,12 @@ export function AutoRefresh({ hasExecutingScan, onRefresh }: AutoRefreshProps) {
             // Default: trigger server-side refresh
             router.refresh();
           }
-        } catch {
+        } catch (error) {
+          console.error("Scan auto-refresh failed:", error);
           return;
         }
 
-        window.dispatchEvent(new Event(SCAN_DATA_REFRESHED_EVENT));
+        window.dispatchEvent(new Event(SCAN_POLL_TICK_EVENT));
       };
 
       void refresh();

--- a/ui/dependency-log.json
+++ b/ui/dependency-log.json
@@ -595,9 +595,9 @@
     "section": "dependencies",
     "name": "sharp",
     "from": "0.33.5",
-    "to": "0.33.5",
+    "to": "0.35.3",
     "strategy": "installed",
-    "generatedAt": "2025-10-22T12:36:37.962Z"
+    "generatedAt": "2026-08-11T11:35:35.609Z"
   },
   {
     "section": "dependencies",


### PR DESCRIPTION
### Context

The default Cloud trial allows one scan, but the shared sidebar banner only represented day-based trial usage. The UI also needed a generic way to notify persistent layout state after scan polling refreshes.

Internal task: PROWLER-2189. Private billing mapping remains in `prowler-cloud`; this PR contains only reusable OSS presentation and refresh behavior.

### Description

- Add a reusable `TrialSidebarBanner` for active day-based trials, active scan-based trials, unlimited trials, and expired trials.
- Emit a generic browser event after successful scan-data polling refreshes so persistent UI can reload dependent state.
- Add focused regression coverage for banner urgency/copy and refresh-event behavior.
- Add the UI changelog fragment.

No private billing logic or Cloud-only container wiring is included.

### Steps to review

1. Run `cd ui && pnpm exec vitest run components/layout/app-sidebar/trial-sidebar-banner.test.tsx components/scans/auto-refresh.test.tsx`.
2. Run `cd ui && pnpm run typecheck`.
3. Run targeted ESLint and Prettier checks for the changed files.
4. Verify scan-based trials render a healthy `1 scan left` state and expired trials render the critical expiration state.
5. Verify `AutoRefresh` dispatches `prowler:scan-data-refreshed` only after successful refreshes.

Validation completed locally: 15 focused tests passed, TypeScript passed, targeted ESLint passed, Prettier check passed, and both staged and unstaged diff checks passed. The one-scan transition was exercised in an isolated local Cloud stack.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is tracked internally as PROWLER-2189
- [x] It is assigned through the internal task
- [x] I reviewed open pull requests and found no existing PR implementing the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code documentation is needed; no public API documentation changes are required.
- [x] Review if backport is needed; no backport is required.
- [x] Review if README changes are needed; none are required.
- [x] Ensure a changelog fragment is added, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] No npm dependencies are added or updated
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [x] A changelog fragment is included under `ui/changelog.d/`

#### API

Not applicable.

#### MCP Server

Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sidebar trial banner for active, unlimited, expired, and default one-scan trials, with remaining usage, expiration details, and billing actions.
  * Added accessible status messaging and optional interactive visual effects.
  * Added scan data refresh notifications after successful automatic refreshes.

* **Bug Fixes**
  * Improved refresh error handling and suppressed unnecessary polling when appropriate.

* **Tests**
  * Added comprehensive coverage for trial banners and automatic scan refreshing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->