### PR TITLE
fix(cmmc): remove stale config_requirements

### DIFF
--- a/prowler/compliance/cmmc_2.0.json
+++ b/prowler/compliance/cmmc_2.0.json
@@ -265,20 +265,6 @@
           "Operator": "lte",
           "Value": 90,
           "Provider": "aws"
-        },
-        {
-          "Check": "iam_user_accesskey_unused",
-          "ConfigKey": "max_unused_access_keys_days",
-          "Operator": "lte",
-          "Value": 45,
-          "Provider": "aws"
-        },
-        {
-          "Check": "iam_user_console_access_unused",
-          "ConfigKey": "max_console_access_days",
-          "Operator": "lte",
-          "Value": 45,
-          "Provider": "aws"
         }
       ]
     },
@@ -1063,20 +1049,6 @@
           "ConfigKey": "max_unused_sagemaker_access_days",
           "Operator": "lte",
           "Value": 90,
-          "Provider": "aws"
-        },
-        {
-          "Check": "iam_user_accesskey_unused",
-          "ConfigKey": "max_unused_access_keys_days",
-          "Operator": "lte",
-          "Value": 45,
-          "Provider": "aws"
-        },
-        {
-          "Check": "iam_user_console_access_unused",
-          "ConfigKey": "max_console_access_days",
-          "Operator": "lte",
-          "Value": 45,
           "Provider": "aws"
         }
       ]
@@ -2008,23 +1980,7 @@
         "alibabacloud": [],
         "oraclecloud": [],
         "m365": []
-      },
-      "config_requirements": [
-        {
-          "Check": "guardduty_is_enabled",
-          "ConfigKey": "mute_non_default_regions",
-          "Operator": "eq",
-          "Value": false,
-          "Provider": "aws"
-        },
-        {
-          "Check": "securityhub_enabled",
-          "ConfigKey": "mute_non_default_regions",
-          "Operator": "eq",
-          "Value": false,
-          "Provider": "aws"
-        }
-      ]
+      }
     },
     {
       "id": "AU.L2-3.3.5",


### PR DESCRIPTION
### Context

PR #12401 applied review feedback that trimmed check mappings in `cmmc_2.0.json` (`AC.L1-b.1.ii` / `AC.L2-3.1.2` reduced to least-privilege checks, `AU.L2-3.3.4` moved to manual), but the `config_requirements` guardrails for the removed checks were left behind. The constraint well-formedness test (`compliance_config_requirements_data_test.py`) merged in parallel, so both PRs were green independently while master ended up with 7 failing SDK tests. Master push CI did not catch it because subsequent merges were UI/docs-only and the SDK test suite was skipped by path filters.

### Description

Removes the 6 stale `config_requirements` entries from `prowler/compliance/cmmc_2.0.json` that target checks no longer mapped by their requirement:

- `AC.L1-b.1.ii` / `AC.L2-3.1.2`: `iam_user_accesskey_unused`, `iam_user_console_access_unused`
- `AU.L2-3.3.4`: `guardduty_is_enabled`, `securityhub_enabled` (requirement is manual, so its `config_requirements` block is dropped entirely)

The trimmed mappings themselves are intentional and untouched; only the orphaned guardrails are removed. No changelog fragment: CMMC 2.0 has not been released yet (`no-changelog`).

### Steps to review

- `uv run pytest tests/lib/check/compliance_config_requirements_data_test.py -q` → previously 7 failed on master, now all pass
- `uv run pytest -n auto tests/lib/outputs/compliance/ tests/lib/check/compliance_config_eval_test.py tests/lib/check/compliance_check_test.py -q` → 474 passed
- Verify in `cmmc_2.0.json` that every remaining `config_requirements` entry targets a check present in its requirement's `checks` list

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
