### PR TITLE
docs(mcp): document the Cloud organization tools and Jira dispatch options

### DIFF
--- a/docs/getting-started/basic-usage/prowler-mcp-tools.mdx
+++ b/docs/getting-started/basic-usage/prowler-mcp-tools.mdx
@@ -11,10 +11,10 @@ Complete reference guide for all tools available in the Prowler MCP Server. Tool
 | Prowler Hub | 10 tools | No | Cloud and Local MCP Server |
 | Prowler Documentation | 2 tools | No | Cloud and Local MCP Server |
 | Prowler Cloud, Private Cloud & Local Server | 49 tools | Yes | Cloud and Local MCP Server |
-| Prowler Cloud management | 32 tools | Yes | Cloud MCP Server only |
+| Prowler Cloud management | 40 tools | Yes | Cloud MCP Server only |
 
 <Note>
-48 of the 49 Prowler tools are available on both servers. `prowler_schedule_daily_scan` is the exception: it is Local-only, because the Cloud MCP Server supersedes it with the `prowler_cloud_*` [Scan Scheduling](#scan-scheduling) tools.
+48 of the 49 Prowler tools are available on both servers. `prowler_schedule_daily_scan` is the exception: it is Local-only, because the Cloud MCP Server supersedes it with the `prowler_cloud_*` [Scan Scheduling](#scan-scheduling) tools. `prowler_send_findings_to_jira` is exposed by both servers but accepts two [extra parameters](#jira-operations) on the Cloud MCP Server.
 </Note>
 
 ## Tool Naming Convention
@@ -124,7 +124,20 @@ Tools for managing where Prowler sends its results: Amazon S3 buckets, AWS Secur
 #### Jira Operations
 
 - **`prowler_get_jira_issue_types`** - List the issue types available in a Jira project, fetched live from Jira
-- **`prowler_send_findings_to_jira`** - Create one Jira work item per finding, with its severity, resource, risk, and remediation steps
+- **`prowler_send_findings_to_jira`** - Create Jira work items from findings, each carrying the check title, severity, status, provider, region, resource, risk, and remediation steps. Select the findings either by ID with `finding_ids`, or — on Prowler Cloud only — by check with `check_ids`, and choose between one work item per finding or one per check with `dispatch_mode`
+
+<Note>
+`check_ids` and `dispatch_mode` are **Prowler Cloud only**:
+
+- **`check_ids`** - Send the failing findings of a check (for example `s3_bucket_public_access`) without listing their IDs. Prowler resolves them server-side, taking only the failed findings of the latest completed scan of every provider. Get the check IDs from `prowler_list_finding_groups`. Exactly one of `finding_ids` or `check_ids` is required — Prowler combines both filters, so sending both would only dispatch their intersection. A Local MCP Server rejects `check_ids` with a client error.
+- **`dispatch_mode`** - `individual` (the default) creates one work item per finding. `grouped` creates one work item per check instead, listing up to 50 affected resources and linking back to the finding group in Prowler Cloud, which keeps a noisy check to a single ticket. Grouped dispatch only covers failed, unmuted findings of the latest completed scan of every provider. A Local MCP Server ignores `dispatch_mode` instead of rejecting it, and creates one work item per finding.
+
+In `grouped` mode the response counters change meaning: `created_count` counts work items (one per check) rather than findings, `failed_count` counts the entries of the new `failed_groups` field, and `failed_groups` details each failure with its reason and the `check_id` whose work item could not be created.
+</Note>
+
+<Warning>
+`prowler_send_findings_to_jira` creates real work items that Prowler cannot delete or update afterwards. Only retry the same dispatch when the previous response returned `safe_to_retry: true`, otherwise the work items already created are duplicated. Combining `check_ids` with the default `individual` mode opens one work item per failing resource, which can be hundreds of them — use `dispatch_mode="grouped"` to keep it to one per check.
+</Warning>
 
 ### Attack Paths Analysis
 
@@ -166,6 +179,23 @@ Manage Prowler Cloud-only features and configuration. **Requires authentication.
 <Note>
 These tools are available **only on the Cloud MCP Server** (`https://mcp.prowler.com/mcp`). A Local MCP Server does not expose them, because the features they manage exist only in Prowler Cloud.
 </Note>
+
+### Organizations
+
+Tools for onboarding a cloud provider organization as a whole — an AWS Organization, an Azure tenant with its management groups, or a GCP organization with its folders. An organization holds org-level credentials, discovers the real account, subscription, or project structure in the cloud, and turns a selection from that discovery into Prowler providers linked into a hierarchy of nodes. Every tool that changes something — creating, updating, deleting, discovering, applying a discovery, or adjusting provider membership — requires the **Manage Providers** permission; listing and reading do not.
+
+<Note>
+Use these tools for the whole organization. To register providers one by one, use the [Provider Management](#provider-management) tools instead; to build arbitrary RBAC buckets of providers, use provider groups.
+</Note>
+
+- **`prowler_cloud_list_organizations`** - Browse the registered organizations with lightweight data (name, type, external id, provider and node counts), filtered by type or cloud-side external id
+- **`prowler_cloud_get_organization`** - Get one organization in full: attributes, linked providers, credentials status, latest discovery, and the OU / management group / folder hierarchy. Set `include_hierarchy` to `false` to skip the tree on large organizations
+- **`prowler_cloud_create_organization`** - Register an organization, optionally storing its org-level credentials in the same call. Idempotent: an organization with the same type and external id is reused and its credentials rotated, reported as `created: false`
+- **`prowler_cloud_update_organization`** - Rename an organization, replace its metadata, and/or create or rotate its org-level credentials. `org_type` and `external_id` are immutable after creation
+- **`prowler_cloud_delete_organization`** - Delete an organization, its entire hierarchy, and every linked provider
+- **`prowler_cloud_discover_organization`** - Enumerate the real cloud structure: AWS accounts and OUs, Azure subscriptions and management groups, or GCP projects and folders. Each item comes back with its registration state so you can choose what to onboard
+- **`prowler_cloud_apply_organization_discovery`** - Turn a discovery selection into Prowler providers and hierarchy nodes
+- **`prowler_cloud_manage_organization_providers`** - Manually `add`, `replace`, or `remove` the providers linked to an organization or to one of its hierarchy nodes. Providers are detached, never deleted
 
 ### Scan Configurations
 


### PR DESCRIPTION
### Context

Two Cloud MCP Server features landed without ever reaching the tools reference. The page was last updated when the `prowler_cloud_*` namespace was introduced, so both have been shipping undocumented:

- `feat(mcp): add provider organization management tools` — eight `prowler_cloud_*` organization tools
- `feat(mcp): add Prowler Cloud Jira dispatch capabilities` — two Cloud-only parameters on `prowler_send_findings_to_jira`

### Description

Documentation only, single file: `docs/getting-started/basic-usage/prowler-mcp-tools.mdx`.

**New Organizations section** under Prowler Cloud Tools, listing the eight tools (`list`, `get`, `create`, `update`, `delete`, `discover`, `apply_organization_discovery`, `manage_organization_providers`), explaining what an organization is — org-level credentials, discovery of the real cloud structure, providers linked into a node hierarchy — and noting that everything except listing and reading requires the **Manage Providers** permission. A note points readers at the Provider Management tools for onboarding providers one at a time.

**Jira Operations**, rewritten `prowler_send_findings_to_jira` entry plus a note and a warning covering:

- `check_ids` — select the findings by check instead of by ID; Prowler resolves them server-side from the latest completed scan of every provider. Exactly one of `finding_ids`/`check_ids` is required, since the API ANDs both filters. A Local MCP Server rejects it with a client error.
- `dispatch_mode` — `grouped` opens one work item per check listing up to 50 affected resources, instead of one per finding. A Local MCP Server **ignores** this parameter rather than rejecting it, which is the surprising half and is called out explicitly.
- The response counters change meaning in `grouped` mode, and `failed_groups` is new.

**Summary table** — Cloud management tool count 32 → 40, and the "48 of 49 available on both servers" note now flags that `prowler_send_findings_to_jira` is shared but takes two extra parameters on Cloud.

### Steps to review

1. Check the tool names and descriptions against `mcp_server/prowler_mcp_server/prowler_cloud/tools/organizations.py` and the `send_findings_to_jira` docstring in `mcp_server/prowler_mcp_server/prowler_app/tools/integrations.py`. Descriptions were written from those docstrings.
2. Confirm the 40 count: 8 organizations + 6 scan configurations + 7 triage + 5 scheduling + 14 alerts.
3. Verify the permission split — `list_organizations` and `get_organization` are documented as not needing Manage Providers, matching the docstrings.
4. Render check: the new `<Note>` / `<Warning>` blocks and the `#jira-operations` / `#provider-management` anchors.

### Checklist

- [x] Review if the code is being covered by tests. — N/A, documentation only
- [x] Review if code is being documented. — this is the documentation
- [ ] Review if backport is needed.
- [x] Review if is needed to change the README.md — not needed
- [x] Ensure a changelog fragment is added. — N/A, the feature changelog fragments shipped with the tools themselves

#### MCP Server
- [x] All issue/task requirements work as expected on the MCP Server — no behavior change, documentation only

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tool category counts and clarified server availability, including Jira-specific differences.
  * Documented additional Jira options, grouped dispatch behavior, response counters, and retry considerations.
  * Added guidance for managing organizations, credentials, provider connections, hierarchies, and permissions in Prowler Cloud.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->