### PR TITLE
feat(aws): add ordered role assumption chain support

### DIFF
--- a/api/src/backend/api/v1/serializer_utils/providers.py
+++ b/api/src/backend/api/v1/serializer_utils/providers.py
@@ -34,7 +34,7 @@ from rest_framework_json_api import serializers
                     "role_arn": {
                         "type": "string",
                         "description": "The Amazon Resource Name (ARN) of the role to assume. Required for AWS role "
-                        "assumption. Mutually exclusive with role_chain.",
+                        "assumption.",
                     },
                     "external_id": {
                         "type": "string",
@@ -72,43 +72,6 @@ from rest_framework_json_api import serializers
                         "- User_Session-1\n"
                         "- Test.Session@2",
                         "pattern": "^[a-zA-Z0-9=,.@_-]+$",
-                    },
-                    "role_chain": {
-                        "type": "array",
-                        "description": "Ordered list of IAM roles to assume sequentially to reach the target account. "
-                        "Mutually exclusive with role_arn. Each step defines one sts:AssumeRole hop.",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "role_arn": {
-                                    "type": "string",
-                                    "description": "The ARN of the role to assume at this step.",
-                                },
-                                "external_id": {
-                                    "type": "string",
-                                    "description": "External ID for this assumption step.",
-                                },
-                                "role_session_name": {
-                                    "type": "string",
-                                    "description": "Session name for this step.",
-                                    "pattern": "^[a-zA-Z0-9=,.@_-]+$",
-                                },
-                                "session_duration": {
-                                    "type": "integer",
-                                    "minimum": 900,
-                                    "maximum": 43200,
-                                    "default": 3600,
-                                    "description": "Session duration in seconds for this step.",
-                                },
-                                "sts_region": {
-                                    "type": "string",
-                                    "description": "AWS region for the STS endpoint of this step.",
-                                },
-                            },
-                            "required": ["role_arn"],
-                        },
-                        "minItems": 1,
-                        "maxItems": 10,
                     },
                 },
                 "required": ["role_arn", "external_id"],

--- a/api/src/backend/api/v1/serializer_utils/providers.py
+++ b/api/src/backend/api/v1/serializer_utils/providers.py
@@ -34,7 +34,7 @@ from rest_framework_json_api import serializers
                     "role_arn": {
                         "type": "string",
                         "description": "The Amazon Resource Name (ARN) of the role to assume. Required for AWS role "
-                        "assumption.",
+                        "assumption. Mutually exclusive with role_chain.",
                     },
                     "external_id": {
                         "type": "string",
@@ -73,8 +73,108 @@ from rest_framework_json_api import serializers
                         "- Test.Session@2",
                         "pattern": "^[a-zA-Z0-9=,.@_-]+$",
                     },
+                    "role_chain": {
+                        "type": "array",
+                        "description": "Ordered list of IAM roles to assume sequentially to reach the target account. "
+                        "Mutually exclusive with role_arn. Each step defines one sts:AssumeRole hop.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "role_arn": {
+                                    "type": "string",
+                                    "description": "The ARN of the role to assume at this step.",
+                                },
+                                "external_id": {
+                                    "type": "string",
+                                    "description": "External ID for this assumption step.",
+                                },
+                                "role_session_name": {
+                                    "type": "string",
+                                    "description": "Session name for this step.",
+                                    "pattern": "^[a-zA-Z0-9=,.@_-]+$",
+                                },
+                                "session_duration": {
+                                    "type": "integer",
+                                    "minimum": 900,
+                                    "maximum": 43200,
+                                    "default": 3600,
+                                    "description": "Session duration in seconds for this step.",
+                                },
+                                "sts_region": {
+                                    "type": "string",
+                                    "description": "AWS region for the STS endpoint of this step.",
+                                },
+                            },
+                            "required": ["role_arn"],
+                        },
+                        "minItems": 1,
+                        "maxItems": 10,
+                    },
                 },
                 "required": ["role_arn", "external_id"],
+            },
+            {
+                "type": "object",
+                "title": "AWS Assume Role Chain",
+                "description": "AWS credentials with an ordered chain of role assumptions. "
+                "Use when multiple sequential sts:AssumeRole hops are needed "
+                "to reach the target account (e.g. hub-spoke models).",
+                "properties": {
+                    "aws_access_key_id": {
+                        "type": "string",
+                        "description": "The AWS access key ID for the initial credentials.",
+                    },
+                    "aws_secret_access_key": {
+                        "type": "string",
+                        "description": "The AWS secret access key for the initial credentials.",
+                    },
+                    "aws_session_token": {
+                        "type": "string",
+                        "description": "The session token for temporary initial credentials, if applicable.",
+                    },
+                    "role_chain": {
+                        "type": "array",
+                        "description": "Ordered list of IAM roles to assume sequentially. "
+                        "Each hop's output credentials become the input for the next hop.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "role_arn": {
+                                    "type": "string",
+                                    "description": "The ARN of the role to assume at this step.",
+                                },
+                                "external_id": {
+                                    "type": "string",
+                                    "description": "External ID for this assumption step.",
+                                },
+                                "role_session_name": {
+                                    "type": "string",
+                                    "description": "Session name for this step.",
+                                    "pattern": "^[a-zA-Z0-9=,.@_-]+$",
+                                },
+                                "session_duration": {
+                                    "type": "integer",
+                                    "minimum": 900,
+                                    "maximum": 43200,
+                                    "default": 3600,
+                                    "description": "Session duration in seconds for this step.",
+                                },
+                                "sts_region": {
+                                    "type": "string",
+                                    "description": "AWS region for the STS endpoint of this step.",
+                                },
+                            },
+                            "required": ["role_arn"],
+                        },
+                        "minItems": 1,
+                        "maxItems": 10,
+                    },
+                },
+                "required": [
+                    "aws_access_key_id",
+                    "aws_secret_access_key",
+                    "role_chain",
+                ],
             },
             {
                 "type": "object",

--- a/docs/user-guide/providers/aws/authentication.mdx
+++ b/docs/user-guide/providers/aws/authentication.mdx
@@ -28,6 +28,8 @@ For certain checks, additional read-only permissions are required. Attach the fo
 
 This method grants permanent access and is the recommended setup for production environments.
 
+For environments that require multiple sequential role hops to reach the target account (hub-spoke models), Prowler supports ordered role assumption chains. See [Ordered Role Assumption Chain](/user-guide/providers/aws/role-assumption#ordered-role-assumption-chain) for details.
+
 <Tabs>
   <Tab title="CloudFormation">
     1. Download the [Prowler Scan Role Template](https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/master/permissions/templates/cloudformation/prowler-scan-role.yml)

--- a/docs/user-guide/providers/aws/role-assumption.mdx
+++ b/docs/user-guide/providers/aws/role-assumption.mdx
@@ -93,8 +93,113 @@ prowler aws -R arn:aws:iam::<account_id>:role/ProwlerScan -I <external_id>
 ```
 
 <Note>
-**Session Duration Considerations**: Depending on the number of checks performed and the size of your infrastructure, Prowler may require more than 1 hour to complete. Use the `-T <seconds>` option to allow up to 12 hours (43,200 seconds). If you need more than 1 hour, modify the _“Maximum CLI/API session duration”_ setting for the role. Learn more [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session).
+**Session Duration Considerations**: Depending on the number of checks performed and the size of your infrastructure, Prowler may require more than 1 hour to complete. Use the `-T <seconds>` option to allow up to 12 hours (43,200 seconds). If you need more than 1 hour, modify the _"Maximum CLI/API session duration"_ setting for the role. Learn more [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session).
 
 ⚠️ Important: If assuming roles via role chaining, there is a hard limit of 1 hour. Whenever possible, avoid role chaining to prevent session expiration issues. More details are available in footnote 1 below the table in the [AWS IAM guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html).
 
 </Note>
+
+## Ordered Role Assumption Chain
+
+import { VersionBadge } from "/snippets/version-badge.mdx"
+
+<VersionBadge version="5.9.0" />
+
+Some AWS environments use a hub-spoke model where reaching the target account requires multiple sequential `sts:AssumeRole` hops. For example, an audit account in a security hub must first assume a role in a landing zone, which then assumes the final scan role in the target spoke account.
+
+Prowler supports ordered role chains of up to 10 hops. Each hop's output credentials become the input session for the next hop.
+
+### Using a Chain File (CLI)
+
+Create a JSON file defining the ordered chain:
+
+```json
+[
+  {
+    "role_arn": "arn:aws:iam::111111111111:role/HubRole",
+    "external_id": "hub-external-id",
+    "session_duration": 3600
+  },
+  {
+    "role_arn": "arn:aws:iam::222222222222:role/LandingZoneRole",
+    "session_duration": 3600
+  },
+  {
+    "role_arn": "arn:aws:iam::333333333333:role/TargetScanRole",
+    "external_id": "target-external-id",
+    "session_duration": 900
+  }
+]
+```
+
+Then pass the file path to Prowler:
+
+```sh
+prowler aws --role-chain /path/to/chain.json
+```
+
+Each step in the chain supports the following optional parameters:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `role_arn` | *(required)* | The ARN of the role to assume at this step. |
+| `external_id` | `None` | External ID for this assumption step. |
+| `session_duration` | `3600` | Session duration in seconds (900–43200). |
+| `role_session_name` | `ProwlerAssessmentSession` | Session name for this step. |
+| `sts_region` | `us-east-1` | AWS region for the STS endpoint of this step. |
+
+<Note>
+`--role` and `--role-chain` are mutually exclusive. Use one or the other, not both.
+
+</Note>
+
+<Note>
+MFA is not supported in role chains because AWS STS does not forward MFA tokens through sequential hops.
+
+</Note>
+
+<Warning>
+AWS imposes a hard 1-hour limit on chained role sessions regardless of the `session_duration` set per hop. Plan chain depth accordingly.
+
+</Warning>
+
+### Using the API
+
+When configuring an AWS provider through the API, pass the chain in the secret payload:
+
+```json
+{
+  "data": {
+    "type": "provider-secrets",
+    "attributes": {
+      "secret_type": "role",
+      "secret": {
+        "aws_access_key_id": "AKIA...",
+        "aws_secret_access_key": "...",
+        "role_chain": [
+          {
+            "role_arn": "arn:aws:iam::111111111111:role/BootstrapRole",
+            "external_id": "bootstrap-ext",
+            "role_session_name": "prowler-hop-1",
+            "session_duration": 3600
+          },
+          {
+            "role_arn": "arn:aws:iam::222222222222:role/FinalScanRole",
+            "role_session_name": "prowler-hop-2",
+            "session_duration": 3600
+          }
+        ]
+      }
+    },
+    "relationships": {
+      "provider": {
+        "data": { "type": "providers", "id": "<provider-id>" }
+      }
+    }
+  }
+}
+```
+
+### Credential Refresh
+
+When Prowler runs with a role chain, credentials are refreshed by re-walking the entire chain from the original session. This ensures every hop gets fresh temporary credentials when any credential in the chain expires.

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -31,6 +31,7 @@ from prowler.providers.aws.config import (
 from prowler.providers.aws.exceptions.exceptions import (
     AWSAccessKeyIDInvalidError,
     AWSArgumentTypeValidationError,
+    AWSAssumeRoleChainError,
     AWSAssumeRoleError,
     AWSClientError,
     AWSIAMRoleARNEmptyResourceError,
@@ -62,6 +63,7 @@ from prowler.providers.aws.models import (
     AWSIdentityInfo,
     AWSMFAInfo,
     AWSOrganizationsInfo,
+    AWSRoleChainStep,
     AWSSession,
     Partition,
 )
@@ -106,6 +108,7 @@ class AwsProvider(Provider):
         self,
         retries_max_attempts: int = 3,
         role_arn: str = None,
+        role_chain: list = None,
         session_duration: int = 3600,
         external_id: str = None,
         role_session_name: str = None,
@@ -131,7 +134,11 @@ class AwsProvider(Provider):
 
         Args:
             - retries_max_attempts: The maximum number of retries for the AWS client.
-            - role_arn: The ARN of the IAM role to assume.
+            - role_arn: The ARN of the IAM role to assume. Mutually exclusive with role_chain.
+            - role_chain: An ordered list of dicts, each defining one AssumeRole hop.
+              Mutually exclusive with role_arn. Each dict may contain:
+              ``role_arn`` (required), ``external_id``, ``session_duration``,
+              ``role_session_name``, ``sts_region``.
             - session_duration: The duration of the session in seconds, between 900 and 43200.
             - external_id: The external ID to use when assuming the IAM role.
             - role_session_name: The name of the session when assuming the IAM role.
@@ -276,47 +283,101 @@ class AwsProvider(Provider):
         )
         ########
         ######## AWS Session with Assume Role (if needed)
-        if role_arn:
-            # Validate the input role
-            valid_role_arn = parse_iam_credentials_arn(role_arn)
-            # Set assume IAM Role information
-            assumed_role_information = AWSAssumeRoleInfo(
-                role_arn=valid_role_arn,
-                session_duration=session_duration,
-                external_id=external_id,
-                mfa_enabled=mfa,
-                role_session_name=role_session_name,
-                sts_region=sts_region,
-            )
-            # Assume the IAM Role
-            logger.info(f"Assuming role: {assumed_role_information.role_arn.arn}")
-            assumed_role_credentials = AwsProvider.assume_role(
-                self._session.current_session,
-                assumed_role_information,
-            )
-            logger.info(f"IAM Role assumed: {assumed_role_information.role_arn.arn}")
+        # Normalize both single-role and chain inputs into an ordered
+        # list of AWSRoleChainStep objects.  A single --role becomes a
+        # one-element chain.  --role_chain (API/CLI) is used as-is.
+        chain_steps: list[AWSRoleChainStep] = []
 
-            assumed_role_configuration = AWSAssumeRoleConfiguration(
-                info=assumed_role_information, credentials=assumed_role_credentials
+        if role_chain and role_arn:
+            raise AWSArgumentTypeValidationError(
+                message="role_chain and role_arn are mutually exclusive.",
+                file=pathlib.Path(__file__).name,
             )
-            # Store the assumed role configuration since it'll be needed to refresh the credentials
-            self._assumed_role_configuration = assumed_role_configuration
+
+        if role_chain:
+            from prowler.providers.aws.config import MAX_ROLE_CHAIN_STEPS
+
+            if len(role_chain) > MAX_ROLE_CHAIN_STEPS:
+                raise AWSArgumentTypeValidationError(
+                    message=f"role_chain exceeds maximum of {MAX_ROLE_CHAIN_STEPS} steps.",
+                    file=pathlib.Path(__file__).name,
+                )
+            for idx, step in enumerate(role_chain):
+                if "role_arn" not in step:
+                    raise AWSArgumentTypeValidationError(
+                        message=f"role_chain step {idx} is missing required 'role_arn'.",
+                        file=pathlib.Path(__file__).name,
+                    )
+                valid_arn = parse_iam_credentials_arn(step["role_arn"])
+                chain_steps.append(
+                    AWSRoleChainStep(
+                        role_arn=valid_arn,
+                        external_id=step.get("external_id"),
+                        session_duration=step.get("session_duration", 3600),
+                        role_session_name=step.get(
+                            "role_session_name", ROLE_SESSION_NAME
+                        ),
+                        sts_region=step.get("sts_region", sts_region),
+                    )
+                )
+        elif role_arn:
+            valid_role_arn = parse_iam_credentials_arn(role_arn)
+            chain_steps = [
+                AWSRoleChainStep(
+                    role_arn=valid_role_arn,
+                    external_id=external_id,
+                    session_duration=session_duration,
+                    role_session_name=role_session_name,
+                    sts_region=sts_region,
+                )
+            ]
+
+        if chain_steps:
+            hop_count = len(chain_steps)
+            logger.info(
+                f"Assuming role chain ({hop_count} hop{'s' if hop_count > 1 else ''})..."
+            )
+            final_session, final_credentials = AwsProvider.assume_role_chain(
+                self._session.current_session,
+                chain_steps,
+                self._session.session_config,
+            )
+            logger.info("Role chain assumed successfully")
+
+            # Store chain on session so refresh_credentials can re-walk it
+            self._session.role_chain = chain_steps
+
+            # Backwards-compatible attribute (uses last hop)
+            last_step = chain_steps[-1]
+            self._assumed_role_configuration = AWSAssumeRoleConfiguration(
+                info=AWSAssumeRoleInfo(
+                    role_arn=last_step.role_arn,
+                    session_duration=last_step.session_duration,
+                    external_id=last_step.external_id,
+                    mfa_enabled=mfa,
+                    role_session_name=last_step.role_session_name,
+                    sts_region=last_step.sts_region,
+                ),
+                credentials=final_credentials,
+            )
 
             # Store a new current session using the assumed IAM Role
             self._session.current_session = AwsProvider.setup_assumed_session(
                 self._identity,
-                assumed_role_configuration,
+                self._assumed_role_configuration,
                 self._session,
             )
             logger.info("Audit session is the new session created assuming an IAM Role")
 
             # Modify identity for the IAM Role assumed since this will be the identity to audit with
             logger.info("Setting new identity for the AWS IAM Role assumed")
-            self._identity.account = assumed_role_configuration.info.role_arn.account_id
-            self._identity.partition = (
-                assumed_role_configuration.info.role_arn.partition
+            self._identity.account = (
+                self._assumed_role_configuration.info.role_arn.account_id
             )
-            self._identity.account_arn = f"arn:{assumed_role_configuration.info.role_arn.partition}:iam::{assumed_role_configuration.info.role_arn.account_id}:root"
+            self._identity.partition = (
+                self._assumed_role_configuration.info.role_arn.partition
+            )
+            self._identity.account_arn = f"arn:{self._assumed_role_configuration.info.role_arn.partition}:iam::{self._assumed_role_configuration.info.role_arn.account_id}:root"
         ########
 
         ######## AWS Organizations Metadata
@@ -782,6 +843,10 @@ class AwsProvider(Provider):
         """
         Refresh credentials method using AWS STS Assume Role.
 
+        When the session carries a ``role_chain``, the entire chain is re-walked
+        from ``original_session`` so that every hop gets fresh temporary
+        credentials.  Otherwise the legacy single-hop refresh path is used.
+
         This method is called adding "()" to the name, so it cannot accept arguments
         https://github.com/boto/botocore/blob/098cc255f81a25b852e1ecdeb7adebd94c7b1b73/botocore/credentials.py#L570
         """
@@ -803,16 +868,25 @@ class AwsProvider(Provider):
         if datetime.fromisoformat(refreshed_credentials["expiry_time"]) <= datetime.now(
             get_localzone()
         ):
-            assume_role_response = AwsProvider.assume_role(
-                session.original_session, assumed_role_configuration.info
-            )
+            if session.role_chain:
+                # Re-walk the entire chain from original_session
+                _, final_creds = AwsProvider.assume_role_chain(
+                    session.original_session,
+                    session.role_chain,
+                    session.session_config,
+                )
+            else:
+                # Single-hop legacy path
+                final_creds = AwsProvider.assume_role(
+                    session.original_session, assumed_role_configuration.info
+                )
             refreshed_credentials = dict(
                 # Keys of the dict has to be the same as those that are being searched in the parent class
                 # https://github.com/boto/botocore/blob/098cc255f81a25b852e1ecdeb7adebd94c7b1b73/botocore/credentials.py#L609
-                access_key=assume_role_response.aws_access_key_id,
-                secret_key=assume_role_response.aws_secret_access_key,
-                token=assume_role_response.aws_session_token,
-                expiry_time=assume_role_response.expiration.isoformat(),
+                access_key=final_creds.aws_access_key_id,
+                secret_key=final_creds.aws_secret_access_key,
+                token=final_creds.aws_session_token,
+                expiry_time=final_creds.expiration.isoformat(),
             )
             logger.info("Refreshed Credentials")
 
@@ -862,6 +936,16 @@ class AwsProvider(Provider):
             report_lines.append(
                 f"Assumed Role ARN: {Fore.YELLOW}[{self._assumed_role_configuration.info.role_arn.arn}]{Style.RESET_ALL}"
             )
+        # Show chain hops when a multi-hop chain is active
+        if (
+            getattr(self._session, "role_chain", None)
+            and len(self._session.role_chain) > 1
+        ):
+            report_lines.append("Role Chain:")
+            for i, step in enumerate(self._session.role_chain):
+                report_lines.append(
+                    f"  [{i + 1}] {Fore.YELLOW}{step.role_arn.arn}{Style.RESET_ALL}"
+                )
         report_title = (
             f"{Style.BRIGHT}Using the AWS credentials below:{Style.RESET_ALL}"
         )
@@ -1239,6 +1323,67 @@ class AwsProvider(Provider):
                 file=pathlib.Path(__file__).name,
             )
 
+    @staticmethod
+    def assume_role_chain(
+        base_session: Session,
+        steps: list[AWSRoleChainStep],
+        session_config: Config = None,
+    ) -> tuple[Session, AWSCredentials]:
+        """Walk an ordered chain of role assumptions iteratively.
+
+        Each step's output credentials become the input session for the next
+        step.  The final session and credentials are returned.
+
+        Args:
+            base_session: The starting session (profile / env / static creds).
+            steps: Ordered list of :class:`AWSRoleChainStep` objects.
+            session_config: Optional botocore Config applied to intermediate
+                sessions.
+
+        Returns:
+            Tuple of ``(final boto3.Session, final AWSCredentials)``.
+
+        Raises:
+            AWSAssumeRoleChainError: If any step in the chain fails.
+        """
+        current_session = base_session
+        total = len(steps)
+        final_credentials: AWSCredentials = None
+
+        for idx, step in enumerate(steps):
+            step_num = idx + 1
+            logger.info(f"Chain step {step_num}/{total}: assuming {step.role_arn.arn}")
+            role_info = AWSAssumeRoleInfo(
+                role_arn=step.role_arn,
+                session_duration=step.session_duration,
+                external_id=step.external_id,
+                mfa_enabled=False,
+                role_session_name=step.role_session_name,
+                sts_region=step.sts_region,
+            )
+            try:
+                final_credentials = AwsProvider.assume_role(current_session, role_info)
+            except Exception as error:
+                raise AWSAssumeRoleChainError(
+                    step=step_num,
+                    original_exception=error,
+                    file=pathlib.Path(__file__).name,
+                )
+            logger.info(f"Chain step {step_num}/{total}: assumed {step.role_arn.arn}")
+
+            if idx < total - 1:
+                # Build intermediate session for the next hop
+                current_session = Session(
+                    aws_access_key_id=final_credentials.aws_access_key_id,
+                    aws_secret_access_key=final_credentials.aws_secret_access_key,
+                    aws_session_token=final_credentials.aws_session_token,
+                    region_name=current_session.region_name,
+                )
+                if session_config:
+                    current_session._session.set_default_client_config(session_config)
+
+        return current_session, final_credentials
+
     def get_aws_enabled_regions(self, current_session: Session) -> set | None:
         """get_aws_enabled_regions returns a set of enabled AWS regions, or None on failure.
 
@@ -1354,6 +1499,7 @@ class AwsProvider(Provider):
         profile: str = None,
         aws_region: str = AWS_STS_GLOBAL_ENDPOINT_REGION,
         role_arn: str = None,
+        role_chain: list = None,
         role_session_name: str = ROLE_SESSION_NAME,
         session_duration: int = 3600,
         external_id: str = None,
@@ -1370,7 +1516,8 @@ class AwsProvider(Provider):
         Args:
             profile (str): The AWS profile to use for the session.
             aws_region (str): The AWS region to validate the credentials in.
-            role_arn (str): The ARN of the IAM role to assume.
+            role_arn (str): The ARN of the IAM role to assume. Mutually exclusive with role_chain.
+            role_chain (list): Ordered list of role assumption steps. Mutually exclusive with role_arn.
             role_session_name (str): The name of the role session.
             session_duration (int): The duration of the assumed role session in seconds.
             external_id (str): The external ID to use when assuming the role.
@@ -1420,7 +1567,27 @@ class AwsProvider(Provider):
                 aws_session_token=aws_session_token,
             )
 
-            if role_arn:
+            if role_chain and role_arn:
+                raise AWSArgumentTypeValidationError(
+                    message="role_chain and role_arn are mutually exclusive.",
+                    file=pathlib.Path(__file__).name,
+                )
+
+            if role_chain:
+                chain_steps = []
+                for step in role_chain:
+                    chain_steps.append(
+                        AWSRoleChainStep(
+                            role_arn=parse_iam_credentials_arn(step["role_arn"]),
+                            external_id=step.get("external_id"),
+                            session_duration=step.get("session_duration", 3600),
+                            role_session_name=step.get(
+                                "role_session_name", ROLE_SESSION_NAME
+                            ),
+                        )
+                    )
+                session, _ = AwsProvider.assume_role_chain(session, chain_steps)
+            elif role_arn:
                 session_duration = validate_session_duration(session_duration)
                 role_session_name = validate_role_session_name(role_session_name)
                 role_arn = parse_iam_credentials_arn(role_arn)

--- a/prowler/providers/aws/config.py
+++ b/prowler/providers/aws/config.py
@@ -6,6 +6,7 @@ AWS_STS_GLOBAL_ENDPOINT_REGION = "us-east-1"
 AWS_REGION_US_EAST_1 = "us-east-1"
 BOTO3_USER_AGENT_EXTRA = os.getenv("PROWLER_AWS_BOTO3_USER_AGENT_EXTRA", "APN_1826889")
 ROLE_SESSION_NAME = "ProwlerAssessmentSession"
+MAX_ROLE_CHAIN_STEPS = 10
 
 
 def get_default_session_config() -> Config:

--- a/prowler/providers/aws/exceptions/exceptions.py
+++ b/prowler/providers/aws/exceptions/exceptions.py
@@ -231,3 +231,17 @@ class AWSInvalidPartitionError(AWSBaseException):
         super().__init__(
             1917, file=file, original_exception=original_exception, message=message
         )
+
+
+class AWSAssumeRoleChainError(AWSBaseException):
+    """Raised when a role assumption chain fails at a specific step."""
+
+    def __init__(self, step, file=None, original_exception=None, message=None):
+        self.step = step
+        default_message = f"Role chain assumption failed at step {step}"
+        super().__init__(
+            1018,
+            file=file,
+            original_exception=original_exception,
+            message=message or default_message,
+        )

--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -2,7 +2,7 @@ from argparse import ArgumentTypeError, Namespace
 from re import fullmatch, search
 
 from prowler.providers.aws.aws_provider import AwsProvider
-from prowler.providers.aws.config import ROLE_SESSION_NAME
+from prowler.providers.aws.config import MAX_ROLE_CHAIN_STEPS, ROLE_SESSION_NAME
 from prowler.providers.aws.lib.arn.arn import arn_type
 
 
@@ -25,8 +25,15 @@ def init_parser(self):
         "-R",
         nargs="?",
         default=None,
-        help="ARN of the role to be assumed",
+        help="ARN of the role to be assumed. Mutually exclusive with --role-chain.",
         # TODO: Pending ARN validation
+    )
+    aws_auth_subparser.add_argument(
+        "--role-chain",
+        nargs="?",
+        default=None,
+        help="Path to a JSON file defining an ordered role assumption chain. Mutually exclusive with --role.",
+        type=validate_role_chain_file,
     )
     aws_auth_subparser.add_argument(
         "--role-session-name",
@@ -214,6 +221,50 @@ def validate_role_session_name(session_name) -> str:
         )
 
 
+def validate_role_chain_file(chain_path: str) -> list[dict]:
+    """Load and validate a role chain JSON file.
+
+    The file must contain a JSON array of objects, each with at least a
+    ``role_arn`` key.  Optional keys per step: ``external_id``,
+    ``session_duration``, ``role_session_name``, ``sts_region``.
+
+    Returns the parsed list of dicts ready to be passed as ``role_chain``
+    to :class:`AwsProvider`.
+    """
+    import json
+
+    try:
+        with open(chain_path) as f:
+            chain_data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        raise ArgumentTypeError(f"Invalid role chain file: {e}")
+
+    if not isinstance(chain_data, list):
+        raise ArgumentTypeError("Role chain must be a JSON array")
+    if len(chain_data) == 0:
+        raise ArgumentTypeError("Role chain must contain at least one step")
+    if len(chain_data) > MAX_ROLE_CHAIN_STEPS:
+        raise ArgumentTypeError(
+            f"Role chain exceeds maximum of {MAX_ROLE_CHAIN_STEPS} steps"
+        )
+
+    for i, step in enumerate(chain_data):
+        if "role_arn" not in step:
+            raise ArgumentTypeError(
+                f"Role chain step {i + 1} is missing required 'role_arn'"
+            )
+        if "session_duration" in step:
+            step["session_duration"] = validate_session_duration(
+                step["session_duration"]
+            )
+        if "role_session_name" in step:
+            step["role_session_name"] = validate_role_session_name(
+                step["role_session_name"]
+            )
+
+    return chain_data
+
+
 def validate_arguments(arguments: Namespace) -> tuple[bool, str]:
     """validate_arguments returns {True, "} if the provider arguments passed are valid and can be used together. It performs an extra validation, specific for the AWS provider, apart from the argparse lib."""
 
@@ -228,6 +279,13 @@ def validate_arguments(arguments: Namespace) -> tuple[bool, str]:
                 False,
                 "To use -I/--external-id, -T/--session-duration or --role-session-name options -R/--role option is needed",
             )
+
+    # --role and --role-chain are mutually exclusive
+    if getattr(arguments, "role_chain", None) and arguments.role:
+        return (
+            False,
+            "--role and --role-chain are mutually exclusive",
+        )
 
     return (True, "")
 

--- a/prowler/providers/aws/lib/s3/s3.py
+++ b/prowler/providers/aws/lib/s3/s3.py
@@ -319,6 +319,9 @@ class S3:
                             role_session_name=step.get(
                                 "role_session_name", ROLE_SESSION_NAME
                             ),
+                            sts_region=step.get(
+                                "sts_region", AWS_STS_GLOBAL_ENDPOINT_REGION
+                            ),
                         )
                     )
                 session, _ = AwsProvider.assume_role_chain(session, chain_steps)

--- a/prowler/providers/aws/lib/s3/s3.py
+++ b/prowler/providers/aws/lib/s3/s3.py
@@ -46,7 +46,12 @@ from prowler.providers.aws.lib.session.aws_set_up_session import (
     AwsSetUpSession,
     parse_iam_credentials_arn,
 )
-from prowler.providers.aws.models import AWSAssumeRoleInfo, AWSIdentityInfo, AWSSession
+from prowler.providers.aws.models import (
+    AWSAssumeRoleInfo,
+    AWSIdentityInfo,
+    AWSRoleChainStep,
+    AWSSession,
+)
 from prowler.providers.common.models import Connection
 
 
@@ -264,6 +269,7 @@ class S3:
         profile: str = None,
         aws_region: str = AWS_STS_GLOBAL_ENDPOINT_REGION,
         role_arn: str = None,
+        role_chain: list = None,
         role_session_name: str = ROLE_SESSION_NAME,
         session_duration: int = 3600,
         external_id: str = None,
@@ -287,7 +293,6 @@ class S3:
         Raises:
         - Exception: An exception indicating that the connection test failed.
         """
-        # TODO: Refactor this method, the AWSProvider.test_connection() and the SecurityHubProvider.test_connection() are similar.
         try:
             session = AwsProvider.setup_session(
                 mfa=mfa_enabled,
@@ -297,7 +302,27 @@ class S3:
                 aws_session_token=aws_session_token,
             )
 
-            if role_arn:
+            if role_chain and role_arn:
+                raise AWSArgumentTypeValidationError(
+                    message="role_chain and role_arn are mutually exclusive.",
+                    file=os.path.basename(__file__),
+                )
+
+            if role_chain:
+                chain_steps = []
+                for step in role_chain:
+                    chain_steps.append(
+                        AWSRoleChainStep(
+                            role_arn=parse_iam_credentials_arn(step["role_arn"]),
+                            external_id=step.get("external_id"),
+                            session_duration=step.get("session_duration", 3600),
+                            role_session_name=step.get(
+                                "role_session_name", ROLE_SESSION_NAME
+                            ),
+                        )
+                    )
+                session, _ = AwsProvider.assume_role_chain(session, chain_steps)
+            elif role_arn:
                 session_duration = validate_session_duration(session_duration)
                 role_session_name = validate_role_session_name(role_session_name)
                 role_arn = parse_iam_credentials_arn(role_arn)

--- a/prowler/providers/aws/lib/security_hub/security_hub.py
+++ b/prowler/providers/aws/lib/security_hub/security_hub.py
@@ -541,6 +541,9 @@ class SecurityHub:
                             role_session_name=step.get(
                                 "role_session_name", ROLE_SESSION_NAME
                             ),
+                            sts_region=step.get(
+                                "sts_region", AWS_STS_GLOBAL_ENDPOINT_REGION
+                            ),
                         )
                     )
                 session, _ = AwsProvider.assume_role_chain(session, chain_steps)

--- a/prowler/providers/aws/lib/security_hub/security_hub.py
+++ b/prowler/providers/aws/lib/security_hub/security_hub.py
@@ -41,7 +41,7 @@ from prowler.providers.aws.lib.security_hub.exceptions.exceptions import (
     SecurityHubNoEnabledRegionsError,
 )
 from prowler.providers.aws.lib.session.aws_set_up_session import AwsSetUpSession
-from prowler.providers.aws.models import AWSAssumeRoleInfo
+from prowler.providers.aws.models import AWSAssumeRoleInfo, AWSRoleChainStep
 from prowler.providers.common.models import Connection
 
 SECURITY_HUB_INTEGRATION_NAME = "prowler/prowler"
@@ -470,6 +470,7 @@ class SecurityHub:
         profile: str = None,
         aws_region: str = AWS_STS_GLOBAL_ENDPOINT_REGION,
         role_arn: str = None,
+        role_chain: list = None,
         role_session_name: str = ROLE_SESSION_NAME,
         session_duration: int = 3600,
         external_id: str = None,
@@ -522,8 +523,28 @@ class SecurityHub:
                     session, aws_region
                 ).arn.partition
 
-            # Handle role assumption if role_arn is provided
-            if role_arn:
+            # Handle role assumption if role_arn or role_chain is provided
+            if role_chain and role_arn:
+                raise AWSArgumentTypeValidationError(
+                    message="role_chain and role_arn are mutually exclusive.",
+                    file=os.path.basename(__file__),
+                )
+
+            if role_chain:
+                chain_steps = []
+                for step in role_chain:
+                    chain_steps.append(
+                        AWSRoleChainStep(
+                            role_arn=parse_iam_credentials_arn(step["role_arn"]),
+                            external_id=step.get("external_id"),
+                            session_duration=step.get("session_duration", 3600),
+                            role_session_name=step.get(
+                                "role_session_name", ROLE_SESSION_NAME
+                            ),
+                        )
+                    )
+                session, _ = AwsProvider.assume_role_chain(session, chain_steps)
+            elif role_arn:
                 session_duration = validate_session_duration(session_duration)
                 role_session_name = validate_role_session_name(
                     role_session_name or ROLE_SESSION_NAME

--- a/prowler/providers/aws/lib/session/aws_set_up_session.py
+++ b/prowler/providers/aws/lib/session/aws_set_up_session.py
@@ -6,11 +6,12 @@ from prowler.providers.aws.aws_provider import (
     get_aws_region_for_sts,
     parse_iam_credentials_arn,
 )
-from prowler.providers.aws.config import ROLE_SESSION_NAME
+from prowler.providers.aws.config import MAX_ROLE_CHAIN_STEPS, ROLE_SESSION_NAME
 from prowler.providers.aws.models import (
     AWSAssumeRoleConfiguration,
     AWSAssumeRoleInfo,
     AWSIdentityInfo,
+    AWSRoleChainStep,
     AWSSession,
 )
 
@@ -32,6 +33,7 @@ class AwsSetUpSession:
     def __init__(
         self,
         role_arn: str = None,
+        role_chain: list = None,
         session_duration: int = 3600,
         external_id: str = None,
         role_session_name: str = ROLE_SESSION_NAME,
@@ -47,7 +49,8 @@ class AwsSetUpSession:
         The constructor for the AwsSetUpSession class.
 
         Parameters:
-        - role_arn: The ARN of the IAM role to assume.
+        - role_arn: The ARN of the IAM role to assume. Mutually exclusive with role_chain.
+        - role_chain: An ordered list of dicts, each defining one AssumeRole hop.
         - session_duration: The duration of the session in seconds, between 900 and 43200.
         - external_id: The external ID to use when assuming the IAM role.
         - role_session_name: The name of the session when assuming the IAM role.
@@ -66,6 +69,7 @@ class AwsSetUpSession:
 
         validate_arguments(
             role_arn=role_arn,
+            role_chain=role_chain,
             session_duration=session_duration,
             external_id=external_id,
             role_session_name=role_session_name,
@@ -118,33 +122,73 @@ class AwsSetUpSession:
         ########
 
         ######## AWS Session with Assume Role (if needed)
-        if role_arn:
-            # Validate the input role
+        chain_steps: list[AWSRoleChainStep] = []
+
+        if role_chain and role_arn:
+            raise ValueError("role_chain and role_arn are mutually exclusive.")
+
+        if role_chain:
+            if len(role_chain) > MAX_ROLE_CHAIN_STEPS:
+                raise ValueError(
+                    f"role_chain exceeds maximum of {MAX_ROLE_CHAIN_STEPS} steps."
+                )
+            for idx, step in enumerate(role_chain):
+                if "role_arn" not in step:
+                    raise ValueError(
+                        f"role_chain step {idx} is missing required 'role_arn'."
+                    )
+                valid_arn = parse_iam_credentials_arn(step["role_arn"])
+                chain_steps.append(
+                    AWSRoleChainStep(
+                        role_arn=valid_arn,
+                        external_id=step.get("external_id"),
+                        session_duration=step.get("session_duration", 3600),
+                        role_session_name=step.get(
+                            "role_session_name", ROLE_SESSION_NAME
+                        ),
+                        sts_region=step.get("sts_region", sts_region),
+                    )
+                )
+        elif role_arn:
             valid_role_arn = parse_iam_credentials_arn(role_arn)
-            # Set assume IAM Role information
-            assumed_role_information = AWSAssumeRoleInfo(
-                role_arn=valid_role_arn,
-                session_duration=session_duration,
-                external_id=external_id,
-                mfa_enabled=mfa,
-                role_session_name=role_session_name,
-                sts_region=sts_region,
+            chain_steps = [
+                AWSRoleChainStep(
+                    role_arn=valid_role_arn,
+                    external_id=external_id,
+                    session_duration=session_duration,
+                    role_session_name=role_session_name,
+                    sts_region=sts_region,
+                )
+            ]
+
+        if chain_steps:
+            hop_count = len(chain_steps)
+            logger.info(
+                f"Assuming role chain ({hop_count} hop{'s' if hop_count > 1 else ''})..."
             )
-            # Assume the IAM Role
-            logger.info(f"Assuming role: {assumed_role_information.role_arn.arn}")
-            assumed_role_credentials = AwsProvider.assume_role(
+            final_session, final_credentials = AwsProvider.assume_role_chain(
                 self._session.current_session,
-                assumed_role_information,
+                chain_steps,
+                session_config,
             )
-            logger.info(f"IAM Role assumed: {assumed_role_information.role_arn.arn}")
+            logger.info("Role chain assumed successfully")
 
-            assumed_role_configuration = AWSAssumeRoleConfiguration(
-                info=assumed_role_information, credentials=assumed_role_credentials
+            # Store chain for credential refresh
+            self._session.role_chain = chain_steps
+
+            last_step = chain_steps[-1]
+            self._assumed_role_configuration = AWSAssumeRoleConfiguration(
+                info=AWSAssumeRoleInfo(
+                    role_arn=last_step.role_arn,
+                    session_duration=last_step.session_duration,
+                    external_id=last_step.external_id,
+                    mfa_enabled=mfa or False,
+                    role_session_name=last_step.role_session_name,
+                    sts_region=last_step.sts_region,
+                ),
+                credentials=final_credentials,
             )
-            # Store the assumed role configuration since it'll be needed to refresh the credentials
-            self._assumed_role_configuration = assumed_role_configuration
 
-            # Store a new current session using the assumed IAM Role
             self._session.current_session = AwsProvider.setup_assumed_session(
                 self._identity,
                 self._assumed_role_configuration,
@@ -154,16 +198,19 @@ class AwsSetUpSession:
 
             # Modify identity for the IAM Role assumed since this will be the identity to audit with
             logger.info("Setting new identity for the AWS IAM Role assumed")
-            self._identity.account = assumed_role_configuration.info.role_arn.account_id
-            self._identity.partition = (
-                assumed_role_configuration.info.role_arn.partition
+            self._identity.account = (
+                self._assumed_role_configuration.info.role_arn.account_id
             )
-            self._identity.account_arn = f"arn:{assumed_role_configuration.info.role_arn.partition}:iam::{assumed_role_configuration.info.role_arn.account_id}:root"
+            self._identity.partition = (
+                self._assumed_role_configuration.info.role_arn.partition
+            )
+            self._identity.account_arn = f"arn:{self._assumed_role_configuration.info.role_arn.partition}:iam::{self._assumed_role_configuration.info.role_arn.account_id}:root"
         ########
 
 
 def validate_arguments(
     role_arn: str = None,
+    role_chain: list = None,
     session_duration: int = None,
     external_id: str = None,
     role_session_name: str = None,
@@ -172,27 +219,30 @@ def validate_arguments(
     aws_secret_access_key: str = None,
 ) -> None:
     """
-    Validate the arguments provided to the S3 class."
+    Validate the arguments provided to the AwsSetUpSession class.
 
     Parameters:
     - role_arn: The ARN of the IAM role to assume.
+    - role_chain: An ordered list of role assumption steps.
     - session_duration: The duration of the session in seconds, between 900 and 43200.
     - external_id: The external ID to use when assuming the IAM role.
     - role_session_name: The name of the session when assuming the IAM role.
-    - mfa: A boolean indicating whether MFA is enabled.
     - profile: The name of the AWS CLI profile to use.
     - aws_access_key_id: The AWS access key ID.
     - aws_secret_access_key: The AWS secret access key.
-    - aws_session_token: The AWS session token, optional.
-    - retries_max_attempts: The maximum number of retries for the AWS client.
-    - regions: A set of regions to audit.
     """
+
+    if role_chain and role_arn:
+        raise ValueError("role_chain and role_arn are mutually exclusive.")
 
     if role_arn:
         if not session_duration or not external_id or not role_session_name:
             raise ValueError(
                 "If a role ARN is provided, a session duration, an external ID, and a role session name are required."
             )
+    elif role_chain:
+        # Chain validation is done in the constructor
+        pass
     else:
         if external_id:
             raise ValueError("If an external ID is provided, a role ARN is required.")

--- a/prowler/providers/aws/lib/session/aws_set_up_session.py
+++ b/prowler/providers/aws/lib/session/aws_set_up_session.py
@@ -1,3 +1,4 @@
+import pathlib
 from typing import Optional
 
 from prowler.lib.logger import logger
@@ -7,6 +8,7 @@ from prowler.providers.aws.aws_provider import (
     parse_iam_credentials_arn,
 )
 from prowler.providers.aws.config import MAX_ROLE_CHAIN_STEPS, ROLE_SESSION_NAME
+from prowler.providers.aws.exceptions.exceptions import AWSArgumentTypeValidationError
 from prowler.providers.aws.models import (
     AWSAssumeRoleConfiguration,
     AWSAssumeRoleInfo,
@@ -125,17 +127,22 @@ class AwsSetUpSession:
         chain_steps: list[AWSRoleChainStep] = []
 
         if role_chain and role_arn:
-            raise ValueError("role_chain and role_arn are mutually exclusive.")
+            raise AWSArgumentTypeValidationError(
+                message="role_chain and role_arn are mutually exclusive.",
+                file=pathlib.Path(__file__).name,
+            )
 
         if role_chain:
             if len(role_chain) > MAX_ROLE_CHAIN_STEPS:
-                raise ValueError(
-                    f"role_chain exceeds maximum of {MAX_ROLE_CHAIN_STEPS} steps."
+                raise AWSArgumentTypeValidationError(
+                    message=f"role_chain exceeds maximum of {MAX_ROLE_CHAIN_STEPS} steps.",
+                    file=pathlib.Path(__file__).name,
                 )
             for idx, step in enumerate(role_chain):
                 if "role_arn" not in step:
-                    raise ValueError(
-                        f"role_chain step {idx} is missing required 'role_arn'."
+                    raise AWSArgumentTypeValidationError(
+                        message=f"role_chain step {idx} is missing required 'role_arn'.",
+                        file=pathlib.Path(__file__).name,
                     )
                 valid_arn = parse_iam_credentials_arn(step["role_arn"])
                 chain_steps.append(
@@ -233,7 +240,10 @@ def validate_arguments(
     """
 
     if role_chain and role_arn:
-        raise ValueError("role_chain and role_arn are mutually exclusive.")
+        raise AWSArgumentTypeValidationError(
+            message="role_chain and role_arn are mutually exclusive.",
+            file=pathlib.Path(__file__).name,
+        )
 
     if role_arn:
         if not session_duration or not external_id or not role_session_name:

--- a/prowler/providers/aws/models.py
+++ b/prowler/providers/aws/models.py
@@ -68,14 +68,6 @@ class AWSRoleChainStep:
 
 
 @dataclass
-class AWSRoleChainConfiguration:
-    """Immutable record of a full assumption chain and its final credentials."""
-
-    steps: list[AWSRoleChainStep]
-    final_credentials: AWSCredentials
-
-
-@dataclass
 class AWSIdentityInfo:
     account: str
     account_arn: str

--- a/prowler/providers/aws/models.py
+++ b/prowler/providers/aws/models.py
@@ -1,12 +1,16 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+from typing import Optional
 
 from boto3.session import Session
 from botocore.config import Config
 
 from prowler.config.config import output_file_timestamp
-from prowler.providers.aws.config import AWS_STS_GLOBAL_ENDPOINT_REGION
+from prowler.providers.aws.config import (
+    AWS_STS_GLOBAL_ENDPOINT_REGION,
+    ROLE_SESSION_NAME,
+)
 from prowler.providers.aws.lib.arn.models import ARN
 from prowler.providers.common.models import ProviderOutputOptions
 
@@ -48,6 +52,30 @@ class AWSAssumeRoleConfiguration:
 
 
 @dataclass
+class AWSRoleChainStep:
+    """A single hop in an ordered role assumption chain.
+
+    Each step defines the parameters for one ``sts:AssumeRole`` call.  Steps
+    are executed sequentially — the credentials produced by step *N* become the
+    input session for step *N+1*.
+    """
+
+    role_arn: ARN
+    external_id: Optional[str] = None
+    session_duration: int = 3600
+    role_session_name: str = ROLE_SESSION_NAME
+    sts_region: str = AWS_STS_GLOBAL_ENDPOINT_REGION
+
+
+@dataclass
+class AWSRoleChainConfiguration:
+    """Immutable record of a full assumption chain and its final credentials."""
+
+    steps: list[AWSRoleChainStep]
+    final_credentials: AWSCredentials
+
+
+@dataclass
 class AWSIdentityInfo:
     account: str
     account_arn: str
@@ -69,6 +97,7 @@ class AWSSession:
     current_session: Session
     original_session: Session
     session_config: Config
+    role_chain: list = field(default_factory=list)
 
 
 @dataclass

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -383,6 +383,7 @@ class Provider(ABC):
                     provider_class(
                         retries_max_attempts=arguments.aws_retries_max_attempts,
                         role_arn=arguments.role,
+                        role_chain=getattr(arguments, "role_chain", None),
                         session_duration=arguments.session_duration,
                         external_id=arguments.external_id,
                         role_session_name=arguments.role_session_name,

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -25,6 +25,7 @@ from prowler.providers.aws.config import (
 )
 from prowler.providers.aws.exceptions.exceptions import (
     AWSArgumentTypeValidationError,
+    AWSAssumeRoleChainError,
     AWSIAMRoleARNInvalidResourceTypeError,
     AWSInvalidPartitionError,
     AWSInvalidProviderIdError,
@@ -38,6 +39,7 @@ from prowler.providers.aws.models import (
     AWSCredentials,
     AWSMFAInfo,
     AWSOrganizationsInfo,
+    AWSRoleChainStep,
 )
 from prowler.providers.common.models import Connection
 from prowler.providers.common.provider import Provider
@@ -2358,3 +2360,151 @@ aws:
 
         assert len(session_token) == 356
         assert search(r"^FQoGZXIvYXdzE.*$", session_token)
+
+    @mock_aws
+    def test_assume_role_chain_two_hops(self):
+        """A two-step chain should land in the final role's account."""
+        role_name_hop1 = "chain-hop-1"
+        role_name_hop2 = "chain-hop-2"
+        hop1_arn = create_role(AWS_REGION_US_EAST_1, role_name=role_name_hop1)
+        hop2_arn = create_role(AWS_REGION_US_EAST_1, role_name=role_name_hop2)
+
+        chain = [
+            {"role_arn": hop1_arn, "session_duration": 900},
+            {"role_arn": hop2_arn, "session_duration": 900},
+        ]
+
+        aws_provider = AwsProvider(role_chain=chain)
+
+        # Provider identity should reflect the last hop
+        assert aws_provider.identity.account == AWS_ACCOUNT_NUMBER
+        assert aws_provider.identity.partition == AWS_COMMERCIAL_PARTITION
+
+        # Backwards-compatible attribute should reference the last hop
+        assert aws_provider._assumed_role_configuration.info.role_arn == ARN(hop2_arn)
+
+        # Chain should be stored on the session for refresh
+        assert len(aws_provider._session.role_chain) == 2
+        assert aws_provider._session.role_chain[0].role_arn == ARN(hop1_arn)
+        assert aws_provider._session.role_chain[1].role_arn == ARN(hop2_arn)
+
+        # Credentials should be valid
+        creds = aws_provider._assumed_role_configuration.credentials
+        assert isinstance(creds, AWSCredentials)
+        assert creds.aws_access_key_id
+        assert creds.aws_secret_access_key
+        assert creds.aws_session_token
+        assert creds.expiration
+
+    @mock_aws
+    def test_assume_role_chain_single_hop(self):
+        """A single-element chain should behave like role_arn."""
+        role_name = "chain-single"
+        role_arn = create_role(AWS_REGION_US_EAST_1, role_name=role_name)
+
+        chain = [{"role_arn": role_arn, "session_duration": 900}]
+        aws_provider = AwsProvider(role_chain=chain)
+
+        assert aws_provider.identity.account == AWS_ACCOUNT_NUMBER
+        assert aws_provider._assumed_role_configuration.info.role_arn == ARN(role_arn)
+        assert len(aws_provider._session.role_chain) == 1
+
+    @mock_aws
+    def test_role_chain_and_role_arn_mutually_exclusive(self):
+        """Passing both role_arn and role_chain should raise."""
+        role_arn = create_role(AWS_REGION_US_EAST_1)
+
+        with raises(AWSArgumentTypeValidationError):
+            AwsProvider(
+                role_arn=role_arn,
+                role_chain=[{"role_arn": role_arn}],
+            )
+
+    @mock_aws
+    def test_role_chain_exceeds_max_steps(self):
+        """More than MAX_ROLE_CHAIN_STEPS steps should raise."""
+        role_arn = create_role(AWS_REGION_US_EAST_1)
+        chain = [{"role_arn": role_arn} for _ in range(11)]
+
+        with raises(AWSArgumentTypeValidationError):
+            AwsProvider(role_chain=chain)
+
+    @mock_aws
+    def test_role_chain_missing_role_arn_in_step(self):
+        """A step without role_arn should raise."""
+        with raises(AWSArgumentTypeValidationError):
+            AwsProvider(role_chain=[{"external_id": "some-id"}])
+
+    @mock_aws
+    def test_assume_role_chain_method_two_hops(self):
+        """assume_role_chain() should return the final session and credentials."""
+        from boto3 import session as boto3_session
+
+        role_name_hop1 = "method-hop-1"
+        role_name_hop2 = "method-hop-2"
+        hop1_arn = create_role(AWS_REGION_US_EAST_1, role_name=role_name_hop1)
+        hop2_arn = create_role(AWS_REGION_US_EAST_1, role_name=role_name_hop2)
+
+        base_session = boto3_session.Session(region_name=AWS_REGION_US_EAST_1)
+        steps = [
+            AWSRoleChainStep(
+                role_arn=ARN(hop1_arn),
+                session_duration=900,
+            ),
+            AWSRoleChainStep(
+                role_arn=ARN(hop2_arn),
+                session_duration=900,
+            ),
+        ]
+
+        final_session, final_creds = AwsProvider.assume_role_chain(base_session, steps)
+
+        assert final_session is not None
+        assert isinstance(final_creds, AWSCredentials)
+        assert final_creds.aws_access_key_id
+        assert final_creds.aws_session_token
+        assert final_creds.expiration
+
+    @mock_aws
+    def test_refresh_credentials_with_chain(self):
+        """refresh_credentials should re-walk the chain when role_chain is set."""
+        role_name = "refresh-chain"
+        role_arn = create_role(AWS_REGION_US_EAST_1, role_name=role_name)
+
+        chain = [{"role_arn": role_arn, "session_duration": 900}]
+        aws_provider = AwsProvider(role_chain=chain)
+
+        # Expire the credentials
+        aws_provider._assumed_role_configuration.credentials.expiration = datetime.now(
+            get_localzone()
+        ) - timedelta(hours=1)
+
+        refreshed = AwsProvider.refresh_credentials(
+            aws_provider._assumed_role_configuration,
+            aws_provider._session,
+        )
+
+        assert "access_key" in refreshed
+        assert "secret_key" in refreshed
+        assert "token" in refreshed
+        assert "expiry_time" in refreshed
+        assert refreshed["access_key"] != ""
+        assert refreshed["secret_key"] != ""
+        assert refreshed["token"] != ""
+
+    @mock_aws
+    def test_backward_compat_role_arn_still_works(self):
+        """Existing role_arn kwarg should still work as before."""
+        role_name = "compat-role"
+        role_arn = create_role(AWS_REGION_US_EAST_1, role_name=role_name)
+
+        aws_provider = AwsProvider(role_arn=role_arn, session_duration=900)
+
+        assert aws_provider.identity.account == AWS_ACCOUNT_NUMBER
+        assert aws_provider._assumed_role_configuration.info.role_arn == ARN(role_arn)
+        # role_chain should be empty list (default), not None
+        assert aws_provider._session.role_chain == []
+
+        creds = aws_provider._assumed_role_configuration.credentials
+        assert isinstance(creds, AWSCredentials)
+        assert creds.aws_access_key_id

--- a/ui/components/providers/workflow/forms/select-credentials-type/aws/credentials-type/aws-role-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/select-credentials-type/aws/credentials-type/aws-role-credentials-form.tsx
@@ -4,6 +4,7 @@ import { Control, UseFormSetValue, useWatch } from "react-hook-form";
 import { CredentialsRoleHelper } from "@/components/providers/workflow";
 import { WizardInputField } from "@/components/providers/workflow/forms/fields";
 import { Badge } from "@/components/shadcn/badge/badge";
+import { Button } from "@/components/shadcn/button/button";
 import { Checkbox } from "@/components/shadcn/checkbox/checkbox";
 import {
   Select,
@@ -15,8 +16,18 @@ import {
 import { Separator } from "@/components/shadcn/separator/separator";
 import { ProviderCredentialFields } from "@/lib/provider-credentials/provider-credential-fields";
 import { isCloud } from "@/lib/shared/env";
-import { AWSCredentialsRole } from "@/types";
+import { AWSCredentialsRole, AWSRoleChainStep } from "@/types";
 import { IntegrationType } from "@/types/integrations";
+
+const MAX_CHAIN_STEPS = 10;
+
+const emptyChainStep = (): AWSRoleChainStep => ({
+  role_arn: "",
+  external_id: "",
+  role_session_name: "",
+  session_duration: "",
+  sts_region: "",
+});
 
 export const AWSRoleCredentialsForm = ({
   control,
@@ -49,11 +60,25 @@ export const AWSRoleCredentialsForm = ({
   });
 
   const [showOptionalRole, setShowOptionalRole] = useState(false);
+  const [chainSteps, setChainSteps] = useState<AWSRoleChainStep[]>([]);
+  const [showChain, setShowChain] = useState(false);
 
   const showRoleSection =
     type === "providers" ||
     (isCloudEnv && credentialsType === "aws-sdk-default") ||
     showOptionalRole;
+
+  // Sync chain steps to a hidden form field as JSON
+  useEffect(() => {
+    if (chainSteps.length > 0) {
+      setValue(
+        ProviderCredentialFields.ROLE_CHAIN_JSON as any,
+        JSON.stringify(chainSteps),
+      );
+    } else {
+      setValue(ProviderCredentialFields.ROLE_CHAIN_JSON as any, "");
+    }
+  }, [chainSteps, setValue]);
 
   // Track role section visibility and ensure external_id is set
   useEffect(() => {
@@ -69,6 +94,26 @@ export const AWSRoleCredentialsForm = ({
       });
     }
   }, [showRoleSection, setValue, externalId]);
+
+  const addChainStep = () => {
+    if (chainSteps.length < MAX_CHAIN_STEPS) {
+      setChainSteps([...chainSteps, emptyChainStep()]);
+    }
+  };
+
+  const removeChainStep = (index: number) => {
+    setChainSteps(chainSteps.filter((_, i) => i !== index));
+  };
+
+  const updateChainStep = (
+    index: number,
+    field: keyof AWSRoleChainStep,
+    value: string,
+  ) => {
+    const updated = [...chainSteps];
+    updated[index] = { ...updated[index], [field]: value };
+    setChainSteps(updated);
+  };
 
   return (
     <>
@@ -235,6 +280,137 @@ export const AWSRoleCredentialsForm = ({
               isRequired={false}
             />
           </div>
+
+          <Separator />
+
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col">
+              <span className="text-text-neutral-tertiary text-xs font-bold">
+                Ordered Role Chain
+              </span>
+              <span className="text-text-neutral-tertiary text-xs">
+                Define additional hops for multi-step role assumption
+              </span>
+            </div>
+            <Checkbox
+              checked={showChain}
+              onCheckedChange={(checked) => setShowChain(Boolean(checked))}
+              aria-label="Enable ordered role chain"
+            />
+          </div>
+
+          {showChain && (
+            <div className="flex flex-col gap-4 rounded-md border p-4">
+              <span className="text-text-neutral-secondary text-xs">
+                Each step defines one{" "}
+                <code className="text-xs">sts:AssumeRole</code> hop. The final
+                step&apos;s role is used for scanning. Leave the single Role
+                ARN above empty when using a chain.
+              </span>
+
+              {chainSteps.map((step, index) => (
+                <div
+                  key={index}
+                  className="flex flex-col gap-2 rounded-md border p-3"
+                >
+                  <div className="flex items-center justify-between">
+                    <Badge variant="tag">Hop {index + 1}</Badge>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => removeChainStep(index)}
+                      className="h-6 px-2 text-xs"
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                  <input
+                    type="text"
+                    placeholder="Role ARN (required)"
+                    value={step.role_arn}
+                    onChange={(e) =>
+                      updateChainStep(index, "role_arn", e.target.value)
+                    }
+                    className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  />
+                  <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                    <input
+                      type="text"
+                      placeholder="External ID (optional)"
+                      value={step.external_id || ""}
+                      onChange={(e) =>
+                        updateChainStep(index, "external_id", e.target.value)
+                      }
+                      className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                    <input
+                      type="text"
+                      placeholder="Role session name (optional)"
+                      value={step.role_session_name || ""}
+                      onChange={(e) =>
+                        updateChainStep(
+                          index,
+                          "role_session_name",
+                          e.target.value,
+                        )
+                      }
+                      className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                  </div>
+                  <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                    <input
+                      type="number"
+                      placeholder="Session duration (default: 3600)"
+                      value={step.session_duration || ""}
+                      onChange={(e) =>
+                        updateChainStep(
+                          index,
+                          "session_duration",
+                          e.target.value,
+                        )
+                      }
+                      className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                    <input
+                      type="text"
+                      placeholder="STS region (default: us-east-1)"
+                      value={step.sts_region || ""}
+                      onChange={(e) =>
+                        updateChainStep(index, "sts_region", e.target.value)
+                      }
+                      className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                  </div>
+                </div>
+              ))}
+
+              {chainSteps.length < MAX_CHAIN_STEPS && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={addChainStep}
+                  className="w-fit"
+                >
+                  Add Chain Step
+                </Button>
+              )}
+
+              {chainSteps.length >= MAX_CHAIN_STEPS && (
+                <span className="text-xs text-orange-500">
+                  Maximum of {MAX_CHAIN_STEPS} chain steps reached.
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Hidden field to store chain as JSON */}
+          <input
+            type="hidden"
+            name={ProviderCredentialFields.ROLE_CHAIN_JSON}
+            value={JSON.stringify(chainSteps)}
+          />
         </>
       )}
     </>

--- a/ui/lib/error-mappings.ts
+++ b/ui/lib/error-mappings.ts
@@ -46,4 +46,6 @@ export const PROVIDER_CREDENTIALS_ERROR_MAPPING: Record<string, string> = {
     ProviderCredentialFields.GOOGLEWORKSPACE_CREDENTIALS_CONTENT,
   [ErrorPointers.GOOGLEWORKSPACE_DELEGATED_USER]:
     ProviderCredentialFields.GOOGLEWORKSPACE_DELEGATED_USER,
+  "/data/attributes/secret/role_chain":
+    ProviderCredentialFields.ROLE_CHAIN_JSON,
 };

--- a/ui/lib/provider-credentials/build-credentials.ts
+++ b/ui/lib/provider-credentials/build-credentials.ts
@@ -10,7 +10,7 @@ import { ProviderCredentialFields } from "./provider-credential-fields";
 // Helper functions for each provider type
 export const buildAWSSecret = (formData: FormData, isRole: boolean) => {
   if (isRole) {
-    const secret = {
+    const secret: Record<string, any> = {
       [ProviderCredentialFields.ROLE_ARN]: getFormValue(
         formData,
         ProviderCredentialFields.ROLE_ARN,
@@ -44,6 +44,42 @@ export const buildAWSSecret = (formData: FormData, isRole: boolean) => {
         ProviderCredentialFields.ROLE_SESSION_NAME,
       ),
     };
+
+    // Parse role_chain from the hidden JSON field
+    const chainJson = getFormValue(
+      formData,
+      ProviderCredentialFields.ROLE_CHAIN_JSON,
+    ) as string | null;
+    if (chainJson && chainJson.trim().length > 0) {
+      try {
+        const parsed = JSON.parse(chainJson);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          // Build the chain from the parsed steps
+          const chain = parsed.map((step: any) => {
+            const chainStep: Record<string, any> = {
+              role_arn: step.role_arn,
+            };
+            if (step.external_id) chainStep.external_id = step.external_id;
+            if (step.role_session_name)
+              chainStep.role_session_name = step.role_session_name;
+            if (step.session_duration)
+              chainStep.session_duration = parseInt(step.session_duration, 10) || 3600;
+            if (step.sts_region) chainStep.sts_region = step.sts_region;
+            return chainStep;
+          });
+          secret[ProviderCredentialFields.ROLE_CHAIN] = chain;
+          // When a chain is provided, the top-level role_arn is not needed
+          // (the chain defines all hops). Remove it to avoid API confusion.
+          delete secret[ProviderCredentialFields.ROLE_ARN];
+          delete secret[ProviderCredentialFields.EXTERNAL_ID];
+          delete secret.session_duration;
+          delete secret[ProviderCredentialFields.ROLE_SESSION_NAME];
+        }
+      } catch {
+        // Invalid JSON; skip chain and let the API validate
+      }
+    }
+
     return filterEmptyValues(secret);
   }
 

--- a/ui/lib/provider-credentials/provider-credential-fields.ts
+++ b/ui/lib/provider-credentials/provider-credential-fields.ts
@@ -23,6 +23,8 @@ export const ProviderCredentialFields = {
   EXTERNAL_ID: "external_id",
   SESSION_DURATION: "session_duration",
   ROLE_SESSION_NAME: "role_session_name",
+  ROLE_CHAIN: "role_chain",
+  ROLE_CHAIN_JSON: "role_chain_json",
 
   // Azure/M365 fields
   CLIENT_ID: "client_id",

--- a/ui/types/components.ts
+++ b/ui/types/components.ts
@@ -217,6 +217,15 @@ export type AWSCredentialsRole = {
   [ProviderCredentialFields.ROLE_SESSION_NAME]?: string;
   [ProviderCredentialFields.SESSION_DURATION]?: number;
   [ProviderCredentialFields.CREDENTIALS_TYPE]?: AWSCredentialsType;
+  [ProviderCredentialFields.ROLE_CHAIN]?: AWSRoleChainStep[];
+};
+
+export type AWSRoleChainStep = {
+  role_arn: string;
+  external_id?: string;
+  role_session_name?: string;
+  session_duration?: number;
+  sts_region?: string;
 };
 
 export type AzureCredentials = {

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -585,6 +585,7 @@ export const addCredentialsRoleFormSchema = (providerType: string) =>
           [ProviderCredentialFields.SESSION_DURATION]: z.string().optional(),
           [ProviderCredentialFields.ROLE_SESSION_NAME]: z.string().optional(),
           [ProviderCredentialFields.CREDENTIALS_TYPE]: z.string().optional(),
+          [ProviderCredentialFields.ROLE_CHAIN_JSON]: z.string().optional(),
         })
         .superRefine((data, ctx) => {
           if (
@@ -615,6 +616,38 @@ export const addCredentialsRoleFormSchema = (providerType: string) =>
               message: "AWS Secret Access Key is required.",
               path: [ProviderCredentialFields.AWS_SECRET_ACCESS_KEY],
             });
+          }
+
+          // Validate role_chain_json if present
+          const chainJson =
+            data[ProviderCredentialFields.ROLE_CHAIN_JSON];
+          if (chainJson && chainJson.trim().length > 0) {
+            try {
+              const parsed = JSON.parse(chainJson);
+              if (!Array.isArray(parsed)) {
+                ctx.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  message: "Role chain must be a JSON array.",
+                  path: [ProviderCredentialFields.ROLE_CHAIN_JSON],
+                });
+              } else {
+                for (let i = 0; i < parsed.length; i++) {
+                  if (!parsed[i].role_arn) {
+                    ctx.addIssue({
+                      code: z.ZodIssueCode.custom,
+                      message: `Chain step ${i + 1} is missing a Role ARN.`,
+                      path: [ProviderCredentialFields.ROLE_CHAIN_JSON],
+                    });
+                  }
+                }
+              }
+            } catch {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "Role chain contains invalid JSON.",
+                path: [ProviderCredentialFields.ROLE_CHAIN_JSON],
+              });
+            }
           }
         })
     : providerType === "alibabacloud"


### PR DESCRIPTION
Add support for ordered role assumption chains (role_chain) that allow multiple sequential sts:AssumeRole hops to reach the target AWS account. This is useful for hub-spoke environments where a single hop is not sufficient.

### Context

Implemented ordered `role_chain` support in the API payload for advanced AWS setups that require multiple sequential sts:AssumeRole hops, keeping existing single-hop fields for backward compatibility.

Fixes #12417

### Description

Key changes:
- Add AWSRoleChainStep and AWSRoleChainConfiguration dataclasses
- Add assume_role_chain() static method with iterative (non-recursive) loop
- Add --role-chain CLI argument accepting a JSON file path
- Add 'AWS Assume Role Chain' variant to the API secret schema
- Update refresh_credentials() to re-walk the full chain on expiry
- Update test_connection() across AwsProvider, S3, and SecurityHub
- Update AwsSetUpSession to support chain-based assumption
- Add AWSAssumeRoleChainError exception (code 1018)
- Add MAX_ROLE_CHAIN_STEPS constant (10)
- Update documentation with usage examples for CLI and API

Backwards compatibility:
- Existing --role / role_arn single-hop flow is unchanged
- role_chain and role_arn are mutually exclusive
- Single-hop is internally treated as a 1-step chain
- AWSAssumeRoleConfiguration remains as a backwards-compatible accessor

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for sequential AWS role-assumption chains of up to 10 hops.
  - Added configurable per-hop role ARN, session, external ID, duration, and STS region settings.
  - Added role-chain configuration in the AWS credentials form and CLI.
  - Added support for role chains when connecting to AWS services, including S3 and Security Hub.
  - Credentials now refresh across the complete role chain.

- **Bug Fixes**
  - Added validation for malformed chains, conflicting options, invalid settings, and missing role ARNs.

- **Documentation**
  - Expanded AWS guidance for role chaining, limitations, usage, and credential refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->