### PR TITLE
ci(labeler): cover existing provider labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -52,6 +52,16 @@ provider/alibabacloud:
       - any-glob-to-any-file: "prowler/providers/alibabacloud/**"
       - any-glob-to-any-file: "tests/providers/alibabacloud/**"
 
+provider/huaweicloud:
+  - changed-files:
+      - any-glob-to-any-file: "prowler/providers/huaweicloud/**"
+      - any-glob-to-any-file: "tests/providers/huaweicloud/**"
+
+provider/image:
+  - changed-files:
+      - any-glob-to-any-file: "prowler/providers/image/**"
+      - any-glob-to-any-file: "tests/providers/image/**"
+
 provider/cloudflare:
   - changed-files:
       - any-glob-to-any-file: "prowler/providers/cloudflare/**"
@@ -81,6 +91,11 @@ provider/linode:
   - changed-files:
       - any-glob-to-any-file: "prowler/providers/linode/**"
       - any-glob-to-any-file: "tests/providers/linode/**"
+
+provider/stackit:
+  - changed-files:
+      - any-glob-to-any-file: "prowler/providers/stackit/**"
+      - any-glob-to-any-file: "tests/providers/stackit/**"
 
 github_actions:
   - changed-files:


### PR DESCRIPTION
### Context

The automatic PR labeler did not cover every existing `provider/*` repository label, so provider changes could miss their corresponding labels.

### Description

- Add automatic labeling for `provider/huaweicloud`.
- Add the other existing provider labels missing from the labeler: `provider/image` and `provider/stackit`.
- Reuse existing GitHub labels only; this PR does not create labels.

### Steps to review

1. Review the new entries in `.github/labeler.yml`.
2. Confirm each rule targets both `prowler/providers/<provider>/**` and `tests/providers/<provider>/**`.
3. Confirm `provider/huaweicloud`, `provider/image`, and `provider/stackit` already exist in the repository.

Validation performed:
- `check yaml` pre-commit hook passed.
- `git diff --check` passed.
- YAML parsed successfully with 36 rules.
- Source and test directories exist for all three providers.
- Set comparison confirmed every existing `provider/*` label is represented in the labeler.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI

Not applicable.

#### API

Not applicable.

#### MCP Server

Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic labeling for changes related to Huawei Cloud, image providers, and StackIT.
  * Labels are applied based on the affected source and test areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->