### PR TITLE
fix(ui): settle scan auto-refresh safely

### DIFF
--- a/ui/changelog.d/scan-auto-refresh-settlement.fixed.md
+++ b/ui/changelog.d/scan-auto-refresh-settlement.fixed.md
@@ -1,0 +1,1 @@
+Scan auto-refresh no longer overlaps slow client refreshes and now signals when scan execution settles

--- a/ui/components/scans/auto-refresh.test.tsx
+++ b/ui/components/scans/auto-refresh.test.tsx
@@ -11,7 +11,11 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => navigationState.searchParams,
 }));
 
-import { AutoRefresh, SCAN_POLL_TICK_EVENT } from "./auto-refresh";
+import {
+  AutoRefresh,
+  SCAN_EXECUTION_SETTLED_EVENT,
+  SCAN_POLL_TICK_EVENT,
+} from "./auto-refresh";
 
 describe("AutoRefresh", () => {
   beforeEach(() => {
@@ -81,6 +85,58 @@ describe("AutoRefresh", () => {
     expect(onRefresh).toHaveBeenCalledOnce();
     expect(eventListener).not.toHaveBeenCalled();
     window.removeEventListener(SCAN_POLL_TICK_EVENT, eventListener);
+  });
+
+  it("does not start another refresh while the previous one is pending", async () => {
+    // Given
+    let resolveRefresh!: () => void;
+    const refreshPromise = new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const onRefresh = vi.fn().mockReturnValue(refreshPromise);
+    render(<AutoRefresh hasExecutingScan onRefresh={onRefresh} />);
+
+    // When
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // Then
+    expect(onRefresh).toHaveBeenCalledOnce();
+
+    // When
+    resolveRefresh();
+    await refreshPromise;
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    // Then
+    expect(onRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("signals when scan execution settles", () => {
+    // Given
+    const eventListener = vi.fn();
+    window.addEventListener(SCAN_EXECUTION_SETTLED_EVENT, eventListener);
+    const { rerender } = render(<AutoRefresh hasExecutingScan />);
+
+    // When
+    rerender(<AutoRefresh hasExecutingScan={false} />);
+    rerender(<AutoRefresh hasExecutingScan={false} />);
+
+    // Then
+    expect(eventListener).toHaveBeenCalledOnce();
+    window.removeEventListener(SCAN_EXECUTION_SETTLED_EVENT, eventListener);
+  });
+
+  it("does not signal settled execution on an idle initial render", () => {
+    // Given
+    const eventListener = vi.fn();
+    window.addEventListener(SCAN_EXECUTION_SETTLED_EVENT, eventListener);
+
+    // When
+    render(<AutoRefresh hasExecutingScan={false} />);
+
+    // Then
+    expect(eventListener).not.toHaveBeenCalled();
+    window.removeEventListener(SCAN_EXECUTION_SETTLED_EVENT, eventListener);
   });
 
   it.each([

--- a/ui/components/scans/auto-refresh.test.tsx
+++ b/ui/components/scans/auto-refresh.test.tsx
@@ -111,6 +111,32 @@ describe("AutoRefresh", () => {
     expect(onRefresh).toHaveBeenCalledTimes(2);
   });
 
+  it("does not dispatch a poll tick after unmounting a pending refresh", async () => {
+    // Given
+    let resolveRefresh!: () => void;
+    const refreshPromise = new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const onRefresh = vi.fn().mockReturnValue(refreshPromise);
+    const eventListener = vi.fn();
+    window.addEventListener(SCAN_POLL_TICK_EVENT, eventListener);
+    const { unmount } = render(
+      <AutoRefresh hasExecutingScan onRefresh={onRefresh} />,
+    );
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    // When
+    unmount();
+    resolveRefresh();
+    await refreshPromise;
+    await Promise.resolve();
+
+    // Then
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(eventListener).not.toHaveBeenCalled();
+    window.removeEventListener(SCAN_POLL_TICK_EVENT, eventListener);
+  });
+
   it("signals when scan execution settles", () => {
     // Given
     const eventListener = vi.fn();

--- a/ui/components/scans/auto-refresh.tsx
+++ b/ui/components/scans/auto-refresh.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 /**
  * Signals that a poll cycle ran, not that fresh data landed: the default branch
@@ -10,15 +10,28 @@ import { useEffect } from "react";
  */
 export const SCAN_POLL_TICK_EVENT = "prowler:scan-poll-tick";
 
+/** Signals the transition from an executing scan to no executing scan. */
+export const SCAN_EXECUTION_SETTLED_EVENT = "prowler:scan-execution-settled";
+
 interface AutoRefreshProps {
   hasExecutingScan: boolean;
   /** Optional callback for client-side refresh (used when data is managed in local state) */
   onRefresh?: () => void | Promise<void>;
 }
 
-export function AutoRefresh({ hasExecutingScan, onRefresh }: AutoRefreshProps) {
+const useAutoRefresh = ({ hasExecutingScan, onRefresh }: AutoRefreshProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const refreshInProgress = useRef(false);
+  const previouslyExecuting = useRef(hasExecutingScan);
+
+  useEffect(() => {
+    if (previouslyExecuting.current && !hasExecutingScan) {
+      window.dispatchEvent(new Event(SCAN_EXECUTION_SETTLED_EVENT));
+    }
+
+    previouslyExecuting.current = hasExecutingScan;
+  }, [hasExecutingScan]);
 
   useEffect(() => {
     if (!hasExecutingScan) return;
@@ -27,8 +40,13 @@ export function AutoRefresh({ hasExecutingScan, onRefresh }: AutoRefreshProps) {
     const scanId = searchParams.get("scanId");
     if (scanId) return;
 
+    let active = true;
     const interval = setInterval(() => {
+      if (refreshInProgress.current) return;
+
       const refresh = async () => {
+        refreshInProgress.current = true;
+
         try {
           if (onRefresh) {
             // Use custom refresh callback for client-side state management
@@ -40,16 +58,27 @@ export function AutoRefresh({ hasExecutingScan, onRefresh }: AutoRefreshProps) {
         } catch (error) {
           console.error("Scan auto-refresh failed:", error);
           return;
+        } finally {
+          refreshInProgress.current = false;
         }
 
-        window.dispatchEvent(new Event(SCAN_POLL_TICK_EVENT));
+        if (active) {
+          window.dispatchEvent(new Event(SCAN_POLL_TICK_EVENT));
+        }
       };
 
       void refresh();
     }, 5000);
 
-    return () => clearInterval(interval);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
   }, [hasExecutingScan, router, searchParams, onRefresh]);
+};
+
+export function AutoRefresh(props: AutoRefreshProps) {
+  useAutoRefresh(props);
 
   return null;
 }


### PR DESCRIPTION
### Context

Follow-up to #12420. Scan polling can overlap when a client-side refresh takes longer than the five-second interval, and Cloud needs an authoritative signal when scan execution transitions to a settled state.

Internal task: PROWLER-2189.

### Description

- Prevent overlapping client-side scan refresh callbacks.
- Emit a reusable browser event when scan execution transitions from running to settled.
- Avoid emitting poll events after the component has been cleaned up.
- Add focused regression coverage and a UI changelog fragment.

No private billing logic or Cloud-only integration is included.

### Steps to review

1. Run `cd ui && pnpm exec vitest run components/scans/auto-refresh.test.tsx`.
2. Run `cd ui && pnpm run typecheck`.
3. Run targeted ESLint and Prettier checks for the changed files.
4. Verify a pending client refresh is not started again by the next interval.
5. Verify `prowler:scan-execution-settled` fires once when execution changes from active to inactive.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This change is tracked internally as PROWLER-2189
- [x] It is assigned through the internal task

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code documentation is needed; no public API documentation changes are required.
- [x] Review if backport is needed; no backport is required.
- [x] Review if README changes are needed; none are required.
- [x] Ensure a changelog fragment is added, if applicable.

#### UI

- [x] All issue/task requirements work as expected on the UI
- [x] No npm dependencies are added or updated
- [x] No visual changes; screenshots are not applicable
- [x] A changelog fragment is included under `ui/changelog.d/`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scan auto-refresh now prevents overlapping refresh requests.
  * Scan execution settlement is signaled when an executing scan becomes idle.

* **Bug Fixes**
  * Improved refresh behavior for slow-running scans.
  * Prevented unnecessary settlement signals when scans are already idle.
  * Stopped pending refresh activity and polling after the scan view is closed.
  * Ensured refresh state is correctly reset after each completed or failed request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->