### PR TITLE
chore(v4): show prowler cloud + version upgrade

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
+import threading
 from os import environ
 
 from colorama import Fore, Style
@@ -10,11 +11,16 @@ from colorama import init as colorama_init
 from prowler.config.config import (
     csv_file_suffix,
     get_available_compliance_frameworks,
+    get_available_update,
     html_file_suffix,
     json_asff_file_suffix,
     json_ocsf_file_suffix,
 )
-from prowler.lib.banner import print_banner
+from prowler.lib.banner import (
+    print_banner,
+    print_prowler_cloud_banner,
+    print_update_notice,
+)
 from prowler.lib.check.check import (
     exclude_checks_to_run,
     exclude_services_to_run,
@@ -117,6 +123,18 @@ def prowler():
 
     if args.no_color:
         colorama_init(strip=True)
+
+    # Check in the background whether a newer Prowler release is available;
+    # the result is printed at the end of the scan so the check never adds
+    # latency. Skipped with --no-banner/--only-logs and via
+    # PROWLER_NO_VERSION_CHECK/DO_NOT_TRACK (handled in get_available_update).
+    available_update = {}
+    update_check_thread = threading.Thread(
+        target=lambda: available_update.update(latest=get_available_update()),
+        daemon=True,
+    )
+    if not args.no_banner and not args.only_logs:
+        update_check_thread.start()
 
     if not args.no_banner:
         legend = args.verbose or getattr(args, "fixer", None)
@@ -718,6 +736,15 @@ def prowler():
                 print(
                     f"\nDetailed compliance results are in {Fore.YELLOW}{output_options.output_directory}/compliance/{Style.RESET_ALL}\n"
                 )
+
+    # Promote Prowler Cloud as the last thing the user sees after the results,
+    # preceded by an update notice when a newer release is available
+    if not args.no_banner and not args.only_logs:
+        if update_check_thread.is_alive():
+            update_check_thread.join(timeout=2)
+        if available_update.get("latest"):
+            print_update_notice(available_update["latest"])
+        print_prowler_cloud_banner()
 
     # If custom checks were passed, remove the modules
     if checks_folder:

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -12,7 +12,7 @@ from prowler.lib.logger import logger
 
 timestamp = datetime.today()
 timestamp_utc = datetime.now(timezone.utc).replace(tzinfo=timezone.utc)
-prowler_version = "4.6.2"
+prowler_version = "4.6.3"
 html_logo_url = "https://github.com/prowler-cloud/prowler/"
 square_logo_img = "https://prowler.com/wp-content/uploads/logo-html.png"
 aws_logo = "https://user-images.githubusercontent.com/38561120/235953920-3e3fba08-0795-41dc-b480-9bea57db9f2e.png"
@@ -86,23 +86,50 @@ def get_default_mute_file_path(provider: str):
     return mutelist_path
 
 
-def check_current_version():
+def get_latest_release_version():
+    """Return the latest Prowler release tag name from GitHub, or None if it cannot be retrieved."""
     try:
-        prowler_version_string = f"Prowler {prowler_version}"
         release_response = requests.get(
             "https://api.github.com/repos/prowler-cloud/prowler/tags", timeout=1
         )
-        latest_version = release_response.json()[0]["name"]
+        return release_response.json()[0]["name"]
+    except Exception:
+        return None
+
+
+def get_available_update():
+    """Return the latest Prowler version if it is newer than the running one, None otherwise.
+
+    Honors the PROWLER_NO_VERSION_CHECK and DO_NOT_TRACK environment variables:
+    when either is set, no network call is made and None is returned.
+    """
+    if os.environ.get("PROWLER_NO_VERSION_CHECK") or os.environ.get("DO_NOT_TRACK"):
+        return None
+    latest_version = get_latest_release_version()
+    try:
+        if latest_version and version.parse(latest_version) > version.parse(
+            prowler_version
+        ):
+            return latest_version
+    except Exception:
+        return None
+    return None
+
+
+def check_current_version():
+    prowler_version_string = f"Prowler {prowler_version}"
+    latest_version = get_latest_release_version()
+    if not latest_version:
+        return prowler_version_string
+    try:
         if version.parse(latest_version) > version.parse(prowler_version):
             return f"{prowler_version_string} (latest is {latest_version}, upgrade for the latest features)"
         else:
             return (
                 f"{prowler_version_string} (You are running the latest version, yay!)"
             )
-    except requests.RequestException:
-        return f"{prowler_version_string}"
     except Exception:
-        return f"{prowler_version_string}"
+        return prowler_version_string
 
 
 def load_and_validate_config_file(provider: str, config_file_path: str) -> dict:

--- a/prowler/lib/banner.py
+++ b/prowler/lib/banner.py
@@ -2,6 +2,75 @@ from colorama import Fore, Style
 
 from prowler.config.config import banner_color, orange_color, prowler_version, timestamp
 
+# Prowler Cloud landing URL used by the CLI banner. The visible text stays
+# "cloud.prowler.com" while the clickable target carries the UTM parameters so
+# terminals that support OSC 8 hyperlinks attribute the visit to the v4 CLI.
+CLOUD_DISPLAY_TEXT = "cloud.prowler.com"
+CLOUD_BANNER_URL = (
+    "https://cloud.prowler.com/sign-up?utm_source=prowler-cli&utm_content=v4"
+)
+
+
+def _hyperlink(url: str, text: str) -> str:
+    """Wrap ``text`` in an OSC 8 terminal hyperlink pointing to ``url``.
+
+    Terminals that support OSC 8 render ``text`` as a clickable link to ``url``;
+    those that do not simply display ``text`` unchanged.
+    """
+    return f"\033]8;;{url}\033\\{text}\033]8;;\033\\"
+
+
+def print_update_notice(latest_version: str):
+    """
+    Prints a notice that a newer Prowler version is available.
+
+    Parameters:
+    - latest_version (str): The latest released Prowler version.
+
+    Returns:
+    - None
+    """
+    print(
+        f"\n{Fore.YELLOW}A new version of Prowler is available: {prowler_version} → {latest_version}{Style.RESET_ALL}\n"
+        f"Upgrading from Prowler v4 is a major version upgrade — see the release notes at\n"
+        f"https://github.com/prowler-cloud/prowler/releases before upgrading.\n"
+        f"Upgrade with: {Style.BRIGHT}pipx upgrade prowler{Style.RESET_ALL} "
+        f"(disable this check with PROWLER_NO_VERSION_CHECK=1)"
+    )
+
+
+def print_prowler_cloud_banner():
+    """
+    Prints a promotional banner highlighting what Prowler Cloud adds on top of
+    the open-source CLI.
+
+    Shown at the end of a scan to let users know about the managed platform
+    capabilities they are missing.
+
+    Returns:
+    - None
+    """
+    check = f"{Fore.GREEN}✓{Style.RESET_ALL}"
+    bar = f"{banner_color}│{Style.RESET_ALL}"
+    print(
+        f"""
+{bar} {Style.BRIGHT}You're getting a snapshot 📸. Prowler Cloud gives you the full picture:{Style.RESET_ALL}
+{bar}
+{bar} {check} {Style.BRIGHT}Send your findings{Style.RESET_ALL} - directly from the Prowler CLI to Prowler Cloud.
+{bar} {check} {Style.BRIGHT}Continuous Security Monitoring{Style.RESET_ALL} - custom scheduling and scan configuration with history, trends and alerts.
+{bar} {check} {Style.BRIGHT}Triage{Style.RESET_ALL} - review findings, flag false positives and track accepted risk with your team.
+{bar} {check} {Style.BRIGHT}Lighthouse AI + MCP{Style.RESET_ALL} - autonomous triage, custom dashboards, prioritization with prevention and remediation.
+{bar} {check} {Style.BRIGHT}Alerts{Style.RESET_ALL} - get notified when anything you want is happening.
+{bar} {check} {Style.BRIGHT}Live Compliance{Style.RESET_ALL} - dashboards for 50+ frameworks, always up to date.
+{bar} {check} {Style.BRIGHT}Remediation{Style.RESET_ALL} - complete guided remediation including Autonomous remediation with Lighthouse AI.
+{bar} {check} {Style.BRIGHT}Attack Path Visualization{Style.RESET_ALL} - see how attackers chain risks to reach your crown jewels.
+{bar} {check} {Style.BRIGHT}Bulk Provisioning{Style.RESET_ALL} - add your entire AWS Organization in seconds.
+{bar} {check} {Style.BRIGHT}Integrations{Style.RESET_ALL} - Anything with our MCP + Jira, Slack, AWS Security Hub, Amazon S3, SSO and RBAC.
+{bar}
+{bar} {banner_color}Start free at 👉 {_hyperlink(CLOUD_BANNER_URL, CLOUD_DISPLAY_TEXT)}{Style.RESET_ALL}
+"""
+    )
+
 
 def print_banner(legend: bool = False):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [
   {include = "dashboard"}
 ]
 readme = "README.md"
-version = "4.6.2"
+version = "4.6.3"
 
 [tool.poetry.dependencies]
 alive-progress = "3.2.0"

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -8,6 +8,7 @@ from requests import Response
 from prowler.config.config import (
     check_current_version,
     get_available_compliance_frameworks,
+    get_available_update,
     load_and_validate_config_file,
     load_and_validate_fixer_config_file,
 )
@@ -376,6 +377,44 @@ class Test_Config:
             check_current_version()
             == f"Prowler {MOCK_PROWLER_MASTER_VERSION} (You are running the latest version, yay!)"
         )
+
+    @mock.patch(
+        "prowler.config.config.requests.get", new=mock_prowler_get_latest_release
+    )
+    @mock.patch("prowler.config.config.prowler_version", new=MOCK_OLD_PROWLER_VERSION)
+    def test_get_available_update_with_old_version(self):
+        assert get_available_update() == MOCK_PROWLER_VERSION
+
+    @mock.patch(
+        "prowler.config.config.requests.get", new=mock_prowler_get_latest_release
+    )
+    @mock.patch("prowler.config.config.prowler_version", new=MOCK_PROWLER_VERSION)
+    def test_get_available_update_with_latest_version(self):
+        assert get_available_update() is None
+
+    @mock.patch(
+        "prowler.config.config.requests.get", new=mock_prowler_get_latest_release
+    )
+    @mock.patch("prowler.config.config.prowler_version", new=MOCK_OLD_PROWLER_VERSION)
+    @mock.patch.dict(os.environ, {"PROWLER_NO_VERSION_CHECK": "1"})
+    def test_get_available_update_opt_out_env_var(self):
+        assert get_available_update() is None
+
+    @mock.patch(
+        "prowler.config.config.requests.get", new=mock_prowler_get_latest_release
+    )
+    @mock.patch("prowler.config.config.prowler_version", new=MOCK_OLD_PROWLER_VERSION)
+    @mock.patch.dict(os.environ, {"DO_NOT_TRACK": "1"})
+    def test_get_available_update_do_not_track(self):
+        assert get_available_update() is None
+
+    @mock.patch(
+        "prowler.config.config.requests.get",
+        new=mock.MagicMock(side_effect=Exception("network error")),
+    )
+    @mock.patch("prowler.config.config.prowler_version", new=MOCK_OLD_PROWLER_VERSION)
+    def test_get_available_update_network_failure(self):
+        assert get_available_update() is None
 
     def test_get_available_compliance_frameworks(self):
         compliance_frameworks = [


### PR DESCRIPTION
### Description

Final v4 awareness backport: makes the Prowler v4 CLI tell users that a newer major version and Prowler Cloud exist. Prowler v4 installations are still widely used (~9% of PyPI downloads in the last 90 days, and the `v4-latest`/`v4-stable` Docker tags still receive weekly pulls), but today a v4 user gets no signal at all unless they run a bare `prowler -v`.

This is the v4 counterpart of the v3 backport in #12441, porting the same mechanism added to v5:

- **Version check on every scan, with zero added latency**: `get_available_update()` runs in a daemon thread started at scan start and its result is consumed at the end of the scan (`join` with a 2s cap). On any network failure it stays silent.
- **Update notice at the end of the scan**: shows `4.6.3 → <latest>`, explicitly warns that upgrading from v4 is a **major version upgrade** pointing to the release notes, and suggests `pipx upgrade prowler`.
- **Prowler Cloud banner** (ported from v5) printed right after the notice, as the last thing the user sees. The `cloud.prowler.com` link carries `utm_source=prowler-cli&utm_content=v4` so conversions from this release can be attributed.
- **Opt-outs**: `--no-banner` / `--only-logs` skip everything (the check thread is not even started), and `PROWLER_NO_VERSION_CHECK=1` or `DO_NOT_TRACK=1` disable the check without any network call. The notice itself documents how to disable it.
- `check_current_version()` (the `prowler -v` path) is refactored on top of the new helpers but keeps its exact output strings (unlike v3, this branch keeps using `packaging.version` for the comparison, same as v5).
- Version bump `4.6.2` → `4.6.3` (`pyproject.toml` + `prowler/config/config.py`).

Implementation notes:
- The branch is cut from the `4.6.2` tag on purpose, so the eventual `4.6.3` release ships only this change and not the ~150 unreleased commits accumulated on `v4.6` since December 2024. When cutting the release, target this branch's history rather than the `v4.6` tip.
- `prowler dashboard` keeps working unchanged: `print_banner()` keeps its signature.
- Heads-up on CI: the **Safety** step will report ~89 CVEs coming from the frozen 2024 dependency pins (same situation as #12441, where it is the step that fails). This is pre-existing on the branch and unrelated to this diff.

### Steps to review

1. Review the diff — it is self-contained: `prowler/config/config.py`, `prowler/lib/banner.py`, `prowler/__main__.py`, `pyproject.toml`, plus tests.
2. Run the config tests (Python 3.12 env with the v4 dependencies): `pytest tests/config/config_test.py` → 20 passed (5 new tests: outdated version, latest version, both opt-out env vars, network failure).
3. `prowler -v` → still prints `Prowler 4.6.3 (latest is 5.x.y, upgrade for the latest features)` with the historical format.
4. Run any scan without flags → at the end, after the summary/compliance tables, the update notice and the Prowler Cloud banner are printed.
5. Repeat with `--no-banner`, `--only-logs`, `PROWLER_NO_VERSION_CHECK=1` and with no network → nothing is printed and the scan is unaffected.
6. Local verification already done on this branch with the CI pins: black 24.10.0, flake8 7.1.1, pylint 3.3.2, bandit and vulture all clean; `poetry check --lock` OK.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. (This PR is the v4 counterpart of the v3 backport in #12441; the v5 change lands on master separately.)
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. (Not applicable: `changelog.d/` does not exist on v4.6; the change will be described in the `4.6.3` GitHub Release notes.)

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
