### PR TITLE
chore(v3): show prowler cloud + version upgrade

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -3,10 +3,16 @@
 
 import os
 import sys
+import threading
 
 from colorama import Fore, Style
 
-from prowler.lib.banner import print_banner
+from prowler.config.config import get_available_update
+from prowler.lib.banner import (
+    print_banner,
+    print_prowler_cloud_banner,
+    print_update_notice,
+)
 from prowler.lib.check.check import (
     bulk_load_checks_metadata,
     bulk_load_compliance_frameworks,
@@ -72,6 +78,18 @@ def prowler():
     severities = args.severity
     compliance_framework = args.compliance
     custom_checks_metadata_file = args.custom_checks_metadata_file
+
+    # Check in the background whether a newer Prowler release is available;
+    # the result is printed at the end of the scan so the check never adds
+    # latency. Skipped with --no-banner/--only-logs and via
+    # PROWLER_NO_VERSION_CHECK/DO_NOT_TRACK (handled in get_available_update).
+    available_update = {}
+    update_check_thread = threading.Thread(
+        target=lambda: available_update.update(latest=get_available_update()),
+        daemon=True,
+    )
+    if not args.no_banner and not args.only_logs:
+        update_check_thread.start()
 
     if not args.no_banner:
         print_banner(args)
@@ -324,6 +342,15 @@ def prowler():
                     audit_output_options.output_filename,
                     audit_output_options.output_directory,
                 )
+
+    # Promote Prowler Cloud as the last thing the user sees after the results,
+    # preceded by an update notice when a newer release is available
+    if not args.no_banner and not args.only_logs:
+        if update_check_thread.is_alive():
+            update_check_thread.join(timeout=2)
+        if available_update.get("latest"):
+            print_update_notice(available_update["latest"])
+        print_prowler_cloud_banner()
 
     # If custom checks were passed, remove the modules
     if checks_folder:

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -11,7 +11,7 @@ from prowler.lib.logger import logger
 
 timestamp = datetime.today()
 timestamp_utc = datetime.now(timezone.utc).replace(tzinfo=timezone.utc)
-prowler_version = "3.16.17"
+prowler_version = "3.16.18"
 html_logo_url = "https://github.com/prowler-cloud/prowler/"
 html_logo_img = "https://user-images.githubusercontent.com/3985464/113734260-7ba06900-96fb-11eb-82bc-d4f68a1e2710.png"
 square_logo_img = "https://user-images.githubusercontent.com/38561120/235905862-9ece5bd7-9aa3-4e48-807a-3a9035eb8bfb.png"
@@ -64,23 +64,50 @@ default_config_file_path = (
 encoding_format_utf_8 = "utf-8"
 
 
-def check_current_version():
+def get_latest_release_version():
+    """Return the latest Prowler release tag name from GitHub, or None if it cannot be retrieved."""
     try:
-        prowler_version_string = f"Prowler {prowler_version}"
         release_response = requests.get(
             "https://api.github.com/repos/prowler-cloud/prowler/tags", timeout=1
         )
-        latest_version = release_response.json()[0]["name"]
-        if latest_version != prowler_version:
-            return f"{prowler_version_string} (latest is {latest_version}, upgrade for the latest features)"
-        else:
-            return (
-                f"{prowler_version_string} (You are running the latest version, yay!)"
-            )
-    except requests.RequestException:
-        return f"{prowler_version_string}"
+        return release_response.json()[0]["name"]
     except Exception:
-        return f"{prowler_version_string}"
+        return None
+
+
+def _version_tuple(version_string):
+    """Return a comparable tuple from a dotted version string."""
+    return tuple(int(part) for part in version_string.split("."))
+
+
+def get_available_update():
+    """Return the latest Prowler version if it is newer than the running one, None otherwise.
+
+    Honors the PROWLER_NO_VERSION_CHECK and DO_NOT_TRACK environment variables:
+    when either is set, no network call is made and None is returned.
+    """
+    if os.environ.get("PROWLER_NO_VERSION_CHECK") or os.environ.get("DO_NOT_TRACK"):
+        return None
+    latest_version = get_latest_release_version()
+    try:
+        if latest_version and _version_tuple(latest_version) > _version_tuple(
+            prowler_version
+        ):
+            return latest_version
+    except Exception:
+        return None
+    return None
+
+
+def check_current_version():
+    prowler_version_string = f"Prowler {prowler_version}"
+    latest_version = get_latest_release_version()
+    if not latest_version:
+        return prowler_version_string
+    if latest_version != prowler_version:
+        return f"{prowler_version_string} (latest is {latest_version}, upgrade for the latest features)"
+    else:
+        return f"{prowler_version_string} (You are running the latest version, yay!)"
 
 
 def change_config_var(variable: str, value: str, audit_info):

--- a/prowler/lib/banner.py
+++ b/prowler/lib/banner.py
@@ -2,6 +2,73 @@ from colorama import Fore, Style
 
 from prowler.config.config import banner_color, orange_color, prowler_version, timestamp
 
+# Prowler Cloud landing URL used by the CLI banner. The visible text stays
+# "cloud.prowler.com" while the clickable target carries the UTM parameters so
+# terminals that support OSC 8 hyperlinks attribute the visit to the v3 CLI.
+CLOUD_DISPLAY_TEXT = "cloud.prowler.com"
+CLOUD_BANNER_URL = (
+    "https://cloud.prowler.com/sign-up?utm_source=prowler-cli&utm_content=v3"
+)
+
+
+def _hyperlink(url, text):
+    """Wrap ``text`` in an OSC 8 terminal hyperlink pointing to ``url``.
+
+    Terminals that support OSC 8 render ``text`` as a clickable link to ``url``;
+    those that do not simply display ``text`` unchanged.
+    """
+    return f"\033]8;;{url}\033\\{text}\033]8;;\033\\"
+
+
+def print_update_notice(latest_version):
+    """
+    Prints a notice that a newer Prowler version is available.
+
+    Parameters:
+    - latest_version (str): The latest released Prowler version.
+
+    Returns:
+    - None
+    """
+    print(
+        f"\n{Fore.YELLOW}A new version of Prowler is available: {prowler_version} → {latest_version}{Style.RESET_ALL}\n"
+        f"Upgrading from Prowler v3 is a major version upgrade — see the release notes at\n"
+        f"https://github.com/prowler-cloud/prowler/releases before upgrading.\n"
+        f"Upgrade with: {Style.BRIGHT}pipx upgrade prowler{Style.RESET_ALL} "
+        f"(disable this check with PROWLER_NO_VERSION_CHECK=1)"
+    )
+
+
+def print_prowler_cloud_banner():
+    """
+    Prints a promotional banner highlighting what Prowler Cloud adds on top of
+    the open-source CLI.
+
+    Shown at the end of a scan to let users know about the managed platform
+    capabilities they are missing.
+
+    Returns:
+    - None
+    """
+    check = f"{Fore.GREEN}✓{Style.RESET_ALL}"
+    bar = f"{banner_color}│{Style.RESET_ALL}"
+    print(f"""
+{bar} {Style.BRIGHT}You're getting a snapshot 📸. Prowler Cloud gives you the full picture:{Style.RESET_ALL}
+{bar}
+{bar} {check} {Style.BRIGHT}Send your findings{Style.RESET_ALL} - directly from the Prowler CLI to Prowler Cloud.
+{bar} {check} {Style.BRIGHT}Continuous Security Monitoring{Style.RESET_ALL} - custom scheduling and scan configuration with history, trends and alerts.
+{bar} {check} {Style.BRIGHT}Triage{Style.RESET_ALL} - review findings, flag false positives and track accepted risk with your team.
+{bar} {check} {Style.BRIGHT}Lighthouse AI + MCP{Style.RESET_ALL} - autonomous triage, custom dashboards, prioritization with prevention and remediation.
+{bar} {check} {Style.BRIGHT}Alerts{Style.RESET_ALL} - get notified when anything you want is happening.
+{bar} {check} {Style.BRIGHT}Live Compliance{Style.RESET_ALL} - dashboards for 50+ frameworks, always up to date.
+{bar} {check} {Style.BRIGHT}Remediation{Style.RESET_ALL} - complete guided remediation including Autonomous remediation with Lighthouse AI.
+{bar} {check} {Style.BRIGHT}Attack Path Visualization{Style.RESET_ALL} - see how attackers chain risks to reach your crown jewels.
+{bar} {check} {Style.BRIGHT}Bulk Provisioning{Style.RESET_ALL} - add your entire AWS Organization in seconds.
+{bar} {check} {Style.BRIGHT}Integrations{Style.RESET_ALL} - Anything with our MCP + Jira, Slack, AWS Security Hub, Amazon S3, SSO and RBAC.
+{bar}
+{bar} {banner_color}Start free at 👉 {_hyperlink(CLOUD_BANNER_URL, CLOUD_DISPLAY_TEXT)}{Style.RESET_ALL}
+""")
+
 
 def print_banner(args):
     banner = rf"""{banner_color}                         _

--- a/prowler/lib/banner.py
+++ b/prowler/lib/banner.py
@@ -52,7 +52,8 @@ def print_prowler_cloud_banner():
     """
     check = f"{Fore.GREEN}✓{Style.RESET_ALL}"
     bar = f"{banner_color}│{Style.RESET_ALL}"
-    print(f"""
+    print(
+        f"""
 {bar} {Style.BRIGHT}You're getting a snapshot 📸. Prowler Cloud gives you the full picture:{Style.RESET_ALL}
 {bar}
 {bar} {check} {Style.BRIGHT}Send your findings{Style.RESET_ALL} - directly from the Prowler CLI to Prowler Cloud.
@@ -67,7 +68,8 @@ def print_prowler_cloud_banner():
 {bar} {check} {Style.BRIGHT}Integrations{Style.RESET_ALL} - Anything with our MCP + Jira, Slack, AWS Security Hub, Amazon S3, SSO and RBAC.
 {bar}
 {bar} {banner_color}Start free at 👉 {_hyperlink(CLOUD_BANNER_URL, CLOUD_DISPLAY_TEXT)}{Style.RESET_ALL}
-""")
+"""
+    )
 
 
 def print_banner(args):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
   {include = "prowler"}
 ]
 readme = "README.md"
-version = "3.16.17"
+version = "3.16.18"
 
 [tool.poetry.dependencies]
 alive-progress = "3.1.5"

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -8,6 +8,7 @@ from prowler.config.config import (
     change_config_var,
     check_current_version,
     get_available_compliance_frameworks,
+    get_available_update,
     load_and_validate_config_file,
 )
 from prowler.providers.aws.aws_provider import get_aws_available_regions
@@ -133,6 +134,44 @@ class Test_Config:
             check_current_version()
             == f"Prowler {MOCK_OLD_PROWLER_VERSION} (latest is {MOCK_PROWLER_VERSION}, upgrade for the latest features)"
         )
+
+    @mock.patch(
+        "prowler.config.config.requests.get", new=mock_prowler_get_latest_release
+    )
+    @mock.patch("prowler.config.config.prowler_version", new=MOCK_OLD_PROWLER_VERSION)
+    def test_get_available_update_with_old_version(self):
+        assert get_available_update() == MOCK_PROWLER_VERSION
+
+    @mock.patch(
+        "prowler.config.config.requests.get", new=mock_prowler_get_latest_release
+    )
+    @mock.patch("prowler.config.config.prowler_version", new=MOCK_PROWLER_VERSION)
+    def test_get_available_update_with_latest_version(self):
+        assert get_available_update() is None
+
+    @mock.patch(
+        "prowler.config.config.requests.get", new=mock_prowler_get_latest_release
+    )
+    @mock.patch("prowler.config.config.prowler_version", new=MOCK_OLD_PROWLER_VERSION)
+    @mock.patch.dict(os.environ, {"PROWLER_NO_VERSION_CHECK": "1"})
+    def test_get_available_update_opt_out_env_var(self):
+        assert get_available_update() is None
+
+    @mock.patch(
+        "prowler.config.config.requests.get", new=mock_prowler_get_latest_release
+    )
+    @mock.patch("prowler.config.config.prowler_version", new=MOCK_OLD_PROWLER_VERSION)
+    @mock.patch.dict(os.environ, {"DO_NOT_TRACK": "1"})
+    def test_get_available_update_do_not_track(self):
+        assert get_available_update() is None
+
+    @mock.patch(
+        "prowler.config.config.requests.get",
+        new=mock.MagicMock(side_effect=Exception("network error")),
+    )
+    @mock.patch("prowler.config.config.prowler_version", new=MOCK_OLD_PROWLER_VERSION)
+    def test_get_available_update_network_failure(self):
+        assert get_available_update() is None
 
     def test_change_config_var_aws(self):
         audit_info = AWS_Audit_Info(

--- a/tests/providers/gcp/services/kms/kms_key_rotation_enabled/kms_key_rotation_enabled_test.py
+++ b/tests/providers/gcp/services/kms/kms_key_rotation_enabled/kms_key_rotation_enabled_test.py
@@ -1,8 +1,14 @@
 from unittest import mock
 
+from freezegun import freeze_time
+
 from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, GCP_US_CENTER1_LOCATION
 
 
+# The check compares the keys' next_rotation_time against the current date and
+# the test fixtures use hardcoded dates, so the tests are frozen to a date that
+# keeps those fixtures meaningful.
+@freeze_time("2024-08-01")
 class Test_kms_key_rotation_enabled:
     def test_kms_no_key(self):
         kms_client = mock.MagicMock


### PR DESCRIPTION
### Description

Final v3 awareness backport: makes the Prowler v3 CLI tell users that a newer major version and Prowler Cloud exist. Prowler v3 installations are still widely used (v3 accounts for ~17% of PyPI downloads in the last 90 days, and the `v3-latest`/`v3-stable` Docker tags still receive weekly pulls), but today a v3 user gets no signal at all unless they run a bare `prowler -v`.

This PR backports to v3 the same mechanism added to v5 in the version-check work:

- **Version check on every scan, with zero added latency**: `get_available_update()` runs in a daemon thread started at scan start and its result is consumed at the end of the scan (`join` with a 2s cap). On any network failure it stays silent.
- **Update notice at the end of the scan**: shows `3.16.18 → <latest>`, explicitly warns that upgrading from v3 is a **major version upgrade** pointing to the release notes, and suggests `pipx upgrade prowler`.
- **Prowler Cloud banner** (ported from v5) printed right after the notice, as the last thing the user sees. The `cloud.prowler.com` link carries `utm_source=prowler-cli&utm_content=v3` so conversions from this release can be attributed.
- **Opt-outs**: `--no-banner` / `--only-logs` skip everything (the check thread is not even started), and `PROWLER_NO_VERSION_CHECK=1` or `DO_NOT_TRACK=1` disable the check without any network call. The notice itself documents how to disable it.
- `check_current_version()` (the `prowler -v` path) is refactored on top of the new helpers but keeps its exact output strings and v3 comparison semantics.
- Version bump `3.16.17` → `3.16.18` (`pyproject.toml` + `prowler/config/config.py`).

Implementation notes:
- The version comparison uses a small internal `_version_tuple()` helper instead of `packaging.version` because `packaging` is not a direct dependency of v3.
- The branch is cut from the `3.16.17` tag on purpose, so the eventual `3.16.18` release ships only this change and not the unreleased commits accumulated on `v3` since 2024. When cutting the release, target this branch's history rather than the `v3` tip.

### Steps to review

1. Review the diff — it is self-contained: `prowler/config/config.py`, `prowler/lib/banner.py`, `prowler/__main__.py`, `pyproject.toml`, plus tests.
2. Run the config tests (Python 3.12 env with the v3 dependencies): `pytest tests/config/config_test.py` → 15 passed (5 new tests: outdated version, latest version, both opt-out env vars, network failure).
3. `prowler -v` → still prints `Prowler 3.16.18 (latest is 5.x.y, upgrade for the latest features)` with the historical format.
4. Run any scan without flags → at the end, after the summary/compliance tables, the update notice and the Prowler Cloud banner are printed.
5. Repeat with `--no-banner`, `--only-logs`, `PROWLER_NO_VERSION_CHECK=1` and with no network → nothing is printed and the scan is unaffected.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. (This PR is itself the v3 backport of the v5 version-check work; the v4 backport will be a separate PR.)
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. (Not applicable: `changelog.d/` does not exist on v3; the change will be described in the `3.16.18` GitHub Release notes.)

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
