### PR TITLE
feat(ui): add Slack integration connect flow

### DIFF
--- a/ui/__tests__/msw/handlers/slack.fixtures.ts
+++ b/ui/__tests__/msw/handlers/slack.fixtures.ts
@@ -160,6 +160,11 @@ export const slackFixture = (
 /**
  * A tenant that already approved Prowler in its workspace, and has chosen no
  * destination channel yet — the state the OAuth exchange leaves behind.
+ *
+ * `connected` is `null`, not `true`: the check runs against the destination
+ * channel, so with none recorded it has never run (design.md, "Connection
+ * state, in order"). A `true` here would model a state the contract says
+ * cannot exist, and would disagree with the exchange handler that mints it.
  */
 export const connectedSlackFixture = (
   overrides: Partial<SlackFixture> = {},
@@ -167,8 +172,8 @@ export const connectedSlackFixture = (
   slackFixture({
     install: {
       id: SLACK_INTEGRATION_ID,
-      connected: true,
-      connectionLastCheckedAt: "2026-08-10T09:30:00Z",
+      connected: null,
+      connectionLastCheckedAt: null,
       workspace: { ...PROWLER_HQ },
     },
     exchangeOutcome: SLACK_EXCHANGE_OUTCOME.REINSTALLED,

--- a/ui/__tests__/msw/handlers/slack.fixtures.ts
+++ b/ui/__tests__/msw/handlers/slack.fixtures.ts
@@ -73,6 +73,13 @@ export interface SlackFixture {
    * Slack-backed endpoints answer the same way.
    */
   rateLimited: boolean;
+  /**
+   * The shared `GET /integrations` read answers `500`. Not a Slack refusal: the
+   * endpoint is the generic integrations list, so nothing names the reason in
+   * `code`, and the UI's own helper turns a `5xx` into a thrown error rather
+   * than into a result.
+   */
+  listServerError: boolean;
 }
 
 export const SLACK_INTEGRATION_ID = "slack-integration-1";
@@ -122,6 +129,12 @@ export const SLACK_NO_CHANNEL_DETAIL =
   "This Slack integration has no channel configured.";
 export const SLACK_RATE_LIMITED_DETAIL =
   "Slack is rate limiting requests from Prowler.";
+/**
+ * What a `500` from the shared `GET /integrations` read carries. The API's own
+ * wording about its own failure: nothing here is for the user to act on, which
+ * is why the UI answers a server error in its own words instead.
+ */
+export const INTEGRATIONS_SERVER_ERROR_DETAIL = "A server error occurred.";
 
 /**
  * The `code` a different-workspace refusal is named by. A wire value, spelled
@@ -154,6 +167,7 @@ export const slackFixture = (
   exchangeOutcome: SLACK_EXCHANGE_OUTCOME.CREATED,
   connection: { connected: true, error: null },
   rateLimited: false,
+  listServerError: false,
   ...overrides,
 });
 

--- a/ui/__tests__/msw/handlers/slack.fixtures.ts
+++ b/ui/__tests__/msw/handlers/slack.fixtures.ts
@@ -1,0 +1,128 @@
+/**
+ * Fixture data for the Slack integration handlers.
+ *
+ * A fixture describes a world — "this deployment has no Slack app", "this
+ * tenant already connected Prowler HQ", "the exchange will be refused" — and
+ * `handlersForSlack` serves it. The shapes are derived from the API contract in
+ * `openspec/changes/add-slack-integration/design.md`; that contract, not this
+ * file, is where a disagreement with the deployed backend gets settled.
+ */
+
+export interface SlackWorkspaceFixture {
+  teamId: string;
+  teamName: string;
+  /** The integration's default destination, null until one is chosen. */
+  channelId: string | null;
+  channelName: string | null;
+}
+
+export interface SlackInstallFixture {
+  id: string;
+  /** `null` until the first connection check runs, as the API upserts it. */
+  connected: boolean | null;
+  connectionLastCheckedAt: string | null;
+  workspace: SlackWorkspaceFixture;
+}
+
+export const SLACK_EXCHANGE_OUTCOME = {
+  /** First install for the tenant: the exchange creates the integration. */
+  CREATED: "created",
+  /** The same workspace re-installed: the existing row keeps its id. */
+  REINSTALLED: "reinstalled",
+  /** The API could not match the `state` it minted, so it refuses. */
+  REFUSED_STATE: "refused-state",
+  /** Slack itself rejected the code; its reason travels in `detail`. */
+  SLACK_REFUSED: "slack-refused",
+  /** A different workspace is already connected — one per tenant. */
+  DIFFERENT_WORKSPACE: "different-workspace",
+} as const;
+
+export type SlackExchangeOutcome =
+  (typeof SLACK_EXCHANGE_OUTCOME)[keyof typeof SLACK_EXCHANGE_OUTCOME];
+
+export interface SlackConnectionFixture {
+  connected: boolean;
+  error: string | null;
+}
+
+export interface SlackFixture {
+  /**
+   * The deployment has `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` /
+   * `SLACK_REDIRECT_URI`. Without them every Slack OAuth call answers 503.
+   */
+  appConfigured: boolean;
+  /** The workspace this tenant has already connected, if any. */
+  install: SlackInstallFixture | null;
+  /** The workspace an exchange connects. */
+  exchangeWorkspace: SlackWorkspaceFixture;
+  exchangeOutcome: SlackExchangeOutcome;
+  /** What a connection check reports. */
+  connection: SlackConnectionFixture;
+}
+
+export const SLACK_INTEGRATION_ID = "slack-integration-1";
+
+/** Exactly the scopes D2 justifies — the picker and the posting need no more. */
+export const SLACK_BOT_SCOPES = [
+  "chat:write",
+  "chat:write.public",
+  "channels:read",
+  "groups:read",
+] as const;
+
+export const SLACK_REDIRECT_URI =
+  "https://cloud.prowler.com/integrations/slack/callback";
+
+/** Server-minted, single-use, bound to the tenant and user (design D5). */
+export const SLACK_OAUTH_STATE = "st-2f1c9d7a";
+export const SLACK_OAUTH_CODE = "slack-code-1f4a";
+
+/** The consent URL the API returns, with the state already inside it. */
+export const SLACK_AUTHORIZE_URL =
+  "https://slack.com/oauth/v2/authorize" +
+  "?client_id=1234567890.0987654321" +
+  `&scope=${encodeURIComponent(SLACK_BOT_SCOPES.join(","))}` +
+  `&state=${SLACK_OAUTH_STATE}` +
+  `&redirect_uri=${encodeURIComponent(SLACK_REDIRECT_URI)}`;
+
+export const SLACK_UNCONFIGURED_DETAIL =
+  "Slack is not configured for this deployment.";
+export const SLACK_REFUSED_STATE_DETAIL =
+  "This install could not be matched to the session that started it.";
+export const SLACK_INVALID_CODE_DETAIL =
+  "Slack rejected the install: invalid_code.";
+export const SLACK_DIFFERENT_WORKSPACE_DETAIL =
+  "Another Slack workspace is already connected. Disconnect it first.";
+
+const PROWLER_HQ: SlackWorkspaceFixture = {
+  teamId: "T01PROWLER",
+  teamName: "Prowler HQ",
+  channelId: null,
+  channelName: null,
+};
+
+export const slackFixture = (
+  overrides: Partial<SlackFixture> = {},
+): SlackFixture => ({
+  appConfigured: true,
+  install: null,
+  exchangeWorkspace: { ...PROWLER_HQ },
+  exchangeOutcome: SLACK_EXCHANGE_OUTCOME.CREATED,
+  connection: { connected: true, error: null },
+  ...overrides,
+});
+
+/** A tenant that already approved Prowler in its workspace. */
+export const connectedSlackFixture = (
+  overrides: Partial<SlackFixture> = {},
+): SlackFixture =>
+  slackFixture({
+    install: {
+      id: SLACK_INTEGRATION_ID,
+      connected: true,
+      connectionLastCheckedAt: "2026-08-10T09:30:00Z",
+      workspace: { ...PROWLER_HQ },
+    },
+    exchangeOutcome: SLACK_EXCHANGE_OUTCOME.REINSTALLED,
+    ...overrides,
+  });

--- a/ui/__tests__/msw/handlers/slack.fixtures.ts
+++ b/ui/__tests__/msw/handlers/slack.fixtures.ts
@@ -193,6 +193,17 @@ export const connectedSlackFixture = (
     ...overrides,
   });
 
+const configuredInstall = (): SlackInstallFixture => ({
+  id: SLACK_INTEGRATION_ID,
+  connected: true,
+  connectionLastCheckedAt: "2026-08-10T09:30:00Z",
+  workspace: {
+    ...PROWLER_HQ,
+    channelId: SLACK_DEFAULT_CHANNEL.id,
+    channelName: SLACK_DEFAULT_CHANNEL.name,
+  },
+});
+
 /**
  * A workspace connected *and* a channel on record. Anything the API refuses
  * until a channel exists (the connection check) needs this fixture.
@@ -200,16 +211,17 @@ export const connectedSlackFixture = (
 export const configuredSlackFixture = (
   overrides: Partial<SlackFixture> = {},
 ): SlackFixture =>
+  connectedSlackFixture({ install: configuredInstall(), ...overrides });
+
+/**
+ * The same finished setup, with a check time no parser can read: a zero date
+ * from a bad write or a serializer change. The contract types the attribute as
+ * a string and rules nothing else out.
+ */
+export const unreadableCheckTimeSlackFixture = (): SlackFixture =>
   connectedSlackFixture({
     install: {
-      id: SLACK_INTEGRATION_ID,
-      connected: true,
-      connectionLastCheckedAt: "2026-08-10T09:30:00Z",
-      workspace: {
-        ...PROWLER_HQ,
-        channelId: SLACK_DEFAULT_CHANNEL.id,
-        channelName: SLACK_DEFAULT_CHANNEL.name,
-      },
+      ...configuredInstall(),
+      connectionLastCheckedAt: "0000-00-00T00:00:00Z",
     },
-    ...overrides,
   });

--- a/ui/__tests__/msw/handlers/slack.fixtures.ts
+++ b/ui/__tests__/msw/handlers/slack.fixtures.ts
@@ -1,22 +1,15 @@
 /**
- * Fixture data for the Slack integration handlers.
- *
- * A fixture describes a world — "this deployment has no Slack app", "this
- * tenant already connected Prowler HQ", "the exchange will be refused" — and
- * `handlersForSlack` serves it. The shapes are derived from the API contract in
- * `openspec/changes/add-slack-integration/design.md`; that contract, not this
- * file, is where a disagreement with the deployed backend gets settled.
+ * Fixture data for the Slack handlers. Shapes follow the API contract in
+ * `openspec/changes/add-slack-integration/design.md`.
  */
 
 export interface SlackWorkspaceFixture {
   teamId: string;
   teamName: string;
-  /** The bot the install created, which the API keeps on the configuration. */
   botUserId: string;
   /**
-   * The integration's default destination. Both keys are *absent* from the
-   * serialized configuration until a channel is chosen — the API omits them
-   * rather than sending nulls — so they are optional here for the same reason.
+   * Absent from the serialized configuration until a channel is chosen: the API
+   * omits the keys rather than sending nulls.
    */
   channelId?: string;
   channelName?: string;
@@ -24,38 +17,26 @@ export interface SlackWorkspaceFixture {
 
 export interface SlackInstallFixture {
   id: string;
-  /** `null` until the first connection check runs, as the API upserts it. */
+  /** `null` until the first connection check runs. */
   connected: boolean | null;
   connectionLastCheckedAt: string | null;
   workspace: SlackWorkspaceFixture;
 }
 
 export const SLACK_EXCHANGE_OUTCOME = {
-  /** First install for the tenant: the exchange creates the integration. */
   CREATED: "created",
-  /** The same workspace re-installed: the existing row keeps its id. */
+  /** Same workspace re-installed: the existing row keeps its id. */
   REINSTALLED: "reinstalled",
-  /** The API could not match the `state` it minted, so it refuses. */
   REFUSED_STATE: "refused-state",
-  /** Slack itself rejected the code, so the API refuses the completion. */
   SLACK_REFUSED: "slack-refused",
-  /**
-   * A different workspace is already connected — one per tenant. A `409`,
-   * named by its `code`, not a plain refusal.
-   */
+  /** A `409` named by its `code`: one workspace per tenant. */
   DIFFERENT_WORKSPACE: "different-workspace",
   /**
-   * The three answers below are all the same event: the API validated the
-   * state, consumed the code and upserted the integration — so the workspace
-   * *is* connected — and then answered `2xx` with something the UI cannot read.
-   * They are not refusals: `response.ok` is true for every one of them, so
-   * nothing on the failure path ever sees them.
+   * The three below are `2xx`: the install happened, but the answer is
+   * unreadable, so nothing on the failure path sees them.
    */
-  /** `204`: accepted, with no body at all to describe what was created. */
   UNREADABLE_NO_CONTENT: "unreadable-no-content",
-  /** `200` whose body is a proxy's challenge page rather than the API's JSON. */
   UNREADABLE_HTML: "unreadable-html",
-  /** `200` carrying well-formed JSON:API that names no resource. */
   UNREADABLE_NO_DATA: "unreadable-no-data",
 } as const;
 
@@ -70,51 +51,32 @@ export interface SlackConnectionFixture {
 export interface SlackFixture {
   /**
    * The deployment has `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` /
-   * `SLACK_REDIRECT_URI`. Without them every Slack OAuth call answers 503.
+   * `SLACK_REDIRECT_URI`. Without them every Slack OAuth call answers `503`.
    */
   appConfigured: boolean;
-  /** The workspace this tenant has already connected, if any. */
   install: SlackInstallFixture | null;
-  /** The workspace an exchange connects. */
   exchangeWorkspace: SlackWorkspaceFixture;
   exchangeOutcome: SlackExchangeOutcome;
-  /** What a connection check reports. */
   connection: SlackConnectionFixture;
-  /**
-   * Slack is rate limiting Prowler: the Slack OAuth calls answer `429` with a
-   * `Retry-After`, whatever else the fixture says. Handlers added for other
-   * Slack-backed endpoints answer the same way.
-   */
+  /** The Slack OAuth calls answer `429` with a `Retry-After`. */
   rateLimited: boolean;
   /**
-   * The shared `GET /integrations` read answers `500`. Not a Slack refusal: the
-   * endpoint is the generic integrations list, so nothing names the reason in
-   * `code`, and the UI's own helper turns a `5xx` into a thrown error rather
-   * than into a result.
+   * The shared `GET /integrations` read answers `500`, which the UI's own
+   * helper turns into a thrown error rather than a result.
    */
   listServerError: boolean;
-  /**
-   * The call that mints the consent URL answers `200` with a proxy's HTML page
-   * instead of JSON. The `2xx` equivalent of `listServerError`: nothing refused
-   * anything, so the UI reaches its success path and finds no answer there.
-   */
+  /** The consent-URL call answers `200` with a proxy's HTML page, not JSON. */
   authorizeUrlUnreadable: boolean;
   /**
-   * Both Slack OAuth calls answer `502` — the status the contract reserves for
-   * `internal_error`, `fatal_error`, `service_unavailable` and transport
-   * failures ("Errors — one taxonomy for every Slack failure").
-   *
-   * Distinct from `appConfigured: false`: a `503` is this deployment having no
-   * Slack app, which is a state, while a `502` is Slack's side broken behind a
-   * deployment that is configured correctly — a server fault, and the one Slack
-   * status the UI reports rather than only describing.
+   * Both Slack OAuth calls answer `502`, the contract's status for upstream and
+   * transport failures. Distinct from `appConfigured: false`, which is a `503`.
    */
   oauthUpstreamError: boolean;
 }
 
 export const SLACK_INTEGRATION_ID = "slack-integration-1";
 
-/** Exactly the scopes D2 justifies — the picker and the posting need no more. */
+/** The scopes the channel picker and the posting need (design D2). */
 export const SLACK_BOT_SCOPES = [
   "chat:write",
   "chat:write.public",
@@ -129,7 +91,6 @@ export const SLACK_REDIRECT_URI =
 export const SLACK_OAUTH_STATE = "st-2f1c9d7a";
 export const SLACK_OAUTH_CODE = "slack-code-1f4a";
 
-/** The consent URL the API returns, with the state already inside it. */
 export const SLACK_AUTHORIZE_URL =
   "https://slack.com/oauth/v2/authorize" +
   "?client_id=1234567890.0987654321" +
@@ -138,10 +99,8 @@ export const SLACK_AUTHORIZE_URL =
   `&redirect_uri=${encodeURIComponent(SLACK_REDIRECT_URI)}`;
 
 /**
- * The `detail` strings the implementation actually sends. They are human copy,
- * not the machine-readable reason: that travels in `code`, which is what the UI
- * maps. Keeping the real wording here is what makes a test that reads `detail`
- * (an unmapped refusal) honest.
+ * The `detail` strings the implementation sends. Human copy; the
+ * machine-readable reason travels in `code`, which is what the UI maps.
  */
 export const SLACK_UNCONFIGURED_DETAIL =
   "Slack integration is not configured or temporarily unavailable.";
@@ -152,35 +111,28 @@ export const SLACK_DIFFERENT_WORKSPACE_DETAIL =
   "This tenant is already connected to a different Slack workspace.";
 export const SLACK_UPSTREAM_DETAIL = "Slack is temporarily unavailable.";
 /**
- * The `code` an upstream failure is named by, on the `502` the contract reserves
- * for it. Not one the UI maps to copy of its own — there is nothing for a user
- * to do about Slack being down — so it is the `detail` that reaches them.
+ * The `code` on the contract's `502`. The UI maps no copy of its own to it, so
+ * the `detail` is what reaches the user.
  */
 export const SLACK_UPSTREAM_ERROR_CODE = "service_unavailable";
 /**
- * Raised as a service-level `ValidationError({"channel_id": ...})`, which still
- * points at `/data` rather than at the attribute.
+ * Raised as a `ValidationError({"channel_id": ...})` that still points at
+ * `/data` rather than at the attribute.
  */
 export const SLACK_NO_CHANNEL_DETAIL =
   "This Slack integration has no channel configured.";
 export const SLACK_RATE_LIMITED_DETAIL =
   "Slack is rate limiting requests from Prowler.";
 /**
- * What a `500` from the shared `GET /integrations` read carries. The API's own
- * wording about its own failure: nothing here is for the user to act on, which
- * is why the UI answers a server error in its own words instead.
+ * What a `500` from the shared `GET /integrations` read carries. Nothing here
+ * is for the user to act on, so the UI answers a server error in its own words.
  */
 export const INTEGRATIONS_SERVER_ERROR_DETAIL = "A server error occurred.";
 
 /**
- * What a proxy or WAF answers with when it takes the call instead of the API:
- * a `200` carrying a challenge page.
- *
- * The `<!DOCTYPE html>` opening is the point of it. V8 truncates the parser
- * message for this body to `Unexpected token '<', "<!DOCTYPE "... is not valid
- * JSON` — cut off *before* the word `html` — so the UI's own HTML detection
- * (`HTML_ERROR_PATTERN`) cannot recognise the message either, and a leaked
- * parser error reaches the user with nothing left to intercept it.
+ * A `200` challenge page from a proxy or WAF that took the call instead of the
+ * API. V8 truncates the parser message for this body before the word `html`, so
+ * the UI's own detection (`HTML_ERROR_PATTERN`) cannot recognise it either.
  */
 export const PROXY_CHALLENGE_PAGE = [
   "<!DOCTYPE html>",
@@ -189,16 +141,13 @@ export const PROXY_CHALLENGE_PAGE = [
 ].join("\n");
 
 /**
- * The `code` a different-workspace refusal is named by. A wire value, spelled
- * out rather than imported from the UI's own mapping: a rename on our side must
- * fail these tests, not quietly agree with itself.
+ * A wire value, spelled out rather than imported from the UI's own mapping, so
+ * a rename on our side fails these tests instead of agreeing with itself.
  */
 export const SLACK_WORKSPACE_CONFLICT_CODE = "slack_workspace_conflict";
 
-/** What `Retry-After` carries on a rate-limited answer. */
 export const SLACK_RETRY_AFTER_SECONDS = 30;
 
-/** The channel a finished install posts to. */
 export const SLACK_DEFAULT_CHANNEL = {
   id: "C0123AB",
   name: "security",
@@ -226,13 +175,9 @@ export const slackFixture = (
 });
 
 /**
- * A tenant that already approved Prowler in its workspace, and has chosen no
- * destination channel yet — the state the OAuth exchange leaves behind.
- *
- * `connected` is `null`, not `true`: the check runs against the destination
- * channel, so with none recorded it has never run (design.md, "Connection
- * state, in order"). A `true` here would model a state the contract says
- * cannot exist, and would disagree with the exchange handler that mints it.
+ * A workspace approved with no destination channel yet. `connected` is `null`,
+ * not `true`: the check runs against the channel, so it has never run
+ * (design.md, "Connection state, in order").
  */
 export const connectedSlackFixture = (
   overrides: Partial<SlackFixture> = {},
@@ -249,10 +194,8 @@ export const connectedSlackFixture = (
   });
 
 /**
- * The same tenant with its setup finished: a workspace connected *and* a
- * destination channel on record. Anything the API refuses until a channel
- * exists — the connection check among them — needs this fixture, not the bare
- * connected one.
+ * A workspace connected *and* a channel on record. Anything the API refuses
+ * until a channel exists (the connection check) needs this fixture.
  */
 export const configuredSlackFixture = (
   overrides: Partial<SlackFixture> = {},

--- a/ui/__tests__/msw/handlers/slack.fixtures.ts
+++ b/ui/__tests__/msw/handlers/slack.fixtures.ts
@@ -99,6 +99,17 @@ export interface SlackFixture {
    * anything, so the UI reaches its success path and finds no answer there.
    */
   authorizeUrlUnreadable: boolean;
+  /**
+   * Both Slack OAuth calls answer `502` — the status the contract reserves for
+   * `internal_error`, `fatal_error`, `service_unavailable` and transport
+   * failures ("Errors — one taxonomy for every Slack failure").
+   *
+   * Distinct from `appConfigured: false`: a `503` is this deployment having no
+   * Slack app, which is a state, while a `502` is Slack's side broken behind a
+   * deployment that is configured correctly — a server fault, and the one Slack
+   * status the UI reports rather than only describing.
+   */
+  oauthUpstreamError: boolean;
 }
 
 export const SLACK_INTEGRATION_ID = "slack-integration-1";
@@ -140,6 +151,12 @@ export const SLACK_INVALID_CODE_DETAIL = "The Slack OAuth code is invalid.";
 export const SLACK_DIFFERENT_WORKSPACE_DETAIL =
   "This tenant is already connected to a different Slack workspace.";
 export const SLACK_UPSTREAM_DETAIL = "Slack is temporarily unavailable.";
+/**
+ * The `code` an upstream failure is named by, on the `502` the contract reserves
+ * for it. Not one the UI maps to copy of its own — there is nothing for a user
+ * to do about Slack being down — so it is the `detail` that reaches them.
+ */
+export const SLACK_UPSTREAM_ERROR_CODE = "service_unavailable";
 /**
  * Raised as a service-level `ValidationError({"channel_id": ...})`, which still
  * points at `/data` rather than at the attribute.
@@ -204,6 +221,7 @@ export const slackFixture = (
   rateLimited: false,
   listServerError: false,
   authorizeUrlUnreadable: false,
+  oauthUpstreamError: false,
   ...overrides,
 });
 

--- a/ui/__tests__/msw/handlers/slack.fixtures.ts
+++ b/ui/__tests__/msw/handlers/slack.fixtures.ts
@@ -44,6 +44,19 @@ export const SLACK_EXCHANGE_OUTCOME = {
    * named by its `code`, not a plain refusal.
    */
   DIFFERENT_WORKSPACE: "different-workspace",
+  /**
+   * The three answers below are all the same event: the API validated the
+   * state, consumed the code and upserted the integration — so the workspace
+   * *is* connected — and then answered `2xx` with something the UI cannot read.
+   * They are not refusals: `response.ok` is true for every one of them, so
+   * nothing on the failure path ever sees them.
+   */
+  /** `204`: accepted, with no body at all to describe what was created. */
+  UNREADABLE_NO_CONTENT: "unreadable-no-content",
+  /** `200` whose body is a proxy's challenge page rather than the API's JSON. */
+  UNREADABLE_HTML: "unreadable-html",
+  /** `200` carrying well-formed JSON:API that names no resource. */
+  UNREADABLE_NO_DATA: "unreadable-no-data",
 } as const;
 
 export type SlackExchangeOutcome =
@@ -80,6 +93,12 @@ export interface SlackFixture {
    * than into a result.
    */
   listServerError: boolean;
+  /**
+   * The call that mints the consent URL answers `200` with a proxy's HTML page
+   * instead of JSON. The `2xx` equivalent of `listServerError`: nothing refused
+   * anything, so the UI reaches its success path and finds no answer there.
+   */
+  authorizeUrlUnreadable: boolean;
 }
 
 export const SLACK_INTEGRATION_ID = "slack-integration-1";
@@ -137,6 +156,22 @@ export const SLACK_RATE_LIMITED_DETAIL =
 export const INTEGRATIONS_SERVER_ERROR_DETAIL = "A server error occurred.";
 
 /**
+ * What a proxy or WAF answers with when it takes the call instead of the API:
+ * a `200` carrying a challenge page.
+ *
+ * The `<!DOCTYPE html>` opening is the point of it. V8 truncates the parser
+ * message for this body to `Unexpected token '<', "<!DOCTYPE "... is not valid
+ * JSON` — cut off *before* the word `html` — so the UI's own HTML detection
+ * (`HTML_ERROR_PATTERN`) cannot recognise the message either, and a leaked
+ * parser error reaches the user with nothing left to intercept it.
+ */
+export const PROXY_CHALLENGE_PAGE = [
+  "<!DOCTYPE html>",
+  "<html><head><title>Attention Required</title></head>",
+  "<body><h1>Checking your browser before you proceed.</h1></body></html>",
+].join("\n");
+
+/**
  * The `code` a different-workspace refusal is named by. A wire value, spelled
  * out rather than imported from the UI's own mapping: a rename on our side must
  * fail these tests, not quietly agree with itself.
@@ -168,6 +203,7 @@ export const slackFixture = (
   connection: { connected: true, error: null },
   rateLimited: false,
   listServerError: false,
+  authorizeUrlUnreadable: false,
   ...overrides,
 });
 

--- a/ui/__tests__/msw/handlers/slack.fixtures.ts
+++ b/ui/__tests__/msw/handlers/slack.fixtures.ts
@@ -11,9 +11,15 @@
 export interface SlackWorkspaceFixture {
   teamId: string;
   teamName: string;
-  /** The integration's default destination, null until one is chosen. */
-  channelId: string | null;
-  channelName: string | null;
+  /** The bot the install created, which the API keeps on the configuration. */
+  botUserId: string;
+  /**
+   * The integration's default destination. Both keys are *absent* from the
+   * serialized configuration until a channel is chosen — the API omits them
+   * rather than sending nulls — so they are optional here for the same reason.
+   */
+  channelId?: string;
+  channelName?: string;
 }
 
 export interface SlackInstallFixture {
@@ -31,9 +37,12 @@ export const SLACK_EXCHANGE_OUTCOME = {
   REINSTALLED: "reinstalled",
   /** The API could not match the `state` it minted, so it refuses. */
   REFUSED_STATE: "refused-state",
-  /** Slack itself rejected the code; its reason travels in `detail`. */
+  /** Slack itself rejected the code, so the API refuses the completion. */
   SLACK_REFUSED: "slack-refused",
-  /** A different workspace is already connected — one per tenant. */
+  /**
+   * A different workspace is already connected — one per tenant. A `409`,
+   * named by its `code`, not a plain refusal.
+   */
   DIFFERENT_WORKSPACE: "different-workspace",
 } as const;
 
@@ -58,6 +67,12 @@ export interface SlackFixture {
   exchangeOutcome: SlackExchangeOutcome;
   /** What a connection check reports. */
   connection: SlackConnectionFixture;
+  /**
+   * Slack is rate limiting Prowler: the Slack OAuth calls answer `429` with a
+   * `Retry-After`, whatever else the fixture says. Handlers added for other
+   * Slack-backed endpoints answer the same way.
+   */
+  rateLimited: boolean;
 }
 
 export const SLACK_INTEGRATION_ID = "slack-integration-1";
@@ -85,20 +100,49 @@ export const SLACK_AUTHORIZE_URL =
   `&state=${SLACK_OAUTH_STATE}` +
   `&redirect_uri=${encodeURIComponent(SLACK_REDIRECT_URI)}`;
 
+/**
+ * The `detail` strings the implementation actually sends. They are human copy,
+ * not the machine-readable reason: that travels in `code`, which is what the UI
+ * maps. Keeping the real wording here is what makes a test that reads `detail`
+ * (an unmapped refusal) honest.
+ */
 export const SLACK_UNCONFIGURED_DETAIL =
-  "Slack is not configured for this deployment.";
+  "Slack integration is not configured or temporarily unavailable.";
 export const SLACK_REFUSED_STATE_DETAIL =
-  "This install could not be matched to the session that started it.";
-export const SLACK_INVALID_CODE_DETAIL =
-  "Slack rejected the install: invalid_code.";
+  "OAuth state is invalid, expired, or already consumed.";
+export const SLACK_INVALID_CODE_DETAIL = "The Slack OAuth code is invalid.";
 export const SLACK_DIFFERENT_WORKSPACE_DETAIL =
-  "Another Slack workspace is already connected. Disconnect it first.";
+  "This tenant is already connected to a different Slack workspace.";
+export const SLACK_UPSTREAM_DETAIL = "Slack is temporarily unavailable.";
+/**
+ * Raised as a service-level `ValidationError({"channel_id": ...})`, which still
+ * points at `/data` rather than at the attribute.
+ */
+export const SLACK_NO_CHANNEL_DETAIL =
+  "This Slack integration has no channel configured.";
+export const SLACK_RATE_LIMITED_DETAIL =
+  "Slack is rate limiting requests from Prowler.";
+
+/**
+ * The `code` a different-workspace refusal is named by. A wire value, spelled
+ * out rather than imported from the UI's own mapping: a rename on our side must
+ * fail these tests, not quietly agree with itself.
+ */
+export const SLACK_WORKSPACE_CONFLICT_CODE = "slack_workspace_conflict";
+
+/** What `Retry-After` carries on a rate-limited answer. */
+export const SLACK_RETRY_AFTER_SECONDS = 30;
+
+/** The channel a finished install posts to. */
+export const SLACK_DEFAULT_CHANNEL = {
+  id: "C0123AB",
+  name: "security",
+} as const;
 
 const PROWLER_HQ: SlackWorkspaceFixture = {
   teamId: "T01PROWLER",
   teamName: "Prowler HQ",
-  channelId: null,
-  channelName: null,
+  botUserId: "U01PROWLERBOT",
 };
 
 export const slackFixture = (
@@ -109,10 +153,14 @@ export const slackFixture = (
   exchangeWorkspace: { ...PROWLER_HQ },
   exchangeOutcome: SLACK_EXCHANGE_OUTCOME.CREATED,
   connection: { connected: true, error: null },
+  rateLimited: false,
   ...overrides,
 });
 
-/** A tenant that already approved Prowler in its workspace. */
+/**
+ * A tenant that already approved Prowler in its workspace, and has chosen no
+ * destination channel yet — the state the OAuth exchange leaves behind.
+ */
 export const connectedSlackFixture = (
   overrides: Partial<SlackFixture> = {},
 ): SlackFixture =>
@@ -124,5 +172,28 @@ export const connectedSlackFixture = (
       workspace: { ...PROWLER_HQ },
     },
     exchangeOutcome: SLACK_EXCHANGE_OUTCOME.REINSTALLED,
+    ...overrides,
+  });
+
+/**
+ * The same tenant with its setup finished: a workspace connected *and* a
+ * destination channel on record. Anything the API refuses until a channel
+ * exists — the connection check among them — needs this fixture, not the bare
+ * connected one.
+ */
+export const configuredSlackFixture = (
+  overrides: Partial<SlackFixture> = {},
+): SlackFixture =>
+  connectedSlackFixture({
+    install: {
+      id: SLACK_INTEGRATION_ID,
+      connected: true,
+      connectionLastCheckedAt: "2026-08-10T09:30:00Z",
+      workspace: {
+        ...PROWLER_HQ,
+        channelId: SLACK_DEFAULT_CHANNEL.id,
+        channelName: SLACK_DEFAULT_CHANNEL.name,
+      },
+    },
     ...overrides,
   });

--- a/ui/__tests__/msw/handlers/slack.ts
+++ b/ui/__tests__/msw/handlers/slack.ts
@@ -17,6 +17,7 @@
 import { http, HttpResponse } from "msw";
 
 import {
+  INTEGRATIONS_SERVER_ERROR_DETAIL,
   SLACK_AUTHORIZE_URL,
   SLACK_DIFFERENT_WORKSPACE_DETAIL,
   SLACK_EXCHANGE_OUTCOME,
@@ -183,6 +184,16 @@ export const handlersForSlack = (fx: SlackFixture) => {
 
     // --- Generic integration endpoints the Slack UI reuses -----------------
     http.get(`${API}/integrations`, ({ request }) => {
+      // The shared read failing on the API's own side, which is a different
+      // answer from every Slack refusal above: no `code` names it, and the
+      // status is all the UI has to go on.
+      if (fx.listServerError) {
+        return HttpResponse.json(
+          errorBody(INTEGRATIONS_SERVER_ERROR_DETAIL, 500),
+          { status: 500 },
+        );
+      }
+
       const type = new URL(request.url).searchParams.get(
         "filter[integration_type]",
       );

--- a/ui/__tests__/msw/handlers/slack.ts
+++ b/ui/__tests__/msw/handlers/slack.ts
@@ -22,8 +22,12 @@ import {
   SLACK_EXCHANGE_OUTCOME,
   SLACK_INTEGRATION_ID,
   SLACK_INVALID_CODE_DETAIL,
+  SLACK_NO_CHANNEL_DETAIL,
+  SLACK_RATE_LIMITED_DETAIL,
   SLACK_REFUSED_STATE_DETAIL,
+  SLACK_RETRY_AFTER_SECONDS,
   SLACK_UNCONFIGURED_DETAIL,
+  SLACK_WORKSPACE_CONFLICT_CODE,
 } from "./slack.fixtures";
 import type { SlackFixture, SlackInstallFixture } from "./slack.fixtures";
 
@@ -32,8 +36,34 @@ const TS = "2026-08-10T09:00:00Z";
 
 const CONNECTION_TASK_PREFIX = "slack-conn-task-";
 
-const errorBody = (detail: string, status: number) => ({
-  errors: [{ detail, status: String(status) }],
+/**
+ * A JSON:API error as the Slack endpoints raise it.
+ *
+ * `code` is the machine-readable reason the UI maps; `detail` is human copy.
+ * `status` is a string, per the spec. `source.pointer` is `/data` even when the
+ * API raised a field-shaped `ValidationError` — the errors are about the
+ * request, not about one attribute of it.
+ */
+const errorBody = (detail: string, status: number, code?: string) => ({
+  errors: [
+    {
+      status: String(status),
+      ...(code ? { code } : {}),
+      detail,
+      source: { pointer: "/data" },
+    },
+  ],
+});
+
+const configuration = (workspace: SlackInstallFixture["workspace"]) => ({
+  team_id: workspace.teamId,
+  team_name: workspace.teamName,
+  bot_user_id: workspace.botUserId,
+  // Absent until a channel is chosen — the API omits the keys rather than
+  // serializing nulls, so a consumer that reads `null` as "not chosen" would
+  // be reading a value that never arrives.
+  ...(workspace.channelId ? { channel_id: workspace.channelId } : {}),
+  ...(workspace.channelName ? { channel_name: workspace.channelName } : {}),
 });
 
 const integrationResource = (install: SlackInstallFixture) => ({
@@ -47,12 +77,8 @@ const integrationResource = (install: SlackInstallFixture) => ({
     connection_last_checked_at: install.connectionLastCheckedAt,
     integration_type: "slack",
     // No credentials: the bot token is encrypted at rest and never serialized.
-    configuration: {
-      team_id: install.workspace.teamId,
-      team_name: install.workspace.teamName,
-      channel_id: install.workspace.channelId,
-      channel_name: install.workspace.channelName,
-    },
+    // The configuration carries server-owned keys the UI does not send.
+    configuration: configuration(install.workspace),
   },
   links: { self: `${API}/integrations/${install.id}` },
 });
@@ -85,10 +111,22 @@ export const handlersForSlack = (fx: SlackFixture) => {
       status: 503,
     });
 
+  /**
+   * Slack's own rate limit, surfaced as a `429` carrying `Retry-After`. It is
+   * neither a refusal the user can act on nor "no Slack app here", so it names
+   * no `code`: the status is the whole reason.
+   */
+  const rateLimited = () =>
+    HttpResponse.json(errorBody(SLACK_RATE_LIMITED_DETAIL, 429), {
+      status: 429,
+      headers: { "Retry-After": String(SLACK_RETRY_AFTER_SECONDS) },
+    });
+
   return [
     // --- OAuth ------------------------------------------------------------
     http.post(`${API}/integrations/slack/oauth/authorize-url`, () => {
       if (!fx.appConfigured) return unconfigured();
+      if (fx.rateLimited) return rateLimited();
       // The URL travels in `meta`; the call creates nothing.
       return HttpResponse.json({
         meta: { authorize_url: SLACK_AUTHORIZE_URL },
@@ -97,6 +135,7 @@ export const handlersForSlack = (fx: SlackFixture) => {
 
     http.post(`${API}/integrations/slack/oauth/exchange`, () => {
       if (!fx.appConfigured) return unconfigured();
+      if (fx.rateLimited) return rateLimited();
 
       switch (fx.exchangeOutcome) {
         case SLACK_EXCHANGE_OUTCOME.REFUSED_STATE:
@@ -108,9 +147,15 @@ export const handlersForSlack = (fx: SlackFixture) => {
             status: 400,
           });
         case SLACK_EXCHANGE_OUTCOME.DIFFERENT_WORKSPACE:
+          // A conflict with what the tenant already has, not a bad request:
+          // `409`, named by its `code` so the UI can say which conflict it is.
           return HttpResponse.json(
-            errorBody(SLACK_DIFFERENT_WORKSPACE_DETAIL, 400),
-            { status: 400 },
+            errorBody(
+              SLACK_DIFFERENT_WORKSPACE_DETAIL,
+              409,
+              SLACK_WORKSPACE_CONFLICT_CODE,
+            ),
+            { status: 409 },
           );
         case SLACK_EXCHANGE_OUTCOME.REINSTALLED:
           // Same workspace: the credential is replaced on the row that exists,
@@ -148,15 +193,25 @@ export const handlersForSlack = (fx: SlackFixture) => {
 
     http.post<{ id: string }>(
       `${API}/integrations/:id/connection`,
-      ({ params }) =>
-        HttpResponse.json(
+      ({ params }) => {
+        // The check posts to the integration's channel, so there is nothing to
+        // check until one is recorded: the API refuses rather than reporting a
+        // connection it never tested.
+        if (!install?.workspace.channelId) {
+          return HttpResponse.json(errorBody(SLACK_NO_CHANNEL_DETAIL, 400), {
+            status: 400,
+          });
+        }
+
+        return HttpResponse.json(
           taskResource(
             `${CONNECTION_TASK_PREFIX}${params.id}`,
             "executing",
             null,
           ),
           { status: 202 },
-        ),
+        );
+      },
     ),
 
     http.get<{ taskId: string }>(`${API}/tasks/:taskId`, ({ params }) => {

--- a/ui/__tests__/msw/handlers/slack.ts
+++ b/ui/__tests__/msw/handlers/slack.ts
@@ -1,0 +1,173 @@
+/**
+ * MSW handlers for the Slack integration, derived from the API contract in
+ * `openspec/changes/add-slack-integration/design.md`.
+ *
+ * The Slack API is implemented in the cloud repository, so these handlers are
+ * the UI lane's only view of it: they are what the browser-mode tests run
+ * against, and drift between them and the deployed backend is a contract
+ * conversation, not a local fix.
+ *
+ * State is per-call: an exchange really does create the install the subsequent
+ * `GET /integrations` returns, so a test can drive connect → read without
+ * hand-seeding the result.
+ *
+ * Wire them per test via `worker.use(...handlersForSlack(fx))`.
+ */
+
+import { http, HttpResponse } from "msw";
+
+import {
+  SLACK_AUTHORIZE_URL,
+  SLACK_DIFFERENT_WORKSPACE_DETAIL,
+  SLACK_EXCHANGE_OUTCOME,
+  SLACK_INTEGRATION_ID,
+  SLACK_INVALID_CODE_DETAIL,
+  SLACK_REFUSED_STATE_DETAIL,
+  SLACK_UNCONFIGURED_DETAIL,
+} from "./slack.fixtures";
+import type { SlackFixture, SlackInstallFixture } from "./slack.fixtures";
+
+const API = process.env.UI_API_BASE_URL;
+const TS = "2026-08-10T09:00:00Z";
+
+const CONNECTION_TASK_PREFIX = "slack-conn-task-";
+
+const errorBody = (detail: string, status: number) => ({
+  errors: [{ detail, status: String(status) }],
+});
+
+const integrationResource = (install: SlackInstallFixture) => ({
+  id: install.id,
+  type: "integrations",
+  attributes: {
+    inserted_at: TS,
+    updated_at: TS,
+    enabled: true,
+    connected: install.connected,
+    connection_last_checked_at: install.connectionLastCheckedAt,
+    integration_type: "slack",
+    // No credentials: the bot token is encrypted at rest and never serialized.
+    configuration: {
+      team_id: install.workspace.teamId,
+      team_name: install.workspace.teamName,
+      channel_id: install.workspace.channelId,
+      channel_name: install.workspace.channelName,
+    },
+  },
+  links: { self: `${API}/integrations/${install.id}` },
+});
+
+const collection = (install: SlackInstallFixture | null) => ({
+  data: install ? [integrationResource(install)] : [],
+  meta: {
+    version: "v1",
+    pagination: {
+      page: 1,
+      pages: 1,
+      count: install ? 1 : 0,
+    },
+  },
+});
+
+const taskResource = (id: string, state: string, result: unknown) => ({
+  data: { id, type: "tasks", attributes: { state, result } },
+});
+
+export const handlersForSlack = (fx: SlackFixture) => {
+  // Mutable working copy: the exchange creates or updates the install the
+  // integration reads see afterwards.
+  let install: SlackInstallFixture | null = fx.install
+    ? { ...fx.install, workspace: { ...fx.install.workspace } }
+    : null;
+
+  const unconfigured = () =>
+    HttpResponse.json(errorBody(SLACK_UNCONFIGURED_DETAIL, 503), {
+      status: 503,
+    });
+
+  return [
+    // --- OAuth ------------------------------------------------------------
+    http.post(`${API}/integrations/slack/oauth/authorize-url`, () => {
+      if (!fx.appConfigured) return unconfigured();
+      // The URL travels in `meta`; the call creates nothing.
+      return HttpResponse.json({
+        meta: { authorize_url: SLACK_AUTHORIZE_URL },
+      });
+    }),
+
+    http.post(`${API}/integrations/slack/oauth/exchange`, () => {
+      if (!fx.appConfigured) return unconfigured();
+
+      switch (fx.exchangeOutcome) {
+        case SLACK_EXCHANGE_OUTCOME.REFUSED_STATE:
+          return HttpResponse.json(errorBody(SLACK_REFUSED_STATE_DETAIL, 400), {
+            status: 400,
+          });
+        case SLACK_EXCHANGE_OUTCOME.SLACK_REFUSED:
+          return HttpResponse.json(errorBody(SLACK_INVALID_CODE_DETAIL, 400), {
+            status: 400,
+          });
+        case SLACK_EXCHANGE_OUTCOME.DIFFERENT_WORKSPACE:
+          return HttpResponse.json(
+            errorBody(SLACK_DIFFERENT_WORKSPACE_DETAIL, 400),
+            { status: 400 },
+          );
+        case SLACK_EXCHANGE_OUTCOME.REINSTALLED:
+          // Same workspace: the credential is replaced on the row that exists,
+          // so the tenant still holds exactly one Slack integration.
+          install = {
+            id: install?.id ?? SLACK_INTEGRATION_ID,
+            connected: null,
+            connectionLastCheckedAt: null,
+            workspace: { ...fx.exchangeWorkspace },
+          };
+          return HttpResponse.json({ data: integrationResource(install) });
+        default:
+          install = {
+            id: SLACK_INTEGRATION_ID,
+            connected: null,
+            connectionLastCheckedAt: null,
+            workspace: { ...fx.exchangeWorkspace },
+          };
+          return HttpResponse.json(
+            { data: integrationResource(install) },
+            { status: 201 },
+          );
+      }
+    }),
+
+    // --- Generic integration endpoints the Slack UI reuses -----------------
+    http.get(`${API}/integrations`, ({ request }) => {
+      const type = new URL(request.url).searchParams.get(
+        "filter[integration_type]",
+      );
+      // An unfiltered read would pull every integration type into the Slack
+      // page, so serve the install only for the filter it actually sends.
+      return HttpResponse.json(collection(type === "slack" ? install : null));
+    }),
+
+    http.post<{ id: string }>(
+      `${API}/integrations/:id/connection`,
+      ({ params }) =>
+        HttpResponse.json(
+          taskResource(
+            `${CONNECTION_TASK_PREFIX}${params.id}`,
+            "executing",
+            null,
+          ),
+          { status: 202 },
+        ),
+    ),
+
+    http.get<{ taskId: string }>(`${API}/tasks/:taskId`, ({ params }) => {
+      const { connected, error } = fx.connection;
+      if (install && params.taskId.startsWith(CONNECTION_TASK_PREFIX)) {
+        install.connected = connected;
+        install.connectionLastCheckedAt = TS;
+      }
+      return HttpResponse.json(
+        taskResource(params.taskId, "completed", { connected, error }),
+      );
+    }),
+  ];
+};

--- a/ui/__tests__/msw/handlers/slack.ts
+++ b/ui/__tests__/msw/handlers/slack.ts
@@ -1,15 +1,8 @@
 /**
  * MSW handlers for the Slack integration, derived from the API contract in
- * `openspec/changes/add-slack-integration/design.md`.
- *
- * The Slack API is implemented in the cloud repository, so these handlers are
- * the UI lane's only view of it: they are what the browser-mode tests run
- * against, and drift between them and the deployed backend is a contract
- * conversation, not a local fix.
- *
- * State is per-call: an exchange really does create the install the subsequent
- * `GET /integrations` returns, so a test can drive connect → read without
- * hand-seeding the result.
+ * `openspec/changes/add-slack-integration/design.md` (the API itself lives in
+ * the cloud repository). State is per-call: an exchange creates the install the
+ * subsequent `GET /integrations` returns.
  *
  * Wire them per test via `worker.use(...handlersForSlack(fx))`.
  */
@@ -45,12 +38,8 @@ const TS = "2026-08-10T09:00:00Z";
 const CONNECTION_TASK_PREFIX = "slack-conn-task-";
 
 /**
- * A JSON:API error as the Slack endpoints raise it.
- *
- * `code` is the machine-readable reason the UI maps; `detail` is human copy.
- * `status` is a string, per the spec. `source.pointer` is `/data` even when the
- * API raised a field-shaped `ValidationError` — the errors are about the
- * request, not about one attribute of it.
+ * `status` is a string, per the JSON:API spec. `source.pointer` is `/data` even
+ * for a field-shaped `ValidationError`: the errors are about the request.
  */
 const errorBody = (detail: string, status: number, code?: string) => ({
   errors: [
@@ -67,9 +56,7 @@ const configuration = (workspace: SlackInstallFixture["workspace"]) => ({
   team_id: workspace.teamId,
   team_name: workspace.teamName,
   bot_user_id: workspace.botUserId,
-  // Absent until a channel is chosen — the API omits the keys rather than
-  // serializing nulls, so a consumer that reads `null` as "not chosen" would
-  // be reading a value that never arrives.
+  // The API omits these keys until a channel is chosen, never sending nulls.
   ...(workspace.channelId ? { channel_id: workspace.channelId } : {}),
   ...(workspace.channelName ? { channel_name: workspace.channelName } : {}),
 });
@@ -85,7 +72,6 @@ const integrationResource = (install: SlackInstallFixture) => ({
     connection_last_checked_at: install.connectionLastCheckedAt,
     integration_type: "slack",
     // No credentials: the bot token is encrypted at rest and never serialized.
-    // The configuration carries server-owned keys the UI does not send.
     configuration: configuration(install.workspace),
   },
   links: { self: `${API}/integrations/${install.id}` },
@@ -108,11 +94,8 @@ const taskResource = (id: string, state: string, result: unknown) => ({
 });
 
 /**
- * A completion the API accepted and the UI cannot read back.
- *
- * All three are `2xx`, so `response.ok` is true and none of them travels the
- * refusal path: the first two make `response.json()` throw, the third parses
- * into a body that names no resource.
+ * All three are `2xx`: the first two make `response.json()` throw, the third
+ * parses into a body that names no resource.
  */
 const unreadableExchange = (outcome: SlackExchangeOutcome): Response => {
   switch (outcome) {
@@ -126,8 +109,7 @@ const unreadableExchange = (outcome: SlackExchangeOutcome): Response => {
 };
 
 export const handlersForSlack = (fx: SlackFixture) => {
-  // Mutable working copy: the exchange creates or updates the install the
-  // integration reads see afterwards.
+  // Mutable copy: the exchange must not write through to the caller's fixture.
   let install: SlackInstallFixture | null = fx.install
     ? { ...fx.install, workspace: { ...fx.install.workspace } }
     : null;
@@ -137,22 +119,13 @@ export const handlersForSlack = (fx: SlackFixture) => {
       status: 503,
     });
 
-  /**
-   * Slack's own rate limit, surfaced as a `429` carrying `Retry-After`. It is
-   * neither a refusal the user can act on nor "no Slack app here", so it names
-   * no `code`: the status is the whole reason.
-   */
   const rateLimited = () =>
     HttpResponse.json(errorBody(SLACK_RATE_LIMITED_DETAIL, 429), {
       status: 429,
       headers: { "Retry-After": String(SLACK_RETRY_AFTER_SECONDS) },
     });
 
-  /**
-   * Slack's own side broken, behind a deployment that is configured correctly.
-   * A `502`, per the contract's taxonomy — a server fault rather than a Slack
-   * state, which is the one refusal here the UI reports as well as describes.
-   */
+  /** A `502` per the contract's taxonomy: a server fault, not a Slack state. */
   const upstreamError = () =>
     HttpResponse.json(
       errorBody(SLACK_UPSTREAM_DETAIL, 502, SLACK_UPSTREAM_ERROR_CODE),
@@ -165,8 +138,6 @@ export const handlersForSlack = (fx: SlackFixture) => {
       if (!fx.appConfigured) return unconfigured();
       if (fx.rateLimited) return rateLimited();
       if (fx.oauthUpstreamError) return upstreamError();
-      // A proxy answering in place of the API: a `200` the UI reads as success
-      // and then finds nothing in.
       if (fx.authorizeUrlUnreadable) {
         return HttpResponse.html(PROXY_CHALLENGE_PAGE);
       }
@@ -191,8 +162,6 @@ export const handlersForSlack = (fx: SlackFixture) => {
             status: 400,
           });
         case SLACK_EXCHANGE_OUTCOME.DIFFERENT_WORKSPACE:
-          // A conflict with what the tenant already has, not a bad request:
-          // `409`, named by its `code` so the UI can say which conflict it is.
           return HttpResponse.json(
             errorBody(
               SLACK_DIFFERENT_WORKSPACE_DETAIL,
@@ -204,9 +173,7 @@ export const handlersForSlack = (fx: SlackFixture) => {
         case SLACK_EXCHANGE_OUTCOME.UNREADABLE_NO_CONTENT:
         case SLACK_EXCHANGE_OUTCOME.UNREADABLE_HTML:
         case SLACK_EXCHANGE_OUTCOME.UNREADABLE_NO_DATA:
-          // The install still happened: the API upserts the integration before
-          // it answers, so a subsequent read finds the workspace connected even
-          // though the answer that announced it was unreadable.
+          // The install still happened: the API upserts before it answers.
           install = {
             id: SLACK_INTEGRATION_ID,
             connected: null,
@@ -215,8 +182,6 @@ export const handlersForSlack = (fx: SlackFixture) => {
           };
           return unreadableExchange(fx.exchangeOutcome);
         case SLACK_EXCHANGE_OUTCOME.REINSTALLED:
-          // Same workspace: the credential is replaced on the row that exists,
-          // so the tenant still holds exactly one Slack integration.
           install = {
             id: install?.id ?? SLACK_INTEGRATION_ID,
             connected: null,
@@ -240,9 +205,6 @@ export const handlersForSlack = (fx: SlackFixture) => {
 
     // --- Generic integration endpoints the Slack UI reuses -----------------
     http.get(`${API}/integrations`, ({ request }) => {
-      // The shared read failing on the API's own side, which is a different
-      // answer from every Slack refusal above: no `code` names it, and the
-      // status is all the UI has to go on.
       if (fx.listServerError) {
         return HttpResponse.json(
           errorBody(INTEGRATIONS_SERVER_ERROR_DETAIL, 500),
@@ -253,17 +215,14 @@ export const handlersForSlack = (fx: SlackFixture) => {
       const type = new URL(request.url).searchParams.get(
         "filter[integration_type]",
       );
-      // An unfiltered read would pull every integration type into the Slack
-      // page, so serve the install only for the filter it actually sends.
+      // An unfiltered read would pull every type into the Slack page.
       return HttpResponse.json(collection(type === "slack" ? install : null));
     }),
 
     http.post<{ id: string }>(
       `${API}/integrations/:id/connection`,
       ({ params }) => {
-        // The check posts to the integration's channel, so there is nothing to
-        // check until one is recorded: the API refuses rather than reporting a
-        // connection it never tested.
+        // The check posts to the channel, so the API refuses until one exists.
         if (!install?.workspace.channelId) {
           return HttpResponse.json(errorBody(SLACK_NO_CHANNEL_DETAIL, 400), {
             status: 400,

--- a/ui/__tests__/msw/handlers/slack.ts
+++ b/ui/__tests__/msw/handlers/slack.ts
@@ -29,6 +29,8 @@ import {
   SLACK_REFUSED_STATE_DETAIL,
   SLACK_RETRY_AFTER_SECONDS,
   SLACK_UNCONFIGURED_DETAIL,
+  SLACK_UPSTREAM_DETAIL,
+  SLACK_UPSTREAM_ERROR_CODE,
   SLACK_WORKSPACE_CONFLICT_CODE,
 } from "./slack.fixtures";
 import type {
@@ -146,11 +148,23 @@ export const handlersForSlack = (fx: SlackFixture) => {
       headers: { "Retry-After": String(SLACK_RETRY_AFTER_SECONDS) },
     });
 
+  /**
+   * Slack's own side broken, behind a deployment that is configured correctly.
+   * A `502`, per the contract's taxonomy — a server fault rather than a Slack
+   * state, which is the one refusal here the UI reports as well as describes.
+   */
+  const upstreamError = () =>
+    HttpResponse.json(
+      errorBody(SLACK_UPSTREAM_DETAIL, 502, SLACK_UPSTREAM_ERROR_CODE),
+      { status: 502, statusText: "Bad Gateway" },
+    );
+
   return [
     // --- OAuth ------------------------------------------------------------
     http.post(`${API}/integrations/slack/oauth/authorize-url`, () => {
       if (!fx.appConfigured) return unconfigured();
       if (fx.rateLimited) return rateLimited();
+      if (fx.oauthUpstreamError) return upstreamError();
       // A proxy answering in place of the API: a `200` the UI reads as success
       // and then finds nothing in.
       if (fx.authorizeUrlUnreadable) {
@@ -165,6 +179,7 @@ export const handlersForSlack = (fx: SlackFixture) => {
     http.post(`${API}/integrations/slack/oauth/exchange`, () => {
       if (!fx.appConfigured) return unconfigured();
       if (fx.rateLimited) return rateLimited();
+      if (fx.oauthUpstreamError) return upstreamError();
 
       switch (fx.exchangeOutcome) {
         case SLACK_EXCHANGE_OUTCOME.REFUSED_STATE:

--- a/ui/__tests__/msw/handlers/slack.ts
+++ b/ui/__tests__/msw/handlers/slack.ts
@@ -18,6 +18,7 @@ import { http, HttpResponse } from "msw";
 
 import {
   INTEGRATIONS_SERVER_ERROR_DETAIL,
+  PROXY_CHALLENGE_PAGE,
   SLACK_AUTHORIZE_URL,
   SLACK_DIFFERENT_WORKSPACE_DETAIL,
   SLACK_EXCHANGE_OUTCOME,
@@ -30,7 +31,11 @@ import {
   SLACK_UNCONFIGURED_DETAIL,
   SLACK_WORKSPACE_CONFLICT_CODE,
 } from "./slack.fixtures";
-import type { SlackFixture, SlackInstallFixture } from "./slack.fixtures";
+import type {
+  SlackExchangeOutcome,
+  SlackFixture,
+  SlackInstallFixture,
+} from "./slack.fixtures";
 
 const API = process.env.UI_API_BASE_URL;
 const TS = "2026-08-10T09:00:00Z";
@@ -100,6 +105,24 @@ const taskResource = (id: string, state: string, result: unknown) => ({
   data: { id, type: "tasks", attributes: { state, result } },
 });
 
+/**
+ * A completion the API accepted and the UI cannot read back.
+ *
+ * All three are `2xx`, so `response.ok` is true and none of them travels the
+ * refusal path: the first two make `response.json()` throw, the third parses
+ * into a body that names no resource.
+ */
+const unreadableExchange = (outcome: SlackExchangeOutcome): Response => {
+  switch (outcome) {
+    case SLACK_EXCHANGE_OUTCOME.UNREADABLE_NO_CONTENT:
+      return new HttpResponse(null, { status: 204 });
+    case SLACK_EXCHANGE_OUTCOME.UNREADABLE_HTML:
+      return HttpResponse.html(PROXY_CHALLENGE_PAGE);
+    default:
+      return HttpResponse.json({ meta: { version: "v1" } });
+  }
+};
+
 export const handlersForSlack = (fx: SlackFixture) => {
   // Mutable working copy: the exchange creates or updates the install the
   // integration reads see afterwards.
@@ -128,6 +151,11 @@ export const handlersForSlack = (fx: SlackFixture) => {
     http.post(`${API}/integrations/slack/oauth/authorize-url`, () => {
       if (!fx.appConfigured) return unconfigured();
       if (fx.rateLimited) return rateLimited();
+      // A proxy answering in place of the API: a `200` the UI reads as success
+      // and then finds nothing in.
+      if (fx.authorizeUrlUnreadable) {
+        return HttpResponse.html(PROXY_CHALLENGE_PAGE);
+      }
       // The URL travels in `meta`; the call creates nothing.
       return HttpResponse.json({
         meta: { authorize_url: SLACK_AUTHORIZE_URL },
@@ -158,6 +186,19 @@ export const handlersForSlack = (fx: SlackFixture) => {
             ),
             { status: 409 },
           );
+        case SLACK_EXCHANGE_OUTCOME.UNREADABLE_NO_CONTENT:
+        case SLACK_EXCHANGE_OUTCOME.UNREADABLE_HTML:
+        case SLACK_EXCHANGE_OUTCOME.UNREADABLE_NO_DATA:
+          // The install still happened: the API upserts the integration before
+          // it answers, so a subsequent read finds the workspace connected even
+          // though the answer that announced it was unreadable.
+          install = {
+            id: SLACK_INTEGRATION_ID,
+            connected: null,
+            connectionLastCheckedAt: null,
+            workspace: { ...fx.exchangeWorkspace },
+          };
+          return unreadableExchange(fx.exchangeOutcome);
         case SLACK_EXCHANGE_OUTCOME.REINSTALLED:
           // Same workspace: the credential is replaced on the row that exists,
           // so the tenant still holds exactly one Slack integration.

--- a/ui/actions/integrations/integrations.ts
+++ b/ui/actions/integrations/integrations.ts
@@ -341,6 +341,7 @@ export const testIntegrationConnection = async (
         revalidatePath("/integrations/amazon-s3");
         revalidatePath("/integrations/aws-security-hub");
         revalidatePath("/integrations/jira");
+        revalidatePath("/integrations/slack");
 
         if ("error" in pollResult) {
           return { success: false, error: pollResult.error };

--- a/ui/actions/integrations/slack.test.ts
+++ b/ui/actions/integrations/slack.test.ts
@@ -1,13 +1,6 @@
 /**
- * What the Slack OAuth actions do with a refusal they cannot classify
- * themselves.
- *
- * The outcomes a user sees — unavailable, rate limited, the copy for a refused
- * completion — are covered from the pages in `slack-page.integration.test.tsx`.
- * What cannot be seen from there is whether a failure was *reported*: a Sentry
- * capture leaves no mark on the DOM. That is what these tests are for, so they
- * mock `@sentry/nextjs` and keep `handleApiResponse` real — the report is the
- * behaviour under test, not a collaborator to stub out.
+ * Sentry reporting for the Slack OAuth actions. A capture leaves no mark on the
+ * DOM, so it cannot be covered from `slack-page.integration.test.tsx`.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,13 +10,8 @@ import { SentryErrorSource, SentryErrorType } from "@/sentry";
 const { captureExceptionMock, captureMessageMock, fetchMock } = vi.hoisted(
   () => ({
     /**
-     * Marks what it captured, as the real SDK does.
-     *
-     * `Sentry.captureException` sets a non-enumerable `__sentry_captured__` on
-     * the exception (`checkOrSetAlreadyCaught`), which is precisely how
-     * `handleApiError` knows the throw it caught was already reported. A mock
-     * that skipped it would make "reported once" unobservable here — and would
-     * quietly report twice while the test said nothing.
+     * The real SDK marks the exception `__sentry_captured__`, and
+     * `handleApiError` reads that mark to avoid reporting the same throw twice.
      */
     captureExceptionMock: vi.fn((exception: unknown, _options?: unknown) => {
       if (exception !== null && typeof exception === "object") {
@@ -47,10 +35,8 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
-// `handleApiResponse` is deliberately real — its 5xx capture is what is under
-// test — and it reads its copy from `lib/helper`, which reaches next-auth
-// through `@/auth.config`. Stubbing the session is what lets the real wording
-// (and the real HTML sanitizing) load in a jsdom test.
+// The real `handleApiResponse` reads its copy from `lib/helper`, which reaches
+// next-auth through `@/auth.config`; stubbing the session lets that copy load.
 vi.mock("@/auth.config", () => ({
   auth: vi.fn(() => Promise.resolve({ accessToken: "test-access-token" })),
 }));
@@ -65,7 +51,7 @@ vi.mock("@/lib", () => ({
 
 import { exchangeSlackOAuthCode, getSlackAuthorizeUrl } from "./slack";
 
-/** The status the contract reserves for "Slack upstream broke" (design D). */
+/** The status the contract reserves for an upstream Slack failure. */
 const UPSTREAM_STATUS = 502;
 const UPSTREAM_DETAIL = "Slack is temporarily unavailable.";
 const GENERIC_SERVER_ERROR_MESSAGE =
@@ -103,19 +89,16 @@ describe.each([
   { action: exchange, name: "exchangeSlackOAuthCode" },
 ])("$name", ({ action }) => {
   it("reports an upstream Slack failure instead of only turning it into copy", async () => {
-    // Given — the status the contract reserves for `internal_error`,
-    // `fatal_error`, `service_unavailable` and transport failures.
+    // 502 covers `internal_error`, `fatal_error`, `service_unavailable` and
+    // transport failures.
     fetchMock.mockResolvedValue(
       errorResponse(UPSTREAM_STATUS, UPSTREAM_DETAIL, "service_unavailable"),
     );
 
-    // When
     const result = await action();
 
-    // Then — the repo's own 5xx handling ran, so the failure reached Sentry
-    // rather than being classified locally into an `{ error }` nobody hears
-    // about. Exactly once: it reports and throws, and the action's catch sees a
-    // marked error and does not report it again.
+    // Once, not twice: `handleApiResponse` reports and throws, and the action's
+    // catch sees the mark.
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
     expect(captureExceptionMock.mock.calls[0]?.[1]).toMatchObject({
       tags: {
@@ -127,15 +110,12 @@ describe.each([
     });
     expect(captureMessageMock).not.toHaveBeenCalled();
 
-    // And the user is still told something: the throw lands in the action's
-    // existing catch, so this is a result the page renders — not a rejection
-    // that strands the callback on its spinner.
+    // The throw lands in the action's catch, so the page gets a result to
+    // render rather than a rejection that strands the callback on its spinner.
     expect(result).toEqual({ error: UPSTREAM_DETAIL });
   });
 
   it("answers a 5xx the API described in HTML in Prowler's own words", async () => {
-    // Given — a gateway answering in place of the API, so there is no `detail`
-    // and nothing here can name a Slack condition.
     fetchMock.mockResolvedValue(
       new Response("<html><body><h1>502 Bad Gateway</h1></body></html>", {
         status: UPSTREAM_STATUS,
@@ -144,11 +124,8 @@ describe.each([
       }),
     );
 
-    // When
     const result = await action();
 
-    // Then — the same wording the rest of the UI gives a 5xx, with none of the
-    // gateway's markup in it, and still reported.
     expect(result).toEqual({ error: GENERIC_SERVER_ERROR_MESSAGE });
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
   });
@@ -156,24 +133,22 @@ describe.each([
   it.each([503, 404])(
     "reports nothing for a %s: that is the feature being dark, not a fault",
     async (status) => {
-      // Given — no Slack app in this deployment (503 while `SLACK_CLIENT_*` is
-      // unset, 404 where no Slack API is served at all).
+      // 503 means `SLACK_CLIENT_*` is unset; 404 means no Slack API is served
+      // in this deployment at all.
       fetchMock.mockResolvedValue(
         errorResponse(status, "Slack integration is not configured."),
       );
 
-      // When
       const result = await action();
 
-      // Then — capturing this would report the deliberate ship-dark state from
-      // every tenant on every page load.
+      // Capturing this would report the deliberate ship-dark state from every
+      // tenant on every page load.
       expect(result).toEqual({ unavailable: true });
       expect(captureExceptionMock).not.toHaveBeenCalled();
     },
   );
 
   it("reports nothing when Slack is rate limiting: it is a wait, not a fault", async () => {
-    // Given
     fetchMock.mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -189,10 +164,8 @@ describe.each([
       ),
     );
 
-    // When
     const result = await action();
 
-    // Then
     expect(result).toMatchObject({ rateLimited: true, retryAfterSeconds: 30 });
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });

--- a/ui/actions/integrations/slack.test.ts
+++ b/ui/actions/integrations/slack.test.ts
@@ -1,0 +1,199 @@
+/**
+ * What the Slack OAuth actions do with a refusal they cannot classify
+ * themselves.
+ *
+ * The outcomes a user sees — unavailable, rate limited, the copy for a refused
+ * completion — are covered from the pages in `slack-page.integration.test.tsx`.
+ * What cannot be seen from there is whether a failure was *reported*: a Sentry
+ * capture leaves no mark on the DOM. That is what these tests are for, so they
+ * mock `@sentry/nextjs` and keep `handleApiResponse` real — the report is the
+ * behaviour under test, not a collaborator to stub out.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SentryErrorSource, SentryErrorType } from "@/sentry";
+
+const { captureExceptionMock, captureMessageMock, fetchMock } = vi.hoisted(
+  () => ({
+    /**
+     * Marks what it captured, as the real SDK does.
+     *
+     * `Sentry.captureException` sets a non-enumerable `__sentry_captured__` on
+     * the exception (`checkOrSetAlreadyCaught`), which is precisely how
+     * `handleApiError` knows the throw it caught was already reported. A mock
+     * that skipped it would make "reported once" unobservable here — and would
+     * quietly report twice while the test said nothing.
+     */
+    captureExceptionMock: vi.fn((exception: unknown, _options?: unknown) => {
+      if (exception !== null && typeof exception === "object") {
+        Object.defineProperty(exception, "__sentry_captured__", {
+          configurable: true,
+          value: true,
+        });
+      }
+    }),
+    captureMessageMock: vi.fn(),
+    fetchMock: vi.fn(),
+  }),
+);
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: captureExceptionMock,
+  captureMessage: captureMessageMock,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// `handleApiResponse` is deliberately real — its 5xx capture is what is under
+// test — and it reads its copy from `lib/helper`, which reaches next-auth
+// through `@/auth.config`. Stubbing the session is what lets the real wording
+// (and the real HTML sanitizing) load in a jsdom test.
+vi.mock("@/auth.config", () => ({
+  auth: vi.fn(() => Promise.resolve({ accessToken: "test-access-token" })),
+}));
+
+vi.mock("@/lib", () => ({
+  apiBaseUrl: "https://api.test/api/v1",
+  getAuthHeaders: vi.fn(() =>
+    Promise.resolve({ Authorization: "Bearer test-token" }),
+  ),
+  parseStringify: (value: unknown) => value,
+}));
+
+import { exchangeSlackOAuthCode, getSlackAuthorizeUrl } from "./slack";
+
+/** The status the contract reserves for "Slack upstream broke" (design D). */
+const UPSTREAM_STATUS = 502;
+const UPSTREAM_DETAIL = "Slack is temporarily unavailable.";
+const GENERIC_SERVER_ERROR_MESSAGE =
+  "Server is temporarily unavailable. Please try again in a few minutes.";
+
+const errorResponse = (status: number, detail: string, code?: string) =>
+  new Response(
+    JSON.stringify({
+      errors: [
+        {
+          status: String(status),
+          ...(code ? { code } : {}),
+          detail,
+          source: { pointer: "/data" },
+        },
+      ],
+    }),
+    { status, headers: { "content-type": "application/vnd.api+json" } },
+  );
+
+const exchange = () =>
+  exchangeSlackOAuthCode({ code: "slack-code-1f4a", state: "st-2f1c9d7a" });
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe.each([
+  { action: getSlackAuthorizeUrl, name: "getSlackAuthorizeUrl" },
+  { action: exchange, name: "exchangeSlackOAuthCode" },
+])("$name", ({ action }) => {
+  it("reports an upstream Slack failure instead of only turning it into copy", async () => {
+    // Given — the status the contract reserves for `internal_error`,
+    // `fatal_error`, `service_unavailable` and transport failures.
+    fetchMock.mockResolvedValue(
+      errorResponse(UPSTREAM_STATUS, UPSTREAM_DETAIL, "service_unavailable"),
+    );
+
+    // When
+    const result = await action();
+
+    // Then — the repo's own 5xx handling ran, so the failure reached Sentry
+    // rather than being classified locally into an `{ error }` nobody hears
+    // about. Exactly once: it reports and throws, and the action's catch sees a
+    // marked error and does not report it again.
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock.mock.calls[0]?.[1]).toMatchObject({
+      tags: {
+        api_error: true,
+        error_source: SentryErrorSource.HANDLE_API_RESPONSE,
+        error_type: SentryErrorType.SERVER_ERROR,
+        status_code: String(UPSTREAM_STATUS),
+      },
+    });
+    expect(captureMessageMock).not.toHaveBeenCalled();
+
+    // And the user is still told something: the throw lands in the action's
+    // existing catch, so this is a result the page renders — not a rejection
+    // that strands the callback on its spinner.
+    expect(result).toEqual({ error: UPSTREAM_DETAIL });
+  });
+
+  it("answers a 5xx the API described in HTML in Prowler's own words", async () => {
+    // Given — a gateway answering in place of the API, so there is no `detail`
+    // and nothing here can name a Slack condition.
+    fetchMock.mockResolvedValue(
+      new Response("<html><body><h1>502 Bad Gateway</h1></body></html>", {
+        status: UPSTREAM_STATUS,
+        statusText: "Bad Gateway",
+        headers: { "content-type": "text/html" },
+      }),
+    );
+
+    // When
+    const result = await action();
+
+    // Then — the same wording the rest of the UI gives a 5xx, with none of the
+    // gateway's markup in it, and still reported.
+    expect(result).toEqual({ error: GENERIC_SERVER_ERROR_MESSAGE });
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([503, 404])(
+    "reports nothing for a %s: that is the feature being dark, not a fault",
+    async (status) => {
+      // Given — no Slack app in this deployment (503 while `SLACK_CLIENT_*` is
+      // unset, 404 where no Slack API is served at all).
+      fetchMock.mockResolvedValue(
+        errorResponse(status, "Slack integration is not configured."),
+      );
+
+      // When
+      const result = await action();
+
+      // Then — capturing this would report the deliberate ship-dark state from
+      // every tenant on every page load.
+      expect(result).toEqual({ unavailable: true });
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reports nothing when Slack is rate limiting: it is a wait, not a fault", async () => {
+    // Given
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          errors: [{ status: "429", detail: "Slack is rate limiting." }],
+        }),
+        {
+          status: 429,
+          headers: {
+            "content-type": "application/vnd.api+json",
+            "Retry-After": "30",
+          },
+        },
+      ),
+    );
+
+    // When
+    const result = await action();
+
+    // Then
+    expect(result).toMatchObject({ rateLimited: true, retryAfterSeconds: 30 });
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/actions/integrations/slack.test.ts
+++ b/ui/actions/integrations/slack.test.ts
@@ -170,3 +170,54 @@ describe.each([
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * The URL is rendered as the `Add to Slack` link's `href`, so a value the API
+ * got wrong must not become a redirect to somewhere that is not Slack.
+ */
+describe("getSlackAuthorizeUrl authorize URL", () => {
+  const NO_AUTHORIZE_URL_MESSAGE = "Slack did not return an authorization URL.";
+  const CONSENT_SCREEN_URL =
+    "https://slack.com/oauth/v2/authorize" +
+    "?client_id=1234567890.0987654321&state=st-2f1c9d7a";
+
+  const authorizeUrlResponse = (authorizeUrl: unknown) =>
+    new Response(JSON.stringify({ meta: { authorize_url: authorizeUrl } }), {
+      status: 200,
+      headers: { "content-type": "application/vnd.api+json" },
+    });
+
+  it.each([
+    ["a hostile scheme", "javascript:alert(document.domain)"],
+    ["plain HTTP", "http://slack.com/oauth/v2/authorize?client_id=1"],
+    ["another origin", "https://evil.test/oauth/v2/authorize?client_id=1"],
+    ["a lookalike hostname", "https://slack.com.evil.test/oauth/v2/authorize"],
+    [
+      "another Slack path",
+      "https://slack.com/redirect?to=https%3A%2F%2Fevil.test",
+    ],
+    ["a value that is not a URL", "oauth/v2/authorize"],
+  ])(
+    "refuses %s instead of offering it as the install link",
+    async (_label, authorizeUrl) => {
+      // Given — a 2xx whose `meta.authorize_url` is not Slack's consent screen.
+      fetchMock.mockResolvedValue(authorizeUrlResponse(authorizeUrl));
+
+      // When
+      const result = await getSlackAuthorizeUrl();
+
+      // Then — the answer for no URL at all: nothing here is safe to link to.
+      expect(result).toEqual({ error: NO_AUTHORIZE_URL_MESSAGE });
+    },
+  );
+
+  it("hands over Slack's consent screen with its query untouched", async () => {
+    // Given
+    fetchMock.mockResolvedValue(authorizeUrlResponse(CONSENT_SCREEN_URL));
+
+    // When / Then
+    expect(await getSlackAuthorizeUrl()).toEqual({
+      authorizeUrl: CONSENT_SCREEN_URL,
+    });
+  });
+});

--- a/ui/actions/integrations/slack.test.ts
+++ b/ui/actions/integrations/slack.test.ts
@@ -5,6 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { SLACK_UNREADABLE_RESULT_MESSAGE } from "@/lib/integrations/slack-errors";
 import { SentryErrorSource, SentryErrorType } from "@/sentry";
 
 const { captureExceptionMock, captureMessageMock, fetchMock } = vi.hoisted(
@@ -219,5 +220,58 @@ describe("getSlackAuthorizeUrl authorize URL", () => {
     expect(await getSlackAuthorizeUrl()).toEqual({
       authorizeUrl: CONSENT_SCREEN_URL,
     });
+  });
+});
+
+/**
+ * The callback names the workspace and redirects on `integration` alone, so a
+ * `2xx` body it cannot read back as an integration must not reach it.
+ */
+describe("exchangeSlackOAuthCode result shape", () => {
+  const INTEGRATION = {
+    id: "9b1f4c22-5e7a-4c2e-8f0d-6a3b1c9d7e42",
+    type: "integrations",
+    attributes: {
+      integration_type: "slack",
+      configuration: { team_name: "Prowler HQ" },
+    },
+  };
+
+  const exchangeResponse = (data: unknown) =>
+    new Response(JSON.stringify({ data }), {
+      status: 200,
+      headers: { "content-type": "application/vnd.api+json" },
+    });
+
+  it.each<[string, unknown]>([
+    ["an empty object", {}],
+    ["an array", []],
+    ["a bare string", "invalid"],
+    ["a resource with no id", { type: "integrations", attributes: {} }],
+    [
+      "a resource with no attributes",
+      { id: INTEGRATION.id, type: "integrations" },
+    ],
+  ])("cannot confirm the install from %s", async (_label, data) => {
+    // Given — a 2xx whose `data` is truthy but is not an integration resource.
+    fetchMock.mockResolvedValue(exchangeResponse(data));
+
+    // When
+    const result = await exchange();
+
+    // Then — the answer for a body with no `data`: the install happened, only
+    // its result is unknown.
+    expect(result).toEqual({
+      unconfirmed: true,
+      message: SLACK_UNREADABLE_RESULT_MESSAGE,
+    });
+  });
+
+  it("hands over the workspace the API upserted", async () => {
+    // Given
+    fetchMock.mockResolvedValue(exchangeResponse(INTEGRATION));
+
+    // When / Then
+    expect(await exchange()).toEqual({ integration: INTEGRATION });
   });
 });

--- a/ui/actions/integrations/slack.test.ts
+++ b/ui/actions/integrations/slack.test.ts
@@ -248,9 +248,18 @@ describe("exchangeSlackOAuthCode result shape", () => {
     ["an array", []],
     ["a bare string", "invalid"],
     ["a resource with no id", { type: "integrations", attributes: {} }],
+    ["a resource with an empty id", { ...INTEGRATION, id: "" }],
+    ["a resource of another type", { ...INTEGRATION, type: "tasks" }],
     [
       "a resource with no attributes",
       { id: INTEGRATION.id, type: "integrations" },
+    ],
+    [
+      "another kind of integration",
+      {
+        ...INTEGRATION,
+        attributes: { ...INTEGRATION.attributes, integration_type: "jira" },
+      },
     ],
   ])("cannot confirm the install from %s", async (_label, data) => {
     // Given — a 2xx whose `data` is truthy but is not an integration resource.

--- a/ui/actions/integrations/slack.ts
+++ b/ui/actions/integrations/slack.ts
@@ -12,55 +12,22 @@ import {
 import { handleApiError, handleApiResponse } from "@/lib/server-actions-helper";
 import type { IntegrationProps } from "@/types/integrations";
 
-/**
- * The two OAuth calls the Slack install needs. Everything else — reading the
- * integration, testing the connection, deleting it — goes through the generic
- * integration actions, because Slack rows are plain `integrations` resources.
- *
- * The Slack app (`SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` /
- * `SLACK_REDIRECT_URI`) is a deployment-wide setting, so both endpoints answer
- * `503` until it is configured, and a deployment that serves no Slack API at
- * all answers `404`. Neither is an error the user can act on: both mean "Slack
- * isn't available in this environment yet", which is why they get their own
- * result shape rather than an error string.
- *
- * Rate limiting is a third answer again — Slack is there, the deployment is
- * configured, and the only thing to do is wait — so it gets its own outcome
- * rather than being folded into either of the other two.
- *
- * The OAuth `state` is minted and consumed by the API, bound to the tenant and
- * the user — the UI never inspects it, it only forwards what Slack sent back.
- */
-
 interface SlackUnavailable {
   unavailable: true;
 }
 
-/**
- * Slack is rate limiting Prowler (`429`). Distinct from `SlackUnavailable`: the
- * Slack app exists and works, so the page keeps offering what it offers and
- * only says when to come back.
- */
 interface SlackRateLimited {
   rateLimited: true;
-  /** What `Retry-After` asked for, when the response carried one. */
   retryAfterSeconds: number | null;
-  /** The wait, as copy — so every caller says the same thing about it. */
   message: string;
 }
 
 /**
- * The API accepted the completion and the UI could not read the answer back.
- *
- * Its own outcome rather than an error, for the same reason `unavailable` and
- * `rateLimited` are: `response.ok` was true, so the code was consumed and the
- * integration upserted — what Prowler cannot name is the workspace, not whether
- * one was connected. Callers that report an error would be reporting the one
- * thing this answer rules out.
+ * The API accepted the exchange (`2xx`) and the UI could not read the workspace
+ * back: the install happened, only its result is unknown.
  */
 interface SlackUnconfirmed {
   unconfirmed: true;
-  /** The unread result, as copy — so every caller says the same thing about it. */
   message: string;
 }
 
@@ -95,36 +62,24 @@ export type SlackExchangeResult =
   | SlackActionError;
 
 /**
- * Whether the deployment answered "no Slack app here". Deliberately narrow:
- * widening it to a status that only means "not right now" (a `429`, an upstream
- * `502`) would tell the user Slack is unavailable in their environment when it
- * is Prowler's call that needs retrying.
+ * `503`: no Slack app configured in this deployment. `404`: no Slack API at
+ * all. Both mean "not available here", unlike `429`/`502` which mean "not now".
  */
 const isUnavailableStatus = (status: number): boolean =>
   status === 503 || status === 404;
 
 const RATE_LIMITED_STATUS = 429;
 
-/**
- * Classify a refusal into the outcome the UI acts on.
- *
- * The reason travels in the JSON:API error's `code`, which
- * `slackErrorMessage` maps to copy Prowler owns; `detail` is the API's own
- * human wording and is used only when the code is one this UI has nothing
- * better to say about. `fallback` covers a refusal that carries neither.
- */
 const failureFrom = async (
   response: Response,
   fallback: string,
 ): Promise<SlackUnavailable | SlackRateLimited | SlackActionError> => {
   if (isUnavailableStatus(response.status)) return { unavailable: true };
 
-  // A 5xx that is not the ship-dark 503 is a server fault rather than a Slack
-  // state — and `502` is the status the contract reserves for "Slack upstream
-  // broke" — so it goes through the repo's own 5xx handling, which is where
-  // Sentry hears about one. That call reports *and throws*, so each action's
-  // existing catch is what answers the user. It has to run before
-  // `readSlackFailure`: a response body can only be read once.
+  // A 5xx (including the `502` the contract reserves for "Slack upstream
+  // broke") goes through the repo's 5xx handling, which reports to Sentry and
+  // throws, so the caller's catch answers the user. Must run before
+  // `readSlackFailure`: a body can only be read once.
   if (response.status >= 500) await handleApiResponse(response);
 
   const failure = await readSlackFailure(response);
@@ -140,10 +95,7 @@ const failureFrom = async (
   return { error: slackErrorMessage(failure, fallback) };
 };
 
-/**
- * Mint an OAuth state and get the consent URL to send the user to. Creates no
- * integration: the install only exists once the exchange completes.
- */
+/** Mint an OAuth state and get the consent URL. Creates no integration. */
 export const getSlackAuthorizeUrl =
   async (): Promise<SlackAuthorizeUrlResult> => {
     const headers = await getAuthHeaders({ contentType: true });
@@ -153,18 +105,17 @@ export const getSlackAuthorizeUrl =
       const response = await fetch(url.toString(), { method: "POST", headers });
 
       if (!response.ok) {
-        // Awaited inside the `try`: a returned promise's rejection is not this
-        // `catch`'s to see, and a 5xx now rejects.
+        // Awaited inside the `try`: a returned promise's rejection would skip
+        // this `catch`, and a 5xx rejects.
         return await failureFrom(
           response,
           `Unable to start the Slack install: ${response.statusText}`,
         );
       }
 
-      // The URL travels in JSON:API `meta` — the call creates no resource. A
-      // `2xx` that is not JSON at all (a proxy's HTML page, an empty body) is
-      // read as "no URL here" rather than left to throw a parser message the
-      // user would be shown verbatim.
+      // The URL travels in JSON:API `meta`: the call creates no resource. A
+      // non-JSON `2xx` reads as "no URL" instead of throwing a parser message
+      // the user would be shown verbatim.
       const body = await response.json().catch(() => null);
       const authorizeUrl = body?.meta?.authorize_url;
 
@@ -180,8 +131,8 @@ export const getSlackAuthorizeUrl =
 
 /**
  * Complete the install with what Slack put in the callback URL. The API
- * validates and consumes the `state`, exchanges the single-use `code`, and
- * upserts the tenant's Slack integration.
+ * consumes the `state`, exchanges the single-use `code`, and upserts the
+ * tenant's Slack integration.
  */
 export const exchangeSlackOAuthCode = async ({
   code,
@@ -203,35 +154,22 @@ export const exchangeSlackOAuthCode = async ({
     });
 
     if (!response.ok) {
-      // A refused state and a code Slack rejected arrive as a `400` whose
-      // `detail` is the reason to show. "A different workspace is already
-      // connected" is a `409` named by its `code`, which is what turns it into
-      // copy that says how to get out of it.
-      // Awaited inside the `try`, as above: unawaited, a 5xx's rejection would
-      // pass this `catch` and leave the callback on its spinner.
+      // Awaited inside the `try`: unawaited, a 5xx's rejection would skip this
+      // `catch` and leave the callback on its spinner.
       return await failureFrom(
         response,
         `Unable to connect the Slack workspace: ${response.statusText}`,
       );
     }
 
-    // A `2xx` the UI cannot read is still a completed exchange: a `204`, an
-    // empty body, a proxy's HTML page. Parsing it as it arrives would throw a
-    // V8 parser message that travels the catch below straight to the user.
     const body = await response.json().catch(() => null);
 
-    // Revalidated before the guard, and on both paths. The API consumed the
-    // code and upserted the integration before answering, so the workspace is
-    // connected whatever came back: serving the pages that list it from a cache
-    // filled when there was none would report a connected workspace as missing.
+    // Before the guard and on both paths: the API upserted the integration
+    // before answering, so a cache filled when there was none would list the
+    // connected workspace as missing.
     revalidatePath("/integrations");
     revalidatePath("/integrations/slack");
 
-    // Reported as its own outcome rather than as a connected workspace with no
-    // name: the callback reads `attributes.configuration` off this, and a
-    // fabricated resource would fail there instead, further from the cause.
-    // Not an `{ error }` either — the `2xx` says the install happened, so a
-    // caller reading this as a failure would deny the one fact it establishes.
     if (!body?.data) {
       return { unconfirmed: true, message: SLACK_UNREADABLE_RESULT_MESSAGE };
     }

--- a/ui/actions/integrations/slack.ts
+++ b/ui/actions/integrations/slack.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache";
 import { apiBaseUrl, getAuthHeaders, parseStringify } from "@/lib";
 import {
   readSlackFailure,
+  SLACK_UNREADABLE_RESULT_MESSAGE,
   slackErrorMessage,
   slackRateLimitMessage,
 } from "@/lib/integrations/slack-errors";
@@ -134,8 +135,11 @@ export const getSlackAuthorizeUrl =
         );
       }
 
-      // The URL travels in JSON:API `meta` — the call creates no resource.
-      const body = await response.json();
+      // The URL travels in JSON:API `meta` — the call creates no resource. A
+      // `2xx` that is not JSON at all (a proxy's HTML page, an empty body) is
+      // read as "no URL here" rather than left to throw a parser message the
+      // user would be shown verbatim.
+      const body = await response.json().catch(() => null);
       const authorizeUrl = body?.meta?.authorize_url;
 
       if (typeof authorizeUrl !== "string" || authorizeUrl.length === 0) {
@@ -183,10 +187,22 @@ export const exchangeSlackOAuthCode = async ({
       );
     }
 
-    const body = await response.json();
+    // A `2xx` the UI cannot read is still a completed exchange: a `204`, an
+    // empty body, a proxy's HTML page. Parsing it as it arrives would throw a
+    // V8 parser message that travels the catch below straight to the user.
+    const body = await response.json().catch(() => null);
 
+    // Revalidated before the guard, and on both paths. The API consumed the
+    // code and upserted the integration before answering, so the workspace is
+    // connected whatever came back: serving the pages that list it from a cache
+    // filled when there was none would report a connected workspace as missing.
     revalidatePath("/integrations");
     revalidatePath("/integrations/slack");
+
+    // Reported as its own outcome rather than as a connected workspace with no
+    // name: the callback reads `attributes.configuration` off this, and a
+    // fabricated resource would fail there instead, further from the cause.
+    if (!body?.data) return { error: SLACK_UNREADABLE_RESULT_MESSAGE };
 
     return { integration: parseStringify(body.data) as IntegrationProps };
   } catch (error) {

--- a/ui/actions/integrations/slack.ts
+++ b/ui/actions/integrations/slack.ts
@@ -3,6 +3,11 @@
 import { revalidatePath } from "next/cache";
 
 import { apiBaseUrl, getAuthHeaders, parseStringify } from "@/lib";
+import {
+  readSlackFailure,
+  slackErrorMessage,
+  slackRateLimitMessage,
+} from "@/lib/integrations/slack-errors";
 import { handleApiError } from "@/lib/server-actions-helper";
 import type { IntegrationProps } from "@/types/integrations";
 
@@ -18,12 +23,29 @@ import type { IntegrationProps } from "@/types/integrations";
  * isn't available in this environment yet", which is why they get their own
  * result shape rather than an error string.
  *
+ * Rate limiting is a third answer again — Slack is there, the deployment is
+ * configured, and the only thing to do is wait — so it gets its own outcome
+ * rather than being folded into either of the other two.
+ *
  * The OAuth `state` is minted and consumed by the API, bound to the tenant and
  * the user — the UI never inspects it, it only forwards what Slack sent back.
  */
 
 interface SlackUnavailable {
   unavailable: true;
+}
+
+/**
+ * Slack is rate limiting Prowler (`429`). Distinct from `SlackUnavailable`: the
+ * Slack app exists and works, so the page keeps offering what it offers and
+ * only says when to come back.
+ */
+interface SlackRateLimited {
+  rateLimited: true;
+  /** What `Retry-After` asked for, when the response carried one. */
+  retryAfterSeconds: number | null;
+  /** The wait, as copy — so every caller says the same thing about it. */
+  message: string;
 }
 
 interface SlackActionError {
@@ -37,6 +59,7 @@ interface SlackAuthorizeUrl {
 export type SlackAuthorizeUrlResult =
   | SlackAuthorizeUrl
   | SlackUnavailable
+  | SlackRateLimited
   | SlackActionError;
 
 interface SlackExchangeInput {
@@ -51,18 +74,45 @@ interface SlackExchangeSuccess {
 export type SlackExchangeResult =
   | SlackExchangeSuccess
   | SlackUnavailable
+  | SlackRateLimited
   | SlackActionError;
 
-/** Whether the deployment answered "no Slack app here". */
+/**
+ * Whether the deployment answered "no Slack app here". Deliberately narrow:
+ * widening it to a status that only means "not right now" (a `429`, an upstream
+ * `502`) would tell the user Slack is unavailable in their environment when it
+ * is Prowler's call that needs retrying.
+ */
 const isUnavailableStatus = (status: number): boolean =>
   status === 503 || status === 404;
 
-const detailFrom = async (
+const RATE_LIMITED_STATUS = 429;
+
+/**
+ * Classify a refusal into the outcome the UI acts on.
+ *
+ * The reason travels in the JSON:API error's `code`, which
+ * `slackErrorMessage` maps to copy Prowler owns; `detail` is the API's own
+ * human wording and is used only when the code is one this UI has nothing
+ * better to say about. `fallback` covers a refusal that carries neither.
+ */
+const failureFrom = async (
   response: Response,
   fallback: string,
-): Promise<string> => {
-  const body = await response.json().catch(() => ({}));
-  return body?.errors?.[0]?.detail || fallback;
+): Promise<SlackUnavailable | SlackRateLimited | SlackActionError> => {
+  if (isUnavailableStatus(response.status)) return { unavailable: true };
+
+  const failure = await readSlackFailure(response);
+
+  if (failure.status === RATE_LIMITED_STATUS) {
+    return {
+      rateLimited: true,
+      retryAfterSeconds: failure.retryAfterSeconds,
+      message: slackRateLimitMessage(failure.retryAfterSeconds),
+    };
+  }
+
+  return { error: slackErrorMessage(failure, fallback) };
 };
 
 /**
@@ -77,17 +127,11 @@ export const getSlackAuthorizeUrl =
     try {
       const response = await fetch(url.toString(), { method: "POST", headers });
 
-      if (isUnavailableStatus(response.status)) {
-        return { unavailable: true };
-      }
-
       if (!response.ok) {
-        return {
-          error: await detailFrom(
-            response,
-            `Unable to start the Slack install: ${response.statusText}`,
-          ),
-        };
+        return failureFrom(
+          response,
+          `Unable to start the Slack install: ${response.statusText}`,
+        );
       }
 
       // The URL travels in JSON:API `meta` — the call creates no resource.
@@ -128,20 +172,15 @@ export const exchangeSlackOAuthCode = async ({
       }),
     });
 
-    if (isUnavailableStatus(response.status)) {
-      return { unavailable: true };
-    }
-
     if (!response.ok) {
-      // A refused state, a code Slack rejected and "a different workspace is
-      // already connected" all arrive as a 400 whose detail is the reason to
-      // show — the UI does not need to tell them apart.
-      return {
-        error: await detailFrom(
-          response,
-          `Unable to connect the Slack workspace: ${response.statusText}`,
-        ),
-      };
+      // A refused state and a code Slack rejected arrive as a `400` whose
+      // `detail` is the reason to show. "A different workspace is already
+      // connected" is a `409` named by its `code`, which is what turns it into
+      // copy that says how to get out of it.
+      return failureFrom(
+        response,
+        `Unable to connect the Slack workspace: ${response.statusText}`,
+      );
     }
 
     const body = await response.json();

--- a/ui/actions/integrations/slack.ts
+++ b/ui/actions/integrations/slack.ts
@@ -1,10 +1,12 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { z } from "zod";
 
 import { apiBaseUrl, getAuthHeaders, parseStringify } from "@/lib";
 import {
   readSlackFailure,
+  SLACK_GENERIC_ERROR_MESSAGE,
   SLACK_UNREADABLE_RESULT_MESSAGE,
   slackErrorMessage,
   slackRateLimitMessage,
@@ -49,6 +51,11 @@ interface SlackExchangeInput {
   code: string;
   state: string;
 }
+
+const slackExchangeInputSchema = z.object({
+  code: z.string().min(1),
+  state: z.string().min(1),
+});
 
 interface SlackExchangeSuccess {
   integration: IntegrationProps;
@@ -134,10 +141,13 @@ export const getSlackAuthorizeUrl =
  * consumes the `state`, exchanges the single-use `code`, and upserts the
  * tenant's Slack integration.
  */
-export const exchangeSlackOAuthCode = async ({
-  code,
-  state,
-}: SlackExchangeInput): Promise<SlackExchangeResult> => {
+export const exchangeSlackOAuthCode = async (
+  input: SlackExchangeInput,
+): Promise<SlackExchangeResult> => {
+  const parsed = slackExchangeInputSchema.safeParse(input);
+  if (!parsed.success) return { error: SLACK_GENERIC_ERROR_MESSAGE };
+
+  const { code, state } = parsed.data;
   const headers = await getAuthHeaders({ contentType: true });
   const url = new URL(`${apiBaseUrl}/integrations/slack/oauth/exchange`);
 

--- a/ui/actions/integrations/slack.ts
+++ b/ui/actions/integrations/slack.ts
@@ -49,6 +49,21 @@ interface SlackRateLimited {
   message: string;
 }
 
+/**
+ * The API accepted the completion and the UI could not read the answer back.
+ *
+ * Its own outcome rather than an error, for the same reason `unavailable` and
+ * `rateLimited` are: `response.ok` was true, so the code was consumed and the
+ * integration upserted — what Prowler cannot name is the workspace, not whether
+ * one was connected. Callers that report an error would be reporting the one
+ * thing this answer rules out.
+ */
+interface SlackUnconfirmed {
+  unconfirmed: true;
+  /** The unread result, as copy — so every caller says the same thing about it. */
+  message: string;
+}
+
 interface SlackActionError {
   error: string;
 }
@@ -76,6 +91,7 @@ export type SlackExchangeResult =
   | SlackExchangeSuccess
   | SlackUnavailable
   | SlackRateLimited
+  | SlackUnconfirmed
   | SlackActionError;
 
 /**
@@ -214,7 +230,11 @@ export const exchangeSlackOAuthCode = async ({
     // Reported as its own outcome rather than as a connected workspace with no
     // name: the callback reads `attributes.configuration` off this, and a
     // fabricated resource would fail there instead, further from the cause.
-    if (!body?.data) return { error: SLACK_UNREADABLE_RESULT_MESSAGE };
+    // Not an `{ error }` either — the `2xx` says the install happened, so a
+    // caller reading this as a failure would deny the one fact it establishes.
+    if (!body?.data) {
+      return { unconfirmed: true, message: SLACK_UNREADABLE_RESULT_MESSAGE };
+    }
 
     return { integration: parseStringify(body.data) as IntegrationProps };
   } catch (error) {

--- a/ui/actions/integrations/slack.ts
+++ b/ui/actions/integrations/slack.ts
@@ -9,7 +9,7 @@ import {
   slackErrorMessage,
   slackRateLimitMessage,
 } from "@/lib/integrations/slack-errors";
-import { handleApiError } from "@/lib/server-actions-helper";
+import { handleApiError, handleApiResponse } from "@/lib/server-actions-helper";
 import type { IntegrationProps } from "@/types/integrations";
 
 /**
@@ -103,6 +103,14 @@ const failureFrom = async (
 ): Promise<SlackUnavailable | SlackRateLimited | SlackActionError> => {
   if (isUnavailableStatus(response.status)) return { unavailable: true };
 
+  // A 5xx that is not the ship-dark 503 is a server fault rather than a Slack
+  // state — and `502` is the status the contract reserves for "Slack upstream
+  // broke" — so it goes through the repo's own 5xx handling, which is where
+  // Sentry hears about one. That call reports *and throws*, so each action's
+  // existing catch is what answers the user. It has to run before
+  // `readSlackFailure`: a response body can only be read once.
+  if (response.status >= 500) await handleApiResponse(response);
+
   const failure = await readSlackFailure(response);
 
   if (failure.status === RATE_LIMITED_STATUS) {
@@ -129,7 +137,9 @@ export const getSlackAuthorizeUrl =
       const response = await fetch(url.toString(), { method: "POST", headers });
 
       if (!response.ok) {
-        return failureFrom(
+        // Awaited inside the `try`: a returned promise's rejection is not this
+        // `catch`'s to see, and a 5xx now rejects.
+        return await failureFrom(
           response,
           `Unable to start the Slack install: ${response.statusText}`,
         );
@@ -181,7 +191,9 @@ export const exchangeSlackOAuthCode = async ({
       // `detail` is the reason to show. "A different workspace is already
       // connected" is a `409` named by its `code`, which is what turns it into
       // copy that says how to get out of it.
-      return failureFrom(
+      // Awaited inside the `try`, as above: unawaited, a 5xx's rejection would
+      // pass this `catch` and leave the callback on its spinner.
+      return await failureFrom(
         response,
         `Unable to connect the Slack workspace: ${response.statusText}`,
       );

--- a/ui/actions/integrations/slack.ts
+++ b/ui/actions/integrations/slack.ts
@@ -77,6 +77,27 @@ const isUnavailableStatus = (status: number): boolean =>
 
 const RATE_LIMITED_STATUS = 429;
 
+const SLACK_AUTHORIZE_HOSTNAME = "slack.com";
+const SLACK_AUTHORIZE_PATHNAME = "/oauth/v2/authorize";
+const NO_AUTHORIZE_URL_MESSAGE = "Slack did not return an authorization URL.";
+
+/**
+ * The URL is rendered as the `Add to Slack` link's `href`, so anything that is
+ * not Slack's consent screen is a redirect to an origin the user did not choose.
+ */
+const isSlackAuthorizeUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      url.hostname === SLACK_AUTHORIZE_HOSTNAME &&
+      url.pathname === SLACK_AUTHORIZE_PATHNAME
+    );
+  } catch {
+    return false;
+  }
+};
+
 const failureFrom = async (
   response: Response,
   fallback: string,
@@ -126,8 +147,12 @@ export const getSlackAuthorizeUrl =
       const body = await response.json().catch(() => null);
       const authorizeUrl = body?.meta?.authorize_url;
 
-      if (typeof authorizeUrl !== "string" || authorizeUrl.length === 0) {
-        return { error: "Slack did not return an authorization URL." };
+      // A URL that is not Slack's own is no more usable than a missing one.
+      if (
+        typeof authorizeUrl !== "string" ||
+        !isSlackAuthorizeUrl(authorizeUrl)
+      ) {
+        return { error: NO_AUTHORIZE_URL_MESSAGE };
       }
 
       return { authorizeUrl };

--- a/ui/actions/integrations/slack.ts
+++ b/ui/actions/integrations/slack.ts
@@ -98,6 +98,26 @@ const isSlackAuthorizeUrl = (value: string): boolean => {
   }
 };
 
+/**
+ * The callback names the workspace and redirects on this value alone, so a `2xx`
+ * payload that is not a JSON:API resource (`{}`, `[]`, `"invalid"`) must read as
+ * unreadable rather than as a connected workspace.
+ */
+const isIntegrationResource = (value: unknown): boolean => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const { id, attributes } = value as Record<string, unknown>;
+
+  return (
+    typeof id === "string" &&
+    typeof attributes === "object" &&
+    attributes !== null &&
+    !Array.isArray(attributes)
+  );
+};
+
 const failureFrom = async (
   response: Response,
   fallback: string,
@@ -205,7 +225,7 @@ export const exchangeSlackOAuthCode = async (
     revalidatePath("/integrations");
     revalidatePath("/integrations/slack");
 
-    if (!body?.data) {
+    if (!isIntegrationResource(body?.data)) {
       return { unconfirmed: true, message: SLACK_UNREADABLE_RESULT_MESSAGE };
     }
 

--- a/ui/actions/integrations/slack.ts
+++ b/ui/actions/integrations/slack.ts
@@ -1,0 +1,156 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { apiBaseUrl, getAuthHeaders, parseStringify } from "@/lib";
+import { handleApiError } from "@/lib/server-actions-helper";
+import type { IntegrationProps } from "@/types/integrations";
+
+/**
+ * The two OAuth calls the Slack install needs. Everything else — reading the
+ * integration, testing the connection, deleting it — goes through the generic
+ * integration actions, because Slack rows are plain `integrations` resources.
+ *
+ * The Slack app (`SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` /
+ * `SLACK_REDIRECT_URI`) is a deployment-wide setting, so both endpoints answer
+ * `503` until it is configured, and a deployment that serves no Slack API at
+ * all answers `404`. Neither is an error the user can act on: both mean "Slack
+ * isn't available in this environment yet", which is why they get their own
+ * result shape rather than an error string.
+ *
+ * The OAuth `state` is minted and consumed by the API, bound to the tenant and
+ * the user — the UI never inspects it, it only forwards what Slack sent back.
+ */
+
+interface SlackUnavailable {
+  unavailable: true;
+}
+
+interface SlackActionError {
+  error: string;
+}
+
+interface SlackAuthorizeUrl {
+  authorizeUrl: string;
+}
+
+export type SlackAuthorizeUrlResult =
+  | SlackAuthorizeUrl
+  | SlackUnavailable
+  | SlackActionError;
+
+interface SlackExchangeInput {
+  code: string;
+  state: string;
+}
+
+interface SlackExchangeSuccess {
+  integration: IntegrationProps;
+}
+
+export type SlackExchangeResult =
+  | SlackExchangeSuccess
+  | SlackUnavailable
+  | SlackActionError;
+
+/** Whether the deployment answered "no Slack app here". */
+const isUnavailableStatus = (status: number): boolean =>
+  status === 503 || status === 404;
+
+const detailFrom = async (
+  response: Response,
+  fallback: string,
+): Promise<string> => {
+  const body = await response.json().catch(() => ({}));
+  return body?.errors?.[0]?.detail || fallback;
+};
+
+/**
+ * Mint an OAuth state and get the consent URL to send the user to. Creates no
+ * integration: the install only exists once the exchange completes.
+ */
+export const getSlackAuthorizeUrl =
+  async (): Promise<SlackAuthorizeUrlResult> => {
+    const headers = await getAuthHeaders({ contentType: true });
+    const url = new URL(`${apiBaseUrl}/integrations/slack/oauth/authorize-url`);
+
+    try {
+      const response = await fetch(url.toString(), { method: "POST", headers });
+
+      if (isUnavailableStatus(response.status)) {
+        return { unavailable: true };
+      }
+
+      if (!response.ok) {
+        return {
+          error: await detailFrom(
+            response,
+            `Unable to start the Slack install: ${response.statusText}`,
+          ),
+        };
+      }
+
+      // The URL travels in JSON:API `meta` — the call creates no resource.
+      const body = await response.json();
+      const authorizeUrl = body?.meta?.authorize_url;
+
+      if (typeof authorizeUrl !== "string" || authorizeUrl.length === 0) {
+        return { error: "Slack did not return an authorization URL." };
+      }
+
+      return { authorizeUrl };
+    } catch (error) {
+      return handleApiError(error);
+    }
+  };
+
+/**
+ * Complete the install with what Slack put in the callback URL. The API
+ * validates and consumes the `state`, exchanges the single-use `code`, and
+ * upserts the tenant's Slack integration.
+ */
+export const exchangeSlackOAuthCode = async ({
+  code,
+  state,
+}: SlackExchangeInput): Promise<SlackExchangeResult> => {
+  const headers = await getAuthHeaders({ contentType: true });
+  const url = new URL(`${apiBaseUrl}/integrations/slack/oauth/exchange`);
+
+  try {
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        data: {
+          type: "slack-oauth-exchanges",
+          attributes: { code, state },
+        },
+      }),
+    });
+
+    if (isUnavailableStatus(response.status)) {
+      return { unavailable: true };
+    }
+
+    if (!response.ok) {
+      // A refused state, a code Slack rejected and "a different workspace is
+      // already connected" all arrive as a 400 whose detail is the reason to
+      // show — the UI does not need to tell them apart.
+      return {
+        error: await detailFrom(
+          response,
+          `Unable to connect the Slack workspace: ${response.statusText}`,
+        ),
+      };
+    }
+
+    const body = await response.json();
+
+    revalidatePath("/integrations");
+    revalidatePath("/integrations/slack");
+
+    return { integration: parseStringify(body.data) as IntegrationProps };
+  } catch (error) {
+    return handleApiError(error);
+  }
+};

--- a/ui/actions/integrations/slack.ts
+++ b/ui/actions/integrations/slack.ts
@@ -12,7 +12,7 @@ import {
   slackRateLimitMessage,
 } from "@/lib/integrations/slack-errors";
 import { handleApiError, handleApiResponse } from "@/lib/server-actions-helper";
-import type { IntegrationProps } from "@/types/integrations";
+import { INTEGRATION_TYPE, type IntegrationProps } from "@/types/integrations";
 
 interface SlackUnavailable {
   unavailable: true;
@@ -98,23 +98,36 @@ const isSlackAuthorizeUrl = (value: string): boolean => {
   }
 };
 
+const INTEGRATIONS_RESOURCE_TYPE = "integrations";
+
 /**
  * The callback names the workspace and redirects on this value alone, so a `2xx`
  * payload that is not a JSON:API resource (`{}`, `[]`, `"invalid"`) must read as
- * unreadable rather than as a connected workspace.
+ * unreadable rather than as a connected workspace. Identity is part of that: an
+ * id the page cannot link to, another resource type, or another integration
+ * kind would each be shown as the Slack workspace just installed.
  */
 const isIntegrationResource = (value: unknown): boolean => {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return false;
   }
 
-  const { id, attributes } = value as Record<string, unknown>;
+  const { id, type, attributes } = value as Record<string, unknown>;
+
+  if (
+    typeof id !== "string" ||
+    id === "" ||
+    type !== INTEGRATIONS_RESOURCE_TYPE ||
+    typeof attributes !== "object" ||
+    attributes === null ||
+    Array.isArray(attributes)
+  ) {
+    return false;
+  }
 
   return (
-    typeof id === "string" &&
-    typeof attributes === "object" &&
-    attributes !== null &&
-    !Array.isArray(attributes)
+    (attributes as Record<string, unknown>).integration_type ===
+    INTEGRATION_TYPE.SLACK
   );
 };
 

--- a/ui/actions/integrations/slack.ts
+++ b/ui/actions/integrations/slack.ts
@@ -103,9 +103,9 @@ const INTEGRATIONS_RESOURCE_TYPE = "integrations";
 /**
  * The callback names the workspace and redirects on this value alone, so a `2xx`
  * payload that is not a JSON:API resource (`{}`, `[]`, `"invalid"`) must read as
- * unreadable rather than as a connected workspace. Identity is part of that: an
- * id the page cannot link to, another resource type, or another integration
- * kind would each be shown as the Slack workspace just installed.
+ * unreadable rather than as a connected workspace. Identity too: a resource
+ * that is not a linkable Slack integration would be shown as the workspace
+ * just installed.
  */
 const isIntegrationResource = (value: unknown): boolean => {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {

--- a/ui/app/(prowler)/integrations/integrations-content.tsx
+++ b/ui/app/(prowler)/integrations/integrations-content.tsx
@@ -7,9 +7,8 @@ import { SsoLinkCard } from "@/components/integrations/sso/sso-link-card";
 import { isCloud } from "@/lib/shared/env";
 
 /**
- * The integrations catalogue, split out of `page.tsx` so it can be rendered
- * without the surrounding `ContentLayout` (whose navbar streams async server
- * children a client renderer can't resolve) in the browser-mode tests.
+ * Split out of `page.tsx` for the browser-mode tests: `ContentLayout`'s navbar
+ * streams async server children a client renderer can't resolve.
  */
 export function IntegrationsContent() {
   return (
@@ -31,8 +30,7 @@ export function IntegrationsContent() {
         {/* Jira Integration */}
         <JiraIntegrationCard />
 
-        {/* Slack Integration — its API lives in the cloud deployment only, so
-            a self-hosted Prowler has nothing to manage. */}
+        {/* Slack Integration - cloud-only API, nothing to manage self-hosted */}
         {isCloud() && <SlackIntegrationCard />}
 
         {/* SSO Configuration - redirects to Profile */}

--- a/ui/app/(prowler)/integrations/integrations-content.tsx
+++ b/ui/app/(prowler)/integrations/integrations-content.tsx
@@ -1,0 +1,46 @@
+import { ApiKeyLinkCard } from "@/components/integrations/api-key/api-key-link-card";
+import { JiraIntegrationCard } from "@/components/integrations/jira/jira-integration-card";
+import { S3IntegrationCard } from "@/components/integrations/s3/s3-integration-card";
+import { SecurityHubIntegrationCard } from "@/components/integrations/security-hub/security-hub-integration-card";
+import { SlackIntegrationCard } from "@/components/integrations/slack/slack-integration-card";
+import { SsoLinkCard } from "@/components/integrations/sso/sso-link-card";
+import { isCloud } from "@/lib/shared/env";
+
+/**
+ * The integrations catalogue, split out of `page.tsx` so it can be rendered
+ * without the surrounding `ContentLayout` (whose navbar streams async server
+ * children a client renderer can't resolve) in the browser-mode tests.
+ */
+export function IntegrationsContent() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          Connect external services to enhance your security workflow and
+          automatically export your scan results.
+        </p>
+      </div>
+
+      <div className="grid gap-6">
+        {/* Amazon S3 Integration */}
+        <S3IntegrationCard />
+
+        {/* AWS Security Hub Integration */}
+        <SecurityHubIntegrationCard />
+
+        {/* Jira Integration */}
+        <JiraIntegrationCard />
+
+        {/* Slack Integration — its API lives in the cloud deployment only, so
+            a self-hosted Prowler has nothing to manage. */}
+        {isCloud() && <SlackIntegrationCard />}
+
+        {/* SSO Configuration - redirects to Profile */}
+        <SsoLinkCard />
+
+        {/* API Keys - redirects to Profile */}
+        <ApiKeyLinkCard />
+      </div>
+    </div>
+  );
+}

--- a/ui/app/(prowler)/integrations/integrations-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/integrations-page.integration.test.tsx
@@ -1,13 +1,7 @@
 /**
- * Browser-mode tests for the integrations catalogue (`/integrations`).
- *
- * Slack is a Prowler Cloud feature — its API only exists in the cloud
- * deployment — so the catalogue offers it there and nowhere else. That gate is
- * the whole of this page's Slack behaviour, which is why these two tests are
- * the whole file.
- *
- * The page is driven through `SlackIntegrationHarness`, the shared harness for
- * the Slack flow: the catalogue is where that flow starts.
+ * Browser-mode tests for the Slack entry in the integrations catalogue
+ * (`/integrations`), which is offered in Prowler Cloud only. Driven through
+ * `SlackIntegrationHarness` against the MSW handlers.
  */
 
 import { describe, expect } from "vitest";
@@ -22,10 +16,8 @@ describe("the integrations catalogue", () => {
     // Given — a Prowler Cloud deployment (the fixtures' default island).
     const harness = new SlackIntegrationHarness(slackFixture());
 
-    // When
     harness.mountCatalogue();
 
-    // Then
     expect(await harness.listedIntegrations()).toContain("Slack");
     expect(harness.offersSlackManagement()).toBe(true);
   }, 30000);
@@ -33,19 +25,16 @@ describe("the integrations catalogue", () => {
   it("omits Slack in a deployment that is not Prowler Cloud", async ({
     seedRuntimeConfig,
   }) => {
-    // Given
     seedRuntimeConfig({ cloudEnabled: false });
     const harness = new SlackIntegrationHarness(slackFixture());
 
-    // When
     harness.mountCatalogue();
 
-    // Then — Slack is gone, and nothing offers to manage it.
     const listed = await harness.listedIntegrations();
     expect(listed).not.toContain("Slack");
     expect(harness.offersSlackManagement()).toBe(false);
-    // Tripwire: the catalogue itself still rendered, so the assertion above is
-    // Slack being absent rather than the page failing to load.
+    // Tripwire: the catalogue rendered, so the assertions above are Slack's
+    // absence rather than the page failing to load.
     expect(listed).toContain("Jira");
   }, 30000);
 });

--- a/ui/app/(prowler)/integrations/integrations-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/integrations-page.integration.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Browser-mode tests for the integrations catalogue (`/integrations`).
+ *
+ * Slack is a Prowler Cloud feature — its API only exists in the cloud
+ * deployment — so the catalogue offers it there and nowhere else. That gate is
+ * the whole of this page's Slack behaviour, which is why these two tests are
+ * the whole file.
+ *
+ * The page is driven through `SlackIntegrationHarness`, the shared harness for
+ * the Slack flow: the catalogue is where that flow starts.
+ */
+
+import { describe, expect } from "vitest";
+
+import { it } from "@/__tests__/fixtures";
+import { slackFixture } from "@/__tests__/msw/handlers/slack.fixtures";
+
+import { SlackIntegrationHarness } from "./slack/slack-integration.harness";
+
+describe("the integrations catalogue", () => {
+  it("offers Slack in Prowler Cloud, with a way to manage it", async () => {
+    // Given — a Prowler Cloud deployment (the fixtures' default island).
+    const harness = new SlackIntegrationHarness(slackFixture());
+
+    // When
+    harness.mountCatalogue();
+
+    // Then
+    expect(await harness.listedIntegrations()).toContain("Slack");
+    expect(harness.offersSlackManagement()).toBe(true);
+  }, 30000);
+
+  it("omits Slack in a deployment that is not Prowler Cloud", async ({
+    seedRuntimeConfig,
+  }) => {
+    // Given
+    seedRuntimeConfig({ cloudEnabled: false });
+    const harness = new SlackIntegrationHarness(slackFixture());
+
+    // When
+    harness.mountCatalogue();
+
+    // Then — Slack is gone, and nothing offers to manage it.
+    const listed = await harness.listedIntegrations();
+    expect(listed).not.toContain("Slack");
+    expect(harness.offersSlackManagement()).toBe(false);
+    // Tripwire: the catalogue itself still rendered, so the assertion above is
+    // Slack being absent rather than the page failing to load.
+    expect(listed).toContain("Jira");
+  }, 30000);
+});

--- a/ui/app/(prowler)/integrations/page.tsx
+++ b/ui/app/(prowler)/integrations/page.tsx
@@ -1,40 +1,11 @@
-import {
-  ApiKeyLinkCard,
-  JiraIntegrationCard,
-  S3IntegrationCard,
-  SecurityHubIntegrationCard,
-  SsoLinkCard,
-} from "@/components/integrations";
 import { ContentLayout } from "@/components/shadcn/content-layout";
+
+import { IntegrationsContent } from "./integrations-content";
 
 export default async function Integrations() {
   return (
     <ContentLayout title="Integrations" icon="lucide:puzzle">
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col gap-4">
-          <p className="text-sm text-gray-600 dark:text-gray-300">
-            Connect external services to enhance your security workflow and
-            automatically export your scan results.
-          </p>
-        </div>
-
-        <div className="grid gap-6">
-          {/* Amazon S3 Integration */}
-          <S3IntegrationCard />
-
-          {/* AWS Security Hub Integration */}
-          <SecurityHubIntegrationCard />
-
-          {/* Jira Integration */}
-          <JiraIntegrationCard />
-
-          {/* SSO Configuration - redirects to Profile */}
-          <SsoLinkCard />
-
-          {/* API Keys - redirects to Profile */}
-          <ApiKeyLinkCard />
-        </div>
-      </div>
+      <IntegrationsContent />
     </ContentLayout>
   );
 }

--- a/ui/app/(prowler)/integrations/slack/callback/page.tsx
+++ b/ui/app/(prowler)/integrations/slack/callback/page.tsx
@@ -12,8 +12,7 @@ export default async function SlackCallbackPage() {
 
   return (
     <ContentLayout title="Slack">
-      {/* `SlackCallback` reads the query string Slack redirected to, so it
-          needs a boundary to render inside. */}
+      {/* `SlackCallback` reads the query string, so it needs a boundary. */}
       <Suspense fallback={null}>
         <SlackCallback />
       </Suspense>

--- a/ui/app/(prowler)/integrations/slack/callback/page.tsx
+++ b/ui/app/(prowler)/integrations/slack/callback/page.tsx
@@ -1,0 +1,22 @@
+import { redirect } from "next/navigation";
+import { Suspense } from "react";
+
+import { SlackCallback } from "@/components/integrations/slack/slack-callback";
+import { ContentLayout } from "@/components/shadcn/content-layout";
+import { isCloud } from "@/lib/shared/env";
+
+export default async function SlackCallbackPage() {
+  if (!isCloud()) {
+    redirect("/");
+  }
+
+  return (
+    <ContentLayout title="Slack">
+      {/* `SlackCallback` reads the query string Slack redirected to, so it
+          needs a boundary to render inside. */}
+      <Suspense fallback={null}>
+        <SlackCallback />
+      </Suspense>
+    </ContentLayout>
+  );
+}

--- a/ui/app/(prowler)/integrations/slack/page.tsx
+++ b/ui/app/(prowler)/integrations/slack/page.tsx
@@ -6,8 +6,8 @@ import { isCloud } from "@/lib/shared/env";
 import { SlackIntegrationContent } from "./slack-integration-content";
 
 export default async function SlackIntegrationPage() {
-  // The Slack API is served by the cloud deployment only, so outside Prowler
-  // Cloud there is nothing behind this page. Mirrors `/alerts`.
+  // The Slack API is cloud-only, so self-hosted has nothing behind this page.
+  // Mirrors `/alerts`.
   if (!isCloud()) {
     redirect("/");
   }

--- a/ui/app/(prowler)/integrations/slack/page.tsx
+++ b/ui/app/(prowler)/integrations/slack/page.tsx
@@ -1,0 +1,26 @@
+import { redirect } from "next/navigation";
+
+import { ContentLayout } from "@/components/shadcn/content-layout";
+import { isCloud } from "@/lib/shared/env";
+
+import { SlackIntegrationContent } from "./slack-integration-content";
+
+export default async function SlackIntegrationPage() {
+  // The Slack API is served by the cloud deployment only, so outside Prowler
+  // Cloud there is nothing behind this page. Mirrors `/alerts`.
+  if (!isCloud()) {
+    redirect("/");
+  }
+
+  return (
+    <ContentLayout title="Slack">
+      <div className="flex flex-col gap-6">
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          Connect a Slack workspace so Prowler can post to one of its channels.
+        </p>
+
+        <SlackIntegrationContent />
+      </div>
+    </ContentLayout>
+  );
+}

--- a/ui/app/(prowler)/integrations/slack/slack-callback-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-callback-page.integration.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * Browser-mode tests for the Slack OAuth callback
+ * (`/integrations/slack/callback`), driven through `SlackIntegrationHarness`.
+ * MSW answers from handlers derived from the API contract in `design.md`.
+ */
+
+import { describe, expect } from "vitest";
+
+import { it } from "@/__tests__/fixtures";
+import {
+  SLACK_EXCHANGE_OUTCOME,
+  SLACK_OAUTH_CODE,
+  SLACK_OAUTH_STATE,
+  slackFixture,
+} from "@/__tests__/msw/handlers/slack.fixtures";
+
+import { SlackIntegrationHarness } from "./slack-integration.harness";
+
+/** The workspace the fixtures connect. */
+const WORKSPACE_NAME = "Prowler HQ";
+
+/**
+ * Callback headlines, spelled out rather than imported so a rename fails here.
+ * `FAILURE_TITLE` is for installs that connected nothing; `UNCONFIRMED_TITLE`
+ * for answers that arrive after the API already upserted the integration.
+ */
+const FAILURE_TITLE = "Slack workspace not connected";
+const UNCONFIRMED_TITLE = "Slack install not confirmed";
+
+describe("returning from Slack", () => {
+  it("completes the install and shows the connected workspace", async () => {
+    const harness = new SlackIntegrationHarness(slackFixture());
+
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    expect(await harness.completedInstall()).toBe(true);
+    expect(await harness.connectedWorkspaceName()).toBe(WORKSPACE_NAME);
+    // The code is single-use and the exchange runs from a render (design D4):
+    // without the once-guard, a second call burns it and reports a failure.
+    expect(harness.exchangeCallCount).toBe(1);
+  }, 30000);
+
+  it("does not report an install the API completed as failed when it answers no content", async () => {
+    // Given — a `204`: the API consumed the code and upserted the integration,
+    // then answered with no body. `response.ok` is true, so this is no refusal.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({
+        exchangeOutcome: SLACK_EXCHANGE_OUTCOME.UNREADABLE_NO_CONTENT,
+      }),
+    );
+
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    const reason = await harness.installFailureReason();
+    expect(reason).toMatch(/could not read the result of the install/);
+    expect(reason).toMatch(/Slack integration page/);
+    expect(reason).not.toMatch(/JSON/i);
+    expect(harness.offersRetry()).toBe(true);
+    // The `204` says the workspace is connected; the headline cannot deny it.
+    expect(await harness.installFailureTitle()).toBe(UNCONFIRMED_TITLE);
+    // The install exists, so the cached "none connected" has to go with it.
+    expect(harness.revalidatedPaths).toEqual(
+      expect.arrayContaining(["/integrations", "/integrations/slack"]),
+    );
+  }, 30000);
+
+  it("shows Prowler's own wording when a proxy answers the completion with an HTML page", async () => {
+    // Given — a proxy answering `200` with a challenge page instead of JSON.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.UNREADABLE_HTML }),
+    );
+
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    // V8's parse message truncates before the word `html`, so the shared
+    // HTML-shaped-error filter cannot catch this one.
+    const reason = await harness.installFailureReason();
+    expect(reason).toMatch(/could not read the result of the install/);
+    expect(reason).not.toMatch(/DOCTYPE/i);
+    expect(reason).not.toMatch(/not valid JSON/i);
+  }, 30000);
+
+  it("says the result is unreadable, not that the workspace is unknown, when the answer names no resource", async () => {
+    // Given — a `200` carrying well-formed JSON:API with no `data` member.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({
+        exchangeOutcome: SLACK_EXCHANGE_OUTCOME.UNREADABLE_NO_DATA,
+      }),
+    );
+
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    const reason = await harness.installFailureReason();
+    expect(reason).toMatch(/could not read the result of the install/);
+    expect(reason).not.toMatch(/undefined/i);
+    expect(await harness.completedInstall()).toBe(false);
+  }, 30000);
+
+  it("connects nothing when the user declines in Slack, and offers to retry", async () => {
+    const harness = new SlackIntegrationHarness(slackFixture());
+
+    await harness.mountCallback({ error: "access_denied" });
+
+    expect(await harness.installFailureReason()).toMatch(
+      /not approved in Slack/,
+    );
+    expect(harness.offersRetry()).toBe(true);
+    // A declined consent carries no code, so there was nothing to exchange.
+    expect(harness.exchangeCallCount).toBe(0);
+  }, 30000);
+
+  it("surfaces the reason when Slack refuses to complete the install", async () => {
+    // Given — Slack rejects the code, and the API's own wording explains it.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.SLACK_REFUSED }),
+    );
+
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    // A refusal Prowler has no wording of its own for falls back to the API's
+    // `detail`, not to a generic failure.
+    expect(await harness.installFailureReason()).toMatch(
+      /OAuth code is invalid/,
+    );
+    expect(harness.offersRetry()).toBe(true);
+  }, 30000);
+
+  it("surfaces a completion the API refuses, and connects nothing", async () => {
+    // Given — the state was minted for another session, or already consumed.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.REFUSED_STATE }),
+    );
+
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: "state-from-another-session",
+    });
+
+    expect(await harness.installFailureReason()).toMatch(
+      /state is invalid, expired, or already consumed/,
+    );
+    // The API refused before consuming anything, so nothing was created and the
+    // headline states that plainly.
+    expect(await harness.installFailureTitle()).toBe(FAILURE_TITLE);
+    expect(await harness.completedInstall()).toBe(false);
+    expect(harness.offersRetry()).toBe(true);
+    // Refused once, not retried into a second burnt code.
+    expect(harness.exchangeCallCount).toBe(1);
+  }, 30000);
+
+  it("says how to resolve a workspace conflict, in Prowler's own words", async () => {
+    // Given — this tenant already has a different workspace connected, which
+    // the API refuses as a 409 naming the conflict in `code`.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({
+        exchangeOutcome: SLACK_EXCHANGE_OUTCOME.DIFFERENT_WORKSPACE,
+      }),
+    );
+
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    // The copy comes from the error `code`: the API's `detail` states the
+    // conflict but not the way out of it.
+    const reason = await harness.installFailureReason();
+    expect(reason).toMatch(/already connected to a different Slack workspace/);
+    expect(reason).toMatch(/Disconnect it before connecting another/);
+    expect(reason).not.toMatch(/tenant/);
+    expect(await harness.completedInstall()).toBe(false);
+    expect(harness.offersRetry()).toBe(true);
+  }, 30000);
+
+  it("tells the user when to come back if Slack is rate limiting the install", async () => {
+    // Given — Slack answers 429 with a Retry-After.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ rateLimited: true }),
+    );
+
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    const reason = await harness.installFailureReason();
+    expect(reason).toMatch(/rate limiting/);
+    expect(reason).toMatch(/about 30 seconds/);
+    expect(reason).not.toMatch(/not available in this environment/);
+    // A 429 refuses the exchange outright, so nothing was connected: the plain
+    // headline, unlike the unreadable `2xx` that arrives after the upsert.
+    expect(await harness.installFailureTitle()).toBe(FAILURE_TITLE);
+    expect(harness.offersRetry()).toBe(true);
+  }, 30000);
+
+  it("reports Slack being broken upstream, rather than leaving the callback spinning", async () => {
+    // Given — the completion answers `502`, the contract's status for a Slack
+    // upstream failure. The shared 5xx handling throws, so the callback only
+    // renders this if the action answers that rejection itself.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ oauthUpstreamError: true }),
+    );
+
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    // The API refused, so nothing was created: not the "could not confirm" the
+    // page falls back to when the action never answers at all.
+    const reason = await harness.installFailureReason();
+    expect(reason).toMatch(/temporarily unavailable/);
+    expect(reason).not.toMatch(/could not confirm/);
+    expect(await harness.completedInstall()).toBe(false);
+    expect(harness.offersRetry()).toBe(true);
+  }, 30000);
+
+  it("does not attempt an exchange when the completion carries no state", async () => {
+    const harness = new SlackIntegrationHarness(slackFixture());
+
+    await harness.mountCallback({ code: SLACK_OAUTH_CODE });
+
+    // Refused before the API is ever asked, so no code is spent.
+    expect(await harness.installFailureReason()).toMatch(/incomplete response/);
+    expect(harness.exchangeCallCount).toBe(0);
+  }, 30000);
+});

--- a/ui/app/(prowler)/integrations/slack/slack-callback-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-callback-page.integration.test.tsx
@@ -41,6 +41,10 @@ describe("returning from Slack", () => {
     // The code is single-use and the exchange runs from a render (design D4):
     // without the once-guard, a second call burns it and reports a failure.
     expect(harness.exchangeCallCount).toBe(1);
+    // A completed install invalidates the cached "none connected".
+    expect(harness.revalidatedPaths).toEqual(
+      expect.arrayContaining(["/integrations", "/integrations/slack"]),
+    );
   }, 30000);
 
   it("does not report an install the API completed as failed when it answers no content", async () => {

--- a/ui/app/(prowler)/integrations/slack/slack-integration-content.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-integration-content.tsx
@@ -2,7 +2,7 @@ import { getIntegrations } from "@/actions/integrations/integrations";
 import { getSlackAuthorizeUrl } from "@/actions/integrations/slack";
 import { SlackIntegrationManager } from "@/components/integrations/slack/slack-integration-manager";
 import { GENERIC_SERVER_ERROR_MESSAGE } from "@/lib/helper";
-import type { IntegrationProps } from "@/types/integrations";
+import { INTEGRATION_TYPE, type IntegrationProps } from "@/types/integrations";
 
 /**
  * `getIntegrations` throws a `>= 500` answer past its own catch, which covers
@@ -26,7 +26,7 @@ const readSlackIntegrations = async (searchParams: URLSearchParams) => {
  */
 export async function SlackIntegrationContent() {
   const searchParams = new URLSearchParams();
-  searchParams.set("filter[integration_type]", "slack");
+  searchParams.set("filter[integration_type]", INTEGRATION_TYPE.SLACK);
   // One workspace per tenant, so one row is the whole result set.
   searchParams.set("page[size]", "1");
 

--- a/ui/app/(prowler)/integrations/slack/slack-integration-content.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-integration-content.tsx
@@ -5,49 +5,28 @@ import { GENERIC_SERVER_ERROR_MESSAGE } from "@/lib/helper";
 import type { IntegrationProps } from "@/types/integrations";
 
 /**
- * Read the tenant's Slack row, reporting a server failure the same way the API's
- * own refusals arrive — as `{ error }` — so both take the page's one error path.
- *
- * `getIntegrations` returns its `handleApiResponse(...)` promise without
- * awaiting it, so its own `catch` covers only a transport failure: a `>= 500`
- * answer is *thrown*, past that catch, at whoever awaited the action. Left
- * uncaught it escapes this page and trips the route's error boundary, replacing
- * a page that could still offer the install with a full-page error. Awaiting
- * inside the shared action would fix this rejection in the wrong place: the
- * Jira / S3 / Security Hub pages read the same result with nowhere to route an
- * error into, so they would silently render an empty list instead.
- *
- * `handleApiResponse` already reported the throw to Sentry, so this only
- * classifies it.
+ * `getIntegrations` throws a `>= 500` answer past its own catch, which covers
+ * only transport. Uncaught it trips the route's error boundary and replaces a
+ * page that could still offer the install, so report it as `{ error }` and take
+ * the page's one error path.
  */
 const readSlackIntegrations = async (searchParams: URLSearchParams) => {
   try {
     return await getIntegrations(searchParams);
   } catch {
-    // The thrown message can carry the server's own wording; a server error is
-    // answered in Prowler's, as the rest of the UI answers one.
+    // The thrown message can carry the server's own wording; `handleApiResponse`
+    // already reported it to Sentry.
     return { error: GENERIC_SERVER_ERROR_MESSAGE };
   }
 };
 
 /**
- * Loads the tenant's Slack install and, when there is none, the consent URL to
- * start one — split out of `page.tsx` so it can be rendered without the
- * surrounding `ContentLayout` in the browser-mode tests.
- *
- * The authorize URL is requested here rather than behind the Connect click:
- * minting a short-lived, single-use OAuth state costs nothing, it keeps the
- * install one click (a plain link to Slack's consent screen, no interstitial),
- * and it is what surfaces "Slack isn't available in this environment yet" on
- * arrival instead of after a click that goes nowhere. It is skipped entirely
- * once a workspace is connected — there is no install left to start.
+ * Split out of `page.tsx` so the browser-mode tests can render it without the
+ * surrounding `ContentLayout`.
  */
 export async function SlackIntegrationContent() {
-  // The React Compiler (enabled for the browser-mode project) otherwise
-  // instruments this as a client component and injects `useMemoCache`, which
-  // needs a React dispatcher. An async server component renders once per
-  // request, so there is nothing to memoize — and the injected hook makes it
-  // uncallable outside a render, which is exactly how the tests mount it.
+  // Without this the React Compiler (on for the browser-mode project) injects
+  // `useMemoCache`, which makes this async component uncallable outside a render.
   "use no memo";
 
   const searchParams = new URLSearchParams();
@@ -72,8 +51,8 @@ export async function SlackIntegrationContent() {
         authorize && "authorizeUrl" in authorize ? authorize.authorizeUrl : null
       }
       unavailable={Boolean(authorize && "unavailable" in authorize)}
-      // Slack being busy is not the same as this deployment having no Slack
-      // app: the install is still on offer, it just cannot be started yet.
+      // Rate limited is not unavailable: the install is still on offer, it just
+      // cannot be started yet.
       rateLimitMessage={
         authorize && "rateLimited" in authorize ? authorize.message : null
       }

--- a/ui/app/(prowler)/integrations/slack/slack-integration-content.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-integration-content.tsx
@@ -45,6 +45,11 @@ export async function SlackIntegrationContent() {
         authorize && "authorizeUrl" in authorize ? authorize.authorizeUrl : null
       }
       unavailable={Boolean(authorize && "unavailable" in authorize)}
+      // Slack being busy is not the same as this deployment having no Slack
+      // app: the install is still on offer, it just cannot be started yet.
+      rateLimitMessage={
+        authorize && "rateLimited" in authorize ? authorize.message : null
+      }
       loadError={
         loadError ??
         (authorize && "error" in authorize ? authorize.error : null)

--- a/ui/app/(prowler)/integrations/slack/slack-integration-content.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-integration-content.tsx
@@ -25,10 +25,6 @@ const readSlackIntegrations = async (searchParams: URLSearchParams) => {
  * surrounding `ContentLayout`.
  */
 export async function SlackIntegrationContent() {
-  // Without this the React Compiler (on for the browser-mode project) injects
-  // `useMemoCache`, which makes this async component uncallable outside a render.
-  "use no memo";
-
   const searchParams = new URLSearchParams();
   searchParams.set("filter[integration_type]", "slack");
   // One workspace per tenant, so one row is the whole result set.

--- a/ui/app/(prowler)/integrations/slack/slack-integration-content.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-integration-content.tsx
@@ -1,0 +1,54 @@
+import { getIntegrations } from "@/actions/integrations/integrations";
+import { getSlackAuthorizeUrl } from "@/actions/integrations/slack";
+import { SlackIntegrationManager } from "@/components/integrations/slack/slack-integration-manager";
+import type { IntegrationProps } from "@/types/integrations";
+
+/**
+ * Loads the tenant's Slack install and, when there is none, the consent URL to
+ * start one — split out of `page.tsx` so it can be rendered without the
+ * surrounding `ContentLayout` in the browser-mode tests.
+ *
+ * The authorize URL is requested here rather than behind the Connect click:
+ * minting a short-lived, single-use OAuth state costs nothing, it keeps the
+ * install one click (a plain link to Slack's consent screen, no interstitial),
+ * and it is what surfaces "Slack isn't available in this environment yet" on
+ * arrival instead of after a click that goes nowhere. It is skipped entirely
+ * once a workspace is connected — there is no install left to start.
+ */
+export async function SlackIntegrationContent() {
+  // The React Compiler (enabled for the browser-mode project) otherwise
+  // instruments this as a client component and injects `useMemoCache`, which
+  // needs a React dispatcher. An async server component renders once per
+  // request, so there is nothing to memoize — and the injected hook makes it
+  // uncallable outside a render, which is exactly how the tests mount it.
+  "use no memo";
+
+  const searchParams = new URLSearchParams();
+  searchParams.set("filter[integration_type]", "slack");
+  // One workspace per tenant, so one row is the whole result set.
+  searchParams.set("page[size]", "1");
+
+  const integrations = await getIntegrations(searchParams);
+  const loadError =
+    integrations && "error" in integrations
+      ? (integrations.error as string)
+      : null;
+  const integration: IntegrationProps | null =
+    (integrations?.data?.[0] as IntegrationProps | undefined) ?? null;
+
+  const authorize = integration ? null : await getSlackAuthorizeUrl();
+
+  return (
+    <SlackIntegrationManager
+      integration={integration}
+      authorizeUrl={
+        authorize && "authorizeUrl" in authorize ? authorize.authorizeUrl : null
+      }
+      unavailable={Boolean(authorize && "unavailable" in authorize)}
+      loadError={
+        loadError ??
+        (authorize && "error" in authorize ? authorize.error : null)
+      }
+    />
+  );
+}

--- a/ui/app/(prowler)/integrations/slack/slack-integration-content.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-integration-content.tsx
@@ -1,7 +1,34 @@
 import { getIntegrations } from "@/actions/integrations/integrations";
 import { getSlackAuthorizeUrl } from "@/actions/integrations/slack";
 import { SlackIntegrationManager } from "@/components/integrations/slack/slack-integration-manager";
+import { GENERIC_SERVER_ERROR_MESSAGE } from "@/lib/helper";
 import type { IntegrationProps } from "@/types/integrations";
+
+/**
+ * Read the tenant's Slack row, reporting a server failure the same way the API's
+ * own refusals arrive — as `{ error }` — so both take the page's one error path.
+ *
+ * `getIntegrations` returns its `handleApiResponse(...)` promise without
+ * awaiting it, so its own `catch` covers only a transport failure: a `>= 500`
+ * answer is *thrown*, past that catch, at whoever awaited the action. Left
+ * uncaught it escapes this page and trips the route's error boundary, replacing
+ * a page that could still offer the install with a full-page error. Awaiting
+ * inside the shared action would fix this rejection in the wrong place: the
+ * Jira / S3 / Security Hub pages read the same result with nowhere to route an
+ * error into, so they would silently render an empty list instead.
+ *
+ * `handleApiResponse` already reported the throw to Sentry, so this only
+ * classifies it.
+ */
+const readSlackIntegrations = async (searchParams: URLSearchParams) => {
+  try {
+    return await getIntegrations(searchParams);
+  } catch {
+    // The thrown message can carry the server's own wording; a server error is
+    // answered in Prowler's, as the rest of the UI answers one.
+    return { error: GENERIC_SERVER_ERROR_MESSAGE };
+  }
+};
 
 /**
  * Loads the tenant's Slack install and, when there is none, the consent URL to
@@ -28,7 +55,7 @@ export async function SlackIntegrationContent() {
   // One workspace per tenant, so one row is the whole result set.
   searchParams.set("page[size]", "1");
 
-  const integrations = await getIntegrations(searchParams);
+  const integrations = await readSlackIntegrations(searchParams);
   const loadError =
     integrations && "error" in integrations
       ? (integrations.error as string)

--- a/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
+++ b/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
@@ -20,14 +20,6 @@ import { IntegrationsContent } from "../integrations-content";
 
 import { SlackIntegrationContent } from "./slack-integration-content";
 
-export const CONNECTION_OUTCOME = {
-  SUCCESS: "success",
-  FAILURE: "failure",
-} as const;
-
-export type ConnectionOutcome =
-  (typeof CONNECTION_OUTCOME)[keyof typeof CONNECTION_OUTCOME];
-
 interface CallbackParams {
   code?: string;
   state?: string;
@@ -227,13 +219,13 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return (badge.textContent ?? "").trim();
   }
 
-  async offersConnectionTest(): Promise<boolean> {
-    const button = await this.waitFor(
-      () => this.buttonByText(/Test connection/),
-      5000,
-      "the Test connection button",
-    );
-    return !button.disabled;
+  /**
+   * A check the user can actually run. A control that is absent, or there but
+   * disabled, is not one — both are "the page does not offer it".
+   */
+  offersConnectionTest(): boolean {
+    const button = this.buttonByText(/Test connection/);
+    return button !== null && !button.disabled;
   }
 
   saysChannelIsNextStep(): boolean {
@@ -249,24 +241,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
       this.container.querySelectorAll<HTMLElement>("p"),
     ).find((p) => /^Last checked:/.test((p.textContent ?? "").trim()));
     return line ? (line.textContent ?? "").trim() : null;
-  }
-
-  async testConnection(): Promise<ConnectionOutcome> {
-    await this.clickButton(/Test connection/);
-
-    return this.waitFor(
-      () => {
-        if (this.containsText(/Connection test successful/)) {
-          return CONNECTION_OUTCOME.SUCCESS;
-        }
-        if (this.containsText(/Connection test failed/)) {
-          return CONNECTION_OUTCOME.FAILURE;
-        }
-        return null;
-      },
-      15000,
-      "the connection test outcome",
-    );
   }
 
   // --- Returning from Slack -----------------------------------------------

--- a/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
+++ b/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
@@ -14,7 +14,9 @@
  * trick the providers harness uses.
  */
 
+import { revalidatePath } from "next/cache";
 import { createElement } from "react";
+import { vi } from "vitest";
 
 import { BrowserHarness } from "@/__tests__/browser-harness";
 import { handlersForSlack } from "@/__tests__/msw/handlers/slack";
@@ -53,9 +55,25 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return this.countRequests("POST", "/slack/oauth/authorize-url");
   }
 
+  /**
+   * The pages the actions asked Next to refresh since this harness mounted.
+   *
+   * `next/cache` is stubbed for the browser lane — there is no request scope to
+   * hold a cache — so the calls are observable, which is what makes "the pages
+   * that list the install are refreshed even when the answer was unreadable"
+   * something a test can assert rather than assume.
+   */
+  get revalidatedPaths(): string[] {
+    return vi.mocked(revalidatePath).mock.calls.map(([path]) => path);
+  }
+
   // --- Mounting -----------------------------------------------------------
 
   private wireHandlers(): void {
+    // The stub is module-level and shared, so its call log would otherwise
+    // carry whatever earlier tests in the file revalidated. Clearing it at
+    // mount makes `revalidatedPaths` mean "since this mount".
+    vi.mocked(revalidatePath).mockClear();
     worker.use(...handlersForSlack(this.fixture));
     this.trackRequests(worker);
   }

--- a/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
+++ b/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
@@ -191,6 +191,22 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return (description.textContent ?? "").trim();
   }
 
+  /**
+   * What the page says when the tenant's Slack install could not be read.
+   *
+   * Reaching this at all is part of the assertion: the read fails by throwing,
+   * so a page that does not catch it never renders — the mount itself fails.
+   */
+  async loadErrorNotice(): Promise<string> {
+    await this.waitForText(/Could not load your Slack integration/, 10000);
+    const description = await this.waitFor(
+      () => this.q('[data-slot="alert-description"]'),
+      5000,
+      "the load error notice",
+    );
+    return (description.textContent ?? "").trim();
+  }
+
   // --- Connected state ----------------------------------------------------
 
   /**

--- a/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
+++ b/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
@@ -219,10 +219,7 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return (badge.textContent ?? "").trim();
   }
 
-  /**
-   * A check the user can actually run. A control that is absent, or there but
-   * disabled, is not one — both are "the page does not offer it".
-   */
+  /** Absent, or there but disabled: both read as "not offered". */
   offersConnectionTest(): boolean {
     const button = this.buttonByText(/Test connection/);
     return button !== null && !button.disabled;

--- a/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
+++ b/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
@@ -198,6 +198,11 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return this.containsText(/Slack is not available in this environment yet/);
   }
 
+  /** Whether the page reports the tenant's install as unreadable. */
+  saysLoadFailed(): boolean {
+    return this.containsText(/Could not load your Slack integration/);
+  }
+
   /** What the page says about Slack rate limiting Prowler, once it says it. */
   async rateLimitNotice(): Promise<string> {
     await this.waitForText(/Slack is busy right now/, 10000);

--- a/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
+++ b/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
@@ -314,12 +314,30 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
 
   // --- Returning from Slack -----------------------------------------------
 
+  /**
+   * The way out the callback renders on every outcome that is not a connected
+   * workspace — the one element every one of them has in common.
+   *
+   * The anchor for "the callback settled on something other than success", in
+   * place of the failure alert's own title: two of those outcomes cannot claim
+   * the workspace is not connected (the API consumes the code before it
+   * answers), so they carry a different title, and a harness keyed on copy would
+   * wait for a headline that never arrives.
+   */
+  private backLink(): HTMLAnchorElement | null {
+    return (
+      Array.from(this.container.querySelectorAll("a")).find(
+        (anchor) =>
+          anchor.getAttribute("href") === "/integrations/slack" &&
+          /Back to Slack integration/.test(anchor.textContent ?? ""),
+      ) ?? null
+    );
+  }
+
   /** Whether the callback settled on a connected workspace. */
   async completedInstall(): Promise<boolean> {
     const outcome = await this.waitFor(
-      () =>
-        this.containsText(/Connected to /) ||
-        this.containsText(/Slack workspace not connected/),
+      () => this.containsText(/Connected to /) || this.backLink() !== null,
       10000,
       "the callback outcome",
     );
@@ -328,7 +346,7 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
 
   /** What the user is told when the install did not complete. */
   async installFailureReason(): Promise<string> {
-    await this.waitForText(/Slack workspace not connected/, 10000);
+    await this.waitFor(() => this.backLink(), 10000, "the failed callback");
     const description = await this.waitFor(
       () => this.q('[data-slot="alert-description"]'),
       5000,
@@ -337,14 +355,23 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return (description.textContent ?? "").trim();
   }
 
+  /**
+   * The headline the callback puts on an install that did not complete — which
+   * is not the same claim for every outcome: an answer the UI could not read is
+   * an unknown state, not a workspace it can say was left unconnected.
+   */
+  async installFailureTitle(): Promise<string> {
+    await this.waitFor(() => this.backLink(), 10000, "the failed callback");
+    const title = await this.waitFor(
+      () => this.q('[data-slot="alert-title"]'),
+      5000,
+      "the failure title",
+    );
+    return (title.textContent ?? "").trim();
+  }
+
   /** Whether the page offers a way back to try the install again. */
   offersRetry(): boolean {
-    return (
-      Array.from(this.container.querySelectorAll("a")).some(
-        (anchor) =>
-          anchor.getAttribute("href") === "/integrations/slack" &&
-          /Back to Slack integration/.test(anchor.textContent ?? ""),
-      ) || this.offersInstall()
-    );
+    return this.backLink() !== null || this.offersInstall();
   }
 }

--- a/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
+++ b/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
@@ -1,0 +1,264 @@
+/**
+ * Page-level test harness for the Slack integration (Vitest Browser Mode).
+ *
+ * Owns mounting and MSW wiring for the real pages the flow touches — the
+ * integrations catalogue Slack is listed on, the management page and the OAuth
+ * callback — and exposes Slack vocabulary ("connect", "the connected
+ * workspace", "test the connection") so the tests never reach for a selector.
+ * The DOM and wait primitives stay `protected` in `BrowserHarness`.
+ *
+ * Every mount renders production's own components: the async server component
+ * that loads the install, and the client components the callback and the
+ * catalogue pages render. A client renderer cannot render an async component,
+ * so it is called and its returned element is what gets rendered — the same
+ * trick the providers harness uses.
+ */
+
+import { createElement } from "react";
+
+import { BrowserHarness } from "@/__tests__/browser-harness";
+import { handlersForSlack } from "@/__tests__/msw/handlers/slack";
+import type { SlackFixture } from "@/__tests__/msw/handlers/slack.fixtures";
+import { worker } from "@/__tests__/msw/worker";
+import { render } from "@/__tests__/render-browser";
+import { SlackCallback } from "@/components/integrations/slack/slack-callback";
+
+import { IntegrationsContent } from "../integrations-content";
+
+import { SlackIntegrationContent } from "./slack-integration-content";
+
+export const CONNECTION_OUTCOME = {
+  SUCCESS: "success",
+  FAILURE: "failure",
+} as const;
+
+export type ConnectionOutcome =
+  (typeof CONNECTION_OUTCOME)[keyof typeof CONNECTION_OUTCOME];
+
+/** What Slack put on the callback URL when it sent the user back. */
+interface CallbackParams {
+  code?: string;
+  state?: string;
+  /** Slack's own refusal, e.g. `access_denied` when the user declined. */
+  error?: string;
+}
+
+export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
+  /** Exchanges issued — the callback's once-guard is what keeps this at 1. */
+  get exchangeCallCount(): number {
+    return this.countRequests("POST", "/slack/oauth/exchange");
+  }
+
+  get authorizeUrlCallCount(): number {
+    return this.countRequests("POST", "/slack/oauth/authorize-url");
+  }
+
+  // --- Mounting -----------------------------------------------------------
+
+  private wireHandlers(): void {
+    worker.use(...handlersForSlack(this.fixture));
+    this.trackRequests(worker);
+  }
+
+  /** Mount the Slack management page at `/integrations/slack`. */
+  async mount(): Promise<void> {
+    window.history.replaceState(null, "", "/integrations/slack");
+    this.wireHandlers();
+
+    render(await SlackIntegrationContent());
+  }
+
+  /** Mount the OAuth callback with the query string Slack redirected to. */
+  async mountCallback({ code, state, error }: CallbackParams): Promise<void> {
+    const params = new URLSearchParams();
+    if (code) params.set("code", code);
+    if (state) params.set("state", state);
+    if (error) params.set("error", error);
+    window.history.replaceState(
+      null,
+      "",
+      `/integrations/slack/callback?${params.toString()}`,
+    );
+    this.wireHandlers();
+
+    render(createElement(SlackCallback));
+  }
+
+  /**
+   * Mount the integrations catalogue at `/integrations` — the page Slack is
+   * listed on. No handlers are wired: every card there is static.
+   */
+  mountCatalogue(): void {
+    window.history.replaceState(null, "", "/integrations");
+
+    render(createElement(IntegrationsContent));
+  }
+
+  // --- The integrations catalogue ------------------------------------------
+
+  /** The integrations the catalogue offers, by the name shown on each card. */
+  async listedIntegrations(): Promise<string[]> {
+    const headings = await this.waitFor(
+      () => {
+        const found = Array.from(
+          this.container.querySelectorAll<HTMLElement>("h4"),
+        );
+        return found.length > 0 ? found : null;
+      },
+      5000,
+      "the integrations catalogue",
+    );
+    return headings.map((heading) => (heading.textContent ?? "").trim());
+  }
+
+  /** Whether the catalogue offers a way into the Slack management page. */
+  offersSlackManagement(): boolean {
+    return this.q('a[href="/integrations/slack"]') !== null;
+  }
+
+  // --- Starting the install -----------------------------------------------
+
+  private connectLink(): HTMLAnchorElement | null {
+    return (
+      Array.from(this.container.querySelectorAll("a")).find((anchor) =>
+        /Add to Slack/.test(anchor.textContent ?? ""),
+      ) ?? null
+    );
+  }
+
+  /** The consent URL the install affordance points at, once it is offered. */
+  async authorizeUrl(): Promise<string> {
+    const link = await this.waitFor(
+      () => this.connectLink(),
+      5000,
+      "the Add to Slack link",
+    );
+    return link.href;
+  }
+
+  /**
+   * Start the install the way a user does, and report where Slack's consent
+   * screen would have been reached at.
+   *
+   * The click is real — it goes through user-event, so a disabled or
+   * unclickable affordance still fails the test — but its default action is
+   * cancelled: following the link would navigate the test frame off the app.
+   */
+  async connect(): Promise<string> {
+    const link = await this.waitFor(
+      () => this.connectLink(),
+      5000,
+      "the Add to Slack link",
+    );
+
+    let destination = "";
+    const intercept = (event: MouseEvent) => {
+      event.preventDefault();
+      destination = link.href;
+    };
+    link.addEventListener("click", intercept);
+    try {
+      await this.clickElement(link, { fallbackToDomClick: true });
+    } finally {
+      link.removeEventListener("click", intercept);
+    }
+
+    return destination;
+  }
+
+  /** Whether the install is offered at all (it is not without a Slack app). */
+  offersInstall(): boolean {
+    return this.connectLink() !== null;
+  }
+
+  async waitForUnavailable(): Promise<void> {
+    await this.waitForText(/Slack is not available in this environment yet/);
+  }
+
+  // --- Connected state ----------------------------------------------------
+
+  /**
+   * The workspace the page reports as connected — on the management page and
+   * on the callback alike.
+   *
+   * Read from the element that carries the heading, not from the page's text:
+   * "Connected to <workspace>" runs straight into the copy that follows it in
+   * `textContent`, so matching the whole page would report that copy as part of
+   * the workspace's name.
+   */
+  async connectedWorkspaceName(): Promise<string> {
+    const heading = await this.waitFor(
+      () => this.deepestElementMatching(/^Connected to \S/),
+      5000,
+      "the connected workspace name",
+    );
+    return (heading.textContent ?? "").trim().replace(/^Connected to /, "");
+  }
+
+  /**
+   * The most specific element whose own text matches: the last one in document
+   * order, since every ancestor of a match matches too.
+   */
+  private deepestElementMatching(pattern: RegExp): HTMLElement | null {
+    return (
+      Array.from(this.container.querySelectorAll<HTMLElement>("*"))
+        .reverse()
+        .find((element) => pattern.test((element.textContent ?? "").trim())) ??
+      null
+    );
+  }
+
+  async testConnection(): Promise<ConnectionOutcome> {
+    await this.clickButton(/Test connection/);
+
+    return this.waitFor(
+      () => {
+        if (this.containsText(/Connection test successful/)) {
+          return CONNECTION_OUTCOME.SUCCESS;
+        }
+        if (this.containsText(/Connection test failed/)) {
+          return CONNECTION_OUTCOME.FAILURE;
+        }
+        return null;
+      },
+      15000,
+      "the connection test outcome",
+    );
+  }
+
+  // --- Returning from Slack -----------------------------------------------
+
+  /** Whether the callback settled on a connected workspace. */
+  async completedInstall(): Promise<boolean> {
+    const outcome = await this.waitFor(
+      () =>
+        this.containsText(/Connected to /) ||
+        this.containsText(/Slack workspace not connected/),
+      10000,
+      "the callback outcome",
+    );
+    return outcome && this.containsText(/Connected to /);
+  }
+
+  /** What the user is told when the install did not complete. */
+  async installFailureReason(): Promise<string> {
+    await this.waitForText(/Slack workspace not connected/, 10000);
+    const description = await this.waitFor(
+      () => this.q('[data-slot="alert-description"]'),
+      5000,
+      "the failure reason",
+    );
+    return (description.textContent ?? "").trim();
+  }
+
+  /** Whether the page offers a way back to try the install again. */
+  offersRetry(): boolean {
+    return (
+      Array.from(this.container.querySelectorAll("a")).some(
+        (anchor) =>
+          anchor.getAttribute("href") === "/integrations/slack" &&
+          /Back to Slack integration/.test(anchor.textContent ?? ""),
+      ) || this.offersInstall()
+    );
+  }
+}

--- a/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
+++ b/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
@@ -175,6 +175,22 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     await this.waitForText(/Slack is not available in this environment yet/);
   }
 
+  /** Whether the page claims this deployment has no Slack app. */
+  saysUnavailable(): boolean {
+    return this.containsText(/Slack is not available in this environment yet/);
+  }
+
+  /** What the page says about Slack rate limiting Prowler, once it says it. */
+  async rateLimitNotice(): Promise<string> {
+    await this.waitForText(/Slack is busy right now/, 10000);
+    const description = await this.waitFor(
+      () => this.q('[data-slot="alert-description"]'),
+      5000,
+      "the rate limit notice",
+    );
+    return (description.textContent ?? "").trim();
+  }
+
   // --- Connected state ----------------------------------------------------
 
   /**

--- a/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
+++ b/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
@@ -1,17 +1,8 @@
 /**
  * Page-level test harness for the Slack integration (Vitest Browser Mode).
  *
- * Owns mounting and MSW wiring for the real pages the flow touches — the
- * integrations catalogue Slack is listed on, the management page and the OAuth
- * callback — and exposes Slack vocabulary ("connect", "the connected
- * workspace", "test the connection") so the tests never reach for a selector.
- * The DOM and wait primitives stay `protected` in `BrowserHarness`.
- *
- * Every mount renders production's own components: the async server component
- * that loads the install, and the client components the callback and the
- * catalogue pages render. A client renderer cannot render an async component,
- * so it is called and its returned element is what gets rendered — the same
- * trick the providers harness uses.
+ * A client renderer cannot render an async server component, so the component is
+ * called and the element it returns is what gets rendered.
  */
 
 import { revalidatePath } from "next/cache";
@@ -37,16 +28,14 @@ export const CONNECTION_OUTCOME = {
 export type ConnectionOutcome =
   (typeof CONNECTION_OUTCOME)[keyof typeof CONNECTION_OUTCOME];
 
-/** What Slack put on the callback URL when it sent the user back. */
 interface CallbackParams {
   code?: string;
   state?: string;
-  /** Slack's own refusal, e.g. `access_denied` when the user declined. */
+  /** Slack's own refusal code, e.g. `access_denied`. */
   error?: string;
 }
 
 export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
-  /** Exchanges issued — the callback's once-guard is what keeps this at 1. */
   get exchangeCallCount(): number {
     return this.countRequests("POST", "/slack/oauth/exchange");
   }
@@ -55,14 +44,7 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return this.countRequests("POST", "/slack/oauth/authorize-url");
   }
 
-  /**
-   * The pages the actions asked Next to refresh since this harness mounted.
-   *
-   * `next/cache` is stubbed for the browser lane — there is no request scope to
-   * hold a cache — so the calls are observable, which is what makes "the pages
-   * that list the install are refreshed even when the answer was unreadable"
-   * something a test can assert rather than assume.
-   */
+  /** Paths the actions asked Next to refresh (`next/cache` is stubbed in this lane). */
   get revalidatedPaths(): string[] {
     return vi.mocked(revalidatePath).mock.calls.map(([path]) => path);
   }
@@ -70,15 +52,13 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
   // --- Mounting -----------------------------------------------------------
 
   private wireHandlers(): void {
-    // The stub is module-level and shared, so its call log would otherwise
-    // carry whatever earlier tests in the file revalidated. Clearing it at
-    // mount makes `revalidatedPaths` mean "since this mount".
+    // The stub is module-level and shared, so clearing it here is what makes
+    // `revalidatedPaths` mean "since this mount".
     vi.mocked(revalidatePath).mockClear();
     worker.use(...handlersForSlack(this.fixture));
     this.trackRequests(worker);
   }
 
-  /** Mount the Slack management page at `/integrations/slack`. */
   async mount(): Promise<void> {
     window.history.replaceState(null, "", "/integrations/slack");
     this.wireHandlers();
@@ -86,7 +66,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     render(await SlackIntegrationContent());
   }
 
-  /** Mount the OAuth callback with the query string Slack redirected to. */
   async mountCallback({ code, state, error }: CallbackParams): Promise<void> {
     const params = new URLSearchParams();
     if (code) params.set("code", code);
@@ -102,10 +81,7 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     render(createElement(SlackCallback));
   }
 
-  /**
-   * Mount the integrations catalogue at `/integrations` — the page Slack is
-   * listed on. No handlers are wired: every card there is static.
-   */
+  /** Mount the integrations catalogue. No handlers: every card there is static. */
   mountCatalogue(): void {
     window.history.replaceState(null, "", "/integrations");
 
@@ -114,7 +90,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
 
   // --- The integrations catalogue ------------------------------------------
 
-  /** The integrations the catalogue offers, by the name shown on each card. */
   async listedIntegrations(): Promise<string[]> {
     const headings = await this.waitFor(
       () => {
@@ -129,7 +104,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return headings.map((heading) => (heading.textContent ?? "").trim());
   }
 
-  /** Whether the catalogue offers a way into the Slack management page. */
   offersSlackManagement(): boolean {
     return this.q('a[href="/integrations/slack"]') !== null;
   }
@@ -144,7 +118,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     );
   }
 
-  /** The consent URL the install affordance points at, once it is offered. */
   async authorizeUrl(): Promise<string> {
     const link = await this.waitFor(
       () => this.connectLink(),
@@ -155,12 +128,8 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
   }
 
   /**
-   * Start the install the way a user does, and report where Slack's consent
-   * screen would have been reached at.
-   *
-   * The click is real — it goes through user-event, so a disabled or
-   * unclickable affordance still fails the test — but its default action is
-   * cancelled: following the link would navigate the test frame off the app.
+   * Clicks the install affordance and reports where it points. The default
+   * action is cancelled: following the link navigates the test frame off the app.
    */
   async connect(): Promise<string> {
     const link = await this.waitFor(
@@ -184,7 +153,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return destination;
   }
 
-  /** Whether the install is offered at all (it is not without a Slack app). */
   offersInstall(): boolean {
     return this.connectLink() !== null;
   }
@@ -193,17 +161,14 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     await this.waitForText(/Slack is not available in this environment yet/);
   }
 
-  /** Whether the page claims this deployment has no Slack app. */
   saysUnavailable(): boolean {
     return this.containsText(/Slack is not available in this environment yet/);
   }
 
-  /** Whether the page reports the tenant's install as unreadable. */
   saysLoadFailed(): boolean {
     return this.containsText(/Could not load your Slack integration/);
   }
 
-  /** What the page says about Slack rate limiting Prowler, once it says it. */
   async rateLimitNotice(): Promise<string> {
     await this.waitForText(/Slack is busy right now/, 10000);
     const description = await this.waitFor(
@@ -214,12 +179,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return (description.textContent ?? "").trim();
   }
 
-  /**
-   * What the page says when the tenant's Slack install could not be read.
-   *
-   * Reaching this at all is part of the assertion: the read fails by throwing,
-   * so a page that does not catch it never renders — the mount itself fails.
-   */
   async loadErrorNotice(): Promise<string> {
     await this.waitForText(/Could not load your Slack integration/, 10000);
     const description = await this.waitFor(
@@ -233,13 +192,8 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
   // --- Connected state ----------------------------------------------------
 
   /**
-   * The workspace the page reports as connected — on the management page and
-   * on the callback alike.
-   *
-   * Read from the element that carries the heading, not from the page's text:
-   * "Connected to <workspace>" runs straight into the copy that follows it in
-   * `textContent`, so matching the whole page would report that copy as part of
-   * the workspace's name.
+   * Read from the heading element, not the page text: in `textContent`
+   * "Connected to <workspace>" runs straight into the copy that follows it.
    */
   async connectedWorkspaceName(): Promise<string> {
     const heading = await this.waitFor(
@@ -250,10 +204,7 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return (heading.textContent ?? "").trim().replace(/^Connected to /, "");
   }
 
-  /**
-   * The most specific element whose own text matches: the last one in document
-   * order, since every ancestor of a match matches too.
-   */
+  /** Last match in document order: every ancestor of a match matches too. */
   private deepestElementMatching(pattern: RegExp): HTMLElement | null {
     return (
       Array.from(this.container.querySelectorAll<HTMLElement>("*"))
@@ -264,11 +215,8 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
   }
 
   /**
-   * How the page reports the connection, in the badge's own words.
-   *
-   * Read off the badge's own state attribute rather than by matching copy: the
-   * heading right beside it starts "Connected to …", so a text search would
-   * happily report the heading as the badge.
+   * Keyed on the badge's state attribute, not its copy: the heading beside it
+   * also starts "Connected to …".
    */
   async connectionBadge(): Promise<string> {
     const badge = await this.waitFor(
@@ -279,7 +227,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return (badge.textContent ?? "").trim();
   }
 
-  /** Whether the page offers a connection check the user can actually run. */
   async offersConnectionTest(): Promise<boolean> {
     const button = await this.waitFor(
       () => this.buttonByText(/Test connection/),
@@ -289,7 +236,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return !button.disabled;
   }
 
-  /** Whether the page names choosing a channel as what comes next. */
   saysChannelIsNextStep(): boolean {
     return this.containsText(/Choosing a destination channel is the next step/);
   }
@@ -315,14 +261,8 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
   // --- Returning from Slack -----------------------------------------------
 
   /**
-   * The way out the callback renders on every outcome that is not a connected
-   * workspace — the one element every one of them has in common.
-   *
-   * The anchor for "the callback settled on something other than success", in
-   * place of the failure alert's own title: two of those outcomes cannot claim
-   * the workspace is not connected (the API consumes the code before it
-   * answers), so they carry a different title, and a harness keyed on copy would
-   * wait for a headline that never arrives.
+   * The one element every non-success outcome renders. Keyed on it rather than
+   * the alert title, which is not the same claim on every outcome.
    */
   private backLink(): HTMLAnchorElement | null {
     return (
@@ -334,7 +274,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     );
   }
 
-  /** Whether the callback settled on a connected workspace. */
   async completedInstall(): Promise<boolean> {
     const outcome = await this.waitFor(
       () => this.containsText(/Connected to /) || this.backLink() !== null,
@@ -344,7 +283,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return outcome && this.containsText(/Connected to /);
   }
 
-  /** What the user is told when the install did not complete. */
   async installFailureReason(): Promise<string> {
     await this.waitFor(() => this.backLink(), 10000, "the failed callback");
     const description = await this.waitFor(
@@ -355,11 +293,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return (description.textContent ?? "").trim();
   }
 
-  /**
-   * The headline the callback puts on an install that did not complete — which
-   * is not the same claim for every outcome: an answer the UI could not read is
-   * an unknown state, not a workspace it can say was left unconnected.
-   */
   async installFailureTitle(): Promise<string> {
     await this.waitFor(() => this.backLink(), 10000, "the failed callback");
     const title = await this.waitFor(
@@ -370,7 +303,6 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return (title.textContent ?? "").trim();
   }
 
-  /** Whether the page offers a way back to try the install again. */
   offersRetry(): boolean {
     return this.backLink() !== null || this.offersInstall();
   }

--- a/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
+++ b/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
@@ -224,6 +224,37 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     );
   }
 
+  /**
+   * How the page reports the connection, in the badge's own words.
+   *
+   * Read off the badge's own state attribute rather than by matching copy: the
+   * heading right beside it starts "Connected to …", so a text search would
+   * happily report the heading as the badge.
+   */
+  async connectionBadge(): Promise<string> {
+    const badge = await this.waitFor(
+      () => this.q("[data-connection-status]"),
+      5000,
+      "the connection badge",
+    );
+    return (badge.textContent ?? "").trim();
+  }
+
+  /** Whether the page offers a connection check the user can actually run. */
+  async offersConnectionTest(): Promise<boolean> {
+    const button = await this.waitFor(
+      () => this.buttonByText(/Test connection/),
+      5000,
+      "the Test connection button",
+    );
+    return !button.disabled;
+  }
+
+  /** Whether the page names choosing a channel as what comes next. */
+  saysChannelIsNextStep(): boolean {
+    return this.containsText(/Choosing a destination channel is the next step/);
+  }
+
   async testConnection(): Promise<ConnectionOutcome> {
     await this.clickButton(/Test connection/);
 

--- a/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
+++ b/ui/app/(prowler)/integrations/slack/slack-integration.harness.ts
@@ -240,6 +240,17 @@ export class SlackIntegrationHarness extends BrowserHarness<SlackFixture> {
     return this.containsText(/Choosing a destination channel is the next step/);
   }
 
+  /**
+   * The "last checked" line as rendered, or null when the page shows none —
+   * which is what a workspace whose connection was never checked shows.
+   */
+  lastCheckedLine(): string | null {
+    const line = Array.from(
+      this.container.querySelectorAll<HTMLElement>("p"),
+    ).find((p) => /^Last checked:/.test((p.textContent ?? "").trim()));
+    return line ? (line.textContent ?? "").trim() : null;
+  }
+
   async testConnection(): Promise<ConnectionOutcome> {
     await this.clickButton(/Test connection/);
 

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -113,6 +113,26 @@ describe("starting the install", () => {
     expect(notice).not.toMatch(INTEGRATIONS_SERVER_ERROR_DETAIL);
     expect(harness.offersInstall()).toBe(true);
   }, 30000);
+
+  it("names the missing consent URL when a proxy answers that call with an HTML page", async () => {
+    // Given — a 200 that is a challenge page rather than the API's JSON.
+    // Nothing refused the call, so the action reaches its success path and
+    // finds no URL where one was promised.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ authorizeUrlUnreadable: true }),
+    );
+
+    // When
+    await harness.mount();
+
+    // Then — the page says what is missing in Prowler's words. The parser's
+    // message for this body is truncated to `"<!DOCTYPE "`, before the word
+    // `html`, so nothing downstream could have filtered it out.
+    const notice = await harness.loadErrorNotice();
+    expect(notice).toMatch(/did not return an authorization URL/);
+    expect(notice).not.toMatch(/DOCTYPE/i);
+    expect(notice).not.toMatch(/not valid JSON/i);
+  }, 30000);
 });
 
 describe("returning from Slack", () => {
@@ -133,6 +153,83 @@ describe("returning from Slack", () => {
     // (design D4): a second call would burn the code and report a failure for
     // an install that actually succeeded. The once-guard is what prevents it.
     expect(harness.exchangeCallCount).toBe(1);
+  }, 30000);
+
+  it("does not report an install the API completed as failed when it answers no content", async () => {
+    // Given — the exchange ran to the end: the API validated the state,
+    // consumed the code and upserted the integration, then answered `204`.
+    // `response.ok` is true, so this is not a refusal — there is simply no body
+    // describing what was created.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({
+        exchangeOutcome: SLACK_EXCHANGE_OUTCOME.UNREADABLE_NO_CONTENT,
+      }),
+    );
+
+    // When
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    // Then — Prowler's own words, pointing at the page that can show the
+    // workspace, instead of the parser's "Unexpected end of JSON input".
+    const reason = await harness.installFailureReason();
+    expect(reason).toMatch(/could not read the result of the install/);
+    expect(reason).toMatch(/Slack integration page/);
+    expect(reason).not.toMatch(/JSON/i);
+    expect(harness.offersRetry()).toBe(true);
+    // And the install that *does* exist is not hidden behind a cached "none
+    // connected": this outcome keeps the user on the callback, whose only way
+    // out is the link to the Slack integration page.
+    expect(harness.revalidatedPaths).toEqual(
+      expect.arrayContaining(["/integrations", "/integrations/slack"]),
+    );
+  }, 30000);
+
+  it("shows Prowler's own wording when a proxy answers the completion with an HTML page", async () => {
+    // Given — a WAF or gateway answering `200` with a challenge page in place
+    // of the API's JSON.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.UNREADABLE_HTML }),
+    );
+
+    // When
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    // Then — nothing of the parser's message reaches the user. This is the one
+    // shape no downstream filter can rescue: V8 truncates its message to
+    // `Unexpected token '<', "<!DOCTYPE "...`, cutting it off before the word
+    // `html`, so the UI's own HTML-shaped-error detection never matches it.
+    const reason = await harness.installFailureReason();
+    expect(reason).toMatch(/could not read the result of the install/);
+    expect(reason).not.toMatch(/DOCTYPE/i);
+    expect(reason).not.toMatch(/not valid JSON/i);
+  }, 30000);
+
+  it("says the result is unreadable, not that the workspace is unknown, when the answer names no resource", async () => {
+    // Given — a `200` carrying well-formed JSON:API with no `data` member.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({
+        exchangeOutcome: SLACK_EXCHANGE_OUTCOME.UNREADABLE_NO_DATA,
+      }),
+    );
+
+    // When
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    // Then — the page cannot name the workspace, so it does not claim one, and
+    // it does not hand the user `"undefined" is not valid JSON` either.
+    const reason = await harness.installFailureReason();
+    expect(reason).toMatch(/could not read the result of the install/);
+    expect(reason).not.toMatch(/undefined/i);
+    expect(await harness.completedInstall()).toBe(false);
   }, 30000);
 
   it("connects nothing when the user declines in Slack, and offers to retry", async () => {

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -114,6 +114,25 @@ describe("starting the install", () => {
     expect(harness.offersInstall()).toBe(true);
   }, 30000);
 
+  it("keeps the page usable when Slack's own side is broken upstream", async () => {
+    // Given — the `502` the contract reserves for a Slack upstream failure.
+    // The action hands that to the UI's shared 5xx handling, which *throws*, so
+    // this is the page's other rejection path: uncaught, the mount itself fails
+    // and the user gets the route's error boundary instead of the Slack page.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ oauthUpstreamError: true }),
+    );
+
+    // When
+    await harness.mount();
+
+    // Then — the failure is named, and it is not reported as this deployment
+    // having no Slack app: the app is configured, Slack is down.
+    const notice = await harness.loadErrorNotice();
+    expect(notice).toMatch(/temporarily unavailable/);
+    expect(harness.saysUnavailable()).toBe(false);
+  }, 30000);
+
   it("names the missing consent URL when a proxy answers that call with an HTML page", async () => {
     // Given — a 200 that is a challenge page rather than the API's JSON.
     // Nothing refused the call, so the action reaches its success path and
@@ -333,6 +352,32 @@ describe("returning from Slack", () => {
     expect(reason).toMatch(/rate limiting/);
     expect(reason).toMatch(/about 30 seconds/);
     expect(reason).not.toMatch(/not available in this environment/);
+    expect(harness.offersRetry()).toBe(true);
+  }, 30000);
+
+  it("reports Slack being broken upstream, rather than leaving the callback spinning", async () => {
+    // Given — the completion answers `502`, the contract's status for a Slack
+    // upstream failure. The action reports that through the UI's shared 5xx
+    // handling, which throws, so what the callback renders depends on the
+    // rejection being answered inside the action.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ oauthUpstreamError: true }),
+    );
+
+    // When
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    // Then — the reason the API gave, not the "could not confirm whether the
+    // workspace was connected" the page falls back to when the call to the
+    // action never comes back at all: the API refused, so nothing was created,
+    // and telling the user to go check would send them looking for nothing.
+    const reason = await harness.installFailureReason();
+    expect(reason).toMatch(/temporarily unavailable/);
+    expect(reason).not.toMatch(/could not confirm/);
+    expect(await harness.completedInstall()).toBe(false);
     expect(harness.offersRetry()).toBe(true);
   }, 30000);
 

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -1,7 +1,8 @@
 /**
- * Browser-mode tests for the Slack integration page (`/integrations/slack`) and
- * its OAuth callback, driven through `SlackIntegrationHarness`. MSW answers
- * from handlers derived from the API contract in `design.md`.
+ * Browser-mode tests for the Slack integration page (`/integrations/slack`),
+ * driven through `SlackIntegrationHarness`. MSW answers from handlers derived
+ * from the API contract in `design.md`. The OAuth callback is its own route,
+ * covered in `slack-callback-page.integration.test.tsx`.
  */
 
 import { describe, expect } from "vitest";
@@ -11,9 +12,6 @@ import {
   configuredSlackFixture,
   connectedSlackFixture,
   INTEGRATIONS_SERVER_ERROR_DETAIL,
-  SLACK_EXCHANGE_OUTCOME,
-  SLACK_OAUTH_CODE,
-  SLACK_OAUTH_STATE,
   slackFixture,
 } from "@/__tests__/msw/handlers/slack.fixtures";
 
@@ -24,14 +22,6 @@ import {
 
 /** The workspace the fixtures connect. */
 const WORKSPACE_NAME = "Prowler HQ";
-
-/**
- * Callback headlines, spelled out rather than imported so a rename fails here.
- * `FAILURE_TITLE` is for installs that connected nothing; `UNCONFIRMED_TITLE`
- * for answers that arrive after the API already upserted the integration.
- */
-const FAILURE_TITLE = "Slack workspace not connected";
-const UNCONFIRMED_TITLE = "Slack install not confirmed";
 
 /** The only scopes Prowler asks a workspace for (design D2). */
 const REQUIRED_SCOPES = [
@@ -156,220 +146,6 @@ describe("starting the install", () => {
     expect(notice).toMatch(/did not return an authorization URL/);
     expect(notice).not.toMatch(/DOCTYPE/i);
     expect(notice).not.toMatch(/not valid JSON/i);
-  }, 30000);
-});
-
-describe("returning from Slack", () => {
-  it("completes the install and shows the connected workspace", async () => {
-    const harness = new SlackIntegrationHarness(slackFixture());
-
-    await harness.mountCallback({
-      code: SLACK_OAUTH_CODE,
-      state: SLACK_OAUTH_STATE,
-    });
-
-    expect(await harness.completedInstall()).toBe(true);
-    expect(await harness.connectedWorkspaceName()).toBe(WORKSPACE_NAME);
-    // The code is single-use and the exchange runs from a render (design D4):
-    // without the once-guard, a second call burns it and reports a failure.
-    expect(harness.exchangeCallCount).toBe(1);
-  }, 30000);
-
-  it("does not report an install the API completed as failed when it answers no content", async () => {
-    // Given — a `204`: the API consumed the code and upserted the integration,
-    // then answered with no body. `response.ok` is true, so this is no refusal.
-    const harness = new SlackIntegrationHarness(
-      slackFixture({
-        exchangeOutcome: SLACK_EXCHANGE_OUTCOME.UNREADABLE_NO_CONTENT,
-      }),
-    );
-
-    await harness.mountCallback({
-      code: SLACK_OAUTH_CODE,
-      state: SLACK_OAUTH_STATE,
-    });
-
-    const reason = await harness.installFailureReason();
-    expect(reason).toMatch(/could not read the result of the install/);
-    expect(reason).toMatch(/Slack integration page/);
-    expect(reason).not.toMatch(/JSON/i);
-    expect(harness.offersRetry()).toBe(true);
-    // The `204` says the workspace is connected; the headline cannot deny it.
-    expect(await harness.installFailureTitle()).toBe(UNCONFIRMED_TITLE);
-    // The install exists, so the cached "none connected" has to go with it.
-    expect(harness.revalidatedPaths).toEqual(
-      expect.arrayContaining(["/integrations", "/integrations/slack"]),
-    );
-  }, 30000);
-
-  it("shows Prowler's own wording when a proxy answers the completion with an HTML page", async () => {
-    // Given — a proxy answering `200` with a challenge page instead of JSON.
-    const harness = new SlackIntegrationHarness(
-      slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.UNREADABLE_HTML }),
-    );
-
-    await harness.mountCallback({
-      code: SLACK_OAUTH_CODE,
-      state: SLACK_OAUTH_STATE,
-    });
-
-    // V8's parse message truncates before the word `html`, so the shared
-    // HTML-shaped-error filter cannot catch this one.
-    const reason = await harness.installFailureReason();
-    expect(reason).toMatch(/could not read the result of the install/);
-    expect(reason).not.toMatch(/DOCTYPE/i);
-    expect(reason).not.toMatch(/not valid JSON/i);
-  }, 30000);
-
-  it("says the result is unreadable, not that the workspace is unknown, when the answer names no resource", async () => {
-    // Given — a `200` carrying well-formed JSON:API with no `data` member.
-    const harness = new SlackIntegrationHarness(
-      slackFixture({
-        exchangeOutcome: SLACK_EXCHANGE_OUTCOME.UNREADABLE_NO_DATA,
-      }),
-    );
-
-    await harness.mountCallback({
-      code: SLACK_OAUTH_CODE,
-      state: SLACK_OAUTH_STATE,
-    });
-
-    const reason = await harness.installFailureReason();
-    expect(reason).toMatch(/could not read the result of the install/);
-    expect(reason).not.toMatch(/undefined/i);
-    expect(await harness.completedInstall()).toBe(false);
-  }, 30000);
-
-  it("connects nothing when the user declines in Slack, and offers to retry", async () => {
-    const harness = new SlackIntegrationHarness(slackFixture());
-
-    await harness.mountCallback({ error: "access_denied" });
-
-    expect(await harness.installFailureReason()).toMatch(
-      /not approved in Slack/,
-    );
-    expect(harness.offersRetry()).toBe(true);
-    // A declined consent carries no code, so there was nothing to exchange.
-    expect(harness.exchangeCallCount).toBe(0);
-  }, 30000);
-
-  it("surfaces the reason when Slack refuses to complete the install", async () => {
-    // Given — Slack rejects the code, and the API's own wording explains it.
-    const harness = new SlackIntegrationHarness(
-      slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.SLACK_REFUSED }),
-    );
-
-    await harness.mountCallback({
-      code: SLACK_OAUTH_CODE,
-      state: SLACK_OAUTH_STATE,
-    });
-
-    // A refusal Prowler has no wording of its own for falls back to the API's
-    // `detail`, not to a generic failure.
-    expect(await harness.installFailureReason()).toMatch(
-      /OAuth code is invalid/,
-    );
-    expect(harness.offersRetry()).toBe(true);
-  }, 30000);
-
-  it("surfaces a completion the API refuses, and connects nothing", async () => {
-    // Given — the state was minted for another session, or already consumed.
-    const harness = new SlackIntegrationHarness(
-      slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.REFUSED_STATE }),
-    );
-
-    await harness.mountCallback({
-      code: SLACK_OAUTH_CODE,
-      state: "state-from-another-session",
-    });
-
-    expect(await harness.installFailureReason()).toMatch(
-      /state is invalid, expired, or already consumed/,
-    );
-    // The API refused before consuming anything, so nothing was created and the
-    // headline states that plainly.
-    expect(await harness.installFailureTitle()).toBe(FAILURE_TITLE);
-    expect(await harness.completedInstall()).toBe(false);
-    expect(harness.offersRetry()).toBe(true);
-    // Refused once, not retried into a second burnt code.
-    expect(harness.exchangeCallCount).toBe(1);
-  }, 30000);
-
-  it("says how to resolve a workspace conflict, in Prowler's own words", async () => {
-    // Given — this tenant already has a different workspace connected, which
-    // the API refuses as a 409 naming the conflict in `code`.
-    const harness = new SlackIntegrationHarness(
-      slackFixture({
-        exchangeOutcome: SLACK_EXCHANGE_OUTCOME.DIFFERENT_WORKSPACE,
-      }),
-    );
-
-    await harness.mountCallback({
-      code: SLACK_OAUTH_CODE,
-      state: SLACK_OAUTH_STATE,
-    });
-
-    // The copy comes from the error `code`: the API's `detail` states the
-    // conflict but not the way out of it.
-    const reason = await harness.installFailureReason();
-    expect(reason).toMatch(/already connected to a different Slack workspace/);
-    expect(reason).toMatch(/Disconnect it before connecting another/);
-    expect(reason).not.toMatch(/tenant/);
-    expect(await harness.completedInstall()).toBe(false);
-    expect(harness.offersRetry()).toBe(true);
-  }, 30000);
-
-  it("tells the user when to come back if Slack is rate limiting the install", async () => {
-    // Given — Slack answers 429 with a Retry-After.
-    const harness = new SlackIntegrationHarness(
-      slackFixture({ rateLimited: true }),
-    );
-
-    await harness.mountCallback({
-      code: SLACK_OAUTH_CODE,
-      state: SLACK_OAUTH_STATE,
-    });
-
-    const reason = await harness.installFailureReason();
-    expect(reason).toMatch(/rate limiting/);
-    expect(reason).toMatch(/about 30 seconds/);
-    expect(reason).not.toMatch(/not available in this environment/);
-    // A 429 refuses the exchange outright, so nothing was connected: the plain
-    // headline, unlike the unreadable `2xx` that arrives after the upsert.
-    expect(await harness.installFailureTitle()).toBe(FAILURE_TITLE);
-    expect(harness.offersRetry()).toBe(true);
-  }, 30000);
-
-  it("reports Slack being broken upstream, rather than leaving the callback spinning", async () => {
-    // Given — the completion answers `502`, the contract's status for a Slack
-    // upstream failure. The shared 5xx handling throws, so the callback only
-    // renders this if the action answers that rejection itself.
-    const harness = new SlackIntegrationHarness(
-      slackFixture({ oauthUpstreamError: true }),
-    );
-
-    await harness.mountCallback({
-      code: SLACK_OAUTH_CODE,
-      state: SLACK_OAUTH_STATE,
-    });
-
-    // The API refused, so nothing was created: not the "could not confirm" the
-    // page falls back to when the action never answers at all.
-    const reason = await harness.installFailureReason();
-    expect(reason).toMatch(/temporarily unavailable/);
-    expect(reason).not.toMatch(/could not confirm/);
-    expect(await harness.completedInstall()).toBe(false);
-    expect(harness.offersRetry()).toBe(true);
-  }, 30000);
-
-  it("does not attempt an exchange when the completion carries no state", async () => {
-    const harness = new SlackIntegrationHarness(slackFixture());
-
-    await harness.mountCallback({ code: SLACK_OAUTH_CODE });
-
-    // Refused before the API is ever asked, so no code is spent.
-    expect(await harness.installFailureReason()).toMatch(/incomplete response/);
-    expect(harness.exchangeCallCount).toBe(0);
   }, 30000);
 });
 

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -1,12 +1,7 @@
 /**
- * Browser-mode tests for the Slack integration pages (`/integrations/slack`
- * and its OAuth callback).
- *
- * Tests are grouped by what the user is doing — starting the install, coming
- * back from Slack, living with a connected workspace — and reach the pages only
- * through `SlackIntegrationHarness`. The API is the cloud lane's, so MSW
- * answers from handlers derived from `design.md`'s contract: a scenario that
- * cannot be expressed here is a contract conversation, not a local fix.
+ * Browser-mode tests for the Slack integration page (`/integrations/slack`) and
+ * its OAuth callback, driven through `SlackIntegrationHarness`. MSW answers
+ * from handlers derived from the API contract in `design.md`.
  */
 
 import { describe, expect } from "vitest";
@@ -31,23 +26,14 @@ import {
 const WORKSPACE_NAME = "Prowler HQ";
 
 /**
- * The two headlines the callback puts on an install that did not finish, spelled
- * out rather than imported so a rename has to fail these tests.
- *
- * `FAILURE_TITLE` states that nothing was connected — true of a refusal, of a
- * declined consent, of a deployment with no Slack app. `UNCONFIRMED_TITLE` is
- * for the answers that arrive *after* the API consumed the code and upserted the
- * integration, where the workspace is connected and only the answer describing
- * it was unreadable.
+ * Callback headlines, spelled out rather than imported so a rename fails here.
+ * `FAILURE_TITLE` is for installs that connected nothing; `UNCONFIRMED_TITLE`
+ * for answers that arrive after the API already upserted the integration.
  */
 const FAILURE_TITLE = "Slack workspace not connected";
 const UNCONFIRMED_TITLE = "Slack install not confirmed";
 
-/**
- * The access Prowler asks a workspace for, and nothing else (design D2): post
- * messages, post to a public channel without being invited, and read the
- * channel list — public, plus the private channels the app was invited to.
- */
+/** The only scopes Prowler asks a workspace for (design D2). */
 const REQUIRED_SCOPES = [
   "chat:write",
   "chat:write.public",
@@ -61,55 +47,46 @@ describe("starting the install", () => {
     const harness = new SlackIntegrationHarness(slackFixture());
     await harness.mount();
 
-    // When
     const consentScreen = new URL(await harness.connect());
 
-    // Then — Slack's own consent screen, carrying the scopes and the
-    // server-minted state that binds this install to the session (design D5).
     expect(`${consentScreen.origin}${consentScreen.pathname}`).toBe(
       "https://slack.com/oauth/v2/authorize",
     );
     expect((consentScreen.searchParams.get("scope") ?? "").split(",")).toEqual(
       expect.arrayContaining(REQUIRED_SCOPES),
     );
+    // The state is server-minted, binding this install to the session
+    // (design D5).
     expect(consentScreen.searchParams.get("state")).toBeTruthy();
   }, 30000);
 
   it("says so when the deployment has no Slack app, instead of offering an install", async () => {
-    // Given — a deployment without SLACK_CLIENT_ID/SECRET/REDIRECT_URI, which
-    // the API answers with a 503 (contract, "API contract").
+    // Given — no SLACK_CLIENT_ID/SECRET/REDIRECT_URI, which the API answers
+    // with a 503.
     const harness = new SlackIntegrationHarness(
       slackFixture({ appConfigured: false }),
     );
 
-    // When
     await harness.mount();
 
-    // Then — nothing to do and nothing to click, rather than an error. The read
-    // itself succeeded (an empty collection is what a deployment with no Slack
-    // app has), so nothing claims it failed either.
+    // The read itself succeeded: an empty collection is what a deployment with
+    // no Slack app has, so nothing claims it failed.
     await harness.waitForUnavailable();
     expect(harness.offersInstall()).toBe(false);
     expect(harness.saysLoadFailed()).toBe(false);
   }, 30000);
 
   it("still says the read failed when the deployment also has no Slack app", async () => {
-    // Given — the UI ships ahead of the endpoints and stays inert until they
-    // are served, and a rollback removes the env vars while leaving the rows in
-    // the database (design.md, Migration Plan §2-3 and §5). So "no Slack app
-    // here" is a standing state for whole deployment phases, not a rare event:
-    // only the read failing underneath it has to coincide.
+    // Given — both states, which coincide during rollout and rollback
+    // (design.md, Migration Plan §2-3 and §5).
     const harness = new SlackIntegrationHarness(
       slackFixture({ appConfigured: false, listServerError: true }),
     );
 
-    // When
     await harness.mount();
 
-    // Then — both notices, because they disagree about what to do next and the
-    // read's is the actionable half: "Nothing to do on your side" alone would
-    // send a tenant whose workspace is still connected away from a page a retry
-    // would have shown it to them on.
+    // Both notices: the read's is the actionable half (a retry may still show a
+    // workspace this tenant has connected).
     const notice = await harness.loadErrorNotice();
     expect(notice).toMatch(/temporarily unavailable/);
     expect(notice).not.toMatch(INTEGRATIONS_SERVER_ERROR_DETAIL);
@@ -119,75 +96,62 @@ describe("starting the install", () => {
   }, 30000);
 
   it("says Slack is busy, not that the deployment has no Slack app, when it is rate limiting", async () => {
-    // Given — the app is configured and working; Slack is just rate limiting
-    // the call that mints the consent URL.
+    // Given — the app is configured; Slack rate limits (429) the call that
+    // mints the consent URL.
     const harness = new SlackIntegrationHarness(
       slackFixture({ rateLimited: true }),
     );
 
-    // When
     await harness.mount();
 
-    // Then — the wait is named, and the page does not claim Slack is missing
-    // from this environment: that answer would send the user to their admin
-    // over something that fixes itself in half a minute.
     expect(await harness.rateLimitNotice()).toMatch(/about 30 seconds/);
     expect(harness.saysUnavailable()).toBe(false);
   }, 30000);
 
   it("keeps the page usable when reading the install fails on the server", async () => {
-    // Given — the shared `GET /integrations` read answers 500. The action lets
-    // that surface as a thrown error rather than as a result, so the page has to
-    // catch it: uncaught, it reaches the route's error boundary and the user
-    // gets an error page instead of the Slack page.
+    // Given — the shared `GET /integrations` read answers 500. The action
+    // throws instead of returning a result, so the page has to catch it:
+    // uncaught, the route's error boundary replaces the Slack page.
     const harness = new SlackIntegrationHarness(
       slackFixture({ listServerError: true }),
     );
 
-    // When
     await harness.mount();
 
-    // Then — the failure is named in Prowler's words, not in the server's, and
-    // the install is still offered: one read failed, the Slack app is fine.
     const notice = await harness.loadErrorNotice();
     expect(notice).toMatch(/temporarily unavailable/);
     expect(notice).not.toMatch(INTEGRATIONS_SERVER_ERROR_DETAIL);
+    // The install stays on offer: one read failed, the Slack app is fine.
     expect(harness.offersInstall()).toBe(true);
   }, 30000);
 
   it("keeps the page usable when Slack's own side is broken upstream", async () => {
     // Given — the `502` the contract reserves for a Slack upstream failure.
-    // The action hands that to the UI's shared 5xx handling, which *throws*, so
-    // this is the page's other rejection path: uncaught, the mount itself fails
-    // and the user gets the route's error boundary instead of the Slack page.
+    // The UI's shared 5xx handling throws, so this is the page's other
+    // rejection path.
     const harness = new SlackIntegrationHarness(
       slackFixture({ oauthUpstreamError: true }),
     );
 
-    // When
     await harness.mount();
 
-    // Then — the failure is named, and it is not reported as this deployment
-    // having no Slack app: the app is configured, Slack is down.
     const notice = await harness.loadErrorNotice();
     expect(notice).toMatch(/temporarily unavailable/);
+    // 502 is not 503: the app is configured, Slack is down.
     expect(harness.saysUnavailable()).toBe(false);
   }, 30000);
 
   it("names the missing consent URL when a proxy answers that call with an HTML page", async () => {
-    // Given — a 200 that is a challenge page rather than the API's JSON.
-    // Nothing refused the call, so the action reaches its success path and
-    // finds no URL where one was promised.
+    // Given — a 200 carrying a challenge page instead of JSON. Nothing refused
+    // the call, so the action reaches its success path with no URL.
     const harness = new SlackIntegrationHarness(
       slackFixture({ authorizeUrlUnreadable: true }),
     );
 
-    // When
     await harness.mount();
 
-    // Then — the page says what is missing in Prowler's words. The parser's
-    // message for this body is truncated to `"<!DOCTYPE "`, before the word
-    // `html`, so nothing downstream could have filtered it out.
+    // V8 truncates the parse message to `"<!DOCTYPE "`, before the word `html`,
+    // so the UI's HTML-shaped-error filter can never match it.
     const notice = await harness.loadErrorNotice();
     expect(notice).toMatch(/did not return an authorization URL/);
     expect(notice).not.toMatch(/DOCTYPE/i);
@@ -197,78 +161,60 @@ describe("starting the install", () => {
 
 describe("returning from Slack", () => {
   it("completes the install and shows the connected workspace", async () => {
-    // Given
     const harness = new SlackIntegrationHarness(slackFixture());
 
-    // When — Slack sends the user back with the code it issued.
     await harness.mountCallback({
       code: SLACK_OAUTH_CODE,
       state: SLACK_OAUTH_STATE,
     });
 
-    // Then
     expect(await harness.completedInstall()).toBe(true);
     expect(await harness.connectedWorkspaceName()).toBe(WORKSPACE_NAME);
-    // The Slack code is single-use, and the exchange runs from a render
-    // (design D4): a second call would burn the code and report a failure for
-    // an install that actually succeeded. The once-guard is what prevents it.
+    // The code is single-use and the exchange runs from a render (design D4):
+    // without the once-guard, a second call burns it and reports a failure.
     expect(harness.exchangeCallCount).toBe(1);
   }, 30000);
 
   it("does not report an install the API completed as failed when it answers no content", async () => {
-    // Given — the exchange ran to the end: the API validated the state,
-    // consumed the code and upserted the integration, then answered `204`.
-    // `response.ok` is true, so this is not a refusal — there is simply no body
-    // describing what was created.
+    // Given — a `204`: the API consumed the code and upserted the integration,
+    // then answered with no body. `response.ok` is true, so this is no refusal.
     const harness = new SlackIntegrationHarness(
       slackFixture({
         exchangeOutcome: SLACK_EXCHANGE_OUTCOME.UNREADABLE_NO_CONTENT,
       }),
     );
 
-    // When
     await harness.mountCallback({
       code: SLACK_OAUTH_CODE,
       state: SLACK_OAUTH_STATE,
     });
 
-    // Then — Prowler's own words, pointing at the page that can show the
-    // workspace, instead of the parser's "Unexpected end of JSON input".
     const reason = await harness.installFailureReason();
     expect(reason).toMatch(/could not read the result of the install/);
     expect(reason).toMatch(/Slack integration page/);
     expect(reason).not.toMatch(/JSON/i);
     expect(harness.offersRetry()).toBe(true);
-    // And the headline does not deny it either: the `204` says the workspace is
-    // connected, and the link below sends the user to the page that lists it as
-    // connected — so "Slack workspace not connected" would contradict both the
-    // line under it and the page it points at.
+    // The `204` says the workspace is connected; the headline cannot deny it.
     expect(await harness.installFailureTitle()).toBe(UNCONFIRMED_TITLE);
-    // And the install that *does* exist is not hidden behind a cached "none
-    // connected": this outcome keeps the user on the callback, whose only way
-    // out is the link to the Slack integration page.
+    // The install exists, so the cached "none connected" has to go with it.
     expect(harness.revalidatedPaths).toEqual(
       expect.arrayContaining(["/integrations", "/integrations/slack"]),
     );
   }, 30000);
 
   it("shows Prowler's own wording when a proxy answers the completion with an HTML page", async () => {
-    // Given — a WAF or gateway answering `200` with a challenge page in place
-    // of the API's JSON.
+    // Given — a proxy answering `200` with a challenge page instead of JSON.
     const harness = new SlackIntegrationHarness(
       slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.UNREADABLE_HTML }),
     );
 
-    // When
     await harness.mountCallback({
       code: SLACK_OAUTH_CODE,
       state: SLACK_OAUTH_STATE,
     });
 
-    // Then — nothing of the parser's message reaches the user. This is the one
-    // shape no downstream filter can rescue: V8 truncates its message to
-    // `Unexpected token '<', "<!DOCTYPE "...`, cutting it off before the word
-    // `html`, so the UI's own HTML-shaped-error detection never matches it.
+    // V8's parse message truncates before the word `html`, so the shared
+    // HTML-shaped-error filter cannot catch this one.
     const reason = await harness.installFailureReason();
     expect(reason).toMatch(/could not read the result of the install/);
     expect(reason).not.toMatch(/DOCTYPE/i);
@@ -283,14 +229,11 @@ describe("returning from Slack", () => {
       }),
     );
 
-    // When
     await harness.mountCallback({
       code: SLACK_OAUTH_CODE,
       state: SLACK_OAUTH_STATE,
     });
 
-    // Then — the page cannot name the workspace, so it does not claim one, and
-    // it does not hand the user `"undefined" is not valid JSON` either.
     const reason = await harness.installFailureReason();
     expect(reason).toMatch(/could not read the result of the install/);
     expect(reason).not.toMatch(/undefined/i);
@@ -298,18 +241,15 @@ describe("returning from Slack", () => {
   }, 30000);
 
   it("connects nothing when the user declines in Slack, and offers to retry", async () => {
-    // Given
     const harness = new SlackIntegrationHarness(slackFixture());
 
-    // When — a declined consent comes back as an error, with no code.
     await harness.mountCallback({ error: "access_denied" });
 
-    // Then
     expect(await harness.installFailureReason()).toMatch(
       /not approved in Slack/,
     );
     expect(harness.offersRetry()).toBe(true);
-    // Nothing was created: there was nothing to exchange.
+    // A declined consent carries no code, so there was nothing to exchange.
     expect(harness.exchangeCallCount).toBe(0);
   }, 30000);
 
@@ -319,14 +259,13 @@ describe("returning from Slack", () => {
       slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.SLACK_REFUSED }),
     );
 
-    // When
     await harness.mountCallback({
       code: SLACK_OAUTH_CODE,
       state: SLACK_OAUTH_STATE,
     });
 
-    // Then — a refusal Prowler has nothing better to say about falls back to
-    // the API's `detail`, rather than to a generic failure.
+    // A refusal Prowler has no wording of its own for falls back to the API's
+    // `detail`, not to a generic failure.
     expect(await harness.installFailureReason()).toMatch(
       /OAuth code is invalid/,
     );
@@ -339,19 +278,16 @@ describe("returning from Slack", () => {
       slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.REFUSED_STATE }),
     );
 
-    // When
     await harness.mountCallback({
       code: SLACK_OAUTH_CODE,
       state: "state-from-another-session",
     });
 
-    // Then — the page reports no workspace connected, with the API's reason.
     expect(await harness.installFailureReason()).toMatch(
       /state is invalid, expired, or already consumed/,
     );
-    // The headline states the fact here, and has to keep doing so: the API
-    // refused before consuming anything, so nothing was created and hedging it
-    // would send the user looking for a workspace that does not exist.
+    // The API refused before consuming anything, so nothing was created and the
+    // headline states that plainly.
     expect(await harness.installFailureTitle()).toBe(FAILURE_TITLE);
     expect(await harness.completedInstall()).toBe(false);
     expect(harness.offersRetry()).toBe(true);
@@ -368,14 +304,13 @@ describe("returning from Slack", () => {
       }),
     );
 
-    // When
     await harness.mountCallback({
       code: SLACK_OAUTH_CODE,
       state: SLACK_OAUTH_STATE,
     });
 
-    // Then — the copy comes from the code, so it says what to do next; the
-    // API's own `detail` states the conflict but not the way out of it.
+    // The copy comes from the error `code`: the API's `detail` states the
+    // conflict but not the way out of it.
     const reason = await harness.installFailureReason();
     expect(reason).toMatch(/already connected to a different Slack workspace/);
     expect(reason).toMatch(/Disconnect it before connecting another/);
@@ -390,44 +325,36 @@ describe("returning from Slack", () => {
       slackFixture({ rateLimited: true }),
     );
 
-    // When
     await harness.mountCallback({
       code: SLACK_OAUTH_CODE,
       state: SLACK_OAUTH_STATE,
     });
 
-    // Then — the wait Slack asked for, not a generic failure, and not "Slack
-    // isn't available in this environment": the app is there and working.
     const reason = await harness.installFailureReason();
     expect(reason).toMatch(/rate limiting/);
     expect(reason).toMatch(/about 30 seconds/);
     expect(reason).not.toMatch(/not available in this environment/);
-    // Rate limiting refuses the exchange outright, so nothing was connected:
-    // this outcome keeps the plain headline, unlike the unreadable `2xx` that
-    // arrives after the API already did the work.
+    // A 429 refuses the exchange outright, so nothing was connected: the plain
+    // headline, unlike the unreadable `2xx` that arrives after the upsert.
     expect(await harness.installFailureTitle()).toBe(FAILURE_TITLE);
     expect(harness.offersRetry()).toBe(true);
   }, 30000);
 
   it("reports Slack being broken upstream, rather than leaving the callback spinning", async () => {
     // Given — the completion answers `502`, the contract's status for a Slack
-    // upstream failure. The action reports that through the UI's shared 5xx
-    // handling, which throws, so what the callback renders depends on the
-    // rejection being answered inside the action.
+    // upstream failure. The shared 5xx handling throws, so the callback only
+    // renders this if the action answers that rejection itself.
     const harness = new SlackIntegrationHarness(
       slackFixture({ oauthUpstreamError: true }),
     );
 
-    // When
     await harness.mountCallback({
       code: SLACK_OAUTH_CODE,
       state: SLACK_OAUTH_STATE,
     });
 
-    // Then — the reason the API gave, not the "could not confirm whether the
-    // workspace was connected" the page falls back to when the call to the
-    // action never comes back at all: the API refused, so nothing was created,
-    // and telling the user to go check would send them looking for nothing.
+    // The API refused, so nothing was created: not the "could not confirm" the
+    // page falls back to when the action never answers at all.
     const reason = await harness.installFailureReason();
     expect(reason).toMatch(/temporarily unavailable/);
     expect(reason).not.toMatch(/could not confirm/);
@@ -436,13 +363,11 @@ describe("returning from Slack", () => {
   }, 30000);
 
   it("does not attempt an exchange when the completion carries no state", async () => {
-    // Given
     const harness = new SlackIntegrationHarness(slackFixture());
 
-    // When — a return without the value the install started with.
     await harness.mountCallback({ code: SLACK_OAUTH_CODE });
 
-    // Then — refused before the API is ever asked, so no code is spent.
+    // Refused before the API is ever asked, so no code is spent.
     expect(await harness.installFailureReason()).toMatch(/incomplete response/);
     expect(harness.exchangeCallCount).toBe(0);
   }, 30000);
@@ -450,20 +375,17 @@ describe("returning from Slack", () => {
 
 describe("a connected workspace", () => {
   it("identifies the workspace and reports the connection as healthy", async () => {
-    // Given — a tenant whose setup is finished: workspace approved and a
-    // destination channel recorded, which is what the API needs before it will
-    // check a connection at all.
+    // Given — a finished setup: workspace approved and a destination channel
+    // recorded, which the API requires before it will check a connection.
     const harness = new SlackIntegrationHarness(configuredSlackFixture());
     await harness.mount();
 
-    // Then
     expect(await harness.connectedWorkspaceName()).toBe(WORKSPACE_NAME);
     expect(await harness.connectionBadge()).toBe("Connected");
     expect(await harness.offersConnectionTest()).toBe(true);
     expect(await harness.testConnection()).toBe(CONNECTION_OUTCOME.SUCCESS);
-    // One workspace per tenant (design D10): a connected tenant is not invited
-    // to install another, and no consent URL is minted for a page that would
-    // never use it.
+    // One workspace per tenant (design D10): no second install on offer, and no
+    // consent URL minted for a page that would never use it.
     expect(harness.offersInstall()).toBe(false);
     expect(harness.authorizeUrlCallCount).toBe(0);
   }, 30000);
@@ -472,28 +394,21 @@ describe("a connected workspace", () => {
     // Given — the state the OAuth exchange leaves behind.
     const harness = new SlackIntegrationHarness(connectedSlackFixture());
 
-    // When
     await harness.mount();
 
-    // Then — the configuration carries no channel keys at all, and the page
-    // reads that as an install with nothing chosen yet rather than as a broken
-    // one.
+    // The configuration carries no channel keys at all, which is "nothing
+    // chosen yet", not a broken install.
     expect(await harness.connectedWorkspaceName()).toBe(WORKSPACE_NAME);
     expect(harness.offersInstall()).toBe(false);
   }, 30000);
 
   it("reports the connection as never checked, not as broken, before the first check", async () => {
     // Given — the state the OAuth exchange leaves behind: `connected` is null,
-    // which is neither true nor false (design.md, "Connection state, in
-    // order").
+    // neither true nor false (design.md, "Connection state, in order").
     const harness = new SlackIntegrationHarness(connectedSlackFixture());
 
-    // When
     await harness.mount();
 
-    // Then — the spec calls this connection "neither confirmed working nor
-    // reported broken", so a red "Disconnected" beside a heading that says the
-    // workspace is connected would report a break nothing has observed.
     const badge = await harness.connectionBadge();
     expect(badge).toBe("Not checked yet");
     expect(badge).not.toMatch(/Disconnected/);
@@ -503,13 +418,10 @@ describe("a connected workspace", () => {
     // Given — a workspace connected and no destination channel recorded.
     const harness = new SlackIntegrationHarness(connectedSlackFixture());
 
-    // When
     await harness.mount();
 
-    // Then — the check posts to the destination channel, so with none recorded
-    // the API answers 400 rather than `connected: false`. Offering the check
-    // here would guarantee a failure the user has no way to resolve, so the
-    // page names the next step instead.
+    // The check posts to the destination channel, so with none recorded the API
+    // answers 400 rather than `connected: false`.
     expect(await harness.offersConnectionTest()).toBe(false);
     expect(harness.saysChannelIsNextStep()).toBe(true);
   }, 30000);

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -31,6 +31,19 @@ import {
 const WORKSPACE_NAME = "Prowler HQ";
 
 /**
+ * The two headlines the callback puts on an install that did not finish, spelled
+ * out rather than imported so a rename has to fail these tests.
+ *
+ * `FAILURE_TITLE` states that nothing was connected — true of a refusal, of a
+ * declined consent, of a deployment with no Slack app. `UNCONFIRMED_TITLE` is
+ * for the answers that arrive *after* the API consumed the code and upserted the
+ * integration, where the workspace is connected and only the answer describing
+ * it was unreadable.
+ */
+const FAILURE_TITLE = "Slack workspace not connected";
+const UNCONFIRMED_TITLE = "Slack install not confirmed";
+
+/**
  * The access Prowler asks a workspace for, and nothing else (design D2): post
  * messages, post to a public channel without being invited, and read the
  * channel list — public, plus the private channels the app was invited to.
@@ -226,6 +239,11 @@ describe("returning from Slack", () => {
     expect(reason).toMatch(/Slack integration page/);
     expect(reason).not.toMatch(/JSON/i);
     expect(harness.offersRetry()).toBe(true);
+    // And the headline does not deny it either: the `204` says the workspace is
+    // connected, and the link below sends the user to the page that lists it as
+    // connected — so "Slack workspace not connected" would contradict both the
+    // line under it and the page it points at.
+    expect(await harness.installFailureTitle()).toBe(UNCONFIRMED_TITLE);
     // And the install that *does* exist is not hidden behind a cached "none
     // connected": this outcome keeps the user on the callback, whose only way
     // out is the link to the Slack integration page.
@@ -331,6 +349,10 @@ describe("returning from Slack", () => {
     expect(await harness.installFailureReason()).toMatch(
       /state is invalid, expired, or already consumed/,
     );
+    // The headline states the fact here, and has to keep doing so: the API
+    // refused before consuming anything, so nothing was created and hedging it
+    // would send the user looking for a workspace that does not exist.
+    expect(await harness.installFailureTitle()).toBe(FAILURE_TITLE);
     expect(await harness.completedInstall()).toBe(false);
     expect(harness.offersRetry()).toBe(true);
     // Refused once, not retried into a second burnt code.
@@ -380,6 +402,10 @@ describe("returning from Slack", () => {
     expect(reason).toMatch(/rate limiting/);
     expect(reason).toMatch(/about 30 seconds/);
     expect(reason).not.toMatch(/not available in this environment/);
+    // Rate limiting refuses the exchange outright, so nothing was connected:
+    // this outcome keeps the plain headline, unlike the unreadable `2xx` that
+    // arrives after the API already did the work.
+    expect(await harness.installFailureTitle()).toBe(FAILURE_TITLE);
     expect(harness.offersRetry()).toBe(true);
   }, 30000);
 

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Browser-mode tests for the Slack integration pages (`/integrations/slack`
+ * and its OAuth callback).
+ *
+ * Tests are grouped by what the user is doing — starting the install, coming
+ * back from Slack, living with a connected workspace — and reach the pages only
+ * through `SlackIntegrationHarness`. The API is the cloud lane's, so MSW
+ * answers from handlers derived from `design.md`'s contract: a scenario that
+ * cannot be expressed here is a contract conversation, not a local fix.
+ */
+
+import { describe, expect } from "vitest";
+
+import { it } from "@/__tests__/fixtures";
+import {
+  connectedSlackFixture,
+  SLACK_EXCHANGE_OUTCOME,
+  SLACK_OAUTH_CODE,
+  SLACK_OAUTH_STATE,
+  slackFixture,
+} from "@/__tests__/msw/handlers/slack.fixtures";
+
+import {
+  CONNECTION_OUTCOME,
+  SlackIntegrationHarness,
+} from "./slack-integration.harness";
+
+/** The workspace the fixtures connect. */
+const WORKSPACE_NAME = "Prowler HQ";
+
+/**
+ * The access Prowler asks a workspace for, and nothing else (design D2): post
+ * messages, post to a public channel without being invited, and read the
+ * channel list — public, plus the private channels the app was invited to.
+ */
+const REQUIRED_SCOPES = [
+  "chat:write",
+  "chat:write.public",
+  "channels:read",
+  "groups:read",
+];
+
+describe("starting the install", () => {
+  it("sends the user to Slack's consent screen for the access Prowler needs", async () => {
+    // Given — a tenant with no workspace connected yet.
+    const harness = new SlackIntegrationHarness(slackFixture());
+    await harness.mount();
+
+    // When
+    const consentScreen = new URL(await harness.connect());
+
+    // Then — Slack's own consent screen, carrying the scopes and the
+    // server-minted state that binds this install to the session (design D5).
+    expect(`${consentScreen.origin}${consentScreen.pathname}`).toBe(
+      "https://slack.com/oauth/v2/authorize",
+    );
+    expect((consentScreen.searchParams.get("scope") ?? "").split(",")).toEqual(
+      expect.arrayContaining(REQUIRED_SCOPES),
+    );
+    expect(consentScreen.searchParams.get("state")).toBeTruthy();
+  }, 30000);
+
+  it("says so when the deployment has no Slack app, instead of offering an install", async () => {
+    // Given — a deployment without SLACK_CLIENT_ID/SECRET/REDIRECT_URI, which
+    // the API answers with a 503 (contract, "API contract").
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ appConfigured: false }),
+    );
+
+    // When
+    await harness.mount();
+
+    // Then — nothing to do and nothing to click, rather than an error.
+    await harness.waitForUnavailable();
+    expect(harness.offersInstall()).toBe(false);
+  }, 30000);
+});
+
+describe("returning from Slack", () => {
+  it("completes the install and shows the connected workspace", async () => {
+    // Given
+    const harness = new SlackIntegrationHarness(slackFixture());
+
+    // When — Slack sends the user back with the code it issued.
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    // Then
+    expect(await harness.completedInstall()).toBe(true);
+    expect(await harness.connectedWorkspaceName()).toBe(WORKSPACE_NAME);
+    // The Slack code is single-use, and the exchange runs from a render
+    // (design D4): a second call would burn the code and report a failure for
+    // an install that actually succeeded. The once-guard is what prevents it.
+    expect(harness.exchangeCallCount).toBe(1);
+  }, 30000);
+
+  it("connects nothing when the user declines in Slack, and offers to retry", async () => {
+    // Given
+    const harness = new SlackIntegrationHarness(slackFixture());
+
+    // When — a declined consent comes back as an error, with no code.
+    await harness.mountCallback({ error: "access_denied" });
+
+    // Then
+    expect(await harness.installFailureReason()).toMatch(
+      /not approved in Slack/,
+    );
+    expect(harness.offersRetry()).toBe(true);
+    // Nothing was created: there was nothing to exchange.
+    expect(harness.exchangeCallCount).toBe(0);
+  }, 30000);
+
+  it("surfaces the reason when Slack refuses to complete the install", async () => {
+    // Given — Slack rejects the code, and its reason travels in the refusal.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.SLACK_REFUSED }),
+    );
+
+    // When
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    // Then — the user reads what Slack said, not a generic failure.
+    expect(await harness.installFailureReason()).toMatch(/invalid_code/);
+    expect(harness.offersRetry()).toBe(true);
+  }, 30000);
+
+  it("surfaces a completion the API refuses, and connects nothing", async () => {
+    // Given — the state was minted for another session, or already consumed.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.REFUSED_STATE }),
+    );
+
+    // When
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: "state-from-another-session",
+    });
+
+    // Then — the page reports no workspace connected, with the API's reason.
+    expect(await harness.installFailureReason()).toMatch(
+      /could not be matched to the session/,
+    );
+    expect(await harness.completedInstall()).toBe(false);
+    expect(harness.offersRetry()).toBe(true);
+    // Refused once, not retried into a second burnt code.
+    expect(harness.exchangeCallCount).toBe(1);
+  }, 30000);
+
+  it("does not attempt an exchange when the completion carries no state", async () => {
+    // Given
+    const harness = new SlackIntegrationHarness(slackFixture());
+
+    // When — a return without the value the install started with.
+    await harness.mountCallback({ code: SLACK_OAUTH_CODE });
+
+    // Then — refused before the API is ever asked, so no code is spent.
+    expect(await harness.installFailureReason()).toMatch(/incomplete response/);
+    expect(harness.exchangeCallCount).toBe(0);
+  }, 30000);
+});
+
+describe("a connected workspace", () => {
+  it("identifies the workspace and reports the connection as healthy", async () => {
+    // Given — a tenant that already approved Prowler.
+    const harness = new SlackIntegrationHarness(connectedSlackFixture());
+    await harness.mount();
+
+    // Then
+    expect(await harness.connectedWorkspaceName()).toBe(WORKSPACE_NAME);
+    expect(await harness.testConnection()).toBe(CONNECTION_OUTCOME.SUCCESS);
+    // One workspace per tenant (design D10): a connected tenant is not invited
+    // to install another, and no consent URL is minted for a page that would
+    // never use it.
+    expect(harness.offersInstall()).toBe(false);
+    expect(harness.authorizeUrlCallCount).toBe(0);
+  }, 30000);
+});

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -13,6 +13,7 @@ import {
   connectedSlackFixture,
   INTEGRATIONS_SERVER_ERROR_DETAIL,
   slackFixture,
+  unreadableCheckTimeSlackFixture,
 } from "@/__tests__/msw/handlers/slack.fixtures";
 
 import {
@@ -188,6 +189,23 @@ describe("a connected workspace", () => {
     const badge = await harness.connectionBadge();
     expect(badge).toBe("Not checked yet");
     expect(badge).not.toMatch(/Disconnected/);
+  }, 30000);
+
+  it("keeps the page usable when the recorded check time is one no parser can read", async () => {
+    // Given — a finished setup whose `connection_last_checked_at` is a zero
+    // date. `date-fns` throws a RangeError on it, which would replace the whole
+    // page with the route's error boundary.
+    const harness = new SlackIntegrationHarness(
+      unreadableCheckTimeSlackFixture(),
+    );
+
+    await harness.mount();
+
+    expect(await harness.connectedWorkspaceName()).toBe(WORKSPACE_NAME);
+    expect(await harness.connectionBadge()).toBe("Connected");
+    // Nothing to show, so nothing is shown: the same line a workspace that was
+    // never checked renders.
+    expect(harness.lastCheckedLine()).toBeNull();
   }, 30000);
 
   it("does not offer a connection check the API is bound to refuse", async () => {

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -43,9 +43,9 @@ describe("starting the install", () => {
     expect(`${consentScreen.origin}${consentScreen.pathname}`).toBe(
       "https://slack.com/oauth/v2/authorize",
     );
-    expect((consentScreen.searchParams.get("scope") ?? "").split(",")).toEqual(
-      expect.arrayContaining(REQUIRED_SCOPES),
-    );
+    const scopes = (consentScreen.searchParams.get("scope") ?? "").split(",");
+    expect(scopes).toHaveLength(REQUIRED_SCOPES.length);
+    expect(scopes).toEqual(expect.arrayContaining(REQUIRED_SCOPES));
     // The state is server-minted, binding this install to the session
     // (design D5).
     expect(consentScreen.searchParams.get("state")).toBeTruthy();

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -210,9 +210,7 @@ describe("a connected workspace", () => {
     await harness.mount();
 
     // The check posts to the destination channel, so with none recorded the API
-    // answers 400 rather than `connected: false`. Nothing on this page can
-    // record one yet, so the check is not offered at all — a control that could
-    // never be enabled reads as broken, which is how it was first reported.
+    // answers 400. Nothing here records one, so it is not offered at all.
     expect(harness.offersConnectionTest()).toBe(false);
     expect(harness.saysChannelIsNextStep()).toBe(true);
   }, 30000);

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -16,10 +16,7 @@ import {
   unreadableCheckTimeSlackFixture,
 } from "@/__tests__/msw/handlers/slack.fixtures";
 
-import {
-  CONNECTION_OUTCOME,
-  SlackIntegrationHarness,
-} from "./slack-integration.harness";
+import { SlackIntegrationHarness } from "./slack-integration.harness";
 
 /** The workspace the fixtures connect. */
 const WORKSPACE_NAME = "Prowler HQ";
@@ -159,8 +156,6 @@ describe("a connected workspace", () => {
 
     expect(await harness.connectedWorkspaceName()).toBe(WORKSPACE_NAME);
     expect(await harness.connectionBadge()).toBe("Connected");
-    expect(await harness.offersConnectionTest()).toBe(true);
-    expect(await harness.testConnection()).toBe(CONNECTION_OUTCOME.SUCCESS);
     // One workspace per tenant (design D10): no second install on offer, and no
     // consent URL minted for a page that would never use it.
     expect(harness.offersInstall()).toBe(false);
@@ -215,8 +210,10 @@ describe("a connected workspace", () => {
     await harness.mount();
 
     // The check posts to the destination channel, so with none recorded the API
-    // answers 400 rather than `connected: false`.
-    expect(await harness.offersConnectionTest()).toBe(false);
+    // answers 400 rather than `connected: false`. Nothing on this page can
+    // record one yet, so the check is not offered at all — a control that could
+    // never be enabled reads as broken, which is how it was first reported.
+    expect(harness.offersConnectionTest()).toBe(false);
     expect(harness.saysChannelIsNextStep()).toBe(true);
   }, 30000);
 });

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -15,6 +15,7 @@ import { it } from "@/__tests__/fixtures";
 import {
   configuredSlackFixture,
   connectedSlackFixture,
+  INTEGRATIONS_SERVER_ERROR_DETAIL,
   SLACK_EXCHANGE_OUTCOME,
   SLACK_OAUTH_CODE,
   SLACK_OAUTH_STATE,
@@ -91,6 +92,26 @@ describe("starting the install", () => {
     // over something that fixes itself in half a minute.
     expect(await harness.rateLimitNotice()).toMatch(/about 30 seconds/);
     expect(harness.saysUnavailable()).toBe(false);
+  }, 30000);
+
+  it("keeps the page usable when reading the install fails on the server", async () => {
+    // Given — the shared `GET /integrations` read answers 500. The action lets
+    // that surface as a thrown error rather than as a result, so the page has to
+    // catch it: uncaught, it reaches the route's error boundary and the user
+    // gets an error page instead of the Slack page.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ listServerError: true }),
+    );
+
+    // When
+    await harness.mount();
+
+    // Then — the failure is named in Prowler's words, not in the server's, and
+    // the install is still offered: one read failed, the Slack app is fine.
+    const notice = await harness.loadErrorNotice();
+    expect(notice).toMatch(/temporarily unavailable/);
+    expect(notice).not.toMatch(INTEGRATIONS_SERVER_ERROR_DETAIL);
+    expect(harness.offersInstall()).toBe(true);
   }, 30000);
 });
 

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -13,6 +13,7 @@ import { describe, expect } from "vitest";
 
 import { it } from "@/__tests__/fixtures";
 import {
+  configuredSlackFixture,
   connectedSlackFixture,
   SLACK_EXCHANGE_OUTCOME,
   SLACK_OAUTH_CODE,
@@ -74,6 +75,23 @@ describe("starting the install", () => {
     await harness.waitForUnavailable();
     expect(harness.offersInstall()).toBe(false);
   }, 30000);
+
+  it("says Slack is busy, not that the deployment has no Slack app, when it is rate limiting", async () => {
+    // Given — the app is configured and working; Slack is just rate limiting
+    // the call that mints the consent URL.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ rateLimited: true }),
+    );
+
+    // When
+    await harness.mount();
+
+    // Then — the wait is named, and the page does not claim Slack is missing
+    // from this environment: that answer would send the user to their admin
+    // over something that fixes itself in half a minute.
+    expect(await harness.rateLimitNotice()).toMatch(/about 30 seconds/);
+    expect(harness.saysUnavailable()).toBe(false);
+  }, 30000);
 });
 
 describe("returning from Slack", () => {
@@ -113,7 +131,7 @@ describe("returning from Slack", () => {
   }, 30000);
 
   it("surfaces the reason when Slack refuses to complete the install", async () => {
-    // Given — Slack rejects the code, and its reason travels in the refusal.
+    // Given — Slack rejects the code, and the API's own wording explains it.
     const harness = new SlackIntegrationHarness(
       slackFixture({ exchangeOutcome: SLACK_EXCHANGE_OUTCOME.SLACK_REFUSED }),
     );
@@ -124,8 +142,11 @@ describe("returning from Slack", () => {
       state: SLACK_OAUTH_STATE,
     });
 
-    // Then — the user reads what Slack said, not a generic failure.
-    expect(await harness.installFailureReason()).toMatch(/invalid_code/);
+    // Then — a refusal Prowler has nothing better to say about falls back to
+    // the API's `detail`, rather than to a generic failure.
+    expect(await harness.installFailureReason()).toMatch(
+      /OAuth code is invalid/,
+    );
     expect(harness.offersRetry()).toBe(true);
   }, 30000);
 
@@ -143,12 +164,58 @@ describe("returning from Slack", () => {
 
     // Then — the page reports no workspace connected, with the API's reason.
     expect(await harness.installFailureReason()).toMatch(
-      /could not be matched to the session/,
+      /state is invalid, expired, or already consumed/,
     );
     expect(await harness.completedInstall()).toBe(false);
     expect(harness.offersRetry()).toBe(true);
     // Refused once, not retried into a second burnt code.
     expect(harness.exchangeCallCount).toBe(1);
+  }, 30000);
+
+  it("says how to resolve a workspace conflict, in Prowler's own words", async () => {
+    // Given — this tenant already has a different workspace connected, which
+    // the API refuses as a 409 naming the conflict in `code`.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({
+        exchangeOutcome: SLACK_EXCHANGE_OUTCOME.DIFFERENT_WORKSPACE,
+      }),
+    );
+
+    // When
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    // Then — the copy comes from the code, so it says what to do next; the
+    // API's own `detail` states the conflict but not the way out of it.
+    const reason = await harness.installFailureReason();
+    expect(reason).toMatch(/already connected to a different Slack workspace/);
+    expect(reason).toMatch(/Disconnect it before connecting another/);
+    expect(reason).not.toMatch(/tenant/);
+    expect(await harness.completedInstall()).toBe(false);
+    expect(harness.offersRetry()).toBe(true);
+  }, 30000);
+
+  it("tells the user when to come back if Slack is rate limiting the install", async () => {
+    // Given — Slack answers 429 with a Retry-After.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ rateLimited: true }),
+    );
+
+    // When
+    await harness.mountCallback({
+      code: SLACK_OAUTH_CODE,
+      state: SLACK_OAUTH_STATE,
+    });
+
+    // Then — the wait Slack asked for, not a generic failure, and not "Slack
+    // isn't available in this environment": the app is there and working.
+    const reason = await harness.installFailureReason();
+    expect(reason).toMatch(/rate limiting/);
+    expect(reason).toMatch(/about 30 seconds/);
+    expect(reason).not.toMatch(/not available in this environment/);
+    expect(harness.offersRetry()).toBe(true);
   }, 30000);
 
   it("does not attempt an exchange when the completion carries no state", async () => {
@@ -166,8 +233,10 @@ describe("returning from Slack", () => {
 
 describe("a connected workspace", () => {
   it("identifies the workspace and reports the connection as healthy", async () => {
-    // Given — a tenant that already approved Prowler.
-    const harness = new SlackIntegrationHarness(connectedSlackFixture());
+    // Given — a tenant whose setup is finished: workspace approved and a
+    // destination channel recorded, which is what the API needs before it will
+    // check a connection at all.
+    const harness = new SlackIntegrationHarness(configuredSlackFixture());
     await harness.mount();
 
     // Then
@@ -178,5 +247,19 @@ describe("a connected workspace", () => {
     // never use it.
     expect(harness.offersInstall()).toBe(false);
     expect(harness.authorizeUrlCallCount).toBe(0);
+  }, 30000);
+
+  it("still identifies the workspace before a destination channel is chosen", async () => {
+    // Given — the state the OAuth exchange leaves behind.
+    const harness = new SlackIntegrationHarness(connectedSlackFixture());
+
+    // When
+    await harness.mount();
+
+    // Then — the configuration carries no channel keys at all, and the page
+    // reads that as an install with nothing chosen yet rather than as a broken
+    // one.
+    expect(await harness.connectedWorkspaceName()).toBe(WORKSPACE_NAME);
+    expect(harness.offersInstall()).toBe(false);
   }, 30000);
 });

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -241,6 +241,8 @@ describe("a connected workspace", () => {
 
     // Then
     expect(await harness.connectedWorkspaceName()).toBe(WORKSPACE_NAME);
+    expect(await harness.connectionBadge()).toBe("Connected");
+    expect(await harness.offersConnectionTest()).toBe(true);
     expect(await harness.testConnection()).toBe(CONNECTION_OUTCOME.SUCCESS);
     // One workspace per tenant (design D10): a connected tenant is not invited
     // to install another, and no consent URL is minted for a page that would
@@ -261,5 +263,37 @@ describe("a connected workspace", () => {
     // one.
     expect(await harness.connectedWorkspaceName()).toBe(WORKSPACE_NAME);
     expect(harness.offersInstall()).toBe(false);
+  }, 30000);
+
+  it("reports the connection as never checked, not as broken, before the first check", async () => {
+    // Given — the state the OAuth exchange leaves behind: `connected` is null,
+    // which is neither true nor false (design.md, "Connection state, in
+    // order").
+    const harness = new SlackIntegrationHarness(connectedSlackFixture());
+
+    // When
+    await harness.mount();
+
+    // Then — the spec calls this connection "neither confirmed working nor
+    // reported broken", so a red "Disconnected" beside a heading that says the
+    // workspace is connected would report a break nothing has observed.
+    const badge = await harness.connectionBadge();
+    expect(badge).toBe("Not checked yet");
+    expect(badge).not.toMatch(/Disconnected/);
+  }, 30000);
+
+  it("does not offer a connection check the API is bound to refuse", async () => {
+    // Given — a workspace connected and no destination channel recorded.
+    const harness = new SlackIntegrationHarness(connectedSlackFixture());
+
+    // When
+    await harness.mount();
+
+    // Then — the check posts to the destination channel, so with none recorded
+    // the API answers 400 rather than `connected: false`. Offering the check
+    // here would guarantee a failure the user has no way to resolve, so the
+    // page names the next step instead.
+    expect(await harness.offersConnectionTest()).toBe(false);
+    expect(harness.saysChannelIsNextStep()).toBe(true);
   }, 30000);
 });

--- a/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
+++ b/ui/app/(prowler)/integrations/slack/slack-page.integration.test.tsx
@@ -72,8 +72,36 @@ describe("starting the install", () => {
     // When
     await harness.mount();
 
-    // Then — nothing to do and nothing to click, rather than an error.
+    // Then — nothing to do and nothing to click, rather than an error. The read
+    // itself succeeded (an empty collection is what a deployment with no Slack
+    // app has), so nothing claims it failed either.
     await harness.waitForUnavailable();
+    expect(harness.offersInstall()).toBe(false);
+    expect(harness.saysLoadFailed()).toBe(false);
+  }, 30000);
+
+  it("still says the read failed when the deployment also has no Slack app", async () => {
+    // Given — the UI ships ahead of the endpoints and stays inert until they
+    // are served, and a rollback removes the env vars while leaving the rows in
+    // the database (design.md, Migration Plan §2-3 and §5). So "no Slack app
+    // here" is a standing state for whole deployment phases, not a rare event:
+    // only the read failing underneath it has to coincide.
+    const harness = new SlackIntegrationHarness(
+      slackFixture({ appConfigured: false, listServerError: true }),
+    );
+
+    // When
+    await harness.mount();
+
+    // Then — both notices, because they disagree about what to do next and the
+    // read's is the actionable half: "Nothing to do on your side" alone would
+    // send a tenant whose workspace is still connected away from a page a retry
+    // would have shown it to them on.
+    const notice = await harness.loadErrorNotice();
+    expect(notice).toMatch(/temporarily unavailable/);
+    expect(notice).not.toMatch(INTEGRATIONS_SERVER_ERROR_DETAIL);
+    expect(harness.saysUnavailable()).toBe(true);
+    // The install is still not on offer: there is no Slack app to install into.
     expect(harness.offersInstall()).toBe(false);
   }, 30000);
 

--- a/ui/app/(prowler)/providers/providers-tab-content.tsx
+++ b/ui/app/(prowler)/providers/providers-tab-content.tsx
@@ -32,13 +32,6 @@ export const ProvidersTabContent = async ({
 }: {
   searchParams: SearchParamsProps;
 }) => {
-  // The React Compiler (`reactCompiler: true`) otherwise instruments this as a
-  // client component and injects `useMemoCache`, which needs a React dispatcher.
-  // An async server component renders once per request, so there is nothing to
-  // memoize — and the injected hook makes it uncallable outside a render, which
-  // is exactly how the browser-mode tests mount it.
-  "use no memo";
-
   const isCloudEnvironment = isCloud();
   const [providersView, scanConfigsState] = await Promise.all([
     loadProvidersAccountsViewData({

--- a/ui/changelog.d/slack-integration-connect-workspace.added.md
+++ b/ui/changelog.d/slack-integration-connect-workspace.added.md
@@ -1,1 +1,1 @@
-Slack integration for Prowler Cloud: connect a Slack workspace by approving Prowler in Slack, with no token to paste, and check the connection from the Slack integration page
+Slack integration: connect a Slack workspace from the Integrations page (Prowler Cloud only)

--- a/ui/changelog.d/slack-integration-connect-workspace.added.md
+++ b/ui/changelog.d/slack-integration-connect-workspace.added.md
@@ -1,0 +1,1 @@
+Slack integration for Prowler Cloud: connect a Slack workspace by approving Prowler in Slack, with no token to paste, and check the connection from the Slack integration page

--- a/ui/components/icons/services/IconServices.tsx
+++ b/ui/components/icons/services/IconServices.tsx
@@ -752,6 +752,53 @@ export const JiraIcon: React.FC<IconSvgProps> = ({
   </svg>
 );
 
+export const SlackIcon: React.FC<IconSvgProps> = ({
+  size = 32,
+  width,
+  height,
+  className = "rounded-md",
+  ...props
+}) => (
+  <svg
+    aria-hidden="false"
+    aria-label="Slack logo"
+    fill="none"
+    focusable="false"
+    height={size || height}
+    role="presentation"
+    viewBox="0 0 48 48"
+    width={size || width}
+    className={className}
+    {...props}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M0 12C0 5.37258 5.37258 0 12 0H36C42.6274 0 48 5.37258 48 12V36C48 42.6274 42.6274 48 36 48H12C5.37258 48 0 42.6274 0 36V12Z"
+      fill="#FFFFFF"
+    />
+    {/* Slack mark, authored on its native 122.8 grid and scaled into the 30px
+        safe area of the 48px tile (30 / 122.8 = 0.2443). */}
+    <g transform="translate(9 9) scale(0.2443)">
+      <path
+        d="M25.8 77.6c0 7.1-5.8 12.9-12.9 12.9S0 84.7 0 77.6s5.8-12.9 12.9-12.9h12.9v12.9zm6.5 0c0-7.1 5.8-12.9 12.9-12.9s12.9 5.8 12.9 12.9v32.3c0 7.1-5.8 12.9-12.9 12.9s-12.9-5.8-12.9-12.9V77.6z"
+        fill="#E01E5A"
+      />
+      <path
+        d="M45.2 25.8c-7.1 0-12.9-5.8-12.9-12.9S38.1 0 45.2 0s12.9 5.8 12.9 12.9v12.9H45.2zm0 6.5c7.1 0 12.9 5.8 12.9 12.9s-5.8 12.9-12.9 12.9H12.9C5.8 58.1 0 52.3 0 45.2s5.8-12.9 12.9-12.9h32.3z"
+        fill="#36C5F0"
+      />
+      <path
+        d="M97 45.2c0-7.1 5.8-12.9 12.9-12.9s12.9 5.8 12.9 12.9-5.8 12.9-12.9 12.9H97V45.2zm-6.5 0c0 7.1-5.8 12.9-12.9 12.9s-12.9-5.8-12.9-12.9V12.9C64.7 5.8 70.5 0 77.6 0s12.9 5.8 12.9 12.9v32.3z"
+        fill="#2EB67D"
+      />
+      <path
+        d="M77.6 97c7.1 0 12.9 5.8 12.9 12.9s-5.8 12.9-12.9 12.9-12.9-5.8-12.9-12.9V97h12.9zm0-6.5c-7.1 0-12.9-5.8-12.9-12.9s5.8-12.9 12.9-12.9h32.3c7.1 0 12.9 5.8 12.9 12.9s-5.8 12.9-12.9 12.9H77.6z"
+        fill="#ECB22E"
+      />
+    </g>
+  </svg>
+);
+
 export const AWSSecurityHubIcon: React.FC<IconSvgProps> = ({
   size = 32,
   width,

--- a/ui/components/icons/services/IconServices.tsx
+++ b/ui/components/icons/services/IconServices.tsx
@@ -776,8 +776,8 @@ export const SlackIcon: React.FC<IconSvgProps> = ({
       d="M0 12C0 5.37258 5.37258 0 12 0H36C42.6274 0 48 5.37258 48 12V36C48 42.6274 42.6274 48 36 48H12C5.37258 48 0 42.6274 0 36V12Z"
       fill="#FFFFFF"
     />
-    {/* Slack mark, authored on its native 122.8 grid and scaled into the 30px
-        safe area of the 48px tile (30 / 122.8 = 0.2443). */}
+    {/* Slack mark on its native 122.8 grid, scaled into the 48px tile's 30px
+        safe area (30 / 122.8 = 0.2443). */}
     <g transform="translate(9 9) scale(0.2443)">
       <path
         d="M25.8 77.6c0 7.1-5.8 12.9-12.9 12.9S0 84.7 0 77.6s5.8-12.9 12.9-12.9h12.9v12.9zm6.5 0c0-7.1 5.8-12.9 12.9-12.9s12.9 5.8 12.9 12.9v32.3c0 7.1-5.8 12.9-12.9 12.9s-12.9-5.8-12.9-12.9V77.6z"

--- a/ui/components/icons/services/IconServices.tsx
+++ b/ui/components/icons/services/IconServices.tsx
@@ -763,10 +763,10 @@ export const SlackIcon: React.FC<IconSvgProps> = ({
     aria-hidden="true"
     fill="none"
     focusable="false"
-    height={size || height}
+    height={height ?? size}
     role="presentation"
     viewBox="0 0 48 48"
-    width={size || width}
+    width={width ?? size}
     className={className}
     {...props}
     xmlns="http://www.w3.org/2000/svg"

--- a/ui/components/icons/services/IconServices.tsx
+++ b/ui/components/icons/services/IconServices.tsx
@@ -764,7 +764,6 @@ export const SlackIcon: React.FC<IconSvgProps> = ({
     fill="none"
     focusable="false"
     height={height ?? size}
-    role="presentation"
     viewBox="0 0 48 48"
     width={width ?? size}
     className={className}

--- a/ui/components/icons/services/IconServices.tsx
+++ b/ui/components/icons/services/IconServices.tsx
@@ -760,8 +760,7 @@ export const SlackIcon: React.FC<IconSvgProps> = ({
   ...props
 }) => (
   <svg
-    aria-hidden="false"
-    aria-label="Slack logo"
+    aria-hidden="true"
     fill="none"
     focusable="false"
     height={size || height}

--- a/ui/components/integrations/shared/integration-card-header.tsx
+++ b/ui/components/integrations/shared/integration-card-header.tsx
@@ -6,18 +6,51 @@ import { ReactNode } from "react";
 import { Badge } from "@/components/shadcn";
 import { cn } from "@/lib/utils";
 
+/**
+ * The three states a connection can be in. `null` is not "not connected": it is
+ * an integration that exists and has never been checked, so painting it with
+ * the fail tokens would report a break nothing has observed.
+ */
+const CONNECTION_BADGE = {
+  connected: {
+    label: "Connected",
+    className:
+      "bg-bg-pass-secondary text-text-success-primary border-transparent",
+  },
+  disconnected: {
+    label: "Disconnected",
+    className:
+      "bg-bg-fail-secondary text-text-error-primary border-transparent",
+  },
+  unchecked: {
+    label: "Not checked yet",
+    className: "border-border-tag bg-bg-tag text-text-neutral-secondary",
+  },
+} as const;
+
+type ConnectionBadgeState = keyof typeof CONNECTION_BADGE;
+
+const connectionBadgeState = (
+  connected: boolean | null,
+): ConnectionBadgeState =>
+  connected === null ? "unchecked" : connected ? "connected" : "disconnected";
+
+interface IntegrationCardChip {
+  label: string;
+  className?: string;
+}
+
+interface IntegrationConnectionStatus {
+  connected: boolean | null;
+  label?: string;
+}
+
 interface IntegrationCardHeaderProps {
   icon: ReactNode;
   title: string;
   subtitle?: string;
-  chips?: Array<{
-    label: string;
-    className?: string;
-  }>;
-  connectionStatus?: {
-    connected: boolean;
-    label?: string;
-  };
+  chips?: IntegrationCardChip[];
+  connectionStatus?: IntegrationConnectionStatus;
   navigationUrl?: string;
 }
 
@@ -29,6 +62,11 @@ export const IntegrationCardHeader = ({
   connectionStatus,
   navigationUrl,
 }: IntegrationCardHeaderProps) => {
+  const badgeState = connectionStatus
+    ? connectionBadgeState(connectionStatus.connected)
+    : null;
+  const badge = badgeState ? CONNECTION_BADGE[badgeState] : null;
+
   return (
     <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex items-center gap-3">
@@ -55,7 +93,7 @@ export const IntegrationCardHeader = ({
           )}
         </div>
       </div>
-      {(chips.length > 0 || connectionStatus) && (
+      {(chips.length > 0 || badge) && (
         <div className="flex flex-wrap items-center gap-2">
           {chips.map((chip, index) => (
             <Badge
@@ -69,18 +107,13 @@ export const IntegrationCardHeader = ({
               {chip.label}
             </Badge>
           ))}
-          {connectionStatus && (
+          {badge && badgeState && (
             <Badge
               variant="outline"
-              className={cn(
-                "text-xs font-normal",
-                connectionStatus.connected
-                  ? "bg-bg-pass-secondary text-text-success-primary border-transparent"
-                  : "bg-bg-fail-secondary text-text-error-primary border-transparent",
-              )}
+              data-connection-status={badgeState}
+              className={cn("text-xs font-normal", badge.className)}
             >
-              {connectionStatus.label ||
-                (connectionStatus.connected ? "Connected" : "Disconnected")}
+              {connectionStatus?.label || badge.label}
             </Badge>
           )}
         </div>

--- a/ui/components/integrations/shared/integration-card-header.tsx
+++ b/ui/components/integrations/shared/integration-card-header.tsx
@@ -6,11 +6,7 @@ import { ReactNode } from "react";
 import { Badge } from "@/components/shadcn";
 import { cn } from "@/lib/utils";
 
-/**
- * The three states a connection can be in. `null` is not "not connected": it is
- * an integration that exists and has never been checked, so painting it with
- * the fail tokens would report a break nothing has observed.
- */
+// `null` means never checked, not disconnected: it must not get the fail tokens.
 const CONNECTION_BADGE = {
   connected: {
     label: "Connected",

--- a/ui/components/integrations/slack/slack-callback.test.tsx
+++ b/ui/components/integrations/slack/slack-callback.test.tsx
@@ -41,6 +41,19 @@ beforeEach(() => {
 
 const SPINNER_COPY = /Connecting your Slack workspace/;
 
+/**
+ * The two headlines the failure alert can carry, spelled out rather than
+ * imported: a rename on the component's side has to fail these tests, not
+ * quietly agree with itself.
+ *
+ * Which one is shown is the assertion. `FAILURE_TITLE` states a fact — nothing
+ * was connected — that only some of the outcomes establish; the rest happen
+ * *after* the API consumed the code, so the workspace may well be connected and
+ * the honest headline is that the result is unknown.
+ */
+const FAILURE_TITLE = "Slack workspace not connected";
+const UNCONFIRMED_TITLE = "Slack install not confirmed";
+
 describe("returning from Slack when the completion answers unexpectedly", () => {
   it("reports an unconfirmed result instead of spinning forever when the exchange call never comes back", async () => {
     // Given — the call to the Server Action rejects rather than resolving: the
@@ -64,6 +77,13 @@ describe("returning from Slack when the completion answers unexpectedly", () => 
       screen.getByRole("link", { name: /Back to Slack integration/ }),
     ).toHaveAttribute("href", "/integrations/slack");
     expect(screen.queryByText(SPINNER_COPY)).not.toBeInTheDocument();
+
+    // And the headline says the same thing the description does. "Slack
+    // workspace not connected" above a line that says Prowler cannot tell, and
+    // that sends the user to look the workspace up, asserts the one fact this
+    // outcome does not have.
+    expect(screen.getByText(UNCONFIRMED_TITLE)).toBeInTheDocument();
+    expect(screen.queryByText(FAILURE_TITLE)).not.toBeInTheDocument();
   });
 
   it("still reports the workspace as connected when the created integration carries no configuration", async () => {
@@ -99,8 +119,11 @@ describe("returning from Slack when the completion answers unexpectedly", () => 
       await screen.findByText(/Connected to your Slack workspace/),
     ).toBeInTheDocument();
     expect(screen.queryByText(SPINNER_COPY)).not.toBeInTheDocument();
+    // No failure alert at all — keyed on the escape link the failure branch is
+    // the only one to render, so this stays true whichever headline that branch
+    // would have carried.
     expect(
-      screen.queryByText(/Slack workspace not connected/),
+      screen.queryByRole("link", { name: /Back to Slack integration/ }),
     ).not.toBeInTheDocument();
   });
 });
@@ -119,6 +142,13 @@ describe("returning from Slack with an error on the callback URL", () => {
       await screen.findByText(/was not approved in Slack/),
     ).toBeInTheDocument();
     expect(exchangeSlackOAuthCode).not.toHaveBeenCalled();
+
+    // And the headline still states the fact, because here there is one: Slack
+    // refused before issuing a code, so nothing was ever exchanged. The
+    // unknowable-state wording belongs to the outcomes that happen after the
+    // API consumed one, and must not spread to this one.
+    expect(screen.getByText(FAILURE_TITLE)).toBeInTheDocument();
+    expect(screen.queryByText(UNCONFIRMED_TITLE)).not.toBeInTheDocument();
   });
 
   it("names a Slack code it does not recognise, so a new failure reason is still diagnosable", async () => {

--- a/ui/components/integrations/slack/slack-callback.test.tsx
+++ b/ui/components/integrations/slack/slack-callback.test.tsx
@@ -15,20 +15,27 @@ import { SlackCallback } from "./slack-callback";
 
 const COMPLETED_QUERY = "code=slack-code-1f4a&state=st-2f1c9d7a";
 
-const { exchangeSlackOAuthCode, callbackQuery } = vi.hoisted(() => ({
-  exchangeSlackOAuthCode: vi.fn(),
-  callbackQuery: { value: "" },
-}));
+const { exchangeSlackOAuthCode, callbackQuery, routerReplace } = vi.hoisted(
+  () => ({
+    exchangeSlackOAuthCode: vi.fn(),
+    callbackQuery: { value: "" },
+    routerReplace: vi.fn(),
+  }),
+);
 
 vi.mock("@/actions/integrations/slack", () => ({ exchangeSlackOAuthCode }));
 
+// One router across renders, so the redirect off the spent code is assertable.
+const router = { replace: routerReplace };
+
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: vi.fn() }),
+  useRouter: () => router,
   useSearchParams: () => new URLSearchParams(callbackQuery.value),
 }));
 
 beforeEach(() => {
   callbackQuery.value = COMPLETED_QUERY;
+  routerReplace.mockClear();
 });
 
 const SPINNER_COPY = /Connecting your Slack workspace/;
@@ -94,6 +101,8 @@ describe("returning from Slack when the completion answers unexpectedly", () => 
     expect(
       screen.queryByRole("link", { name: /Back to Slack integration/ }),
     ).not.toBeInTheDocument();
+    // `replace`, not `push`: a back navigation must not remount onto the code.
+    expect(routerReplace).toHaveBeenCalledWith("/integrations/slack");
   });
 });
 

--- a/ui/components/integrations/slack/slack-callback.test.tsx
+++ b/ui/components/integrations/slack/slack-callback.test.tsx
@@ -1,15 +1,9 @@
 /**
- * What the OAuth callback does with an answer it did not expect.
- *
- * The install itself is covered from the page in
- * `slack-page.integration.test.tsx`, against MSW. These two cases cannot be
- * expressed there: the browser suite runs the Server Action as a plain function,
- * so it never has the client→server transport that can reject on its own, and
- * the exchange handler answers the contract's shapes, not an off-contract one.
- * Both are about the same thing — the callback awaits inside an effect that runs
- * exactly once, so anything it does not handle there leaves the user on a
- * spinner with no error, no retry and no way out. React's error boundaries
- * cannot see a rejection awaited in an effect, which is why it has to be caught.
+ * The cases `slack-page.integration.test.tsx` cannot express: it runs the Server
+ * Action as a plain function, so there is no client→server transport to reject,
+ * and its handler only answers the contract's shapes. React error boundaries
+ * cannot see a rejection awaited in an effect, so an uncaught one leaves the
+ * user on the spinner with no error and no way out.
  */
 
 import { render, screen } from "@testing-library/react";
@@ -23,8 +17,6 @@ const COMPLETED_QUERY = "code=slack-code-1f4a&state=st-2f1c9d7a";
 
 const { exchangeSlackOAuthCode, callbackQuery } = vi.hoisted(() => ({
   exchangeSlackOAuthCode: vi.fn(),
-  // The query Slack came back with, swapped per test — it is the only input
-  // the callback has.
   callbackQuery: { value: "" },
 }));
 
@@ -42,34 +34,23 @@ beforeEach(() => {
 const SPINNER_COPY = /Connecting your Slack workspace/;
 
 /**
- * The two headlines the failure alert can carry, spelled out rather than
- * imported: a rename on the component's side has to fail these tests, not
- * quietly agree with itself.
- *
- * Which one is shown is the assertion. `FAILURE_TITLE` states a fact — nothing
- * was connected — that only some of the outcomes establish; the rest happen
- * *after* the API consumed the code, so the workspace may well be connected and
- * the honest headline is that the result is unknown.
+ * Literals, not imports: a rename on the component's side has to fail here.
+ * `FAILURE_TITLE` claims nothing was connected, which only holds for outcomes
+ * that happen before the API consumed the code.
  */
 const FAILURE_TITLE = "Slack workspace not connected";
 const UNCONFIRMED_TITLE = "Slack install not confirmed";
 
 describe("returning from Slack when the completion answers unexpectedly", () => {
   it("reports an unconfirmed result instead of spinning forever when the exchange call never comes back", async () => {
-    // Given — the call to the Server Action rejects rather than resolving: the
-    // POST to Prowler's own server failed (a dropped connection on the way back
-    // from Slack), a rolling deploy invalidated the action id, or a gateway
-    // answered it with HTML. Next rejects the caller's promise and leaves the
-    // router untouched, so this is the whole of what the page ever hears — the
-    // action's own error handling never runs, because nothing entered it.
+    // The client→server POST itself fails (dropped connection, action id
+    // invalidated by a deploy), so the action's own error handling never runs.
     exchangeSlackOAuthCode.mockRejectedValue(new TypeError("Failed to fetch"));
 
-    // When
     render(<SlackCallback />);
 
-    // Then — the result is reported as unknown, not as a failed install: the
-    // API consumes the single-use code before it answers, so the workspace may
-    // well be connected. And the page settles somewhere the user can leave.
+    // The API consumes the single-use code before answering, so the workspace
+    // may well be connected: unknown, not failed.
     expect(
       await screen.findByText(/could not confirm whether the workspace/i),
     ).toBeInTheDocument();
@@ -78,20 +59,13 @@ describe("returning from Slack when the completion answers unexpectedly", () => 
     ).toHaveAttribute("href", "/integrations/slack");
     expect(screen.queryByText(SPINNER_COPY)).not.toBeInTheDocument();
 
-    // And the headline says the same thing the description does. "Slack
-    // workspace not connected" above a line that says Prowler cannot tell, and
-    // that sends the user to look the workspace up, asserts the one fact this
-    // outcome does not have.
     expect(screen.getByText(UNCONFIRMED_TITLE)).toBeInTheDocument();
     expect(screen.queryByText(FAILURE_TITLE)).not.toBeInTheDocument();
   });
 
   it("still reports the workspace as connected when the created integration carries no configuration", async () => {
-    // Given — a 200 whose resource omits `configuration` altogether. The
-    // contract says it is always there, and this is what the UI does when it is
-    // not: the reply round-trips `parseStringify` intact and only fails when the
-    // callback reads the workspace name off it, on the client, after the install
-    // already happened.
+    // The install already succeeded; `configuration` only goes missing on the
+    // client, where the callback reads the workspace name off it.
     exchangeSlackOAuthCode.mockResolvedValue({
       integration: {
         type: "integrations",
@@ -105,23 +79,18 @@ describe("returning from Slack when the completion answers unexpectedly", () => 
           integration_type: "slack",
         },
         links: { self: "/api/v1/integrations/slack-integration-1" },
-        // Cast because the shape is exactly the one the contract rules out.
+        // Cast: the shape is the one the contract rules out.
       } as unknown as IntegrationProps,
     });
 
-    // When
     render(<SlackCallback />);
 
-    // Then — the install is reported as done, with the workspace unnamed rather
-    // than with a crash: the exchange succeeded, and a name Prowler could not
-    // read is not a reason to tell the user their install did not happen.
     expect(
       await screen.findByText(/Connected to your Slack workspace/),
     ).toBeInTheDocument();
     expect(screen.queryByText(SPINNER_COPY)).not.toBeInTheDocument();
-    // No failure alert at all — keyed on the escape link the failure branch is
-    // the only one to render, so this stays true whichever headline that branch
-    // would have carried.
+    // Keyed on the escape link, the only element unique to the failure branch,
+    // so this holds whichever headline that branch would have carried.
     expect(
       screen.queryByRole("link", { name: /Back to Slack integration/ }),
     ).not.toBeInTheDocument();
@@ -130,38 +99,29 @@ describe("returning from Slack when the completion answers unexpectedly", () => 
 
 describe("returning from Slack with an error on the callback URL", () => {
   it("says the install was declined when Slack reports the approval was refused", async () => {
-    // Given — the one code Slack reliably sends to this redirect.
+    // The one code Slack reliably sends to this redirect.
     callbackQuery.value = "error=access_denied&state=st-2f1c9d7a";
 
-    // When
     render(<SlackCallback />);
 
-    // Then — the wording is about the decision, not about a failure: nothing
-    // broke, and there is no code to exchange.
     expect(
       await screen.findByText(/was not approved in Slack/),
     ).toBeInTheDocument();
     expect(exchangeSlackOAuthCode).not.toHaveBeenCalled();
 
-    // And the headline still states the fact, because here there is one: Slack
-    // refused before issuing a code, so nothing was ever exchanged. The
-    // unknowable-state wording belongs to the outcomes that happen after the
-    // API consumed one, and must not spread to this one.
+    // Slack refused before issuing a code, so the flat "not connected" is a
+    // fact here, unlike in the outcomes that follow an exchange.
     expect(screen.getByText(FAILURE_TITLE)).toBeInTheDocument();
     expect(screen.queryByText(UNCONFIRMED_TITLE)).not.toBeInTheDocument();
   });
 
   it("names a Slack code it does not recognise, so a new failure reason is still diagnosable", async () => {
-    // Given — Slack publishes no closed set of codes for this redirect, so a
-    // code Prowler has never seen has to survive to the screen. Swallowing it
-    // behind generic copy is what leaves support with nothing to go on.
+    // Slack publishes no closed set of codes for this redirect, so the guard is
+    // on the shape of the value rather than on an allowlist.
     callbackQuery.value = "error=invalid_scope&state=st-2f1c9d7a";
 
-    // When
     render(<SlackCallback />);
 
-    // Then — the code is quoted verbatim: the guard is on the shape of the
-    // value, not on an allowlist of the ones Prowler happens to know.
     expect(
       await screen.findByText(
         "Slack could not complete the install (invalid_scope).",
@@ -170,20 +130,14 @@ describe("returning from Slack with an error on the callback URL", () => {
   });
 
   it("drops a sentence smuggled into the error parameter instead of rendering it as Prowler's own copy", async () => {
-    // Given — a link an attacker can hand a victim: `error` is theirs to write,
-    // and the callback is reached from a cold start, since the sign-in redirect
-    // carries the query through. The balancing punctuation is the point — it
-    // closes Prowler's parenthetical and reopens it, so the payload would read
-    // as a grammatical sentence under Prowler's own error title.
+    // The balancing punctuation is the point: it closes Prowler's parenthetical
+    // and reopens it, so the payload would read as Prowler's own sentence.
     const payload =
       "). Slack has flagged this workspace. Contact Prowler support at +1-555-0100 to restore alerting (";
     callbackQuery.value = `error=${encodeURIComponent(payload)}&state=st-2f1c9d7a`;
 
-    // When
     render(<SlackCallback />);
 
-    // Then — the failure is still reported, in wording Prowler owns, and none
-    // of the attacker's text reaches the page.
     expect(
       await screen.findByText("Slack could not complete the install."),
     ).toBeInTheDocument();

--- a/ui/components/integrations/slack/slack-callback.test.tsx
+++ b/ui/components/integrations/slack/slack-callback.test.tsx
@@ -13,23 +13,31 @@
  */
 
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { IntegrationProps } from "@/types/integrations";
 
 import { SlackCallback } from "./slack-callback";
 
-const { exchangeSlackOAuthCode } = vi.hoisted(() => ({
+const COMPLETED_QUERY = "code=slack-code-1f4a&state=st-2f1c9d7a";
+
+const { exchangeSlackOAuthCode, callbackQuery } = vi.hoisted(() => ({
   exchangeSlackOAuthCode: vi.fn(),
+  // The query Slack came back with, swapped per test — it is the only input
+  // the callback has.
+  callbackQuery: { value: "" },
 }));
 
 vi.mock("@/actions/integrations/slack", () => ({ exchangeSlackOAuthCode }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: vi.fn() }),
-  useSearchParams: () =>
-    new URLSearchParams("code=slack-code-1f4a&state=st-2f1c9d7a"),
+  useSearchParams: () => new URLSearchParams(callbackQuery.value),
 }));
+
+beforeEach(() => {
+  callbackQuery.value = COMPLETED_QUERY;
+});
 
 const SPINNER_COPY = /Connecting your Slack workspace/;
 
@@ -94,5 +102,62 @@ describe("returning from Slack when the completion answers unexpectedly", () => 
     expect(
       screen.queryByText(/Slack workspace not connected/),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("returning from Slack with an error on the callback URL", () => {
+  it("says the install was declined when Slack reports the approval was refused", async () => {
+    // Given — the one code Slack reliably sends to this redirect.
+    callbackQuery.value = "error=access_denied&state=st-2f1c9d7a";
+
+    // When
+    render(<SlackCallback />);
+
+    // Then — the wording is about the decision, not about a failure: nothing
+    // broke, and there is no code to exchange.
+    expect(
+      await screen.findByText(/was not approved in Slack/),
+    ).toBeInTheDocument();
+    expect(exchangeSlackOAuthCode).not.toHaveBeenCalled();
+  });
+
+  it("names a Slack code it does not recognise, so a new failure reason is still diagnosable", async () => {
+    // Given — Slack publishes no closed set of codes for this redirect, so a
+    // code Prowler has never seen has to survive to the screen. Swallowing it
+    // behind generic copy is what leaves support with nothing to go on.
+    callbackQuery.value = "error=invalid_scope&state=st-2f1c9d7a";
+
+    // When
+    render(<SlackCallback />);
+
+    // Then — the code is quoted verbatim: the guard is on the shape of the
+    // value, not on an allowlist of the ones Prowler happens to know.
+    expect(
+      await screen.findByText(
+        "Slack could not complete the install (invalid_scope).",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("drops a sentence smuggled into the error parameter instead of rendering it as Prowler's own copy", async () => {
+    // Given — a link an attacker can hand a victim: `error` is theirs to write,
+    // and the callback is reached from a cold start, since the sign-in redirect
+    // carries the query through. The balancing punctuation is the point — it
+    // closes Prowler's parenthetical and reopens it, so the payload would read
+    // as a grammatical sentence under Prowler's own error title.
+    const payload =
+      "). Slack has flagged this workspace. Contact Prowler support at +1-555-0100 to restore alerting (";
+    callbackQuery.value = `error=${encodeURIComponent(payload)}&state=st-2f1c9d7a`;
+
+    // When
+    render(<SlackCallback />);
+
+    // Then — the failure is still reported, in wording Prowler owns, and none
+    // of the attacker's text reaches the page.
+    expect(
+      await screen.findByText("Slack could not complete the install."),
+    ).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain("+1-555-0100");
+    expect(document.body.textContent).not.toContain("flagged this workspace");
   });
 });

--- a/ui/components/integrations/slack/slack-callback.test.tsx
+++ b/ui/components/integrations/slack/slack-callback.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * What the OAuth callback does with an answer it did not expect.
+ *
+ * The install itself is covered from the page in
+ * `slack-page.integration.test.tsx`, against MSW. These two cases cannot be
+ * expressed there: the browser suite runs the Server Action as a plain function,
+ * so it never has the client→server transport that can reject on its own, and
+ * the exchange handler answers the contract's shapes, not an off-contract one.
+ * Both are about the same thing — the callback awaits inside an effect that runs
+ * exactly once, so anything it does not handle there leaves the user on a
+ * spinner with no error, no retry and no way out. React's error boundaries
+ * cannot see a rejection awaited in an effect, which is why it has to be caught.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { IntegrationProps } from "@/types/integrations";
+
+import { SlackCallback } from "./slack-callback";
+
+const { exchangeSlackOAuthCode } = vi.hoisted(() => ({
+  exchangeSlackOAuthCode: vi.fn(),
+}));
+
+vi.mock("@/actions/integrations/slack", () => ({ exchangeSlackOAuthCode }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () =>
+    new URLSearchParams("code=slack-code-1f4a&state=st-2f1c9d7a"),
+}));
+
+const SPINNER_COPY = /Connecting your Slack workspace/;
+
+describe("returning from Slack when the completion answers unexpectedly", () => {
+  it("reports an unconfirmed result instead of spinning forever when the exchange call never comes back", async () => {
+    // Given — the call to the Server Action rejects rather than resolving: the
+    // POST to Prowler's own server failed (a dropped connection on the way back
+    // from Slack), a rolling deploy invalidated the action id, or a gateway
+    // answered it with HTML. Next rejects the caller's promise and leaves the
+    // router untouched, so this is the whole of what the page ever hears — the
+    // action's own error handling never runs, because nothing entered it.
+    exchangeSlackOAuthCode.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    // When
+    render(<SlackCallback />);
+
+    // Then — the result is reported as unknown, not as a failed install: the
+    // API consumes the single-use code before it answers, so the workspace may
+    // well be connected. And the page settles somewhere the user can leave.
+    expect(
+      await screen.findByText(/could not confirm whether the workspace/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Back to Slack integration/ }),
+    ).toHaveAttribute("href", "/integrations/slack");
+    expect(screen.queryByText(SPINNER_COPY)).not.toBeInTheDocument();
+  });
+
+  it("still reports the workspace as connected when the created integration carries no configuration", async () => {
+    // Given — a 200 whose resource omits `configuration` altogether. The
+    // contract says it is always there, and this is what the UI does when it is
+    // not: the reply round-trips `parseStringify` intact and only fails when the
+    // callback reads the workspace name off it, on the client, after the install
+    // already happened.
+    exchangeSlackOAuthCode.mockResolvedValue({
+      integration: {
+        type: "integrations",
+        id: "slack-integration-1",
+        attributes: {
+          inserted_at: "2026-08-10T09:00:00Z",
+          updated_at: "2026-08-10T09:00:00Z",
+          enabled: true,
+          connected: null,
+          connection_last_checked_at: null,
+          integration_type: "slack",
+        },
+        links: { self: "/api/v1/integrations/slack-integration-1" },
+        // Cast because the shape is exactly the one the contract rules out.
+      } as unknown as IntegrationProps,
+    });
+
+    // When
+    render(<SlackCallback />);
+
+    // Then — the install is reported as done, with the workspace unnamed rather
+    // than with a crash: the exchange succeeded, and a name Prowler could not
+    // read is not a reason to tell the user their install did not happen.
+    expect(
+      await screen.findByText(/Connected to your Slack workspace/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(SPINNER_COPY)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Slack workspace not connected/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/ui/components/integrations/slack/slack-callback.tsx
+++ b/ui/components/integrations/slack/slack-callback.tsx
@@ -66,9 +66,15 @@ const describeSlackError = (reason: string): string => {
  * whose state it cannot match is refused there, and surfaced here.
  *
  * The exchange runs **exactly once**: the Slack code is single-use, so a second
- * invocation (a re-render, a Strict Mode double effect, a back navigation)
- * would burn it and report a failure for an install that actually succeeded.
- * The guard is the mechanism, not a nicety.
+ * invocation (a re-render, a Strict Mode double effect) would burn it and
+ * report a failure for an install that actually succeeded. The `hasStarted`
+ * guard is that mechanism, not a nicety — it holds within one mount, which is
+ * all a ref can do.
+ *
+ * A back navigation is a different hazard with a different answer: it remounts
+ * the component with a fresh ref, so what keeps it away from a completed
+ * install is `router.replace` below, which takes the callback URL off the
+ * history stack. Swapping it for a `push` would reopen this.
  */
 export const SlackCallback = () => {
   const router = useRouter();

--- a/ui/components/integrations/slack/slack-callback.tsx
+++ b/ui/components/integrations/slack/slack-callback.tsx
@@ -23,6 +23,17 @@ const STATUS = {
 
 type Status = (typeof STATUS)[keyof typeof STATUS];
 
+/**
+ * What the user is told when the completion never came back with an answer.
+ *
+ * Deliberately not "the install failed": the API consumes the code before it
+ * answers, so a call that never made it back may well have connected the
+ * workspace. The honest report is that the result is unknown and where to look
+ * it up — which is exactly what the escape link below goes to.
+ */
+const UNCONFIRMED_COMPLETION_MESSAGE =
+  "Prowler could not confirm whether the workspace was connected. Open the Slack integration page to check — if none is listed there, start the install again.";
+
 /** Turn the `error` Slack puts on the callback URL into something readable. */
 const describeSlackError = (reason: string): string =>
   reason === "access_denied"
@@ -78,7 +89,7 @@ export const SlackCallback = () => {
 
       if ("integration" in result) {
         setWorkspaceName(
-          result.integration.attributes.configuration.team_name ?? null,
+          result.integration.attributes?.configuration?.team_name ?? null,
         );
         setStatus(STATUS.CONNECTED);
         router.replace(SLACK_INTEGRATION_PATH);
@@ -97,7 +108,18 @@ export const SlackCallback = () => {
       setStatus(STATUS.FAILED);
     };
 
-    void complete();
+    // A rejection here is not a refusal the action reported — it is the call to
+    // it never coming back: the request to Prowler's own server failing (a
+    // dropped connection on the way back from Slack), an action id a rolling
+    // deploy invalidated, a gateway answering with an HTML 502. None of those
+    // reach the action's own error handling, and nothing retries either, since
+    // the once-guard has already fired. Uncaught, the page spins on "Connecting
+    // your Slack workspace..." forever: no error, no way out, no boundary to
+    // catch it (a rejection awaited inside an effect is invisible to React's).
+    void complete().catch(() => {
+      setFailure(UNCONFIRMED_COMPLETION_MESSAGE);
+      setStatus(STATUS.FAILED);
+    });
   }, [router, searchParams]);
 
   if (status === STATUS.CONNECTING) {

--- a/ui/components/integrations/slack/slack-callback.tsx
+++ b/ui/components/integrations/slack/slack-callback.tsx
@@ -23,53 +23,22 @@ const STATUS = {
 
 type Status = (typeof STATUS)[keyof typeof STATUS];
 
-/**
- * What the user is told when the completion never came back with an answer.
- *
- * Deliberately not "the install failed": the API consumes the code before it
- * answers, so a call that never made it back may well have connected the
- * workspace. The honest report is that the result is unknown and where to look
- * it up — which is exactly what the escape link below goes to.
- */
 const UNCONFIRMED_COMPLETION_MESSAGE =
   "Prowler could not confirm whether the workspace was connected. Open the Slack integration page to check — if none is listed there, start the install again.";
 
-/**
- * The headline for a failure that really is one: Slack refused, the callback
- * came back incomplete, the API refused the completion, or this deployment has
- * no Slack app. Nothing was connected in any of them.
- */
 const FAILURE_TITLE = "Slack workspace not connected";
 
 /**
- * The headline for the two outcomes where the state is *unknown*.
- *
- * Both of them leave the workspace possibly — for the unreadable `2xx`,
- * certainly — connected: the API consumes the code and upserts the integration
- * before it answers. Titling those "not connected" contradicts the description
- * right below it and the integration page the escape link goes to, which lists
- * the workspace this very answer created.
- *
- * Kept short deliberately: `AlertTitle` clamps to one line, so a longer
- * headline is silently truncated.
+ * The API consumes the code and upserts the integration before it answers, so an
+ * unreadable or missing answer can still mean a connected workspace. Kept short:
+ * `AlertTitle` clamps to one line.
  */
 const UNCONFIRMED_TITLE = "Slack install not confirmed";
 
-/**
- * The shape of a Slack error code: a snake_case protocol token, never prose.
- *
- * `error` is read straight off the URL, so its value is whoever wrote the link
- * — and the parenthetical below puts it inside Prowler's own error copy. A
- * value carrying spaces and punctuation escapes those parentheses and reads as
- * a sentence Prowler wrote ("Slack has flagged this workspace, call ..."),
- * which is a credible way to hand a user instructions they should not follow.
- * Slack publishes no closed set of codes for this redirect, so the guard is on
- * the shape and not the value: an unknown-but-real code still reaches support,
- * a sentence cannot get through.
- */
+// `error` comes straight off the URL and is interpolated into Prowler's own copy,
+// so gate on the shape of a code: Slack publishes no closed set of values.
 const REASON_TOKEN = /^[a-z0-9_]{1,48}$/;
 
-/** Turn the `error` Slack puts on the callback URL into something readable. */
 const describeSlackError = (reason: string): string => {
   if (reason === "access_denied") {
     return "The install was not approved in Slack, so no workspace was connected.";
@@ -80,22 +49,9 @@ const describeSlackError = (reason: string): string => {
 };
 
 /**
- * Completes the Slack install after Slack redirects the user back here.
- *
- * The UI's only job on return is to forward `code` and `state` to the API,
- * which owns the OAuth secret, mints the state and consumes it — a completion
- * whose state it cannot match is refused there, and surfaced here.
- *
- * The exchange runs **exactly once**: the Slack code is single-use, so a second
- * invocation (a re-render, a Strict Mode double effect) would burn it and
- * report a failure for an install that actually succeeded. The `hasStarted`
- * guard is that mechanism, not a nicety — it holds within one mount, which is
- * all a ref can do.
- *
- * A back navigation is a different hazard with a different answer: it remounts
- * the component with a fresh ref, so what keeps it away from a completed
- * install is `router.replace` below, which takes the callback URL off the
- * history stack. Swapping it for a `push` would reopen this.
+ * Slack's `code` is single-use: `hasStarted` holds the exchange to one run per
+ * mount, and `router.replace` (not `push`) keeps a back navigation from
+ * remounting onto a spent code.
  */
 export const SlackCallback = () => {
   const router = useRouter();
@@ -114,8 +70,8 @@ export const SlackCallback = () => {
     const code = searchParams.get("code");
     const state = searchParams.get("state");
 
-    // Slack answers a declined or rejected install with `error`, and no code —
-    // there is nothing to exchange, so nothing is created.
+    // Slack answers a declined install with `error` and no code, so there is
+    // nothing to exchange.
     if (slackError) {
       setFailure(describeSlackError(slackError));
       setStatus(STATUS.FAILED);
@@ -145,13 +101,8 @@ export const SlackCallback = () => {
       if ("unavailable" in result) {
         setFailure("Slack is not available in this environment yet.");
       } else if ("rateLimited" in result) {
-        // Nothing is wrong with the install — Slack is just busy — so the user
-        // is told when to come back, not that the environment lacks Slack.
         setFailure(result.message);
       } else if ("unconfirmed" in result) {
-        // The API answered `2xx`, so the workspace *is* connected — only the
-        // answer describing it was unreadable. The title has to stop short of
-        // claiming otherwise, or it contradicts the page the link goes to.
         setFailure(result.message);
         setFailureTitle(UNCONFIRMED_TITLE);
       } else {
@@ -160,14 +111,9 @@ export const SlackCallback = () => {
       setStatus(STATUS.FAILED);
     };
 
-    // A rejection here is not a refusal the action reported — it is the call to
-    // it never coming back: the request to Prowler's own server failing (a
-    // dropped connection on the way back from Slack), an action id a rolling
-    // deploy invalidated, a gateway answering with an HTML 502. None of those
-    // reach the action's own error handling, and nothing retries either, since
-    // the once-guard has already fired. Uncaught, the page spins on "Connecting
-    // your Slack workspace..." forever: no error, no way out, no boundary to
-    // catch it (a rejection awaited inside an effect is invisible to React's).
+    // A rejection here means the call never came back (stale action id after a
+    // deploy, HTML 502): error boundaries cannot see a rejection awaited inside
+    // an effect, and the once-guard blocks a retry, so the page would spin.
     void complete().catch(() => {
       setFailure(UNCONFIRMED_COMPLETION_MESSAGE);
       setFailureTitle(UNCONFIRMED_TITLE);

--- a/ui/components/integrations/slack/slack-callback.tsx
+++ b/ui/components/integrations/slack/slack-callback.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { AlertCircle, CircleCheck, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+import { exchangeSlackOAuthCode } from "@/actions/integrations/slack";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+} from "@/components/shadcn";
+
+const SLACK_INTEGRATION_PATH = "/integrations/slack";
+
+const STATUS = {
+  CONNECTING: "connecting",
+  CONNECTED: "connected",
+  FAILED: "failed",
+} as const;
+
+type Status = (typeof STATUS)[keyof typeof STATUS];
+
+/** Turn the `error` Slack puts on the callback URL into something readable. */
+const describeSlackError = (reason: string): string =>
+  reason === "access_denied"
+    ? "The install was not approved in Slack, so no workspace was connected."
+    : `Slack could not complete the install (${reason}).`;
+
+/**
+ * Completes the Slack install after Slack redirects the user back here.
+ *
+ * The UI's only job on return is to forward `code` and `state` to the API,
+ * which owns the OAuth secret, mints the state and consumes it — a completion
+ * whose state it cannot match is refused there, and surfaced here.
+ *
+ * The exchange runs **exactly once**: the Slack code is single-use, so a second
+ * invocation (a re-render, a Strict Mode double effect, a back navigation)
+ * would burn it and report a failure for an install that actually succeeded.
+ * The guard is the mechanism, not a nicety.
+ */
+export const SlackCallback = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<Status>(STATUS.CONNECTING);
+  const [workspaceName, setWorkspaceName] = useState<string | null>(null);
+  const [failure, setFailure] = useState<string>("");
+  const hasStarted = useRef(false);
+
+  useEffect(() => {
+    if (hasStarted.current) return;
+    hasStarted.current = true;
+
+    const slackError = searchParams.get("error");
+    const code = searchParams.get("code");
+    const state = searchParams.get("state");
+
+    // Slack answers a declined or rejected install with `error`, and no code —
+    // there is nothing to exchange, so nothing is created.
+    if (slackError) {
+      setFailure(describeSlackError(slackError));
+      setStatus(STATUS.FAILED);
+      return;
+    }
+
+    if (!code || !state) {
+      setFailure(
+        "Slack sent an incomplete response back, so the install could not be completed.",
+      );
+      setStatus(STATUS.FAILED);
+      return;
+    }
+
+    const complete = async () => {
+      const result = await exchangeSlackOAuthCode({ code, state });
+
+      if ("integration" in result) {
+        setWorkspaceName(
+          result.integration.attributes.configuration.team_name ?? null,
+        );
+        setStatus(STATUS.CONNECTED);
+        router.replace(SLACK_INTEGRATION_PATH);
+        return;
+      }
+
+      setFailure(
+        "unavailable" in result
+          ? "Slack is not available in this environment yet."
+          : result.error,
+      );
+      setStatus(STATUS.FAILED);
+    };
+
+    void complete();
+  }, [router, searchParams]);
+
+  if (status === STATUS.CONNECTING) {
+    return (
+      <div className="flex items-center gap-3 text-sm text-gray-600 dark:text-gray-300">
+        <Loader2 className="animate-spin" size={16} />
+        Connecting your Slack workspace...
+      </div>
+    );
+  }
+
+  if (status === STATUS.CONNECTED) {
+    return (
+      <Alert variant="success">
+        <CircleCheck />
+        <AlertTitle>
+          Connected to {workspaceName ?? "your Slack workspace"}
+        </AlertTitle>
+        <AlertDescription>
+          Taking you back to the Slack integration, where you can choose the
+          channel Prowler posts to.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <Alert variant="error">
+        <AlertCircle />
+        <AlertTitle>Slack workspace not connected</AlertTitle>
+        <AlertDescription>{failure}</AlertDescription>
+      </Alert>
+      <Button asChild variant="outline">
+        <Link href={SLACK_INTEGRATION_PATH}>Back to Slack integration</Link>
+      </Button>
+    </div>
+  );
+};

--- a/ui/components/integrations/slack/slack-callback.tsx
+++ b/ui/components/integrations/slack/slack-callback.tsx
@@ -35,6 +35,27 @@ const UNCONFIRMED_COMPLETION_MESSAGE =
   "Prowler could not confirm whether the workspace was connected. Open the Slack integration page to check — if none is listed there, start the install again.";
 
 /**
+ * The headline for a failure that really is one: Slack refused, the callback
+ * came back incomplete, the API refused the completion, or this deployment has
+ * no Slack app. Nothing was connected in any of them.
+ */
+const FAILURE_TITLE = "Slack workspace not connected";
+
+/**
+ * The headline for the two outcomes where the state is *unknown*.
+ *
+ * Both of them leave the workspace possibly — for the unreadable `2xx`,
+ * certainly — connected: the API consumes the code and upserts the integration
+ * before it answers. Titling those "not connected" contradicts the description
+ * right below it and the integration page the escape link goes to, which lists
+ * the workspace this very answer created.
+ *
+ * Kept short deliberately: `AlertTitle` clamps to one line, so a longer
+ * headline is silently truncated.
+ */
+const UNCONFIRMED_TITLE = "Slack install not confirmed";
+
+/**
  * The shape of a Slack error code: a snake_case protocol token, never prose.
  *
  * `error` is read straight off the URL, so its value is whoever wrote the link
@@ -82,6 +103,7 @@ export const SlackCallback = () => {
   const [status, setStatus] = useState<Status>(STATUS.CONNECTING);
   const [workspaceName, setWorkspaceName] = useState<string | null>(null);
   const [failure, setFailure] = useState<string>("");
+  const [failureTitle, setFailureTitle] = useState<string>(FAILURE_TITLE);
   const hasStarted = useRef(false);
 
   useEffect(() => {
@@ -126,6 +148,12 @@ export const SlackCallback = () => {
         // Nothing is wrong with the install — Slack is just busy — so the user
         // is told when to come back, not that the environment lacks Slack.
         setFailure(result.message);
+      } else if ("unconfirmed" in result) {
+        // The API answered `2xx`, so the workspace *is* connected — only the
+        // answer describing it was unreadable. The title has to stop short of
+        // claiming otherwise, or it contradicts the page the link goes to.
+        setFailure(result.message);
+        setFailureTitle(UNCONFIRMED_TITLE);
       } else {
         setFailure(result.error);
       }
@@ -142,6 +170,7 @@ export const SlackCallback = () => {
     // catch it (a rejection awaited inside an effect is invisible to React's).
     void complete().catch(() => {
       setFailure(UNCONFIRMED_COMPLETION_MESSAGE);
+      setFailureTitle(UNCONFIRMED_TITLE);
       setStatus(STATUS.FAILED);
     });
   }, [router, searchParams]);
@@ -174,7 +203,7 @@ export const SlackCallback = () => {
     <div className="flex flex-col items-start gap-4">
       <Alert variant="error">
         <AlertCircle />
-        <AlertTitle>Slack workspace not connected</AlertTitle>
+        <AlertTitle>{failureTitle}</AlertTitle>
         <AlertDescription>{failure}</AlertDescription>
       </Alert>
       <Button asChild variant="outline">

--- a/ui/components/integrations/slack/slack-callback.tsx
+++ b/ui/components/integrations/slack/slack-callback.tsx
@@ -85,11 +85,15 @@ export const SlackCallback = () => {
         return;
       }
 
-      setFailure(
-        "unavailable" in result
-          ? "Slack is not available in this environment yet."
-          : result.error,
-      );
+      if ("unavailable" in result) {
+        setFailure("Slack is not available in this environment yet.");
+      } else if ("rateLimited" in result) {
+        // Nothing is wrong with the install — Slack is just busy — so the user
+        // is told when to come back, not that the environment lacks Slack.
+        setFailure(result.message);
+      } else {
+        setFailure(result.error);
+      }
       setStatus(STATUS.FAILED);
     };
 

--- a/ui/components/integrations/slack/slack-callback.tsx
+++ b/ui/components/integrations/slack/slack-callback.tsx
@@ -34,11 +34,29 @@ type Status = (typeof STATUS)[keyof typeof STATUS];
 const UNCONFIRMED_COMPLETION_MESSAGE =
   "Prowler could not confirm whether the workspace was connected. Open the Slack integration page to check — if none is listed there, start the install again.";
 
+/**
+ * The shape of a Slack error code: a snake_case protocol token, never prose.
+ *
+ * `error` is read straight off the URL, so its value is whoever wrote the link
+ * — and the parenthetical below puts it inside Prowler's own error copy. A
+ * value carrying spaces and punctuation escapes those parentheses and reads as
+ * a sentence Prowler wrote ("Slack has flagged this workspace, call ..."),
+ * which is a credible way to hand a user instructions they should not follow.
+ * Slack publishes no closed set of codes for this redirect, so the guard is on
+ * the shape and not the value: an unknown-but-real code still reaches support,
+ * a sentence cannot get through.
+ */
+const REASON_TOKEN = /^[a-z0-9_]{1,48}$/;
+
 /** Turn the `error` Slack puts on the callback URL into something readable. */
-const describeSlackError = (reason: string): string =>
-  reason === "access_denied"
-    ? "The install was not approved in Slack, so no workspace was connected."
-    : `Slack could not complete the install (${reason}).`;
+const describeSlackError = (reason: string): string => {
+  if (reason === "access_denied") {
+    return "The install was not approved in Slack, so no workspace was connected.";
+  }
+  return REASON_TOKEN.test(reason)
+    ? `Slack could not complete the install (${reason}).`
+    : "Slack could not complete the install.";
+};
 
 /**
  * Completes the Slack install after Slack redirects the user back here.

--- a/ui/components/integrations/slack/slack-integration-card.tsx
+++ b/ui/components/integrations/slack/slack-integration-card.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { SettingsIcon } from "lucide-react";
 import Link from "next/link";
 

--- a/ui/components/integrations/slack/slack-integration-card.tsx
+++ b/ui/components/integrations/slack/slack-integration-card.tsx
@@ -7,8 +7,7 @@ import { SlackIcon } from "@/components/icons/services/IconServices";
 import { Button, Card, CardContent, CardHeader } from "@/components/shadcn";
 import { CustomLink } from "@/components/shadcn/custom/custom-link";
 
-// Placeholder: the tutorial page is written in the docs slice, which then
-// confirms this slug against `docs/docs.json`.
+// Placeholder slug: the docs slice writes the page and confirms it.
 const SLACK_DOCS_URL =
   "https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app-slack-integration/";
 

--- a/ui/components/integrations/slack/slack-integration-card.tsx
+++ b/ui/components/integrations/slack/slack-integration-card.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { SettingsIcon } from "lucide-react";
+import Link from "next/link";
+
+import { SlackIcon } from "@/components/icons/services/IconServices";
+import { Button, Card, CardContent, CardHeader } from "@/components/shadcn";
+import { CustomLink } from "@/components/shadcn/custom/custom-link";
+
+// Placeholder: the tutorial page is written in the docs slice, which then
+// confirms this slug against `docs/docs.json`.
+const SLACK_DOCS_URL =
+  "https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app-slack-integration/";
+
+export const SlackIntegrationCard = () => {
+  return (
+    <Card variant="base" padding="lg">
+      <CardHeader>
+        <div className="flex w-full flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <SlackIcon size={40} />
+            <div className="flex flex-col gap-1">
+              <h4 className="text-lg font-bold text-gray-900 dark:text-gray-100">
+                Slack
+              </h4>
+              <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
+                <p className="text-xs text-nowrap text-gray-500 dark:text-gray-300">
+                  Send Prowler messages to your Slack workspace.
+                </p>
+                <CustomLink
+                  href={SLACK_DOCS_URL}
+                  aria-label="Learn more about Slack integration"
+                  size="xs"
+                >
+                  Learn more
+                </CustomLink>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 self-end sm:self-center">
+            <Button asChild size="sm">
+              <Link href="/integrations/slack">
+                <SettingsIcon size={14} />
+                Manage
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          Connect a Slack workspace and pick the channel Prowler posts to, so
+          your team gets security updates where it already works.
+        </p>
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/components/integrations/slack/slack-integration-manager.tsx
+++ b/ui/components/integrations/slack/slack-integration-manager.tsx
@@ -86,6 +86,9 @@ export const SlackIntegrationManager = ({
 
   const configuration = integration?.attributes.configuration;
   const workspaceName = configuration?.team_name;
+  // Absent until a channel is chosen, never present-and-null (see the
+  // configuration comment on `IntegrationProps`).
+  const channelId = configuration?.channel_id ?? null;
 
   return (
     <div className="flex flex-col gap-6">
@@ -111,7 +114,7 @@ export const SlackIntegrationManager = ({
               title={`Connected to ${workspaceName ?? "your Slack workspace"}`}
               subtitle="Prowler posts to this workspace only."
               connectionStatus={{
-                connected: integration.attributes.connected === true,
+                connected: integration.attributes.connected,
               }}
             />
           </CardHeader>
@@ -130,11 +133,21 @@ export const SlackIntegrationManager = ({
                     )}
                   </p>
                 )}
+                {!channelId && (
+                  <p>
+                    Choosing a destination channel is the next step — the
+                    connection is checked against it.
+                  </p>
+                )}
               </div>
+              {/* The check posts to the destination channel, so with none
+                  recorded the API refuses it with a 400 rather than reporting a
+                  connection it never tested. Offering the button anyway would
+                  guarantee a failure the user has no way to resolve. */}
               <Button
                 size="sm"
                 variant="outline"
-                disabled={isTesting}
+                disabled={isTesting || !channelId}
                 onClick={() => handleTestConnection(integration.id)}
               >
                 <TestTube size={14} />

--- a/ui/components/integrations/slack/slack-integration-manager.tsx
+++ b/ui/components/integrations/slack/slack-integration-manager.tsx
@@ -71,19 +71,6 @@ export const SlackIntegrationManager = ({
     }
   };
 
-  if (unavailable) {
-    return (
-      <Alert variant="info">
-        <AlertTitle>Slack is not available in this environment yet</AlertTitle>
-        <AlertDescription>
-          The Prowler Slack app is not configured here, so no workspace can be
-          connected. Nothing to do on your side — this page starts working as
-          soon as it is.
-        </AlertDescription>
-      </Alert>
-    );
-  }
-
   const configuration = integration?.attributes.configuration;
   const workspaceName = configuration?.team_name;
   // Absent until a channel is chosen, never present-and-null (see the
@@ -106,7 +93,22 @@ export const SlackIntegrationManager = ({
         </Alert>
       )}
 
-      {integration ? (
+      {/* Replaces the cards rather than the whole page: `unavailable` is a
+          standing state for a whole deployment phase, so returning early here
+          would swallow a read that failed underneath it — and the suppressed
+          notice is the actionable one ("try again in a few minutes"). */}
+      {unavailable ? (
+        <Alert variant="info">
+          <AlertTitle>
+            Slack is not available in this environment yet
+          </AlertTitle>
+          <AlertDescription>
+            The Prowler Slack app is not configured here, so no workspace can be
+            connected. Nothing to do on your side — this page starts working as
+            soon as it is.
+          </AlertDescription>
+        </Alert>
+      ) : integration ? (
         <Card variant="base">
           <CardHeader>
             <IntegrationCardHeader

--- a/ui/components/integrations/slack/slack-integration-manager.tsx
+++ b/ui/components/integrations/slack/slack-integration-manager.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { format } from "date-fns";
+import { TestTube } from "lucide-react";
+import { useState } from "react";
+
+import { testIntegrationConnection } from "@/actions/integrations/integrations";
+import { SlackIcon } from "@/components/icons/services/IconServices";
+import { IntegrationCardHeader } from "@/components/integrations/shared";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  useToast,
+} from "@/components/shadcn";
+import type { IntegrationProps } from "@/types/integrations";
+
+interface SlackIntegrationManagerProps {
+  /** The tenant's Slack integration — at most one exists (one workspace). */
+  integration: IntegrationProps | null;
+  /** Consent URL to start an install with, absent once one is connected. */
+  authorizeUrl: string | null;
+  /** This deployment has no Prowler Slack app, so no install can be started. */
+  unavailable: boolean;
+  /** The install could not be read; the page still renders what it can. */
+  loadError: string | null;
+}
+
+export const SlackIntegrationManager = ({
+  integration,
+  authorizeUrl,
+  unavailable,
+  loadError,
+}: SlackIntegrationManagerProps) => {
+  const [isTesting, setIsTesting] = useState(false);
+  const { toast } = useToast();
+
+  const handleTestConnection = async (id: string) => {
+    setIsTesting(true);
+    try {
+      const result = await testIntegrationConnection(id);
+
+      if (result.success) {
+        toast({
+          title: "Connection test successful!",
+          description:
+            result.message || "Prowler can reach your Slack workspace.",
+        });
+      } else {
+        toast({
+          variant: "destructive",
+          title: "Connection test failed",
+          description: result.error || "Failed to reach your Slack workspace.",
+        });
+      }
+    } catch (_error) {
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: "Failed to test connection. Please try again.",
+      });
+    } finally {
+      setIsTesting(false);
+    }
+  };
+
+  if (unavailable) {
+    return (
+      <Alert variant="info">
+        <AlertTitle>Slack is not available in this environment yet</AlertTitle>
+        <AlertDescription>
+          The Prowler Slack app is not configured here, so no workspace can be
+          connected. Nothing to do on your side — this page starts working as
+          soon as it is.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  const configuration = integration?.attributes.configuration;
+  const workspaceName = configuration?.team_name;
+
+  return (
+    <div className="flex flex-col gap-6">
+      {loadError && (
+        <Alert variant="error">
+          <AlertTitle>Could not load your Slack integration</AlertTitle>
+          <AlertDescription>{loadError}</AlertDescription>
+        </Alert>
+      )}
+
+      {integration ? (
+        <Card variant="base">
+          <CardHeader>
+            <IntegrationCardHeader
+              icon={<SlackIcon size={32} />}
+              title={`Connected to ${workspaceName ?? "your Slack workspace"}`}
+              subtitle="Prowler posts to this workspace only."
+              connectionStatus={{
+                connected: integration.attributes.connected === true,
+              }}
+            />
+          </CardHeader>
+
+          <CardContent className="pt-0">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-xs text-gray-500 dark:text-gray-300">
+                {integration.attributes.connection_last_checked_at && (
+                  <p>
+                    <span className="font-medium">Last checked:</span>{" "}
+                    {format(
+                      new Date(
+                        integration.attributes.connection_last_checked_at,
+                      ),
+                      "yyyy/MM/dd",
+                    )}
+                  </p>
+                )}
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isTesting}
+                onClick={() => handleTestConnection(integration.id)}
+              >
+                <TestTube size={14} />
+                {isTesting ? "Testing..." : "Test connection"}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card variant="base">
+          <CardHeader>
+            <IntegrationCardHeader
+              icon={<SlackIcon size={32} />}
+              title="No workspace connected"
+              subtitle="Approve Prowler in Slack to connect a workspace. No tokens to copy."
+            />
+          </CardHeader>
+
+          <CardContent className="pt-0">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                Prowler asks for permission to post messages and to read the
+                workspace&apos;s channel list.
+              </p>
+              {authorizeUrl ? (
+                <Button asChild>
+                  <a href={authorizeUrl} rel="noopener noreferrer">
+                    <SlackIcon size={16} />
+                    Add to Slack
+                  </a>
+                </Button>
+              ) : (
+                <Button disabled>
+                  <SlackIcon size={16} />
+                  Add to Slack
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+};

--- a/ui/components/integrations/slack/slack-integration-manager.tsx
+++ b/ui/components/integrations/slack/slack-integration-manager.tsx
@@ -26,6 +26,8 @@ interface SlackIntegrationManagerProps {
   authorizeUrl: string | null;
   /** This deployment has no Prowler Slack app, so no install can be started. */
   unavailable: boolean;
+  /** Slack is rate limiting Prowler: what to tell the user about the wait. */
+  rateLimitMessage: string | null;
   /** The install could not be read; the page still renders what it can. */
   loadError: string | null;
 }
@@ -34,6 +36,7 @@ export const SlackIntegrationManager = ({
   integration,
   authorizeUrl,
   unavailable,
+  rateLimitMessage,
   loadError,
 }: SlackIntegrationManagerProps) => {
   const [isTesting, setIsTesting] = useState(false);
@@ -86,6 +89,13 @@ export const SlackIntegrationManager = ({
 
   return (
     <div className="flex flex-col gap-6">
+      {rateLimitMessage && (
+        <Alert variant="warning">
+          <AlertTitle>Slack is busy right now</AlertTitle>
+          <AlertDescription>{rateLimitMessage}</AlertDescription>
+        </Alert>
+      )}
+
       {loadError && (
         <Alert variant="error">
           <AlertTitle>Could not load your Slack integration</AlertTitle>

--- a/ui/components/integrations/slack/slack-integration-manager.tsx
+++ b/ui/components/integrations/slack/slack-integration-manager.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import { format, isValid, parseISO } from "date-fns";
-import { TestTube } from "lucide-react";
-import { useState } from "react";
 
-import { testIntegrationConnection } from "@/actions/integrations/integrations";
 import { SlackIcon } from "@/components/icons/services/IconServices";
 import { IntegrationCardHeader } from "@/components/integrations/shared";
 import {
@@ -15,7 +12,6 @@ import {
   Card,
   CardContent,
   CardHeader,
-  useToast,
 } from "@/components/shadcn";
 import type { IntegrationProps } from "@/types/integrations";
 
@@ -36,38 +32,6 @@ export const SlackIntegrationManager = ({
   rateLimitMessage,
   loadError,
 }: SlackIntegrationManagerProps) => {
-  const [isTesting, setIsTesting] = useState(false);
-  const { toast } = useToast();
-
-  const handleTestConnection = async (id: string) => {
-    setIsTesting(true);
-    try {
-      const result = await testIntegrationConnection(id);
-
-      if (result.success) {
-        toast({
-          title: "Connection test successful!",
-          description:
-            result.message || "Prowler can reach your Slack workspace.",
-        });
-      } else {
-        toast({
-          variant: "destructive",
-          title: "Connection test failed",
-          description: result.error || "Failed to reach your Slack workspace.",
-        });
-      }
-    } catch (_error) {
-      toast({
-        variant: "destructive",
-        title: "Error",
-        description: "Failed to test connection. Please try again.",
-      });
-    } finally {
-      setIsTesting(false);
-    }
-  };
-
   const configuration = integration?.attributes.configuration;
   const workspaceName = configuration?.team_name;
   // Absent until a channel is chosen, never present-and-null.
@@ -124,32 +88,22 @@ export const SlackIntegrationManager = ({
           </CardHeader>
 
           <CardContent className="pt-0">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div className="text-xs text-gray-500 dark:text-gray-300">
-                {lastCheckedOn && (
-                  <p>
-                    <span className="font-medium">Last checked:</span>{" "}
-                    {lastCheckedOn}
-                  </p>
-                )}
-                {!channelId && (
-                  <p>
-                    Choosing a destination channel is the next step — the
-                    connection is checked against it.
-                  </p>
-                )}
-              </div>
-              {/* The check posts to the destination channel: the API answers
-                  400 when none is recorded yet. */}
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={isTesting || !channelId}
-                onClick={() => handleTestConnection(integration.id)}
-              >
-                <TestTube size={14} />
-                {isTesting ? "Testing..." : "Test connection"}
-              </Button>
+            {/* No connection check here: it posts to the destination channel,
+                which nothing on this page can record yet — the picker and the
+                check arrive together. */}
+            <div className="text-xs text-gray-500 dark:text-gray-300">
+              {lastCheckedOn && (
+                <p>
+                  <span className="font-medium">Last checked:</span>{" "}
+                  {lastCheckedOn}
+                </p>
+              )}
+              {!channelId && (
+                <p>
+                  Choosing a destination channel is the next step — the
+                  connection is checked against it.
+                </p>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/ui/components/integrations/slack/slack-integration-manager.tsx
+++ b/ui/components/integrations/slack/slack-integration-manager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { format } from "date-fns";
+import { format, isValid, parseISO } from "date-fns";
 import { TestTube } from "lucide-react";
 import { useState } from "react";
 
@@ -73,6 +73,14 @@ export const SlackIntegrationManager = ({
   // Absent until a channel is chosen, never present-and-null.
   const channelId = configuration?.channel_id ?? null;
 
+  const checkedAt = integration?.attributes.connection_last_checked_at;
+  const checkedOn = checkedAt ? parseISO(checkedAt) : null;
+  // `format` throws a RangeError on an unreadable value, which would replace
+  // the page with the route's error boundary: show nothing instead, as for a
+  // connection that was never checked.
+  const lastCheckedOn =
+    checkedOn && isValid(checkedOn) ? format(checkedOn, "yyyy/MM/dd") : null;
+
   return (
     <div className="flex flex-col gap-6">
       {rateLimitMessage && (
@@ -118,15 +126,10 @@ export const SlackIntegrationManager = ({
           <CardContent className="pt-0">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="text-xs text-gray-500 dark:text-gray-300">
-                {integration.attributes.connection_last_checked_at && (
+                {lastCheckedOn && (
                   <p>
                     <span className="font-medium">Last checked:</span>{" "}
-                    {format(
-                      new Date(
-                        integration.attributes.connection_last_checked_at,
-                      ),
-                      "yyyy/MM/dd",
-                    )}
+                    {lastCheckedOn}
                   </p>
                 )}
                 {!channelId && (

--- a/ui/components/integrations/slack/slack-integration-manager.tsx
+++ b/ui/components/integrations/slack/slack-integration-manager.tsx
@@ -88,9 +88,8 @@ export const SlackIntegrationManager = ({
           </CardHeader>
 
           <CardContent className="pt-0">
-            {/* No connection check here: it posts to the destination channel,
-                which nothing on this page can record yet — the picker and the
-                check arrive together. */}
+            {/* No check here: it needs a destination channel, and nothing on
+                this page records one yet. */}
             <div className="text-xs text-gray-500 dark:text-gray-300">
               {lastCheckedOn && (
                 <p>

--- a/ui/components/integrations/slack/slack-integration-manager.tsx
+++ b/ui/components/integrations/slack/slack-integration-manager.tsx
@@ -20,15 +20,12 @@ import {
 import type { IntegrationProps } from "@/types/integrations";
 
 interface SlackIntegrationManagerProps {
-  /** The tenant's Slack integration — at most one exists (one workspace). */
+  /** At most one exists per tenant (one workspace). */
   integration: IntegrationProps | null;
-  /** Consent URL to start an install with, absent once one is connected. */
   authorizeUrl: string | null;
   /** This deployment has no Prowler Slack app, so no install can be started. */
   unavailable: boolean;
-  /** Slack is rate limiting Prowler: what to tell the user about the wait. */
   rateLimitMessage: string | null;
-  /** The install could not be read; the page still renders what it can. */
   loadError: string | null;
 }
 
@@ -73,8 +70,7 @@ export const SlackIntegrationManager = ({
 
   const configuration = integration?.attributes.configuration;
   const workspaceName = configuration?.team_name;
-  // Absent until a channel is chosen, never present-and-null (see the
-  // configuration comment on `IntegrationProps`).
+  // Absent until a channel is chosen, never present-and-null.
   const channelId = configuration?.channel_id ?? null;
 
   return (
@@ -93,10 +89,8 @@ export const SlackIntegrationManager = ({
         </Alert>
       )}
 
-      {/* Replaces the cards rather than the whole page: `unavailable` is a
-          standing state for a whole deployment phase, so returning early here
-          would swallow a read that failed underneath it — and the suppressed
-          notice is the actionable one ("try again in a few minutes"). */}
+      {/* Replaces the cards, not the whole page: an early return here would
+          swallow the rate-limit and load-error notices above. */}
       {unavailable ? (
         <Alert variant="info">
           <AlertTitle>
@@ -142,10 +136,8 @@ export const SlackIntegrationManager = ({
                   </p>
                 )}
               </div>
-              {/* The check posts to the destination channel, so with none
-                  recorded the API refuses it with a 400 rather than reporting a
-                  connection it never tested. Offering the button anyway would
-                  guarantee a failure the user has no way to resolve. */}
+              {/* The check posts to the destination channel: the API answers
+                  400 when none is recorded yet. */}
               <Button
                 size="sm"
                 variant="outline"

--- a/ui/lib/integrations/slack-errors.test.ts
+++ b/ui/lib/integrations/slack-errors.test.ts
@@ -1,8 +1,6 @@
 /**
- * The Slack code → copy mapping, unit-tested because most of the codes it
- * covers belong to flows this layer does not have yet: the channel picker, the
- * test message and the disconnect all lean on the same mapping, and each of
- * their conditions is a code that has to already resolve to the right words.
+ * Unit-tested because most of the codes in the mapping belong to flows this
+ * layer does not have yet: the channel picker, the test message, the disconnect.
  */
 
 import { describe, expect, it } from "vitest";
@@ -21,15 +19,13 @@ import {
 
 describe("slackErrorMessage", () => {
   it("prefers the code's own copy over the API's wording", () => {
-    // Given — the machine-readable reason and human copy disagree, which they
-    // always do: `detail` states the condition, the code's copy resolves it.
+    // `detail` states the condition; the code's copy states the fix.
     const failure = {
       code: SLACK_ERROR_CODE.WORKSPACE_CONFLICT,
       detail:
         "This tenant is already connected to a different Slack workspace.",
     };
 
-    // Then
     expect(slackErrorMessage(failure)).toBe(
       SLACK_ERROR_MESSAGES[SLACK_ERROR_CODE.WORKSPACE_CONFLICT],
     );
@@ -37,8 +33,7 @@ describe("slackErrorMessage", () => {
   });
 
   it("tells the user how to grant a scope Prowler is missing", () => {
-    // A missing scope is fixable by the person reading it, so the copy has to
-    // name the fix rather than report that something went wrong.
+    // A missing scope is fixable by the reader, so the copy names the fix.
     const message = slackErrorMessage({
       code: SLACK_ERROR_CODE.MISSING_SCOPE,
       detail: "missing_scope",
@@ -62,8 +57,7 @@ describe("slackErrorMessage", () => {
 
   it("points every dead-credential code at reconnecting, not at retrying", () => {
     for (const code of SLACK_TOKEN_ERROR_CODES) {
-      // Given a token the Slack grant no longer honours — revoked, invalid,
-      // inactive or expired — no retry helps, so all four say the same thing.
+      // Revoked, invalid, inactive or expired: no retry helps for any of them.
       expect(slackErrorMessage({ code })).toMatch(
         /Connect the workspace again to restore access/,
       );
@@ -78,8 +72,6 @@ describe("slackErrorMessage", () => {
   });
 
   it("falls back to the API's detail for a code it does not know", () => {
-    // A code this UI has nothing better to say about is not a reason to hide
-    // what the API said.
     expect(
       slackErrorMessage({
         code: "some_future_slack_reason",
@@ -114,8 +106,6 @@ describe("slackRateLimitMessage", () => {
 
 describe("readSlackFailure", () => {
   it("reads the code, the detail and the wait off a JSON:API refusal", async () => {
-    // Given — the shape the API answers with: a string status, the reason in
-    // `code`, and a pointer at the document rather than at an attribute.
     const response = new Response(
       JSON.stringify({
         errors: [
@@ -129,10 +119,8 @@ describe("readSlackFailure", () => {
       { status: 429, headers: { "Retry-After": "30" } },
     );
 
-    // When
     const failure = await readSlackFailure(response);
 
-    // Then
     expect(failure).toEqual({
       status: 429,
       code: null,
@@ -142,7 +130,6 @@ describe("readSlackFailure", () => {
   });
 
   it("survives a body that is not JSON:API at all", async () => {
-    // A 502 from a proxy carries HTML, and the status is still the answer.
     const failure = await readSlackFailure(
       new Response("<html>Bad gateway</html>", { status: 502 }),
     );

--- a/ui/lib/integrations/slack-errors.test.ts
+++ b/ui/lib/integrations/slack-errors.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The Slack code → copy mapping, unit-tested because most of the codes it
+ * covers belong to flows this layer does not have yet: the channel picker, the
+ * test message and the disconnect all lean on the same mapping, and each of
+ * their conditions is a code that has to already resolve to the right words.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isSlackTokenErrorCode,
+  SLACK_ERROR_CODE,
+  SLACK_ERROR_MESSAGES,
+  SLACK_GENERIC_ERROR_MESSAGE,
+  SLACK_RATE_LIMITED_MESSAGE,
+  SLACK_TOKEN_ERROR_CODES,
+  readSlackFailure,
+  slackErrorMessage,
+  slackRateLimitMessage,
+} from "./slack-errors";
+
+describe("slackErrorMessage", () => {
+  it("prefers the code's own copy over the API's wording", () => {
+    // Given — the machine-readable reason and human copy disagree, which they
+    // always do: `detail` states the condition, the code's copy resolves it.
+    const failure = {
+      code: SLACK_ERROR_CODE.WORKSPACE_CONFLICT,
+      detail:
+        "This tenant is already connected to a different Slack workspace.",
+    };
+
+    // Then
+    expect(slackErrorMessage(failure)).toBe(
+      SLACK_ERROR_MESSAGES[SLACK_ERROR_CODE.WORKSPACE_CONFLICT],
+    );
+    expect(slackErrorMessage(failure)).toMatch(/Disconnect it/);
+  });
+
+  it("tells the user how to grant a scope Prowler is missing", () => {
+    // A missing scope is fixable by the person reading it, so the copy has to
+    // name the fix rather than report that something went wrong.
+    const message = slackErrorMessage({
+      code: SLACK_ERROR_CODE.MISSING_SCOPE,
+      detail: "missing_scope",
+    });
+
+    expect(message).toMatch(/Connect the workspace again/);
+    expect(message).not.toMatch(/missing_scope/);
+  });
+
+  it("says what to do about each channel refusal", () => {
+    expect(
+      slackErrorMessage({ code: SLACK_ERROR_CODE.CHANNEL_NOT_FOUND }),
+    ).toMatch(/Choose another one/);
+    expect(
+      slackErrorMessage({ code: SLACK_ERROR_CODE.NOT_IN_CHANNEL }),
+    ).toMatch(/Invite @Prowler/);
+    expect(slackErrorMessage({ code: SLACK_ERROR_CODE.NO_PERMISSION })).toMatch(
+      /Choose another channel/,
+    );
+  });
+
+  it("points every dead-credential code at reconnecting, not at retrying", () => {
+    for (const code of SLACK_TOKEN_ERROR_CODES) {
+      // Given a token the Slack grant no longer honours — revoked, invalid,
+      // inactive or expired — no retry helps, so all four say the same thing.
+      expect(slackErrorMessage({ code })).toMatch(
+        /Connect the workspace again to restore access/,
+      );
+      expect(isSlackTokenErrorCode(code)).toBe(true);
+    }
+  });
+
+  it("does not treat an actionable refusal as a dead credential", () => {
+    expect(isSlackTokenErrorCode(SLACK_ERROR_CODE.MISSING_SCOPE)).toBe(false);
+    expect(isSlackTokenErrorCode(null)).toBe(false);
+    expect(isSlackTokenErrorCode(undefined)).toBe(false);
+  });
+
+  it("falls back to the API's detail for a code it does not know", () => {
+    // A code this UI has nothing better to say about is not a reason to hide
+    // what the API said.
+    expect(
+      slackErrorMessage({
+        code: "some_future_slack_reason",
+        detail: "Slack said no.",
+      }),
+    ).toBe("Slack said no.");
+  });
+
+  it("falls back to the generic line when there is neither", () => {
+    expect(slackErrorMessage({ code: null, detail: null })).toBe(
+      SLACK_GENERIC_ERROR_MESSAGE,
+    );
+    expect(slackErrorMessage(null)).toBe(SLACK_GENERIC_ERROR_MESSAGE);
+    expect(
+      slackErrorMessage({ detail: "   " }, "Could not read channels."),
+    ).toBe("Could not read channels.");
+  });
+});
+
+describe("slackRateLimitMessage", () => {
+  it("names the wait Slack asked for", () => {
+    expect(slackRateLimitMessage(30)).toMatch(/about 30 seconds/);
+    expect(slackRateLimitMessage(1)).toMatch(/about 1 second\b/);
+    expect(slackRateLimitMessage(90)).toMatch(/about 2 minutes/);
+  });
+
+  it("still says to come back when Slack named no wait", () => {
+    expect(slackRateLimitMessage(null)).toBe(SLACK_RATE_LIMITED_MESSAGE);
+    expect(slackRateLimitMessage(0)).toBe(SLACK_RATE_LIMITED_MESSAGE);
+  });
+});
+
+describe("readSlackFailure", () => {
+  it("reads the code, the detail and the wait off a JSON:API refusal", async () => {
+    // Given — the shape the API answers with: a string status, the reason in
+    // `code`, and a pointer at the document rather than at an attribute.
+    const response = new Response(
+      JSON.stringify({
+        errors: [
+          {
+            status: "429",
+            detail: "Slack is rate limiting requests from Prowler.",
+            source: { pointer: "/data" },
+          },
+        ],
+      }),
+      { status: 429, headers: { "Retry-After": "30" } },
+    );
+
+    // When
+    const failure = await readSlackFailure(response);
+
+    // Then
+    expect(failure).toEqual({
+      status: 429,
+      code: null,
+      detail: "Slack is rate limiting requests from Prowler.",
+      retryAfterSeconds: 30,
+    });
+  });
+
+  it("survives a body that is not JSON:API at all", async () => {
+    // A 502 from a proxy carries HTML, and the status is still the answer.
+    const failure = await readSlackFailure(
+      new Response("<html>Bad gateway</html>", { status: 502 }),
+    );
+
+    expect(failure).toEqual({
+      status: 502,
+      code: null,
+      detail: null,
+      retryAfterSeconds: null,
+    });
+  });
+
+  it("ignores a Retry-After it cannot use", async () => {
+    const failure = await readSlackFailure(
+      new Response("{}", { status: 429, headers: { "Retry-After": "soon" } }),
+    );
+
+    expect(failure.retryAfterSeconds).toBeNull();
+  });
+});

--- a/ui/lib/integrations/slack-errors.ts
+++ b/ui/lib/integrations/slack-errors.ts
@@ -1,22 +1,4 @@
-/**
- * What a Slack refusal means, and what to tell the user about it.
- *
- * The API answers a Slack condition with a JSON:API error that carries the
- * machine-readable reason in `code` and human copy in `detail`. `code` is the
- * contract — this module maps it to wording Prowler owns, so no caller ever
- * parses prose. An unrecognised code falls back to the API's `detail`, and a
- * refusal carrying neither falls back to a generic line.
- *
- * The token codes are answered with `400`, not `401`, on purpose: a 401 reads
- * as "your Prowler session expired" when what died is the Slack grant. They are
- * grouped here so a caller can offer a reconnect rather than a retry.
- *
- * Rate limiting (`429`) carries no code — it is classified by status, and gets
- * its own copy so it is never confused with "this deployment has no Slack app".
- */
-
 export const SLACK_ERROR_CODE = {
-  /** The install is missing a Slack scope the action needs. */
   MISSING_SCOPE: "missing_scope",
   CHANNEL_NOT_FOUND: "channel_not_found",
   NOT_IN_CHANNEL: "not_in_channel",
@@ -25,7 +7,7 @@ export const SLACK_ERROR_CODE = {
   INVALID_AUTH: "invalid_auth",
   ACCOUNT_INACTIVE: "account_inactive",
   TOKEN_EXPIRED: "token_expired",
-  /** One workspace per tenant: another one is already connected. */
+  /** One workspace per tenant. */
   WORKSPACE_CONFLICT: "slack_workspace_conflict",
 } as const;
 
@@ -33,9 +15,9 @@ export type SlackErrorCode =
   (typeof SLACK_ERROR_CODE)[keyof typeof SLACK_ERROR_CODE];
 
 /**
- * The codes that mean the Slack grant itself is no longer usable. The
- * integration is marked disconnected when one of these arrives, and the only
- * way out is connecting the workspace again — not retrying the call.
+ * The grant itself is dead: reconnecting is the only way out, not retrying. The
+ * API answers these with `400`, not `401`, so they are not mistaken for an
+ * expired Prowler session.
  */
 export const SLACK_TOKEN_ERROR_CODES = [
   SLACK_ERROR_CODE.TOKEN_REVOKED,
@@ -51,7 +33,6 @@ export const isSlackTokenErrorCode = (
 ): code is SlackTokenErrorCode =>
   SLACK_TOKEN_ERROR_CODES.includes(code as SlackTokenErrorCode);
 
-/** Shown when a refusal names no code and the API sent no detail either. */
 export const SLACK_GENERIC_ERROR_MESSAGE =
   "Slack could not complete that request. Try again in a moment.";
 
@@ -59,14 +40,8 @@ export const SLACK_RATE_LIMITED_MESSAGE =
   "Slack is rate limiting Prowler right now. Try again in a few moments.";
 
 /**
- * Shown when the API accepted the call and the UI could not read the answer: a
- * `2xx` with no body, a proxy's HTML page in place of one, a payload naming no
- * resource.
- *
- * Deliberately not phrased as a failure. The work already happened on the API
- * — it is what the `2xx` says — so telling the user their install did not go
- * through would send them to redo one that did. What Prowler cannot do is name
- * the workspace, and the integration page is where that is listed.
+ * For a `2xx` the UI could not read. Not phrased as a failure: the install
+ * happened, only the workspace cannot be named.
  */
 export const SLACK_UNREADABLE_RESULT_MESSAGE =
   "Prowler could not read the result of the install. Open the Slack integration page to see the workspace — if none is listed there, start the install again.";
@@ -74,8 +49,6 @@ export const SLACK_UNREADABLE_RESULT_MESSAGE =
 const RECONNECT = "Connect the workspace again to restore access.";
 
 export const SLACK_ERROR_MESSAGES = {
-  // Actionable: the user can grant the scope by reconnecting, so say that
-  // rather than reporting a generic failure.
   [SLACK_ERROR_CODE.MISSING_SCOPE]:
     "Prowler is missing a permission it needs in Slack. Connect the workspace again and approve the access Prowler asks for.",
   [SLACK_ERROR_CODE.CHANNEL_NOT_FOUND]:
@@ -98,10 +71,8 @@ export interface SlackErrorSource {
   detail?: string | null;
 }
 
-/** A refusal as it arrived, before it is turned into copy. */
 export interface SlackApiFailure extends SlackErrorSource {
   status: number;
-  /** Seconds the response asked us to wait, from `Retry-After`. */
   retryAfterSeconds: number | null;
 }
 
@@ -109,8 +80,8 @@ const isKnownCode = (code: string | null | undefined): code is SlackErrorCode =>
   typeof code === "string" && code in SLACK_ERROR_MESSAGES;
 
 /**
- * The copy for a refusal: the code's own wording when Prowler has one, the
- * API's `detail` when it does not, and `fallback` when there is neither.
+ * Copy for a refusal: Prowler's wording for a known `code`, else the API's
+ * `detail`, else `fallback`.
  */
 export const slackErrorMessage = (
   error: SlackErrorSource | null | undefined,
@@ -126,7 +97,6 @@ const describeWait = (seconds: number): string => {
   return `${minutes} minute${minutes === 1 ? "" : "s"}`;
 };
 
-/** The copy for a rate-limited response, naming the wait when Slack gave one. */
 export const slackRateLimitMessage = (
   retryAfterSeconds: number | null,
 ): string => {
@@ -147,8 +117,7 @@ const retryAfterFrom = (response: Response): number | null => {
 
 /**
  * Read a non-OK Slack response into the failure it describes. Never throws: a
- * body that is not JSON:API — an HTML error page, an empty `502` — still yields
- * a failure with a status, which is what the caller acts on.
+ * body that is not JSON:API still yields a failure carrying the status.
  */
 export const readSlackFailure = async (
   response: Response,

--- a/ui/lib/integrations/slack-errors.ts
+++ b/ui/lib/integrations/slack-errors.ts
@@ -58,6 +58,19 @@ export const SLACK_GENERIC_ERROR_MESSAGE =
 export const SLACK_RATE_LIMITED_MESSAGE =
   "Slack is rate limiting Prowler right now. Try again in a few moments.";
 
+/**
+ * Shown when the API accepted the call and the UI could not read the answer: a
+ * `2xx` with no body, a proxy's HTML page in place of one, a payload naming no
+ * resource.
+ *
+ * Deliberately not phrased as a failure. The work already happened on the API
+ * — it is what the `2xx` says — so telling the user their install did not go
+ * through would send them to redo one that did. What Prowler cannot do is name
+ * the workspace, and the integration page is where that is listed.
+ */
+export const SLACK_UNREADABLE_RESULT_MESSAGE =
+  "Prowler could not read the result of the install. Open the Slack integration page to see the workspace — if none is listed there, start the install again.";
+
 const RECONNECT = "Connect the workspace again to restore access.";
 
 export const SLACK_ERROR_MESSAGES = {

--- a/ui/lib/integrations/slack-errors.ts
+++ b/ui/lib/integrations/slack-errors.ts
@@ -1,0 +1,152 @@
+/**
+ * What a Slack refusal means, and what to tell the user about it.
+ *
+ * The API answers a Slack condition with a JSON:API error that carries the
+ * machine-readable reason in `code` and human copy in `detail`. `code` is the
+ * contract — this module maps it to wording Prowler owns, so no caller ever
+ * parses prose. An unrecognised code falls back to the API's `detail`, and a
+ * refusal carrying neither falls back to a generic line.
+ *
+ * The token codes are answered with `400`, not `401`, on purpose: a 401 reads
+ * as "your Prowler session expired" when what died is the Slack grant. They are
+ * grouped here so a caller can offer a reconnect rather than a retry.
+ *
+ * Rate limiting (`429`) carries no code — it is classified by status, and gets
+ * its own copy so it is never confused with "this deployment has no Slack app".
+ */
+
+export const SLACK_ERROR_CODE = {
+  /** The install is missing a Slack scope the action needs. */
+  MISSING_SCOPE: "missing_scope",
+  CHANNEL_NOT_FOUND: "channel_not_found",
+  NOT_IN_CHANNEL: "not_in_channel",
+  NO_PERMISSION: "no_permission",
+  TOKEN_REVOKED: "token_revoked",
+  INVALID_AUTH: "invalid_auth",
+  ACCOUNT_INACTIVE: "account_inactive",
+  TOKEN_EXPIRED: "token_expired",
+  /** One workspace per tenant: another one is already connected. */
+  WORKSPACE_CONFLICT: "slack_workspace_conflict",
+} as const;
+
+export type SlackErrorCode =
+  (typeof SLACK_ERROR_CODE)[keyof typeof SLACK_ERROR_CODE];
+
+/**
+ * The codes that mean the Slack grant itself is no longer usable. The
+ * integration is marked disconnected when one of these arrives, and the only
+ * way out is connecting the workspace again — not retrying the call.
+ */
+export const SLACK_TOKEN_ERROR_CODES = [
+  SLACK_ERROR_CODE.TOKEN_REVOKED,
+  SLACK_ERROR_CODE.INVALID_AUTH,
+  SLACK_ERROR_CODE.ACCOUNT_INACTIVE,
+  SLACK_ERROR_CODE.TOKEN_EXPIRED,
+] as const;
+
+export type SlackTokenErrorCode = (typeof SLACK_TOKEN_ERROR_CODES)[number];
+
+export const isSlackTokenErrorCode = (
+  code: string | null | undefined,
+): code is SlackTokenErrorCode =>
+  SLACK_TOKEN_ERROR_CODES.includes(code as SlackTokenErrorCode);
+
+/** Shown when a refusal names no code and the API sent no detail either. */
+export const SLACK_GENERIC_ERROR_MESSAGE =
+  "Slack could not complete that request. Try again in a moment.";
+
+export const SLACK_RATE_LIMITED_MESSAGE =
+  "Slack is rate limiting Prowler right now. Try again in a few moments.";
+
+const RECONNECT = "Connect the workspace again to restore access.";
+
+export const SLACK_ERROR_MESSAGES = {
+  // Actionable: the user can grant the scope by reconnecting, so say that
+  // rather than reporting a generic failure.
+  [SLACK_ERROR_CODE.MISSING_SCOPE]:
+    "Prowler is missing a permission it needs in Slack. Connect the workspace again and approve the access Prowler asks for.",
+  [SLACK_ERROR_CODE.CHANNEL_NOT_FOUND]:
+    "That channel no longer exists in the workspace. Choose another one.",
+  [SLACK_ERROR_CODE.NOT_IN_CHANNEL]:
+    "Prowler is not in that channel. Invite @Prowler to it in Slack, or choose a channel it can already post to.",
+  [SLACK_ERROR_CODE.NO_PERMISSION]:
+    "Slack did not allow Prowler to post there. Choose another channel, or ask a workspace admin to allow it.",
+  [SLACK_ERROR_CODE.TOKEN_REVOKED]: `Prowler's access to Slack was revoked. ${RECONNECT}`,
+  [SLACK_ERROR_CODE.INVALID_AUTH]: `Slack no longer accepts Prowler's credential. ${RECONNECT}`,
+  [SLACK_ERROR_CODE.ACCOUNT_INACTIVE]: `The Slack account Prowler was installed with is no longer active. ${RECONNECT}`,
+  [SLACK_ERROR_CODE.TOKEN_EXPIRED]: `Prowler's Slack credential has expired. ${RECONNECT}`,
+  [SLACK_ERROR_CODE.WORKSPACE_CONFLICT]:
+    "Prowler is already connected to a different Slack workspace. Disconnect it before connecting another one.",
+} as const satisfies Record<SlackErrorCode, string>;
+
+/** The parts of a JSON:API error this mapping reads. */
+export interface SlackErrorSource {
+  code?: string | null;
+  detail?: string | null;
+}
+
+/** A refusal as it arrived, before it is turned into copy. */
+export interface SlackApiFailure extends SlackErrorSource {
+  status: number;
+  /** Seconds the response asked us to wait, from `Retry-After`. */
+  retryAfterSeconds: number | null;
+}
+
+const isKnownCode = (code: string | null | undefined): code is SlackErrorCode =>
+  typeof code === "string" && code in SLACK_ERROR_MESSAGES;
+
+/**
+ * The copy for a refusal: the code's own wording when Prowler has one, the
+ * API's `detail` when it does not, and `fallback` when there is neither.
+ */
+export const slackErrorMessage = (
+  error: SlackErrorSource | null | undefined,
+  fallback: string = SLACK_GENERIC_ERROR_MESSAGE,
+): string => {
+  if (isKnownCode(error?.code)) return SLACK_ERROR_MESSAGES[error.code];
+  return error?.detail?.trim() || fallback;
+};
+
+const describeWait = (seconds: number): string => {
+  if (seconds < 60) return `${seconds} second${seconds === 1 ? "" : "s"}`;
+  const minutes = Math.ceil(seconds / 60);
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+};
+
+/** The copy for a rate-limited response, naming the wait when Slack gave one. */
+export const slackRateLimitMessage = (
+  retryAfterSeconds: number | null,
+): string => {
+  if (retryAfterSeconds === null || retryAfterSeconds <= 0) {
+    return SLACK_RATE_LIMITED_MESSAGE;
+  }
+  return `Slack is rate limiting Prowler right now. Try again in about ${describeWait(
+    Math.ceil(retryAfterSeconds),
+  )}.`;
+};
+
+const retryAfterFrom = (response: Response): number | null => {
+  const header = response.headers.get("retry-after");
+  if (!header) return null;
+  const seconds = Number(header.trim());
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : null;
+};
+
+/**
+ * Read a non-OK Slack response into the failure it describes. Never throws: a
+ * body that is not JSON:API — an HTML error page, an empty `502` — still yields
+ * a failure with a status, which is what the caller acts on.
+ */
+export const readSlackFailure = async (
+  response: Response,
+): Promise<SlackApiFailure> => {
+  const body = await response.json().catch(() => null);
+  const error = Array.isArray(body?.errors) ? body.errors[0] : null;
+
+  return {
+    status: response.status,
+    code: typeof error?.code === "string" ? error.code : null,
+    detail: typeof error?.detail === "string" ? error.detail : null,
+    retryAfterSeconds: retryAfterFrom(response),
+  };
+};

--- a/ui/lib/integrations/slack-errors.ts
+++ b/ui/lib/integrations/slack-errors.ts
@@ -77,7 +77,8 @@ export interface SlackApiFailure extends SlackErrorSource {
 }
 
 const isKnownCode = (code: string | null | undefined): code is SlackErrorCode =>
-  typeof code === "string" && code in SLACK_ERROR_MESSAGES;
+  typeof code === "string" &&
+  Object.prototype.hasOwnProperty.call(SLACK_ERROR_MESSAGES, code);
 
 /**
  * Copy for a refusal: Prowler's wording for a known `code`, else the API's

--- a/ui/types/integrations.ts
+++ b/ui/types/integrations.ts
@@ -2,7 +2,11 @@ import { z } from "zod";
 
 import type { TaskState } from "@/types/tasks";
 
-export type IntegrationType = "amazon_s3" | "aws_security_hub" | "jira";
+export type IntegrationType =
+  | "amazon_s3"
+  | "aws_security_hub"
+  | "jira"
+  | "slack";
 
 export const JIRA_DISPATCH_MODE = {
   INDIVIDUAL: "individual",
@@ -87,6 +91,13 @@ export interface IntegrationProps {
       domain?: string;
       projects?: { [key: string]: string };
       issue_types?: { [key: string]: string[] };
+      // Slack specific configuration. The workspace is fixed at install time;
+      // the channel is the integration's default destination and is null until
+      // one is chosen.
+      team_id?: string;
+      team_name?: string;
+      channel_id?: string | null;
+      channel_name?: string | null;
       [key: string]: unknown;
     };
     url?: string;

--- a/ui/types/integrations.ts
+++ b/ui/types/integrations.ts
@@ -72,9 +72,9 @@ export interface IntegrationProps {
     inserted_at: string;
     updated_at: string;
     enabled: boolean;
-    // `null` until a connection check has actually run: the integration exists
-    // but has never been verified — neither confirmed working nor known broken.
-    // A Slack install lands here, and returns here whenever its channel changes.
+    // `null` until a connection check has run: never verified, neither working
+    // nor broken. A Slack install starts here, and returns here on a channel
+    // change.
     connected: boolean | null;
     connection_last_checked_at: string | null;
     integration_type: IntegrationType;
@@ -94,11 +94,8 @@ export interface IntegrationProps {
       domain?: string;
       projects?: { [key: string]: string };
       issue_types?: { [key: string]: string[] };
-      // Slack specific configuration, all of it server-owned: the workspace and
-      // the bot are fixed at install time, and the channel is the integration's
-      // default destination. The channel keys are *absent* until one is chosen
-      // rather than present and null, so read them with `?? null` and never
-      // treat a missing key as a different state from an unchosen channel.
+      // Slack specific configuration, server-owned. The channel keys are absent
+      // until one is chosen, not present and null: read them with `?? null`.
       team_id?: string;
       team_name?: string;
       bot_user_id?: string;

--- a/ui/types/integrations.ts
+++ b/ui/types/integrations.ts
@@ -2,11 +2,15 @@ import { z } from "zod";
 
 import type { TaskState } from "@/types/tasks";
 
+export const INTEGRATION_TYPE = {
+  AMAZON_S3: "amazon_s3",
+  AWS_SECURITY_HUB: "aws_security_hub",
+  JIRA: "jira",
+  SLACK: "slack",
+} as const;
+
 export type IntegrationType =
-  | "amazon_s3"
-  | "aws_security_hub"
-  | "jira"
-  | "slack";
+  (typeof INTEGRATION_TYPE)[keyof typeof INTEGRATION_TYPE];
 
 export const JIRA_DISPATCH_MODE = {
   INDIVIDUAL: "individual",

--- a/ui/types/integrations.ts
+++ b/ui/types/integrations.ts
@@ -72,7 +72,10 @@ export interface IntegrationProps {
     inserted_at: string;
     updated_at: string;
     enabled: boolean;
-    connected: boolean;
+    // `null` until a connection check has actually run: the integration exists
+    // but has never been verified — neither confirmed working nor known broken.
+    // A Slack install lands here, and returns here whenever its channel changes.
+    connected: boolean | null;
     connection_last_checked_at: string | null;
     integration_type: IntegrationType;
     configuration: {

--- a/ui/types/integrations.ts
+++ b/ui/types/integrations.ts
@@ -91,13 +91,16 @@ export interface IntegrationProps {
       domain?: string;
       projects?: { [key: string]: string };
       issue_types?: { [key: string]: string[] };
-      // Slack specific configuration. The workspace is fixed at install time;
-      // the channel is the integration's default destination and is null until
-      // one is chosen.
+      // Slack specific configuration, all of it server-owned: the workspace and
+      // the bot are fixed at install time, and the channel is the integration's
+      // default destination. The channel keys are *absent* until one is chosen
+      // rather than present and null, so read them with `?? null` and never
+      // treat a missing key as a different state from an unchosen channel.
       team_id?: string;
       team_name?: string;
-      channel_id?: string | null;
-      channel_name?: string | null;
+      bot_user_id?: string;
+      channel_id?: string;
+      channel_name?: string;
       [key: string]: unknown;
     };
     url?: string;

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -1,8 +1,33 @@
-import react from "@vitejs/plugin-react";
+import react, { type BabelOptions } from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
+import fs from "fs";
 import path from "path";
 import type { TestProjectConfiguration } from "vitest/config";
 import { defineConfig } from "vitest/config";
+
+/**
+ * Next runs the React Compiler on the client compilation only — its
+ * `getReactCompilerPlugins` returns nothing when `isServer` — so a Server
+ * Component ships uncompiled. Mirror that: compiled, it calls `useMemoCache`
+ * on the active dispatcher, which a harness invoking the component as a
+ * function has none of, and `react/compiler-runtime` reads the client
+ * internals the `react-server` build does not export anyway.
+ */
+const isServerModule = (id: string): boolean => {
+  const file = id.split("?")[0];
+  if (!file.includes("/app/")) return false;
+  try {
+    return !/^\s*["']use client["']/.test(fs.readFileSync(file, "utf8"));
+  } catch {
+    return false;
+  }
+};
+
+const reactCompilerBabel = (id: string): BabelOptions => ({
+  plugins: isServerModule(id)
+    ? []
+    : [["babel-plugin-react-compiler", { target: "19" }]],
+});
 
 export default defineConfig(() => {
   const apiBaseUrl = process.env.UI_API_BASE_URL ?? "http://localhost/api/v1";
@@ -57,13 +82,7 @@ export default defineConfig(() => {
         },
         {
           extends: true,
-          plugins: [
-            react({
-              babel: {
-                plugins: [["babel-plugin-react-compiler", { target: "19" }]],
-              },
-            }),
-          ],
+          plugins: [react({ babel: reactCompilerBabel })],
           test: {
             name: "integration",
             setupFiles: ["./vitest.integration.setup.ts"],
@@ -109,6 +128,9 @@ export default defineConfig(() => {
         // React runtime (pre-bundle so a cold run doesn't re-optimize and
         // reload mid-test — see the on-demand-reload note above).
         "react-dom/client",
+        // What the compiler's output imports. `@vitejs/plugin-react` adds it
+        // itself only when `babel` is a plain object, and ours is a function.
+        "react/compiler-runtime",
 
         // Next runtime
         "next/headers",


### PR DESCRIPTION
### Context

Tenants have no way to get Prowler output into Slack from the product. The CLI has had a Slack output since v3, and the API's `Integration` model has carried `IntegrationChoices.SLACK` since the integrations migration landed, but nothing implements it: the connection test falls through a bare `pass` and the scan-time dispatch is commented out.

This is **PR 1 of 4** in a stack:

1. **this PR** — connect a workspace
2. choose a channel and verify it
3. disconnect and revoked-credential recovery
4. documentation

**Scope: UI only.** The Slack API is implemented in a separate private repository by the backend lane, against a shared contract mirrored on the Notion page "Alerts: Slack". No Slack code is added to `api/`, and `prowler/` is untouched — both repositories pin the SDK to a git-master commit, so an SDK change on a feature branch would be invisible to the API that calls it.

Planning artifacts live in the `add-slack-integration` OpenSpec change.

### Description

- Slack card on `/integrations` and a `/integrations/slack` management page, both gated on `isCloud()` — the API exists only in the hosted deployment, so elsewhere there is nothing to reach.
- Connection happens through Slack's OAuth v2 app-install flow ("Add to Slack"). The tenant never obtains or pastes a token: the API owns the client secret, mints a short-lived single-use `state` bound to tenant and user, and performs the exchange.
- `/integrations/slack/callback` completes the install **exactly once** behind a guard — the Slack code is single-use, so a double invocation would burn it and show a spurious failure — then routes to the management page with the outcome.
- A deployment with no Slack app configured (`503`) is presented as "Slack is not available in this environment yet" rather than as an error, so this ships dark until the backend lane deploys.
- MSW handlers and fixtures derived from the shared API contract; they are the UI lane's only view of the API.

Requires no API change to land, and no migration: `slack` is already a value of the `integration_type` enum.

### Steps to review

1. `pnpm --filter ui test` — or target the two files directly. Expect 10 passing browser-mode integration tests: 2 in `integrations-page.integration.test.tsx`, 8 in `slack-page.integration.test.tsx`.
2. The flows worth reading as user journeys are in `slack-page.integration.test.tsx`: consent screen carries exactly the four scopes; install completes and names the workspace; user declines; Slack refuses the install; the API refuses the `state`.
3. Check the once-guard is intact — `harness.exchangeCallCount` is asserted at four call sites and is load-bearing, not incidental.
4. There is no reachable backend yet, so the flow cannot be exercised by hand in a deployed environment. Verification against the development backend is a tracked checkpoint, not part of this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the roadmap
- [x] Is it assigned to me

</details>

- Are there new checks included in this PR? **No**
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented — the docs page ships in PR 4 of this stack.
- [ ] Review if backport is needed. **No** — new feature.
- [ ] Review if is needed to change the Readme.md **No.**
- [x] Ensure a changelog fragment is added under `<component>/changelog.d/`.

#### UI

- [x] All issue/task requirements work as expected on the UI — against MSW handlers. **Not yet verified against a real backend**: the API is not deployed, so this is tracked as a separate checkpoint.
- [ ] Screenshots/Video - Mobile (X < 640px) — not captured.
- [ ] Screenshots/Video - Tablet (640px > X < 1024px) — not captured.
- [x] Screenshots/Video - Desktop (X > 1024px) — 1920x1080 captures of these screens ship in PR 4 of this stack, alongside the docs page they illustrate.
- [x] Ensure a changelog fragment is added under `ui/changelog.d/`

#### API

Not applicable — no API change in this PR, by design.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack integration support in Prowler Cloud.
  * Users can install Slack, connect a workspace, configure a channel, and test connection health.
  * Added Slack integration cards, branding, management screens, and OAuth callback handling.
  * Added clear connection statuses, rate-limit notices, retry guidance, and error messages.

* **Bug Fixes**
  * Improved handling of failed, incomplete, declined, malformed, and unavailable Slack authorization responses.
  * Prevented untrusted callback error content from being displayed.

* **Tests**
  * Added comprehensive coverage for Slack installation, connection, callback, error, and availability scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
