### PR TITLE
feat: add check for DMARC records on Exchange Online domains

### DIFF
--- a/prowler/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published.metadata.json
+++ b/prowler/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published.metadata.json
@@ -21,7 +21,7 @@
     "Code": {
       "CLI": "",
       "NativeIaC": "",
-      "Other": "1. Sign in to Microsoft 365 Defender: https://security.microsoft.com\n2. Go to Email & collaboration > Policies & rules > Threat policies > Email authentication settings > DMIM\n3. Review the DMARC status for each domain\n4. Publish a DMARC TXT record at _dmarc.<domain> with v=DMARC1; p=quarantine (or p=reject) at your DNS provider\n5. After DMARC is in place, monitor reports and move from p=none to p=quarantine to p=reject",
+      "Other": "1. Sign in to Microsoft 365 Defender: https://security.microsoft.com\n2. Go to Email & collaboration > Policies & rules > Threat policies > Email authentication settings > DMARC\n3. Review the DMARC status for each domain\n4. Publish a DMARC TXT record at _dmarc.<domain> with v=DMARC1; p=quarantine (or p=reject) at your DNS provider\n5. After DMARC is in place, monitor reports and move from p=none to p=quarantine to p=reject",
       "Terraform": ""
     },
     "Recommendation": {

--- a/prowler/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published.metadata.json
+++ b/prowler/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published.metadata.json
@@ -1,0 +1,39 @@
+{
+  "Provider": "m365",
+  "CheckID": "defender_domain_dmarc_records_published",
+  "CheckTitle": "Ensure DMARC records are published for all Exchange Online domains",
+  "CheckType": [],
+  "ServiceName": "defender",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "NotDefined",
+  "ResourceGroup": "collaboration",
+  "Description": "**Microsoft 365 Exchange Online domains** should have **DMARC TXT records** published in DNS with an enforcing policy. This evaluates each accepted domain to confirm a DMARC record exists at _dmarc.<domain> with p=quarantine or p=reject to prevent domain spoofing and phishing attacks.",
+  "Risk": "Without **DMARC** (or with p=none), attackers can **impersonate your domain** to send spoofed or phishing emails that appear to come from your organization.\n\nThis enables **business email compromise (BEC)**, credential theft, malware delivery, and reputational damage. DMARC builds on SPF and DKIM to provide enforcement and reporting.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dmarc-configure?view=o365-worldwide",
+    "https://learn.microsoft.com/en-us/powershell/module/exchange/set-dkimsigningconfig?view=exchange-ps",
+    "https://dmarc.org/overview/"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "1. Sign in to Microsoft 365 Defender: https://security.microsoft.com\n2. Go to Email & collaboration > Policies & rules > Threat policies > Email authentication settings > DMIM\n3. Review the DMARC status for each domain\n4. Publish a DMARC TXT record at _dmarc.<domain> with v=DMARC1; p=quarantine (or p=reject) at your DNS provider\n5. After DMARC is in place, monitor reports and move from p=none to p=quarantine to p=reject",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "- Publish **DMARC records** for all sending domains and subdomains\n- Start with **p=none** to monitor, then progress to **p=quarantine** and finally **p=reject**\n- Combine with **SPF** and **DKIM** for defense in depth\n- Review DMARC aggregate and forensic reports regularly to detect spoofing attempts",
+      "Url": "https://hub.prowler.com/check/defender_domain_dmarc_records_published"
+    }
+  },
+  "Categories": [
+    "email-security",
+    "e3"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published.py
+++ b/prowler/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published.py
@@ -1,6 +1,7 @@
 import re
 
 from prowler.lib.check.models import Check, CheckReportM365
+from prowler.lib.logger import logger
 from prowler.providers.m365.services.defender.defender_client import defender_client
 
 # DNS exceptions indicating that no answer could be obtained: a genuine
@@ -152,6 +153,9 @@ class defender_domain_dmarc_records_published(Check):
             return None, None
         except Exception as e:
             # Unknown DNS error: treat as resolver failure for safety.
+            logger.error(
+                f"{type(e).__name__}[{e.__traceback__.tb_lineno}]: {e}"
+            )
             return [], f"DNS resolver error ({type(e).__name__})"
 
     def _is_valid_dmarc_record(self, content: str) -> bool:
@@ -176,14 +180,14 @@ class defender_domain_dmarc_records_published(Check):
         if "=" not in first_tag:
             return False
         tag_name, tag_value = first_tag.split("=", 1)
-        if tag_name.strip().upper() != "V" or tag_value.strip().upper() != "DMARC1":
+        if tag_name.strip().lower() != "v" or tag_value.strip() != "DMARC1":
             return False
         # Must contain an exact p tag
         for tag in tags[1:]:
             if "=" not in tag:
                 continue
             name, _ = tag.split("=", 1)
-            if name.strip() == "p":
+            if name.strip().lower() == "p":
                 return True
         return False
 

--- a/prowler/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published.py
+++ b/prowler/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published.py
@@ -29,7 +29,7 @@ class defender_domain_dmarc_records_published(Check):
     or p=reject) for every accepted Exchange Online domain.
     """
 
-    def execute(self):
+    def execute(self) -> list[CheckReportM365]:
         """
         Execute the check to verify if DMARC records are published for all domains.
 
@@ -37,7 +37,7 @@ class defender_domain_dmarc_records_published(Check):
         Online domain and validates that it contains an enforcing policy.
 
         Returns:
-            List[CheckReportM365]: A list of reports containing the result of the check.
+            list[CheckReportM365]: A list of reports containing the result of the check.
         """
         findings = []
         for config in defender_client.dkim_configurations:
@@ -49,7 +49,7 @@ class defender_domain_dmarc_records_published(Check):
                 resource_id=domain,
             )
 
-            records = self._lookup_dmarc_record(domain)
+            records, dns_error = self._lookup_dmarc_record(domain)
 
             if records is None:
                 # No TXT records at _dmarc.<domain> at all.
@@ -58,22 +58,29 @@ class defender_domain_dmarc_records_published(Check):
                     f"No DMARC record found for domain {domain}."
                 )
             elif not records:
-                # DNS resolver failure (Timeout, NoNameservers) -> not an absence.
-                report.status = "MANUAL"
-                report.status_extended = (
-                    f"Could not resolve DMARC record for domain {domain} due to a "
-                    f"DNS resolver error; manual review is required."
-                )
+                # DNS resolver failure -> treat as FAIL.
+                report.status = "FAIL"
+                if dns_error:
+                    report.status_extended = (
+                        f"Could not resolve DMARC record for domain {domain} due to a "
+                        f"{dns_error}; manual review is required."
+                    )
+                else:
+                    report.status_extended = (
+                        f"Could not resolve DMARC record for domain {domain} due to a "
+                        f"DNS resolver error; manual review is required."
+                    )
             else:
-                # Validate cardinality: exactly one DMARC record is expected.
+                # Validate by parsing semicolon-delimited tags.
+                # Each record must have v=DMARC1 as the first tag.
                 dmarc_records = [
-                    r for r in records if r.upper().startswith("V=DMARC1")
+                    r for r in records if self._is_valid_dmarc_record(r)
                 ]
                 if len(dmarc_records) == 0:
                     report.status = "FAIL"
                     report.status_extended = (
                         f"TXT record found at _dmarc.{domain} but it is not a valid "
-                        f"DMARC record: missing V=DMARC1 version tag."
+                        f"DMARC record: malformed or missing V=DMARC1 version tag."
                     )
                 elif len(dmarc_records) > 1:
                     report.status = "FAIL"
@@ -101,7 +108,7 @@ class defender_domain_dmarc_records_published(Check):
                         report.status = "FAIL"
                         report.status_extended = (
                             f"DMARC record found for domain {domain} but has a "
-                            f"missing or unrecognized policy."
+                            f"malformed or unrecognized policy."
                         )
 
             findings.append(report)
@@ -118,30 +125,67 @@ class defender_domain_dmarc_records_published(Check):
             domain: The domain to look up the DMARC record for.
 
         Returns:
-            list: All TXT record strings found, if any.
-            None: If the DNS lookup completed but no TXT records exist
-                (NXDOMAIN, NoAnswer).
-            An empty list: If the DNS resolver failed (Timeout, NoNameservers)
-                and the lookup must be retried manually.
+            tuple: (records, error_message) where:
+            - records is a list of TXT record strings, or None if no records exist
+              (NXDOMAIN, NoAnswer), or an empty list if the DNS resolver failed.
+            - error_message is a string describing the DNS error, or None.
         """
         import dns.resolver
 
         try:
             answers = dns.resolver.resolve(f"_dmarc.{domain}", "TXT")
-            return [
-                b"".join(rdata.strings).decode("utf-8") for rdata in answers
-            ] or None
-        except _DNS_FAILURE_EXCEPTIONS:
+            records = []
+            for rdata in answers:
+                try:
+                    records.append(b"".join(rdata.strings).decode("utf-8"))
+                except (UnicodeDecodeError, ValueError):
+                    # Decode failure: treat as transient resolver failure.
+                    return [], "DNS record decode failure"
+            return records or None, None
+        except _DNS_FAILURE_EXCEPTIONS as e:
             # Transient resolver failure. An empty list is the sentinel for the
-            # caller to report MANUAL instead of FAIL.
-            return []
+            # caller to report FAIL.
+            error_type = type(e).__name__
+            return [], f"DNS resolver error ({error_type})"
         except _DNS_ABSENT_EXCEPTIONS:
             # No TXT records at all (domain absent or no answer).
-            return None
-        except Exception:
-            # Unknown DNS error: treat as resolver failure for safety so the
-            # finding is flagged for manual review rather than silently passing.
-            return []
+            return None, None
+        except Exception as e:
+            # Unknown DNS error: treat as resolver failure for safety.
+            return [], f"DNS resolver error ({type(e).__name__})"
+
+    def _is_valid_dmarc_record(self, content: str) -> bool:
+        """
+        Check whether a TXT record is a valid DMARC record.
+
+        Parses the record as semicolon-delimited tags and requires:
+        - The first tag must be exactly ``v=DMARC1`` (case-insensitive).
+        - The record must contain an exact ``p`` tag.
+
+        Args:
+            content: The TXT record string.
+
+        Returns:
+            bool: True if the record is a valid DMARC record, False otherwise.
+        """
+        tags = [t.strip() for t in content.split(";") if t.strip()]
+        if not tags:
+            return False
+        # First tag must be v=DMARC1
+        first_tag = tags[0]
+        if "=" not in first_tag:
+            return False
+        tag_name, tag_value = first_tag.split("=", 1)
+        if tag_name.strip().upper() != "V" or tag_value.strip().upper() != "DMARC1":
+            return False
+        # Must contain an exact p tag
+        for tag in tags[1:]:
+            if "=" not in tag:
+                continue
+            name, _ = tag.split("=", 1)
+            if name.strip() == "p":
+                return True
+        return False
 
     def _get_policy_value(self, content):
         """

--- a/prowler/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published.py
+++ b/prowler/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published.py
@@ -1,0 +1,124 @@
+import re
+
+from prowler.lib.check.models import Check, CheckReportM365
+from prowler.providers.m365.services.defender.defender_client import defender_client
+
+
+class defender_domain_dmarc_records_published(Check):
+    """
+    Check if DMARC records are published with an enforcing policy for all Exchange Online domains.
+
+    DMARC (Domain-based Message Authentication, Reporting, and Conformance) builds on
+    SPF and DKIM to stop spoofing/phishing from your domains. This check verifies that
+    a DMARC TXT record exists at _dmarc.<domain> with an enforcing policy (p=quarantine
+    or p=reject) for every accepted Exchange Online domain.
+    """
+
+    def execute(self):
+        """
+        Execute the check to verify if DMARC records are published for all domains.
+
+        This method looks up the DMARC TXT record at _dmarc.<domain> for each Exchange
+        Online domain and validates that it contains an enforcing policy.
+
+        Returns:
+            List[CheckReportM365]: A list of reports containing the result of the check.
+        """
+        findings = []
+        for config in defender_client.dkim_configurations:
+            domain = config.id
+            report = CheckReportM365(
+                metadata=self.metadata(),
+                resource=config,
+                resource_name=domain,
+                resource_id=domain,
+            )
+
+            dmarc_record = self._lookup_dmarc_record(domain)
+
+            if not dmarc_record:
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"No DMARC record found for domain {domain}."
+                )
+            else:
+                # Validate the DMARC record has the correct version tag
+                if not dmarc_record.upper().startswith("V=DMARC1"):
+                    report.status = "FAIL"
+                    report.status_extended = (
+                        f"DMARC record found for domain {domain} but is malformed: "
+                        f"missing or invalid V=DMARC1 version tag."
+                    )
+                else:
+                    policy = self._get_policy_value(dmarc_record)
+
+                    if policy in ("reject", "quarantine"):
+                        report.status = "PASS"
+                        report.status_extended = (
+                            f"DMARC record with enforcing policy p={policy} "
+                            f"exists for domain {domain}."
+                        )
+                    elif policy == "none":
+                        report.status = "FAIL"
+                        report.status_extended = (
+                            f"DMARC record exists for domain {domain} but uses "
+                            f"monitoring-only policy p=none."
+                        )
+                    else:
+                        report.status = "FAIL"
+                        report.status_extended = (
+                            f"DMARC record found for domain {domain} but has an "
+                            f"missing or unrecognized policy."
+                        )
+
+            findings.append(report)
+
+        return findings
+
+    def _lookup_dmarc_record(self, domain):
+        """
+        Look up the DMARC TXT record for a given domain.
+
+        DMARC records are published as TXT records at _dmarc.<domain>.
+
+        Args:
+            domain: The domain to look up the DMARC record for.
+
+        Returns:
+            str or None: The DMARC record content if found, None otherwise.
+        """
+        import dns.resolver
+
+        try:
+            answers = dns.resolver.resolve(f"_dmarc.{domain}", "TXT")
+            for rdata in answers:
+                record = b"".join(rdata.strings).decode("utf-8")
+                if "V=DMARC1" in record.upper():
+                    return record
+        except (
+            dns.resolver.NoAnswer,
+            dns.resolver.NXDOMAIN,
+            dns.resolver.NoNameservers,
+            dns.resolver.Timeout,
+            dns.resolver.Timeout,
+        ):
+            pass
+        except Exception:
+            pass
+
+        return None
+
+    def _get_policy_value(self, content):
+        """
+        Extract the DMARC policy value (reject, quarantine, or none) from a DMARC record.
+
+        Args:
+            content: The DMARC record string.
+
+        Returns:
+            str: The policy value ("reject", "quarantine", "none") or empty string if not found.
+        """
+        match = re.search(r"p\s*=\s*(\w+)", content, re.IGNORECASE)
+        if match:
+            return match.group(1).lower()
+        return ""

--- a/prowler/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published.py
+++ b/prowler/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published.py
@@ -3,6 +3,21 @@ import re
 from prowler.lib.check.models import Check, CheckReportM365
 from prowler.providers.m365.services.defender.defender_client import defender_client
 
+# DNS exceptions indicating that no answer could be obtained: a genuine
+# absence (NXDOMAIN, NoAnswer) versus a transient resolver failure (Timeout,
+# NoNameservers). Absent signals "no record found"; failure signals that the
+# lookup must be retried manually.
+import dns.resolver as _dns_resolver
+
+_DNS_ABSENT_EXCEPTIONS = (
+    _dns_resolver.NoAnswer,
+    _dns_resolver.NXDOMAIN,
+)
+_DNS_FAILURE_EXCEPTIONS = (
+    _dns_resolver.NoNameservers,
+    _dns_resolver.Timeout,
+)
+
 
 class defender_domain_dmarc_records_published(Check):
     """
@@ -34,22 +49,40 @@ class defender_domain_dmarc_records_published(Check):
                 resource_id=domain,
             )
 
-            dmarc_record = self._lookup_dmarc_record(domain)
+            records = self._lookup_dmarc_record(domain)
 
-            if not dmarc_record:
+            if records is None:
+                # No TXT records at _dmarc.<domain> at all.
                 report.status = "FAIL"
                 report.status_extended = (
                     f"No DMARC record found for domain {domain}."
                 )
+            elif not records:
+                # DNS resolver failure (Timeout, NoNameservers) -> not an absence.
+                report.status = "MANUAL"
+                report.status_extended = (
+                    f"Could not resolve DMARC record for domain {domain} due to a "
+                    f"DNS resolver error; manual review is required."
+                )
             else:
-                # Validate the DMARC record has the correct version tag
-                if not dmarc_record.upper().startswith("V=DMARC1"):
+                # Validate cardinality: exactly one DMARC record is expected.
+                dmarc_records = [
+                    r for r in records if r.upper().startswith("V=DMARC1")
+                ]
+                if len(dmarc_records) == 0:
                     report.status = "FAIL"
                     report.status_extended = (
-                        f"DMARC record found for domain {domain} but is malformed: "
-                        f"missing or invalid V=DMARC1 version tag."
+                        f"TXT record found at _dmarc.{domain} but it is not a valid "
+                        f"DMARC record: missing V=DMARC1 version tag."
+                    )
+                elif len(dmarc_records) > 1:
+                    report.status = "FAIL"
+                    report.status_extended = (
+                        f"Multiple DMARC records found for domain {domain}: "
+                        f"exactly one V=DMARC1 record is expected."
                     )
                 else:
+                    dmarc_record = dmarc_records[0]
                     policy = self._get_policy_value(dmarc_record)
 
                     if policy in ("reject", "quarantine"):
@@ -67,7 +100,7 @@ class defender_domain_dmarc_records_published(Check):
                     else:
                         report.status = "FAIL"
                         report.status_extended = (
-                            f"DMARC record found for domain {domain} but has an "
+                            f"DMARC record found for domain {domain} but has a "
                             f"missing or unrecognized policy."
                         )
 
@@ -77,7 +110,7 @@ class defender_domain_dmarc_records_published(Check):
 
     def _lookup_dmarc_record(self, domain):
         """
-        Look up the DMARC TXT record for a given domain.
+        Look up the TXT records at _dmarc.<domain>.
 
         DMARC records are published as TXT records at _dmarc.<domain>.
 
@@ -85,32 +118,38 @@ class defender_domain_dmarc_records_published(Check):
             domain: The domain to look up the DMARC record for.
 
         Returns:
-            str or None: The DMARC record content if found, None otherwise.
+            list: All TXT record strings found, if any.
+            None: If the DNS lookup completed but no TXT records exist
+                (NXDOMAIN, NoAnswer).
+            An empty list: If the DNS resolver failed (Timeout, NoNameservers)
+                and the lookup must be retried manually.
         """
         import dns.resolver
 
         try:
             answers = dns.resolver.resolve(f"_dmarc.{domain}", "TXT")
-            for rdata in answers:
-                record = b"".join(rdata.strings).decode("utf-8")
-                if "V=DMARC1" in record.upper():
-                    return record
-        except (
-            dns.resolver.NoAnswer,
-            dns.resolver.NXDOMAIN,
-            dns.resolver.NoNameservers,
-            dns.resolver.Timeout,
-            dns.resolver.Timeout,
-        ):
-            pass
+            return [
+                b"".join(rdata.strings).decode("utf-8") for rdata in answers
+            ] or None
+        except _DNS_FAILURE_EXCEPTIONS:
+            # Transient resolver failure. An empty list is the sentinel for the
+            # caller to report MANUAL instead of FAIL.
+            return []
+        except _DNS_ABSENT_EXCEPTIONS:
+            # No TXT records at all (domain absent or no answer).
+            return None
         except Exception:
-            pass
-
-        return None
+            # Unknown DNS error: treat as resolver failure for safety so the
+            # finding is flagged for manual review rather than silently passing.
+            return []
 
     def _get_policy_value(self, content):
         """
         Extract the DMARC policy value (reject, quarantine, or none) from a DMARC record.
+
+        Validates exact tag boundaries so that tags like ``sp``, ``adkim``,
+        or ``rua`` are not mistaken for the ``p`` (policy) tag, and enforces
+        that the ``p`` tag appears exactly once.
 
         Args:
             content: The DMARC record string.
@@ -118,7 +157,17 @@ class defender_domain_dmarc_records_published(Check):
         Returns:
             str: The policy value ("reject", "quarantine", "none") or empty string if not found.
         """
-        match = re.search(r"p\s*=\s*(\w+)", content, re.IGNORECASE)
-        if match:
-            return match.group(1).lower()
+        # Match the 'p' tag with exact tag boundaries: preceded by ';' or
+        # start-of-string, and the value terminated by ';' or end-of-string.
+        # [a-zA-Z]+ captures only the tag value (no semicolons or separators).
+        matches = re.findall(
+            r"(?:^|;)\s*p\s*=\s*([a-zA-Z]+)\s*(?:;|$)",
+            content,
+            re.IGNORECASE,
+        )
+        if len(matches) == 1:
+            return matches[0].lower()
+        elif len(matches) > 1:
+            # Cardinality violation: 'p' tag appears more than once.
+            return ""
         return ""

--- a/tests/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published_test.py
+++ b/tests/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published_test.py
@@ -371,3 +371,147 @@ class Test_defender_domain_dmarc_records_published:
             assert result[1].resource_id == "bad.com"
             assert result[2].status == "FAIL"
             assert result[2].resource_id == "missing.com"
+
+    def test_dmarc_rejects_lowercase_version(self):
+        """
+        Regression test: v=dmarc1 (lowercase version value) must be rejected.
+        Per RFC 7489, the version value must be exactly DMARC1.
+        """
+        defender_client = mock.MagicMock()
+        defender_client.audited_tenant = "audited_tenant"
+        defender_client.audited_domain = DOMAIN
+
+        mock_dns_answer = mock.MagicMock()
+        mock_dns_answer.strings = [b"v=dmarc1; p=reject"]
+        mock_dns_response = [mock_dns_answer]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published.defender_client",
+                new=defender_client,
+            ),
+            mock.patch(
+                "dns.resolver.resolve",
+                return_value=mock_dns_response,
+            ),
+        ):
+            from prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published import (
+                defender_domain_dmarc_records_published,
+            )
+            from prowler.providers.m365.services.defender.defender_service import (
+                DkimConfig,
+            )
+
+            defender_client.dkim_configurations = [
+                DkimConfig(dkim_signing_enabled=True, id="example.com")
+            ]
+
+            check = defender_domain_dmarc_records_published()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "malformed" in result[0].status_extended
+
+    def test_dmarc_accepts_uppercase_p_tag(self):
+        """
+        Regression test: V=DMARC1; P=reject (uppercase P) must be accepted.
+        Per RFC 9989, DMARC tag names are case-insensitive.
+        """
+        defender_client = mock.MagicMock()
+        defender_client.audited_tenant = "audited_tenant"
+        defender_client.audited_domain = DOMAIN
+
+        mock_dns_answer = mock.MagicMock()
+        mock_dns_answer.strings = [b"v=DMARC1; P=reject"]
+        mock_dns_response = [mock_dns_answer]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published.defender_client",
+                new=defender_client,
+            ),
+            mock.patch(
+                "dns.resolver.resolve",
+                return_value=mock_dns_response,
+            ),
+        ):
+            from prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published import (
+                defender_domain_dmarc_records_published,
+            )
+            from prowler.providers.m365.services.defender.defender_service import (
+                DkimConfig,
+            )
+
+            defender_client.dkim_configurations = [
+                DkimConfig(dkim_signing_enabled=True, id="example.com")
+            ]
+
+            check = defender_domain_dmarc_records_published()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert "p=reject" in result[0].status_extended
+
+    def test_dmarc_rejects_sp_tag_without_p(self):
+        """
+        Regression test: v=DMARC1; sp=reject (no p tag) must be rejected.
+        A valid DMARC record must contain an explicit p tag.
+        """
+        defender_client = mock.MagicMock()
+        defender_client.audited_tenant = "audited_tenant"
+        defender_client.audited_domain = DOMAIN
+
+        mock_dns_answer = mock.MagicMock()
+        mock_dns_answer.strings = [b"v=DMARC1; sp=reject"]
+        mock_dns_response = [mock_dns_answer]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published.defender_client",
+                new=defender_client,
+            ),
+            mock.patch(
+                "dns.resolver.resolve",
+                return_value=mock_dns_response,
+            ),
+        ):
+            from prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published import (
+                defender_domain_dmarc_records_published,
+            )
+            from prowler.providers.m365.services.defender.defender_service import (
+                DkimConfig,
+            )
+
+            defender_client.dkim_configurations = [
+                DkimConfig(dkim_signing_enabled=True, id="example.com")
+            ]
+
+            check = defender_domain_dmarc_records_published()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "malformed" in result[0].status_extended

--- a/tests/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published_test.py
+++ b/tests/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published_test.py
@@ -1,0 +1,327 @@
+from unittest import mock
+
+from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
+
+
+class Test_defender_domain_dmarc_records_published:
+    def test_dmarc_with_reject_policy(self):
+        defender_client = mock.MagicMock()
+        defender_client.audited_tenant = "audited_tenant"
+        defender_client.audited_domain = DOMAIN
+
+        mock_dns_answer = mock.MagicMock()
+        mock_dns_answer.strings = [b"v=DMARC1; p=reject; rua=mailto:dmarc@example.com"]
+        mock_dns_response = [mock_dns_answer]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published.defender_client",
+                new=defender_client,
+            ),
+            mock.patch(
+                "dns.resolver.resolve",
+                return_value=mock_dns_response,
+            ),
+        ):
+            from prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published import (
+                defender_domain_dmarc_records_published,
+            )
+            from prowler.providers.m365.services.defender.defender_service import (
+                DkimConfig,
+            )
+
+            defender_client.dkim_configurations = [
+                DkimConfig(dkim_signing_enabled=True, id="example.com")
+            ]
+
+            check = defender_domain_dmarc_records_published()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].resource_name == "example.com"
+            assert result[0].resource_id == "example.com"
+            assert result[0].location == "global"
+            assert "p=reject" in result[0].status_extended
+
+    def test_dmarc_with_quarantine_policy(self):
+        defender_client = mock.MagicMock()
+        defender_client.audited_tenant = "audited_tenant"
+        defender_client.audited_domain = DOMAIN
+
+        mock_dns_answer = mock.MagicMock()
+        mock_dns_answer.strings = [
+            b"v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com"
+        ]
+        mock_dns_response = [mock_dns_answer]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published.defender_client",
+                new=defender_client,
+            ),
+            mock.patch(
+                "dns.resolver.resolve",
+                return_value=mock_dns_response,
+            ),
+        ):
+            from prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published import (
+                defender_domain_dmarc_records_published,
+            )
+            from prowler.providers.m365.services.defender.defender_service import (
+                DkimConfig,
+            )
+
+            defender_client.dkim_configurations = [
+                DkimConfig(dkim_signing_enabled=True, id="example.com")
+            ]
+
+            check = defender_domain_dmarc_records_published()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].resource_name == "example.com"
+            assert result[0].resource_id == "example.com"
+            assert result[0].location == "global"
+            assert "p=quarantine" in result[0].status_extended
+
+    def test_dmarc_with_none_policy(self):
+        defender_client = mock.MagicMock()
+        defender_client.audited_tenant = "audited_tenant"
+        defender_client.audited_domain = DOMAIN
+
+        mock_dns_answer = mock.MagicMock()
+        mock_dns_answer.strings = [b"v=DMARC1; p=none; rua=mailto:dmarc@example.com"]
+        mock_dns_response = [mock_dns_answer]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published.defender_client",
+                new=defender_client,
+            ),
+            mock.patch(
+                "dns.resolver.resolve",
+                return_value=mock_dns_response,
+            ),
+        ):
+            from prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published import (
+                defender_domain_dmarc_records_published,
+            )
+            from prowler.providers.m365.services.defender.defender_service import (
+                DkimConfig,
+            )
+
+            defender_client.dkim_configurations = [
+                DkimConfig(dkim_signing_enabled=True, id="example.com")
+            ]
+
+            check = defender_domain_dmarc_records_published()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_name == "example.com"
+            assert result[0].resource_id == "example.com"
+            assert result[0].location == "global"
+            assert "p=none" in result[0].status_extended
+
+    def test_dmarc_not_found(self):
+        defender_client = mock.MagicMock()
+        defender_client.audited_tenant = "audited_tenant"
+        defender_client.audited_domain = DOMAIN
+
+        import dns.resolver
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published.defender_client",
+                new=defender_client,
+            ),
+            mock.patch(
+                "dns.resolver.resolve",
+                side_effect=dns.resolver.NoAnswer(),
+            ),
+        ):
+            from prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published import (
+                defender_domain_dmarc_records_published,
+            )
+            from prowler.providers.m365.services.defender.defender_service import (
+                DkimConfig,
+            )
+
+            defender_client.dkim_configurations = [
+                DkimConfig(dkim_signing_enabled=True, id="example.com")
+            ]
+
+            check = defender_domain_dmarc_records_published()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_name == "example.com"
+            assert result[0].resource_id == "example.com"
+            assert result[0].location == "global"
+            assert "No DMARC record found" in result[0].status_extended
+
+    def test_malformed_dmarc_record(self):
+        defender_client = mock.MagicMock()
+        defender_client.audited_tenant = "audited_tenant"
+        defender_client.audited_domain = DOMAIN
+
+        mock_dns_answer = mock.MagicMock()
+        mock_dns_answer.strings = [b"not a valid dmarc record"]
+        mock_dns_response = [mock_dns_answer]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published.defender_client",
+                new=defender_client,
+            ),
+            mock.patch(
+                "dns.resolver.resolve",
+                return_value=mock_dns_response,
+            ),
+        ):
+            from prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published import (
+                defender_domain_dmarc_records_published,
+            )
+            from prowler.providers.m365.services.defender.defender_service import (
+                DkimConfig,
+            )
+
+            defender_client.dkim_configurations = [
+                DkimConfig(dkim_signing_enabled=True, id="example.com")
+            ]
+
+            check = defender_domain_dmarc_records_published()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_name == "example.com"
+            assert result[0].resource_id == "example.com"
+            assert result[0].location == "global"
+            assert "malformed" in result[0].status_extended
+
+    def test_no_domains(self):
+        defender_client = mock.MagicMock()
+        defender_client.audited_tenant = "audited_tenant"
+        defender_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published.defender_client",
+                new=defender_client,
+            ),
+        ):
+            from prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published import (
+                defender_domain_dmarc_records_published,
+            )
+
+            defender_client.dkim_configurations = []
+
+            check = defender_domain_dmarc_records_published()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    def test_multiple_domains_mixed_results(self):
+        defender_client = mock.MagicMock()
+        defender_client.audited_tenant = "audited_tenant"
+        defender_client.audited_domain = DOMAIN
+
+        import dns.resolver
+
+        def dns_side_effect(domain, record_type):
+            mock_answer = mock.MagicMock()
+            if "good.com" in domain:
+                mock_answer.strings = [b"v=DMARC1; p=reject"]
+            elif "bad.com" in domain:
+                mock_answer.strings = [b"v=DMARC1; p=none"]
+            else:
+                raise dns.resolver.NXDOMAIN()
+            return [mock_answer]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published.defender_client",
+                new=defender_client,
+            ),
+            mock.patch(
+                "dns.resolver.resolve",
+                side_effect=dns_side_effect,
+            ),
+        ):
+            from prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published import (
+                defender_domain_dmarc_records_published,
+            )
+            from prowler.providers.m365.services.defender.defender_service import (
+                DkimConfig,
+            )
+
+            defender_client.dkim_configurations = [
+                DkimConfig(dkim_signing_enabled=True, id="good.com"),
+                DkimConfig(dkim_signing_enabled=True, id="bad.com"),
+                DkimConfig(dkim_signing_enabled=False, id="missing.com"),
+            ]
+
+            check = defender_domain_dmarc_records_published()
+            result = check.execute()
+
+            assert len(result) == 3
+            assert result[0].status == "PASS"
+            assert result[0].resource_id == "good.com"
+            assert result[1].status == "FAIL"
+            assert result[1].resource_id == "bad.com"
+            assert result[2].status == "FAIL"
+            assert result[2].resource_id == "missing.com"

--- a/tests/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published_test.py
+++ b/tests/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published_test.py
@@ -192,7 +192,7 @@ class Test_defender_domain_dmarc_records_published:
             assert result[0].location == "global"
             assert "No DMARC record found" in result[0].status_extended
 
-    def test_dns_resolver_failure_marks_manual(self):
+    def test_dns_resolver_failure_marks_fail(self):
         defender_client = mock.MagicMock()
         defender_client.audited_tenant = "audited_tenant"
         defender_client.audited_domain = DOMAIN
@@ -231,7 +231,7 @@ class Test_defender_domain_dmarc_records_published:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].status == "MANUAL"
+            assert result[0].status == "FAIL"
             assert result[0].resource_name == "example.com"
             assert result[0].resource_id == "example.com"
             assert result[0].location == "global"

--- a/tests/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published_test.py
+++ b/tests/providers/m365/services/defender/defender_domain_dmarc_records_published/defender_domain_dmarc_records_published_test.py
@@ -192,6 +192,52 @@ class Test_defender_domain_dmarc_records_published:
             assert result[0].location == "global"
             assert "No DMARC record found" in result[0].status_extended
 
+    def test_dns_resolver_failure_marks_manual(self):
+        defender_client = mock.MagicMock()
+        defender_client.audited_tenant = "audited_tenant"
+        defender_client.audited_domain = DOMAIN
+
+        import dns.resolver
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published.defender_client",
+                new=defender_client,
+            ),
+            mock.patch(
+                "dns.resolver.resolve",
+                side_effect=dns.resolver.Timeout(),
+            ),
+        ):
+            from prowler.providers.m365.services.defender.defender_domain_dmarc_records_published.defender_domain_dmarc_records_published import (
+                defender_domain_dmarc_records_published,
+            )
+            from prowler.providers.m365.services.defender.defender_service import (
+                DkimConfig,
+            )
+
+            defender_client.dkim_configurations = [
+                DkimConfig(dkim_signing_enabled=True, id="example.com")
+            ]
+
+            check = defender_domain_dmarc_records_published()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert result[0].resource_name == "example.com"
+            assert result[0].resource_id == "example.com"
+            assert result[0].location == "global"
+            assert "DNS resolver error" in result[0].status_extended
+            assert "manual review" in result[0].status_extended
+
     def test_malformed_dmarc_record(self):
         defender_client = mock.MagicMock()
         defender_client.audited_tenant = "audited_tenant"


### PR DESCRIPTION
Adds a new Prowler check to ensure DMARC records are published for all Exchange Online domains.

Closes #11800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Microsoft 365 Defender check that evaluates DMARC records for all configured Exchange Online domains.
  * Reports each domain separately, identifying missing, duplicate, malformed, or insufficient DMARC policies.
  * Considers `reject` and `quarantine` policies compliant, while `none` or unavailable policies require attention.
  * Distinguishes DNS resolution failures for manual review.
* **Documentation**
  * Added severity, risk context, remediation guidance, recommendations, and supporting documentation links for the new check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->