### PR TITLE
feat(ui): highlight imported providers

### DIFF
--- a/ui/changelog.d/imported-provider-provenance.added.md
+++ b/ui/changelog.d/imported-provider-provenance.added.md
@@ -1,0 +1,1 @@
+Prowler Cloud indicator for providers created via Import Findings alongside every connection status

--- a/ui/components/providers/table/column-providers.test.tsx
+++ b/ui/components/providers/table/column-providers.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   PROVIDERS_ROW_TYPE,
@@ -10,9 +11,18 @@ import {
 
 import { getColumnProviders } from "./column-providers";
 
-vi.mock("@/components/shadcn", () => ({
-  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
-}));
+vi.mock("@/components/shadcn", async () => {
+  const tooltip = await vi.importActual<
+    typeof import("@/components/shadcn/tooltip")
+  >("@/components/shadcn/tooltip");
+
+  return {
+    Badge: ({ children, ...props }: { children: ReactNode }) => (
+      <span {...props}>{children}</span>
+    ),
+    ...tooltip,
+  };
+});
 
 vi.mock("@/components/shadcn/checkbox/checkbox", () => ({
   Checkbox: () => null,
@@ -64,6 +74,7 @@ const providerRow: ProvidersProviderRow = {
   attributes: {
     provider: "aws",
     is_dynamic: false,
+    is_imported: false,
     uid: "123456789012",
     alias: "Production",
     status: "completed",
@@ -115,6 +126,33 @@ function renderLastScanCell(row: ProvidersTableRow) {
   render(<>{element as ReactNode}</>);
 }
 
+function renderStatusCell(row: ProvidersTableRow) {
+  const statusColumn = getColumnProviders(
+    {},
+    [],
+    [],
+    [],
+    vi.fn(),
+    vi.fn(),
+    vi.fn(),
+  ).find((column) => column.id === "status");
+
+  const cell = statusColumn?.cell;
+  if (typeof cell !== "function") {
+    throw new Error("Status column cell renderer not found");
+  }
+
+  const element = cell({
+    row: { original: row },
+  } as unknown as Parameters<typeof cell>[0]);
+
+  render(<>{element as ReactNode}</>);
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe("getColumnProviders", () => {
   it("falls back to connection last_checked_at when lastScanAt is undefined", () => {
     renderLastScanCell({ ...providerRow, lastScanAt: undefined });
@@ -128,5 +166,134 @@ describe("getColumnProviders", () => {
 
     expect(screen.getByText("Never")).toBeVisible();
     expect(screen.queryByText("2026-01-01T00:00:00Z")).not.toBeInTheDocument();
+  });
+
+  it("shows Not connected with the imported tooltip in Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    const user = userEvent.setup();
+    const importedProvider = {
+      ...providerRow,
+      attributes: {
+        ...providerRow.attributes,
+        is_imported: true,
+        connection: {
+          connected: null,
+          last_checked_at: null,
+        },
+      },
+      relationships: {
+        ...providerRow.relationships,
+        secret: { data: null },
+      },
+    } satisfies ProvidersProviderRow;
+
+    // When
+    renderStatusCell(importedProvider);
+
+    // Then
+    expect(screen.getByText("Not connected")).toBeVisible();
+    const indicator = screen.getByLabelText("Imported provider");
+    expect(indicator).not.toHaveTextContent("Imported");
+    expect(indicator).toHaveAttribute("tabindex", "0");
+    expect(indicator.querySelector(".lucide-terminal")).toBeInTheDocument();
+    expect(indicator.parentElement).toHaveClass("items-stretch");
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(screen.queryByText("Disconnected")).not.toBeInTheDocument();
+
+    await user.hover(indicator);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      /^Created from findings imported with the Prowler CLI$/,
+    );
+  });
+
+  it("shows the imported tooltip beside Connected in Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    const user = userEvent.setup();
+    const connectedImportedProvider = {
+      ...providerRow,
+      attributes: {
+        ...providerRow.attributes,
+        is_imported: true,
+        connection: {
+          connected: true,
+          last_checked_at: "2026-01-01T00:00:00Z",
+        },
+      },
+    } satisfies ProvidersProviderRow;
+
+    // When
+    renderStatusCell(connectedImportedProvider);
+
+    // Then
+    expect(screen.getByText("Connected")).toBeVisible();
+    const indicator = screen.getByLabelText("Imported provider");
+    expect(indicator).toBeVisible();
+    expect(indicator.querySelector(".lucide-terminal")).toBeInTheDocument();
+    expect(indicator.parentElement).toHaveClass("items-stretch");
+    expect(indicator).not.toHaveTextContent("Imported");
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await user.hover(indicator);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      /^Created from findings imported with the Prowler CLI$/,
+    );
+  });
+
+  it("keeps Connection failed for imported providers in Cloud", () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    const importedProviderWithCredentials = {
+      ...providerRow,
+      attributes: {
+        ...providerRow.attributes,
+        is_imported: true,
+        connection: {
+          connected: false,
+          last_checked_at: null,
+        },
+      },
+    } satisfies ProvidersProviderRow;
+
+    // When
+    renderStatusCell(importedProviderWithCredentials);
+
+    // Then
+    expect(screen.getByText("Connection failed")).toBeVisible();
+    expect(screen.queryByText("Not connected")).not.toBeInTheDocument();
+    const indicator = screen.getByLabelText("Imported provider");
+    expect(indicator).not.toHaveTextContent("Imported");
+  });
+
+  it("does not expose imported provenance in OSS", () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+    const importedProvider = {
+      ...providerRow,
+      attributes: {
+        ...providerRow.attributes,
+        is_imported: true,
+        connection: {
+          connected: null,
+          last_checked_at: null,
+        },
+      },
+      relationships: {
+        ...providerRow.relationships,
+        secret: { data: null },
+      },
+    } satisfies ProvidersProviderRow;
+
+    // When
+    renderStatusCell(importedProvider);
+
+    // Then
+    expect(screen.getByText("Not connected")).toBeVisible();
+    expect(
+      screen.queryByLabelText("Imported provider"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/components/providers/table/column-providers.test.tsx
+++ b/ui/components/providers/table/column-providers.test.tsx
@@ -204,7 +204,7 @@ describe("getColumnProviders", () => {
     await user.hover(indicator);
 
     expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      /^Created from findings imported with the Prowler CLI$/,
+      /^This provider has findings imported with the Prowler CLI$/,
     );
   });
 
@@ -239,7 +239,7 @@ describe("getColumnProviders", () => {
     await user.hover(indicator);
 
     expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      /^Created from findings imported with the Prowler CLI$/,
+      /^This provider has findings imported with the Prowler CLI$/,
     );
   });
 

--- a/ui/components/providers/table/column-providers.tsx
+++ b/ui/components/providers/table/column-providers.tsx
@@ -63,7 +63,7 @@ interface ProviderStatusCellProps {
 }
 
 const IMPORTED_PROVIDER_TOOLTIP =
-  "Created from findings imported with the Prowler CLI";
+  "This provider has findings imported with the Prowler CLI";
 
 const ImportedIndicator = () => {
   const indicator = (

--- a/ui/components/providers/table/column-providers.tsx
+++ b/ui/components/providers/table/column-providers.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { ColumnDef, Row, RowSelectionState } from "@tanstack/react-table";
-import { Building2, FolderTree } from "lucide-react";
+import { Building2, FolderTree, Terminal } from "lucide-react";
 
 import type {
   OrgWizardInitialData,
   ProviderWizardInitialData,
 } from "@/components/providers/wizard/types";
-import { Badge } from "@/components/shadcn";
+import {
+  Badge,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/shadcn";
 import { Checkbox } from "@/components/shadcn/checkbox/checkbox";
 import { CodeSnippet } from "@/components/shadcn/code-snippet/code-snippet";
 import { DateWithTime, EntityInfo } from "@/components/shadcn/entities";
@@ -15,6 +20,7 @@ import { DataTableColumnHeader } from "@/components/shadcn/table";
 import { DataTableExpandAllToggle } from "@/components/shadcn/table/data-table-expand-all-toggle";
 import { DataTableExpandableCell } from "@/components/shadcn/table/data-table-expandable-cell";
 import { getNodeLabel } from "@/lib/organizations";
+import { isCloud } from "@/lib/shared/env";
 import {
   isProvidersOrganizationRow,
   PROVIDERS_GROUP_KIND,
@@ -51,28 +57,70 @@ const OrganizationIcon = ({ groupKind }: { groupKind: ProvidersGroupKind }) => {
   );
 };
 
-const ProviderStatusCell = ({ connected }: { connected: boolean | null }) => {
+interface ProviderStatusCellProps {
+  connected: boolean | null;
+  isImported: boolean;
+}
+
+const IMPORTED_PROVIDER_TOOLTIP =
+  "Created from findings imported with the Prowler CLI";
+
+const ImportedIndicator = () => {
+  const indicator = (
+    <Badge
+      variant="info"
+      className="text-sm"
+      aria-label="Imported provider"
+      tabIndex={0}
+    >
+      <Terminal aria-hidden />
+    </Badge>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{indicator}</TooltipTrigger>
+      <TooltipContent>{IMPORTED_PROVIDER_TOOLTIP}</TooltipContent>
+    </Tooltip>
+  );
+};
+
+const ProviderStatusCell = ({
+  connected,
+  isImported,
+}: ProviderStatusCellProps) => {
+  let statusBadge;
+
   if (connected === true) {
-    return (
+    statusBadge = (
       <Badge variant="success" className="text-sm">
         Connected
       </Badge>
     );
-  }
-
-  if (connected === false) {
-    return (
+  } else if (connected === false) {
+    statusBadge = (
       <Badge variant="error" className="text-sm">
         Connection failed
       </Badge>
     );
+  } else {
+    statusBadge = (
+      <Badge variant="tag" className="text-text-neutral-secondary text-sm">
+        Not connected
+      </Badge>
+    );
   }
 
-  return (
-    <Badge variant="tag" className="text-text-neutral-secondary text-sm">
-      Not connected
-    </Badge>
-  );
+  if (isImported) {
+    return (
+      <div className="flex items-stretch gap-2">
+        {statusBadge}
+        <ImportedIndicator />
+      </div>
+    );
+  }
+
+  return statusBadge;
 };
 
 function getSelectionLabel(row: Row<ProvidersTableRow>): string | undefined {
@@ -299,6 +347,9 @@ export function getColumnProviders(
         return (
           <ProviderStatusCell
             connected={row.original.attributes.connection.connected}
+            isImported={
+              isCloud() && Boolean(row.original.attributes.is_imported)
+            }
           />
         );
       },

--- a/ui/types/providers.ts
+++ b/ui/types/providers.ts
@@ -80,13 +80,15 @@ export interface ProviderProps {
   attributes: {
     provider: ProviderType;
     is_dynamic: boolean;
+    /** Import Findings provenance returned only by the Prowler Cloud API. */
+    is_imported?: boolean;
     uid: string;
     alias: string;
     status: "completed" | "pending" | "cancelled";
     resources: number;
     connection: {
-      connected: boolean;
-      last_checked_at: string;
+      connected: boolean | null;
+      last_checked_at: string | null;
     };
     scanner_args: {
       only_logs: boolean;


### PR DESCRIPTION
### Context

Providers created through Import Findings are currently indistinguishable from providers configured directly in the app. This change surfaces their origin while preserving the existing connection status.

Product context: [Highlight Providers added via Import Findings](https://app.notion.com/p/prowlercom/Highlight-Providers-added-via-Import-Findings-39c8202b86e980aa8448e483df38632c)

Depends on the Prowler Cloud API contract introduced by [prowler-cloud/prowler-cloud#5532](https://github.com/prowler-cloud/prowler-cloud/pull/5532): provider resources expose the read-only `attributes.is_imported` boolean. The UI keeps this attribute optional for rollout compatibility.

### Description

- Preserve the existing `Connected`, `Connection failed`, and `Not connected` statuses.
- Add a terminal-icon provenance indicator beside every status when `is_imported` is true.
- Explain the indicator on hover with `Created from findings imported with the Prowler CLI` and make it keyboard-focusable.
- Gate the behavior with `isCloud()` so OSS deployments retain their current UI.
- Add a UI changelog fragment and unit coverage for all connection states and the OSS guard.

### Steps to review

1. Run the UI with `UI_CLOUD_ENABLED=true` against the API from prowler-cloud/prowler-cloud#5532.
2. Open the Providers table with an imported provider whose connection is `true`, `false`, or `null`.
3. Confirm the existing status pill remains unchanged and the terminal indicator appears beside it at the same height.
4. Hover or focus the indicator and confirm the tooltip text is `Created from findings imported with the Prowler CLI`.
5. Run the UI with `UI_CLOUD_ENABLED=false` and confirm the provenance indicator is not rendered.

Validation performed locally:

- 35 related Vitest tests
- TypeScript type-check
- ESLint on changed UI files
- Prettier check on changed UI files

#### Desktop evidence

**Connected imported provider**\n\n<img width="1121" height="998" alt="prowler-imported-provider-connected-tooltip" src="https://github.com/user-attachments/assets/4c039505-59ba-4ea3-a4cf-a8b7ec0417b4" />

**Not connected imported provider**\n\n<img width="1121" height="998" alt="prowler-imported-provider-not-connected-tooltip" src="https://github.com/user-attachments/assets/b196cbb1-5a51-49eb-918c-0c179c66a334" />

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure a changelog fragment is added under <component>/changelog.d/, if applicable.

#### SDK/CLI

- Are there new checks included in this PR? No

#### UI (if applicable)

- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [x] Screenshots/Video - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under ui/changelog.d/

#### API (if applicable)

- API implementation and response contract are covered by prowler-cloud/prowler-cloud#5532.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an imported-provider indicator for cloud providers created through Import Findings.
  * Imported provenance now appears alongside connection status with a helpful tooltip.
  * Connection status displays correctly for connected, disconnected, and failed states.
  * Imported provenance remains hidden in the open-source edition.

* **Documentation**
  * Added a changelog entry documenting the imported-provider indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->