### PR TITLE
fix(pypi): bump to pypa/gh-action-pypi-publish v1.14.2

### DIFF
--- a/.github/workflows/mcp-pypi-release.yml
+++ b/.github/workflows/mcp-pypi-release.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Publish prowler-mcp package to PyPI
         if: steps.pypi-check.outputs.skip != 'true'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: ${{ env.WORKING_DIRECTORY }}/dist/
           print-hash: true

--- a/.github/workflows/sdk-pypi-release.yml
+++ b/.github/workflows/sdk-pypi-release.yml
@@ -85,7 +85,7 @@ jobs:
         run: uv build
 
       - name: Publish Prowler package to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           print-hash: true
 
@@ -129,6 +129,6 @@ jobs:
         run: uv build
 
       - name: Publish prowler-cloud package to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           print-hash: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatchling"]
+requires = ["hatchling==1.32.0"]
 
 [dependency-groups]
 dev = [
@@ -392,7 +392,7 @@ constraint-dependencies = [
 override-dependencies = [
   "okta==3.4.2",
   # alibabacloud-tea-openapi 0.4.5 caps cryptography below 49 and is the latest release.
-  "cryptography==50.0.0",
+  "cryptography==50.0.0"
 ]
 
 [tool.vulture]


### PR DESCRIPTION
### Context

Release 5.39.0 never reached PyPI. Both publish jobs in the SDK PyPI release workflow failed at metadata verification (run 31686169484, attempts 1 and 2):

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Root cause: `build-system.requires` did not pin hatchling, so `uv build` resolved hatchling 1.32.0 (released 2026-08-11), which bumped the default core metadata version to 2.5. Our `gh-action-pypi-publish` pin (v1.14.0) ships
twine 6, which rejects metadata 2.5.

### Description

- Bump `pypa/gh-action-pypi-publish` to v1.14.2 in `sdk-pypi-release.yml` (both publish jobs) and `mcp-pypi-release.yml`. It ships twine 7, which supports metadata 2.5.
- Pin `hatchling==1.32.0` so release builds stop depending on whatever version PyPI serves at build time.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing process for improved reliability.
  * Updated the Python package build tooling to a fixed version.
  * Cleaned up package configuration formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->