### PR TITLE
feat: add check for SharePoint default sharing link permission

### DIFF
--- a/prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured.metadata.json
+++ b/prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured.metadata.json
@@ -1,0 +1,38 @@
+{
+  "Provider": "m365",
+  "CheckID": "sharepoint_default_sharing_link_permission_configured",
+  "CheckTitle": "Ensure the default SharePoint sharing link permission is set to View",
+  "CheckType": [],
+  "ServiceName": "sharepoint",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "low",
+  "ResourceType": "NotDefined",
+  "ResourceGroup": "collaboration",
+  "Description": "**Microsoft 365 SharePoint** default sharing link permission is evaluated to ensure it is set to **View** rather than **Edit**. This enforces the principle of least privilege by ensuring new sharing links grant read-only access by default, reducing the blast radius of accidental oversharing with edit permissions.",
+  "Risk": "When the default sharing link permission is set to Edit, users who share files or folders may unintentionally grant write access to recipients, increasing the risk of unauthorized modifications, data integrity loss, and accidental data exposure.\n- Integrity: unintended collaborators can modify or delete content\n- Confidentiality: broader edit access increases exposure surface\n- Availability: unauthorized changes can disrupt access to shared resources",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+    "https://learn.microsoft.com/en-us/powershell/module/sharepoint-online/set-spotenant?view=sharepoint-ps"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "Set-SPOTenant -DefaultLinkPermission View",
+      "NativeIaC": "",
+      "Other": "1. Go to the SharePoint admin center: https://admin.microsoft.com/sharepoint\n2. Navigate to Policies > Sharing\n3. Scroll to File and folder links\n4. Under Choose the permission that's selected by default for sharing links, select View\n5. Click Save",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Set the default sharing link permission to View to enforce least privilege. Users can still explicitly choose Edit on a per-link basis when needed, but the default behavior minimizes accidental oversharing of edit access.",
+      "Url": "https://hub.prowler.com/check/sharepoint_default_sharing_link_permission_configured"
+    }
+  },
+  "Categories": [
+    "identity-access",
+    "e3"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured.py
+++ b/prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured.py
@@ -35,8 +35,11 @@ class sharepoint_default_sharing_link_permission_configured(Check):
                 resource_name="SharePoint Settings",
                 resource_id="sharepointSettings",
             )
+            permission = settings.defaultLinkPermission or "not configured"
             report.status = "FAIL"
-            report.status_extended = f"The default sharing link permission is set to {settings.defaultLinkPermission} instead of View."
+            report.status_extended = (
+                f"The default sharing link permission is set to {permission} instead of View."
+            )
 
             if settings.defaultLinkPermission == "View":
                 report.status = "PASS"

--- a/prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured.py
+++ b/prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured.py
@@ -36,9 +36,7 @@ class sharepoint_default_sharing_link_permission_configured(Check):
                 resource_id="sharepointSettings",
             )
             report.status = "FAIL"
-            report.status_extended = (
-                "The default sharing link permission is set to Edit instead of View."
-            )
+            report.status_extended = f"The default sharing link permission is set to {settings.defaultLinkPermission} instead of View."
 
             if settings.defaultLinkPermission == "View":
                 report.status = "PASS"

--- a/prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured.py
+++ b/prowler/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured.py
@@ -1,0 +1,50 @@
+from typing import List
+
+from prowler.lib.check.models import Check, CheckReportM365
+from prowler.providers.m365.services.sharepoint.sharepoint_client import (
+    sharepoint_client,
+)
+
+
+class sharepoint_default_sharing_link_permission_configured(Check):
+    """
+    Check if Microsoft 365 SharePoint default sharing link permission is set to View.
+
+    This check verifies that the default sharing link permission in SharePoint is configured to "View"
+    rather than "Edit". Setting the default to "View" enforces the principle of least privilege by
+    ensuring that new sharing links grant read-only access by default, reducing the risk of accidental
+    oversharing with edit permissions.
+    """
+
+    def execute(self) -> List[CheckReportM365]:
+        """
+        Execute the SharePoint default sharing link permission check.
+
+        Iterates over the SharePoint settings retrieved from the Microsoft 365 SharePoint client and
+        generates a report indicating whether the default sharing link permission is set to "View".
+
+        Returns:
+            List[CheckReportM365]: A list containing a report with the result of the check.
+        """
+        findings = []
+        settings = sharepoint_client.settings
+        if settings:
+            report = CheckReportM365(
+                self.metadata(),
+                resource=settings if settings else {},
+                resource_name="SharePoint Settings",
+                resource_id="sharepointSettings",
+            )
+            report.status = "FAIL"
+            report.status_extended = (
+                "The default sharing link permission is set to Edit instead of View."
+            )
+
+            if settings.defaultLinkPermission == "View":
+                report.status = "PASS"
+                report.status_extended = (
+                    "The default sharing link permission is set to View."
+                )
+
+            findings.append(report)
+        return findings

--- a/prowler/providers/m365/services/sharepoint/sharepoint_service.py
+++ b/prowler/providers/m365/services/sharepoint/sharepoint_service.py
@@ -63,6 +63,11 @@ class SharePoint(M365Service):
                 legacyAuth=global_settings.is_legacy_auth_protocols_enabled,
                 resharingEnabled=global_settings.is_resharing_by_external_users_enabled,
                 allowedDomainGuidsForSyncApp=global_settings.allowed_domain_guids_for_sync_app,
+                defaultLinkPermission=(
+                    str(global_settings.default_link_permission).split(".")[-1]
+                    if global_settings.default_link_permission
+                    else None
+                ),
             )
 
         except ODataError as error:
@@ -86,3 +91,4 @@ class SharePointSettings(BaseModel):
     resharingEnabled: bool
     legacyAuth: bool
     allowedDomainGuidsForSyncApp: List[uuid.UUID]
+    defaultLinkPermission: Optional[str] = None

--- a/tests/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured_test.py
+++ b/tests/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured_test.py
@@ -1,0 +1,129 @@
+import uuid
+from unittest import mock
+
+from prowler.providers.m365.services.sharepoint.sharepoint_service import (
+    SharePointSettings,
+)
+from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
+
+
+class Test_sharepoint_default_sharing_link_permission_configured:
+    def test_default_sharing_link_permission_view(self):
+        """
+        Test when defaultLinkPermission is set to "View":
+        The check should PASS because the default sharing link permission is set to View.
+        """
+        sharepoint_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch("prowler.providers.m365.lib.service.service.M365PowerShell"),
+            mock.patch(
+                "prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured.sharepoint_client",
+                new=sharepoint_client,
+            ),
+        ):
+            from prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured import (
+                sharepoint_default_sharing_link_permission_configured,
+            )
+
+            sharepoint_client.settings = SharePointSettings(
+                sharingCapability="ExternalUserSharingOnly",
+                sharingAllowedDomainList=["allowed-domain.com"],
+                sharingBlockedDomainList=["blocked-domain.com"],
+                sharingDomainRestrictionMode="allowList",
+                resharingEnabled=False,
+                legacyAuth=True,
+                allowedDomainGuidsForSyncApp=[uuid.uuid4()],
+                defaultLinkPermission="View",
+            )
+            sharepoint_client.tenant_domain = DOMAIN
+
+            check = sharepoint_default_sharing_link_permission_configured()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].status_extended == (
+                "The default sharing link permission is set to View."
+            )
+            assert result[0].resource_id == "sharepointSettings"
+            assert result[0].location == "global"
+            assert result[0].resource_name == "SharePoint Settings"
+            assert result[0].resource == sharepoint_client.settings.dict()
+
+    def test_default_sharing_link_permission_edit(self):
+        """
+        Test when defaultLinkPermission is set to "Edit":
+        The check should FAIL because the default sharing link permission is set to Edit instead of View.
+        """
+        sharepoint_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch("prowler.providers.m365.lib.service.service.M365PowerShell"),
+            mock.patch(
+                "prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured.sharepoint_client",
+                new=sharepoint_client,
+            ),
+        ):
+            from prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured import (
+                sharepoint_default_sharing_link_permission_configured,
+            )
+
+            sharepoint_client.settings = SharePointSettings(
+                sharingCapability="ExternalUserSharingOnly",
+                sharingAllowedDomainList=["allowed-domain.com"],
+                sharingBlockedDomainList=["blocked-domain.com"],
+                sharingDomainRestrictionMode="allowList",
+                resharingEnabled=False,
+                legacyAuth=True,
+                allowedDomainGuidsForSyncApp=[uuid.uuid4()],
+                defaultLinkPermission="Edit",
+            )
+            sharepoint_client.tenant_domain = DOMAIN
+
+            check = sharepoint_default_sharing_link_permission_configured()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].status_extended == (
+                "The default sharing link permission is set to Edit instead of View."
+            )
+            assert result[0].resource_id == "sharepointSettings"
+            assert result[0].location == "global"
+            assert result[0].resource_name == "SharePoint Settings"
+            assert result[0].resource == sharepoint_client.settings.dict()
+
+    def test_empty_settings(self):
+        """
+        Test when sharepoint_client.settings is empty:
+        The check should return an empty list of findings.
+        """
+        sharepoint_client = mock.MagicMock
+        sharepoint_client.settings = {}
+        sharepoint_client.tenant_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch("prowler.providers.m365.lib.service.service.M365PowerShell"),
+            mock.patch(
+                "prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured.sharepoint_client",
+                new=sharepoint_client,
+            ),
+        ):
+            from prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured import (
+                sharepoint_default_sharing_link_permission_configured,
+            )
+
+            check = sharepoint_default_sharing_link_permission_configured()
+            result = check.execute()
+            assert len(result) == 0

--- a/tests/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured_test.py
+++ b/tests/providers/m365/services/sharepoint/sharepoint_default_sharing_link_permission_configured/sharepoint_default_sharing_link_permission_configured_test.py
@@ -100,6 +100,52 @@ class Test_sharepoint_default_sharing_link_permission_configured:
             assert result[0].resource_name == "SharePoint Settings"
             assert result[0].resource == sharepoint_client.settings.dict()
 
+    def test_default_sharing_link_permission_none(self):
+        """
+        Test when defaultLinkPermission is set to None:
+        The check should FAIL because the default sharing link permission is not configured.
+        """
+        sharepoint_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch("prowler.providers.m365.lib.service.service.M365PowerShell"),
+            mock.patch(
+                "prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured.sharepoint_client",
+                new=sharepoint_client,
+            ),
+        ):
+            from prowler.providers.m365.services.sharepoint.sharepoint_default_sharing_link_permission_configured.sharepoint_default_sharing_link_permission_configured import (
+                sharepoint_default_sharing_link_permission_configured,
+            )
+
+            sharepoint_client.settings = SharePointSettings(
+                sharingCapability="ExternalUserSharingOnly",
+                sharingAllowedDomainList=["allowed-domain.com"],
+                sharingBlockedDomainList=["blocked-domain.com"],
+                sharingDomainRestrictionMode="allowList",
+                resharingEnabled=False,
+                legacyAuth=True,
+                allowedDomainGuidsForSyncApp=[uuid.uuid4()],
+                defaultLinkPermission=None,
+            )
+            sharepoint_client.tenant_domain = DOMAIN
+
+            check = sharepoint_default_sharing_link_permission_configured()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].status_extended == (
+                "The default sharing link permission is set to not configured instead of View."
+            )
+            assert result[0].resource_id == "sharepointSettings"
+            assert result[0].location == "global"
+            assert result[0].resource_name == "SharePoint Settings"
+            assert result[0].resource == sharepoint_client.settings.dict()
+
     def test_empty_settings(self):
         """
         Test when sharepoint_client.settings is empty:

--- a/tests/providers/m365/services/sharepoint/sharepoint_service_test.py
+++ b/tests/providers/m365/services/sharepoint/sharepoint_service_test.py
@@ -20,6 +20,7 @@ async def mock_sharepoint_get_settings(_):
         resharingEnabled=False,
         legacyAuth=True,
         allowedDomainGuidsForSyncApp=[uuid_value],
+        defaultLinkPermission="View",
     )
 
 
@@ -49,3 +50,4 @@ class Test_SharePoint_Service:
         assert settings.legacyAuth is True
         assert settings.allowedDomainGuidsForSyncApp == [uuid_value]
         assert len(settings.allowedDomainGuidsForSyncApp) == 1
+        assert settings.defaultLinkPermission == "View"


### PR DESCRIPTION
Adds a new Prowler check to ensure the default SharePoint sharing link permission is set to View.

Closes #11802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SharePoint security check to verify that default sharing links use **View** permission.
  * Reports noncompliant configurations using **Edit** permission or when no permission is configured.
  * Added risk details, remediation guidance, severity, and documentation references.

* **Bug Fixes**
  * SharePoint settings now correctly capture the default sharing-link permission.

* **Tests**
  * Added coverage for View, Edit, unset, and empty-settings scenarios.
  * Verified reporting behavior for compliant and noncompliant configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->