### PR TITLE
feat: add check for secrets in CodePipeline pipeline definitions

### DIFF
--- a/prowler/providers/aws/services/codepipeline/codepipeline_pipeline_no_secrets_in_definition/codepipeline_pipeline_no_secrets_in_definition.metadata.json
+++ b/prowler/providers/aws/services/codepipeline/codepipeline_pipeline_no_secrets_in_definition/codepipeline_pipeline_no_secrets_in_definition.metadata.json
@@ -1,0 +1,44 @@
+{
+  "Provider": "aws",
+  "CheckID": "codepipeline_pipeline_no_secrets_in_definition",
+  "CheckTitle": "CodePipeline pipeline definition has no sensitive credentials",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "TTPs/Credential Access",
+    "Effects/Data Exposure",
+    "Sensitive Data Identifications/Security"
+  ],
+  "ServiceName": "codepipeline",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:partition:codepipeline:region:account-id:pipeline-name",
+  "Severity": "high",
+  "ResourceType": "AwsCodePipelinePipeline",
+  "ResourceGroup": "devops",
+  "Description": "AWS CodePipeline pipeline definitions are inspected for hardcoded secrets, such as keys, tokens, passwords, or credentials embedded directly in stage action configuration values.",
+  "Risk": "Plaintext secrets in CodePipeline pipeline definitions can be viewed by users with pipeline read permissions and may leak through logs or exported definitions. Exposed credentials can enable unauthorized access to source repositories, build systems, and deployment targets.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_GetPipeline.html",
+    "https://docs.aws.amazon.com/codepipeline/latest/userguide/pipeline-structure.html",
+    "https://docs.prowler.com/developer-guide/secret-scanning-checks"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "1. Review the CodePipeline pipeline definition.\n2. Remove hardcoded credentials from stage action configurations.\n3. Store secrets in AWS Secrets Manager or AWS Systems Manager Parameter Store.\n4. Grant the pipeline role least-privilege access to retrieve secrets securely at runtime.\n5. Rotate any exposed credentials.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Avoid embedding secrets in CodePipeline pipeline definitions. Store sensitive values in AWS Secrets Manager or AWS Systems Manager Parameter Store and reference them securely at runtime with least-privilege IAM permissions.",
+      "Url": "https://hub.prowler.com/check/codepipeline_pipeline_no_secrets_in_definition"
+    }
+  },
+  "Categories": [
+    "secrets",
+    "ci-cd"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/codepipeline/codepipeline_pipeline_no_secrets_in_definition/codepipeline_pipeline_no_secrets_in_definition.py
+++ b/prowler/providers/aws/services/codepipeline/codepipeline_pipeline_no_secrets_in_definition/codepipeline_pipeline_no_secrets_in_definition.py
@@ -15,7 +15,18 @@ class codepipeline_pipeline_no_secrets_in_definition(Check):
     """Check that AWS CodePipeline pipeline definitions contain no hardcoded secrets."""
 
     def execute(self) -> list[Check_Report_AWS]:
-        """Execute the CodePipeline definition secret scan."""
+        """Execute the CodePipeline definition secret scan.
+
+        Scans the action configurations of every CodePipeline pipeline definition
+        for hardcoded secrets (keys, tokens, passwords, credentials) using the
+        batched Kingfisher secret scanner.
+
+        Returns:
+            list[Check_Report_AWS]: One report per CodePipeline pipeline, with
+                status PASS when no secrets are found, FAIL when potential
+                secrets are detected, or MANUAL when the scanner cannot produce
+                a trustworthy result.
+        """
         findings = []
         secrets_ignore_patterns = codepipeline_client.audit_config.get(
             "secrets_ignore_patterns", []

--- a/prowler/providers/aws/services/codepipeline/codepipeline_pipeline_no_secrets_in_definition/codepipeline_pipeline_no_secrets_in_definition.py
+++ b/prowler/providers/aws/services/codepipeline/codepipeline_pipeline_no_secrets_in_definition/codepipeline_pipeline_no_secrets_in_definition.py
@@ -1,0 +1,107 @@
+import json
+
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.utils.utils import (
+    SecretsScanError,
+    annotate_verified_secrets,
+    detect_secrets_scan_batch,
+)
+from prowler.providers.aws.services.codepipeline.codepipeline_client import (
+    codepipeline_client,
+)
+
+
+class codepipeline_pipeline_no_secrets_in_definition(Check):
+    """Check that AWS CodePipeline pipeline definitions contain no hardcoded secrets."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the CodePipeline definition secret scan."""
+        findings = []
+        secrets_ignore_patterns = codepipeline_client.audit_config.get(
+            "secrets_ignore_patterns", []
+        )
+        validate = codepipeline_client.audit_config.get("secrets_validate", False)
+        pipelines = list(codepipeline_client.pipelines.values())
+        line_context_by_pipeline = {}
+        payloads = []
+        for pipeline_index, pipeline in enumerate(pipelines):
+            payload, line_context = _build_definition_payload(pipeline.definition)
+            line_context_by_pipeline[pipeline_index] = line_context
+            if payload:
+                payloads.append((pipeline_index, payload))
+
+        scan_error = None
+        try:
+            batch_results = detect_secrets_scan_batch(
+                payloads, excluded_secrets=secrets_ignore_patterns, validate=validate
+            )
+        except SecretsScanError as error:
+            batch_results = {}
+            scan_error = error
+
+        for pipeline_index, pipeline in enumerate(pipelines):
+            report = Check_Report_AWS(metadata=self.metadata(), resource=pipeline)
+            report.resource_tags = pipeline.tags
+            report.status = "PASS"
+            report.status_extended = (
+                f"No secrets found in CodePipeline {pipeline.name} definition."
+            )
+
+            line_context = line_context_by_pipeline.get(pipeline_index, {})
+            if line_context:
+                if scan_error:
+                    report.status = "MANUAL"
+                    report.status_extended = (
+                        f"Could not scan CodePipeline {pipeline.name} definition "
+                        f"for secrets: {scan_error}; manual review is required."
+                    )
+                    findings.append(report)
+                    continue
+
+                detect_secrets_output = batch_results.get(pipeline_index)
+                if detect_secrets_output:
+                    secrets_string = ", ".join(
+                        [
+                            f"{secret['type']} in {line_context.get(secret['line_number'], 'definition')}"
+                            for secret in detect_secrets_output
+                        ]
+                    )
+                    report.status = "FAIL"
+                    report.status_extended = (
+                        f"Potential {'secrets' if len(detect_secrets_output) > 1 else 'secret'} "
+                        f"found in CodePipeline {pipeline.name} definition -> {secrets_string}."
+                    )
+                    annotate_verified_secrets(report, detect_secrets_output)
+
+            findings.append(report)
+        return findings
+
+
+def _build_definition_payload(definition: list) -> tuple[str, dict[int, str]]:
+    """Build a line-oriented scan payload and map each line to a definition field.
+
+    Iterates over every stage/action configuration in the pipeline definition and
+    emits one JSON line per configuration value so that Kingfisher can scan each
+    value independently and map findings back to the originating stage/action.
+    """
+    lines = []
+    line_context = {}
+
+    def add_line(context: str, value) -> None:
+        if value is None:
+            return
+        lines.append(json.dumps({context: value}))
+        line_context[len(lines)] = context
+
+    for stage in definition:
+        stage_name = stage.get("name", "stage")
+        for action in stage.get("actions", []):
+            action_name = action.get("name", "action")
+            configuration = action.get("configuration", {})
+            for config_key, config_value in configuration.items():
+                add_line(
+                    f"stage {stage_name} action {action_name} configuration {config_key}",
+                    config_value,
+                )
+
+    return "\n".join(lines), line_context

--- a/prowler/providers/aws/services/codepipeline/codepipeline_service.py
+++ b/prowler/providers/aws/services/codepipeline/codepipeline_service.py
@@ -77,7 +77,8 @@ class CodePipeline(AWSService):
     def _get_pipeline_state(self, pipeline):
         """Retrieves the current state of a pipeline.
 
-        Gets detailed information about a pipeline including its source configuration.
+        Gets detailed information about a pipeline including its source configuration
+        and full definition (stages and actions).
 
         Args:
             pipeline: Pipeline object to retrieve state for.
@@ -96,6 +97,7 @@ class CodePipeline(AWSService):
                 repository_id=repository_id,
                 configuration=source_info["configuration"],
             )
+            pipeline.definition = pipeline_info["pipeline"].get("stages", [])
         except ClientError as error:
             logger.error(
                 f"{pipeline.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -154,6 +156,7 @@ class Pipeline(BaseModel):
         arn: The ARN (Amazon Resource Name) of the pipeline.
         region: The AWS region where the pipeline exists.
         source: Optional Source object containing source configuration.
+        definition: Optional pipeline definition containing stages and actions.
         tags: Optional list of pipeline tags.
     """
 
@@ -161,4 +164,5 @@ class Pipeline(BaseModel):
     arn: str
     region: str
     source: Optional[Source] = None
+    definition: Optional[list] = []
     tags: Optional[list] = []

--- a/tests/providers/aws/services/codepipeline/codepipeline_pipeline_no_secrets_in_definition/codepipeline_pipeline_no_secrets_in_definition_test.py
+++ b/tests/providers/aws/services/codepipeline/codepipeline_pipeline_no_secrets_in_definition/codepipeline_pipeline_no_secrets_in_definition_test.py
@@ -1,0 +1,270 @@
+from unittest import mock
+
+from prowler.lib.utils.utils import SecretsScanError
+from prowler.providers.aws.services.codepipeline.codepipeline_service import Pipeline
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+
+class Test_codepipeline_pipeline_no_secrets_in_definition:
+    def test_no_pipelines(self):
+        codepipeline_client = mock.MagicMock()
+        codepipeline_client.pipelines = {}
+        codepipeline_client.audit_config = {"secrets_ignore_patterns": []}
+
+        result = _execute_check(codepipeline_client)
+
+        assert len(result) == 0
+
+    def test_pipeline_with_no_secrets_in_definition(self):
+        pipeline = _build_pipeline(
+            definition=[
+                {
+                    "name": "Source",
+                    "actions": [
+                        {
+                            "name": "SourceAction",
+                            "actionTypeId": {
+                                "category": "Source",
+                                "owner": "AWS",
+                                "provider": "CodeStarSourceConnection",
+                                "version": "1",
+                            },
+                            "configuration": {
+                                "ConnectionArn": "arn:aws:codestar-connections:us-east-1:123456789012:connection/test",
+                                "FullRepositoryId": "myorg/myrepo",
+                                "BranchName": "main",
+                            },
+                        }
+                    ],
+                }
+            ]
+        )
+        codepipeline_client = mock.MagicMock()
+        codepipeline_client.pipelines = {pipeline.arn: pipeline}
+        codepipeline_client.audit_config = {"secrets_ignore_patterns": []}
+
+        result = _execute_check(codepipeline_client)
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert (
+            result[0].status_extended
+            == "No secrets found in CodePipeline test-pipeline definition."
+        )
+        assert result[0].region == AWS_REGION_US_EAST_1
+        assert result[0].resource_id == "test-pipeline"
+        assert result[0].resource_arn == pipeline.arn
+
+    def test_pipeline_with_secrets_in_action_configuration(self):
+        pipeline = _build_pipeline(
+            definition=[
+                {
+                    "name": "Build",
+                    "actions": [
+                        {
+                            "name": "BuildAction",
+                            "actionTypeId": {
+                                "category": "Build",
+                                "owner": "AWS",
+                                "provider": "CodeBuild",
+                                "version": "1",
+                            },
+                            "configuration": {
+                                "ProjectName": "my-project",
+                                "EnvironmentVariables": '[{"name":"API_TOKEN","value":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U","type":"PLAINTEXT"}]',
+                            },
+                        }
+                    ],
+                }
+            ]
+        )
+        codepipeline_client = mock.MagicMock()
+        codepipeline_client.pipelines = {pipeline.arn: pipeline}
+        codepipeline_client.audit_config = {"secrets_ignore_patterns": []}
+
+        result = _execute_check(codepipeline_client)
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert "test-pipeline" in result[0].status_extended
+        assert "BuildAction" in result[0].status_extended
+        assert (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+            not in result[0].status_extended
+        )
+        assert result[0].region == AWS_REGION_US_EAST_1
+        assert result[0].resource_id == "test-pipeline"
+        assert result[0].resource_arn == pipeline.arn
+
+    def test_pipeline_with_verified_secret_escalates_severity(self):
+        from prowler.lib.check.models import Severity
+
+        pipeline = _build_pipeline(
+            definition=[
+                {
+                    "name": "Deploy",
+                    "actions": [
+                        {
+                            "name": "DeployAction",
+                            "configuration": {
+                                "SecretKey": "verified-secret-value",
+                            },
+                        }
+                    ],
+                }
+            ]
+        )
+        codepipeline_client = mock.MagicMock()
+        codepipeline_client.pipelines = {pipeline.arn: pipeline}
+        codepipeline_client.audit_config = {
+            "secrets_ignore_patterns": [],
+            "secrets_validate": True,
+        }
+
+        result, scan_batch = _execute_check_with_mocked_scan(
+            codepipeline_client,
+            return_value={
+                0: [
+                    {
+                        "type": "Secret Keyword",
+                        "line_number": 1,
+                        "filename": "data",
+                        "hashed_secret": "x",
+                        "is_verified": True,
+                    }
+                ]
+            },
+        )
+
+        assert scan_batch.call_args.kwargs.get("validate") is True
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert result[0].check_metadata.Severity == Severity.critical
+        assert "confirmed to be live" in result[0].status_extended
+
+    def test_scan_error_marks_all_scannable_pipelines_manual(self):
+        first_pipeline = _build_pipeline(
+            pipeline_name="first-pipeline",
+            definition=[
+                {
+                    "name": "Source",
+                    "actions": [
+                        {
+                            "name": "SourceAction",
+                            "configuration": {"BranchName": "main"},
+                        }
+                    ],
+                }
+            ],
+        )
+        second_pipeline = _build_pipeline(
+            pipeline_name="second-pipeline",
+            definition=[
+                {
+                    "name": "Build",
+                    "actions": [
+                        {
+                            "name": "BuildAction",
+                            "configuration": {"Password": "secret-value"},
+                        }
+                    ],
+                }
+            ],
+        )
+        codepipeline_client = mock.MagicMock()
+        codepipeline_client.pipelines = {
+            first_pipeline.arn: first_pipeline,
+            second_pipeline.arn: second_pipeline,
+        }
+        codepipeline_client.audit_config = {"secrets_ignore_patterns": []}
+
+        result, scan_batch = _execute_check_with_mocked_scan(
+            codepipeline_client,
+            side_effect=SecretsScanError("scanner unavailable"),
+        )
+
+        scan_payloads = scan_batch.call_args.args[0]
+        assert len(scan_payloads) == 2
+        assert len(result) == 2
+        assert {report.status for report in result} == {"MANUAL"}
+        assert all(
+            "manual review is required" in report.status_extended for report in result
+        )
+
+    def test_pipeline_with_empty_definition_passes(self):
+        pipeline = _build_pipeline(definition=[])
+        codepipeline_client = mock.MagicMock()
+        codepipeline_client.pipelines = {pipeline.arn: pipeline}
+        codepipeline_client.audit_config = {"secrets_ignore_patterns": []}
+
+        result = _execute_check(codepipeline_client)
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert (
+            result[0].status_extended
+            == "No secrets found in CodePipeline test-pipeline definition."
+        )
+
+
+def _build_pipeline(
+    definition: list,
+    pipeline_name: str = "test-pipeline",
+) -> Pipeline:
+    pipeline_arn = f"arn:aws:codepipeline:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:{pipeline_name}"
+    return Pipeline(
+        name=pipeline_name,
+        arn=pipeline_arn,
+        region=AWS_REGION_US_EAST_1,
+        definition=definition,
+    )
+
+
+def _execute_check(codepipeline_client):
+    aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+    with (
+        mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ),
+        mock.patch(
+            "prowler.providers.aws.services.codepipeline.codepipeline_pipeline_no_secrets_in_definition.codepipeline_pipeline_no_secrets_in_definition.codepipeline_client",
+            codepipeline_client,
+        ),
+    ):
+        from prowler.providers.aws.services.codepipeline.codepipeline_pipeline_no_secrets_in_definition.codepipeline_pipeline_no_secrets_in_definition import (
+            codepipeline_pipeline_no_secrets_in_definition,
+        )
+
+        check = codepipeline_pipeline_no_secrets_in_definition()
+        return check.execute()
+
+
+def _execute_check_with_mocked_scan(
+    codepipeline_client, return_value=None, side_effect=None
+):
+    aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+    with (
+        mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ),
+        mock.patch(
+            "prowler.providers.aws.services.codepipeline.codepipeline_pipeline_no_secrets_in_definition.codepipeline_pipeline_no_secrets_in_definition.codepipeline_client",
+            codepipeline_client,
+        ),
+    ):
+        import prowler.providers.aws.services.codepipeline.codepipeline_pipeline_no_secrets_in_definition.codepipeline_pipeline_no_secrets_in_definition as check_module
+
+        with mock.patch.object(
+            check_module,
+            "detect_secrets_scan_batch",
+            return_value=return_value,
+            side_effect=side_effect,
+        ) as scan_batch:
+            check = check_module.codepipeline_pipeline_no_secrets_in_definition()
+            return check.execute(), scan_batch

--- a/tests/providers/aws/services/codepipeline/codepipeline_service_test.py
+++ b/tests/providers/aws/services/codepipeline/codepipeline_service_test.py
@@ -103,3 +103,13 @@ class Test_CodePipeline_Service:
         # Test tags
         assert pipeline.tags[0]["key"] == "Environment"
         assert pipeline.tags[0]["value"] == "Test"
+
+        # Test definition
+        assert isinstance(pipeline.definition, list)
+        assert len(pipeline.definition) == 1
+        assert pipeline.definition[0]["name"] == "Source"
+        assert pipeline.definition[0]["actions"][0]["name"] == "Source"
+        assert (
+            pipeline.definition[0]["actions"][0]["configuration"]["FullRepositoryId"]
+            == repository_id
+        )


### PR DESCRIPTION
Adds a new Prowler check to detect secrets in CodePipeline pipeline definitions.

The check scans all stage/action configuration values using the shared Kingfisher-based `detect_secrets_scan_batch` helper, following the same pattern as the existing `datapipeline_pipeline_no_secrets_in_definition` check.

The `codepipeline_service.py` has been updated to also store the full pipeline definition (stages) from the `get_pipeline` API response.

Closes #11808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scanning for hardcoded secrets in AWS CodePipeline action configurations.
  * Reports clean pipelines, detected secrets, and items requiring manual review.
  * Provides stage, action, and configuration context while redacting exposed secret values.
* **Bug Fixes**
  * Improved visibility into pipeline stages, actions, and configuration details for security checks.
* **Tests**
  * Added coverage for clean pipelines, detected and verified secrets, scanner errors, and pipeline metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->