### PR TITLE
fix(ci): suppress .NET runtime CVE temporarily

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -33,6 +33,19 @@ ignore:
     package:
       name: Microsoft.Bcl.Memory
 
+  # The .NET runtime bundled inside the PowerShell tarball the Dockerfile pins.
+  # CVE-2026-62901 is the same temporary exception documented in .trivyignore.yaml:
+  # fixed in .NET 9.0.19 / 10.0.11 (2026-08-11), but no published PowerShell release
+  # ships a patched runtime yet (7.5.9 bundles 9.0.18; 7.6.4 bundles 10.0.x < 10.0.11).
+  # pwsh runs only local M365 module cmdlets; nothing listens for inbound WebSocket
+  # connections. Remove with the Trivy exception by 2026-09-15.
+  - vulnerability: CVE-2026-62901
+    package:
+      name: Microsoft.NETCore.App.Runtime.linux-x64
+  - vulnerability: CVE-2026-62901
+    package:
+      name: Microsoft.NETCore.App.Runtime.linux-arm64
+
 
   # The CPython interpreter, compiled into the official base image.
   # TEMPORARY, unlike the entries above: moving to Python 3.13 clears seven of these, and

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -118,6 +118,20 @@ vulnerabilities:
       - "pkg:npm/ip-address"
     expired_at: 2027-01-31
 
+  # CVE-2026-62901 is a DoS in System.Net.WebSockets (unchecked input for loop condition,
+  # CWE-606), fixed in .NET 9.0.19 / 10.0.11 (published 2026-08-11). The vulnerable runtime
+  # ships inside the PowerShell tarball the Dockerfile pins: 7.5.9 is the latest 7.5.x and
+  # bundles .NET 9.0.18; 7.6.4 bundles .NET 10.0.x < 10.0.11, so no published PowerShell
+  # release contains the fix yet. Prowler only invokes pwsh locally to run M365 module
+  # cmdlets; the image does not accept inbound WebSocket connections, so the DoS path is
+  # not reachable from the network. Remove this temporary suppression as soon as a
+  # PowerShell release shipping .NET 9.0.19+ is available.
+  - id: CVE-2026-62901
+    purls:
+      - "pkg:nuget/Microsoft.NETCore.App.Runtime.linux-x64"
+      - "pkg:nuget/Microsoft.NETCore.App.Runtime.linux-arm64"
+    expired_at: 2026-09-15
+
   # Modules compiled into the Trivy binary the images ship. The binary is pinned by version
   # and verified by checksum in the Dockerfile; only a rebuild by its vendor moves these.
   # CVE-2026-71556 affects go-git worktree operations that can follow symlinks outside a


### PR DESCRIPTION
### Context

The `sdk-container-build-and-scan` gate is failing on open PRs with:

```
HIGH    CVE-2026-62901    Microsoft.NETCore.App.Runtime.linux-x64 9.0.18
```

This does not come from any PR's changes. [CVE-2026-62901](https://github.com/advisories/GHSA-v3hj-p7qc-c3jc) is a denial-of-service in `System.Net.WebSockets` (CWE-606, unchecked input for loop condition) published on **2026-08-11**, which is why the same master commit (`85c36bb`) that passed on 2026-08-10 fails when re-run today with a fresh Trivy DB ([re-run evidence](https://github.com/prowler-cloud/prowler/actions/runs/31425917144)).

The vulnerable .NET runtime is not a dependency Prowler declares: it ships inside the PowerShell tarball the Dockerfile pins (`POWERSHELL_VERSION=7.5.9`).

#### Upstream evidence

- The fix is in .NET `9.0.19` / `10.0.11` / `8.0.30` (August 2026 servicing release).
- PowerShell `7.5.9` is the **latest 7.5.x** release and bundles .NET `9.0.18` — vulnerable.
- PowerShell `7.6.4` (latest overall, 2026-07-20) bundles .NET `10.0.x < 10.0.11` — also vulnerable.
- No published PowerShell release contains a patched runtime yet; releases typically follow the .NET patch Tuesday by 1–2 weeks.

#### Why the affected path is not reachable

Prowler invokes `pwsh` only to run M365 module cmdlets locally (`Connect-ExchangeOnline`, `Connect-MicrosoftTeams` — outbound REST/HTTPS to Microsoft endpoints). Nothing in the image listens for or processes inbound WebSocket traffic, so the DoS path is not exposed.

### Description

- Temporarily suppress `CVE-2026-62901`, scoped to `Microsoft.NETCore.App.Runtime.linux-x64` and `linux-arm64`, in both `.trivyignore.yaml` and `.grype.yaml` (Grype gates fixable findings and a fixed NuGet version exists, so it would fail next once Trivy passes).
- Document the vulnerability, the PowerShell release evidence, and the reachability analysis next to each exception.
- Expire the Trivy exception on **2026-09-15** and mark the Grype one for removal by the same date, so both must be revisited once a PowerShell release shipping .NET `9.0.19+` is available.

Same approach as #12405 (temporary go-git suppression).

### Steps to review

1. Confirm master fails without this change: the [re-run of the last green master run](https://github.com/prowler-cloud/prowler/actions/runs/31425917144) reports the same finding.
2. Confirm no PowerShell release ships .NET `9.0.19+` yet ([PowerShell releases](https://github.com/PowerShell/PowerShell/releases)).
3. Verify both scanner exceptions match the exact CVE and packages and share the same removal deadline.
4. Optional local reproduction against the failed run's report artifact:

   ```bash
   gh run download 31425917144 -n trivy-scan-report-prowler-85c36bb812417c7968926c89c2704053c7bee1fe
   trivy convert --ignorefile .trivyignore.yaml --format json trivy-report.json \
     | jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH" or .Severity=="CRITICAL")] | length'
   # 0 with this branch's ignorefile; 1 without it
   ```

### Checklist

- [x] No changelog fragment: CI-only suppression, same as #12405.
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added temporary security-scanner exceptions for CVE-2026-62901 affecting bundled .NET runtime components.
  * Documented the affected platforms, versions, scope, and expiration date of September 15, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->