### PR TITLE
chore(api): drop temporary SDK pin overrides after cryptography cap bump

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -491,12 +491,6 @@ override-dependencies = [
   # deployed from this lock with `uv sync --locked`, so the override applies to what runs.
   # Remove when azure-cli-core pins msal>=1.37.0 and workos is on 10.x.
   "cryptography==50.0.0",
-  # prowler@master hard-pins alibabacloud-tea-openapi and oci in [project.dependencies];
-  # the SDK bumped both to lift their cryptography caps. A constraint cannot satisfy the
-  # new pins against the older master rev locked here, so override until the SDK bump
-  # propagates to the pinned master rev, then drop these two.
-  "alibabacloud-tea-openapi==0.4.6",
-  "oci==2.184.1",
   "azure-mgmt-containerservice==34.1.0",
   "microsoft-kiota-abstractions==1.9.10",
   "microsoft-kiota-authentication-azure==1.9.10",

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -376,7 +376,6 @@ constraints = [
     { name = "zstd", specifier = "==1.5.7.2" },
 ]
 overrides = [
-    { name = "alibabacloud-tea-openapi", specifier = "==0.4.6" },
     { name = "azure-mgmt-containerservice", specifier = "==34.1.0" },
     { name = "cryptography", specifier = "==50.0.0" },
     { name = "dulwich", specifier = "==1.2.5" },
@@ -387,7 +386,6 @@ overrides = [
     { name = "microsoft-kiota-serialization-json", specifier = "==1.9.10" },
     { name = "microsoft-kiota-serialization-multipart", specifier = "==1.9.10" },
     { name = "microsoft-kiota-serialization-text", specifier = "==1.9.10" },
-    { name = "oci", specifier = "==2.184.1" },
     { name = "okta", specifier = "==3.4.2" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
 ]
@@ -4837,8 +4835,8 @@ wheels = [
 
 [[package]]
 name = "prowler"
-version = "5.38.0"
-source = { git = "https://github.com/prowler-cloud/prowler.git?rev=master#b3d174d0c1eb202ed7cb9a9daf0500683f4443be" }
+version = "5.40.0"
+source = { git = "https://github.com/prowler-cloud/prowler.git?rev=master#b6e9967da6bebd6c7b8b237317a2a95e2e0c65bc" }
 dependencies = [
     { name = "alibabacloud-actiontrail20200706" },
     { name = "alibabacloud-credentials" },


### PR DESCRIPTION
### Context

Stacked on #12467. That PR bumps `alibabacloud-tea-openapi` and `oci` in the SDK's `[project.dependencies]` to lift their cryptography caps. `api/uv.lock` still resolves prowler from a master rev that predates the bump, so #12467 carries those two versions in api's `[tool.uv] override-dependencies` "until the SDK bump propagates to the pinned master rev" (same pattern as the kiota bump in caf27de6ee).

This PR is that propagation: refresh the locked prowler rev and drop the two temporary overrides. The cryptography override stays; azure-cli-core (via cartography) pins msal exactly (`1.35.0b1` in 2.83.0, `1.36.0` in 2.89.1, both cap cryptography `<49`) and workos 8.3.0 requires `cryptography~=48.0`, and neither can move here.

### Description

- Remove `alibabacloud-tea-openapi==0.4.6` and `oci==2.184.1` from api `override-dependencies`; the constraints already pin them and prowler@master requires them once #12467 is merged.
- `api/uv.lock`: prowler rev advanced to the merge commit of #12467; no other package moves.

### Finalize after #12467 merges (draft until then)

The lock cannot be regenerated before the base merges: it has to reference a prowler commit that exists on master, and a branch sha would be unreachable after squash-merge and break the api image build (`uv sync --locked`).

```
git fetch origin
git rebase --onto origin/master <sha of fix-pypi-installable-package head> fix-api-cryptography-caps
cd api && uv lock --upgrade-package prowler && uv lock --check
git commit -am "chore(api): refresh prowler rev and drop temporary overrides"
git push --force-with-lease
```

Then mark ready for review. Until the base merges, api CI on this PR fails on purpose: the composite action only rewrites the prowler source to the head branch when the PR targets master.

### Steps to review

```
cd api && uv lock --check
rg -n 'override-dependencies' -A4 api/pyproject.toml   # cryptography remains, alibabacloud-tea-openapi and oci gone
git diff origin/master -- api/uv.lock | rg '^[-+](name|version) = |rev=master#'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration by removing two outdated package overrides.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->