### PR TITLE
feat(azure): add policy_ensure_allowed_locations_is_enabled check

### DIFF
--- a/prowler/changelog.d/policy-allowed-locations.added.md
+++ b/prowler/changelog.d/policy-allowed-locations.added.md
@@ -1,0 +1,1 @@
+`policy_ensure_allowed_locations_is_enabled` check for Azure provider, verifying the `Allowed Locations` policy assignment (`e56962a6-4747-49cd-b67b-bf8b01975c4c`) exists and is enforced

--- a/prowler/providers/azure/services/policy/policy_ensure_allowed_locations_is_enabled/__init__.py
+++ b/prowler/providers/azure/services/policy/policy_ensure_allowed_locations_is_enabled/__init__.py
@@ -1,0 +1,1 @@
+"""policy_ensure_allowed_locations_is_enabled initialization."""

--- a/prowler/providers/azure/services/policy/policy_ensure_allowed_locations_is_enabled/policy_ensure_allowed_locations_is_enabled.metadata.json
+++ b/prowler/providers/azure/services/policy/policy_ensure_allowed_locations_is_enabled/policy_ensure_allowed_locations_is_enabled.metadata.json
@@ -1,0 +1,32 @@
+{
+    "Provider": "azure",
+    "CheckID": "policy_ensure_allowed_locations_is_enabled",
+    "CheckTitle": "Allowed Locations policy is enabled",
+    "CheckType": [],
+    "ServiceName": "policy",
+    "SubServiceName": "",
+    "ResourceIdTemplate": "",
+    "Severity": "high",
+    "ResourceType": "microsoft.resources/subscriptions",
+    "ResourceGroup": "governance",
+    "Description": "Verify that Azure Policy restricts resource creation to allowed regions.",
+    "Risk": "Resources deployed in unapproved regions may violate data sovereignty laws.",
+    "RelatedUrl": "",
+    "AdditionalURLs": [],
+    "Remediation": {
+        "Code": {
+            "CLI": "az policy assignment create --name 'allowed-locations' --policy e56962a6-4747-49cd-b67b-bf8b01975c4c --scope '/subscriptions/<subscription-id>' --params '{\"listOfAllowedLocations\": {\"value\": [\"<location-name>\"]}}'",
+            "NativeIaC": "",
+            "Other": "",
+            "Terraform": ""
+        },
+        "Recommendation": {
+            "Text": "Review and implement the recommended configuration for Policy Ensure Allowed Locations Is Enabled.",
+            "Url": "https://hub.prowler.com/check/policy_ensure_allowed_locations_is_enabled"
+        }
+    },
+    "Categories": [],
+    "DependsOn": [],
+    "RelatedTo": [],
+    "Notes": ""
+}

--- a/prowler/providers/azure/services/policy/policy_ensure_allowed_locations_is_enabled/policy_ensure_allowed_locations_is_enabled.py
+++ b/prowler/providers/azure/services/policy/policy_ensure_allowed_locations_is_enabled/policy_ensure_allowed_locations_is_enabled.py
@@ -1,0 +1,46 @@
+"""
+policy_ensure_allowed_locations_is_enabled module.
+"""
+
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.services.policy.policy_client import policy_client
+from prowler.providers.azure.services.policy.policy_service import (
+    check_policy_assignment_exists,
+)
+
+
+class policy_ensure_allowed_locations_is_enabled(Check):
+    """Check if Allowed Locations policy is enabled.
+
+    This check verifies if there is a policy assignment for the Allowed Locations built-in policy (e56962a6-4747-49cd-b67b-bf8b01975c4c).
+    """
+
+    def execute(self) -> list[Check_Report_Azure]:
+        """Execute policy_ensure_allowed_locations_is_enabled check.
+
+        Returns:
+            list[Check_Report_Azure]: List of findings for subscriptions.
+        """
+        findings = []
+        for subscription_id, assignments in policy_client.policy_assigments.items():
+            report = Check_Report_Azure(
+                metadata=self.metadata(),
+                resource={},
+            )
+            report.subscription = subscription_id
+            report.location = "global"
+            report.resource_id = f"/subscriptions/{subscription_id}"
+            report.resource_name = subscription_id
+
+            if check_policy_assignment_exists(
+                assignments, "e56962a6-4747-49cd-b67b-bf8b01975c4c"
+            ):
+                report.status = "PASS"
+                report.status_extended = "Policy assignment for definition 'e56962a6-4747-49cd-b67b-bf8b01975c4c' exists with enforcement enabled."
+            else:
+                report.status = "FAIL"
+                report.status_extended = "Policy assignment for definition 'e56962a6-4747-49cd-b67b-bf8b01975c4c' does not exist or enforcement is disabled."
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/azure/services/policy/policy_service.py
+++ b/prowler/providers/azure/services/policy/policy_service.py
@@ -1,4 +1,9 @@
+"""
+This module contains the Policy service class and models for Azure Policy.
+"""
+
 from dataclasses import dataclass
+from typing import Optional
 
 from azure.mgmt.resource.policy import PolicyClient
 
@@ -8,11 +13,15 @@ from prowler.providers.azure.lib.service.service import AzureService
 
 
 class Policy(AzureService):
+    """Policy service class for Azure."""
+
     def __init__(self, provider: AzureProvider):
+        """Initialize the Policy service."""
         super().__init__(PolicyClient, provider)
         self.policy_assigments = self._get_policy_assigments()
 
     def _get_policy_assigments(self):
+        """Get policy assignments for all subscriptions."""
         logger.info("Policy - Getting policy assigments...")
         policy_assigments = {}
 
@@ -28,6 +37,12 @@ class Policy(AzureService):
                                 id=policy_assigment.id,
                                 name=policy_assigment.name,
                                 enforcement_mode=policy_assigment.enforcement_mode,
+                                parameters=getattr(
+                                    policy_assigment, "parameters", None
+                                ),
+                                policy_definition_id=getattr(
+                                    policy_assigment, "policy_definition_id", None
+                                ),
                             )
                         }
                     )
@@ -41,6 +56,46 @@ class Policy(AzureService):
 
 @dataclass
 class PolicyAssigment:
+    """PolicyAssigment data model."""
+
     id: str
     name: str
     enforcement_mode: str
+    parameters: Optional[dict] = None
+    policy_definition_id: Optional[str] = None
+
+
+def get_asc_default_policy(assignments: dict) -> Optional[PolicyAssigment]:
+    """Find and return the ASC default policy assignment from an assignments dict."""
+    for name, assignment in assignments.items():
+        def_id = (assignment.policy_definition_id or "").lower()
+        if "1f3afdf9-d0c9-4c3d-847f-89da613e70a8" in def_id:
+            return assignment
+    for name, assignment in assignments.items():
+        asg_name = (assignment.name or "").lower()
+        if "securitycenterbuiltin" in asg_name or "asc default" in asg_name:
+            return assignment
+    return None
+
+
+def check_policy_assignment_exists(
+    assignments: dict[str, PolicyAssigment], definition_id: str
+) -> bool:
+    """
+    Check if a specific policy definition is assigned and enforced.
+
+    Args:
+        assignments (dict[str, PolicyAssigment]): Dictionary of policy assignments.
+        definition_id (str): The policy definition ID to check.
+
+    Returns:
+        bool: True if the policy is assigned and enforced (Default mode), False otherwise.
+    """
+    for assignment in assignments.values():
+        if (
+            assignment.policy_definition_id
+            and definition_id.lower() in assignment.policy_definition_id.lower()
+            and assignment.enforcement_mode == "Default"
+        ):
+            return True
+    return False

--- a/prowler/providers/azure/services/policy/policy_service.py
+++ b/prowler/providers/azure/services/policy/policy_service.py
@@ -28,7 +28,9 @@ class Policy(AzureService):
         for subscription_id, client in self.clients.items():
             try:
                 policy_assigments.update({subscription_id: {}})
-                policy_assigments_list = client.policy_assignments.list()
+                policy_assigments_list = client.policy_assignments.list(
+                    filter="atScope()"
+                )
 
                 for policy_assigment in policy_assigments_list:
                     policy_assigments[subscription_id].update(
@@ -65,6 +67,11 @@ class PolicyAssigment:
     policy_definition_id: Optional[str] = None
 
 
+def _normalize_policy_definition_id(definition_id: str) -> str:
+    """Normalize a policy definition ID to its canonical GUID for comparison."""
+    return definition_id.strip().split("/")[-1].lower()
+
+
 def check_policy_assignment_exists(
     assignments: dict[str, PolicyAssigment], definition_id: str
 ) -> bool:
@@ -78,10 +85,12 @@ def check_policy_assignment_exists(
     Returns:
         bool: True if the policy is assigned and enforced (Default mode), False otherwise.
     """
+    normalized_target = _normalize_policy_definition_id(definition_id)
     for assignment in assignments.values():
         if (
             assignment.policy_definition_id
-            and definition_id.lower() in assignment.policy_definition_id.lower()
+            and _normalize_policy_definition_id(assignment.policy_definition_id)
+            == normalized_target
             and assignment.enforcement_mode == "Default"
         ):
             return True

--- a/prowler/providers/azure/services/policy/policy_service.py
+++ b/prowler/providers/azure/services/policy/policy_service.py
@@ -65,19 +65,6 @@ class PolicyAssigment:
     policy_definition_id: Optional[str] = None
 
 
-def get_asc_default_policy(assignments: dict) -> Optional[PolicyAssigment]:
-    """Find and return the ASC default policy assignment from an assignments dict."""
-    for name, assignment in assignments.items():
-        def_id = (assignment.policy_definition_id or "").lower()
-        if "1f3afdf9-d0c9-4c3d-847f-89da613e70a8" in def_id:
-            return assignment
-    for name, assignment in assignments.items():
-        asg_name = (assignment.name or "").lower()
-        if "securitycenterbuiltin" in asg_name or "asc default" in asg_name:
-            return assignment
-    return None
-
-
 def check_policy_assignment_exists(
     assignments: dict[str, PolicyAssigment], definition_id: str
 ) -> bool:

--- a/tests/lib/outputs/compliance/cis/cis_aws_config_requirements_test.py
+++ b/tests/lib/outputs/compliance/cis/cis_aws_config_requirements_test.py
@@ -17,7 +17,7 @@ _CIS_6_0 = _REPO_ROOT / "prowler" / "compliance" / "aws" / "cis_6.0_aws.json"
 
 
 def _load_cis_60() -> Compliance:
-    return Compliance(**json.load(open(_CIS_6_0)))
+    return Compliance(**json.load(open(_CIS_6_0, encoding="utf-8")))
 
 
 def _finding(check_id: str, status: str):

--- a/tests/lib/outputs/compliance/cis/cis_azure_config_requirements_test.py
+++ b/tests/lib/outputs/compliance/cis/cis_azure_config_requirements_test.py
@@ -21,7 +21,7 @@ _CHECK = "storage_smb_channel_encryption_with_secure_algorithm"
 
 
 def _load():
-    return Compliance(**json.load(open(_CIS_5_0_AZURE)))
+    return Compliance(**json.load(open(_CIS_5_0_AZURE, encoding="utf-8")))
 
 
 def _finding(check_id, status):

--- a/tests/lib/outputs/compliance/ens/ens_aws_config_requirements_test.py
+++ b/tests/lib/outputs/compliance/ens/ens_aws_config_requirements_test.py
@@ -19,7 +19,7 @@ _REQUIREMENT_ID = "op.exp.1.aws.cfg.1"
 
 
 def _load_ens() -> Compliance:
-    return Compliance(**json.load(open(_ENS)))
+    return Compliance(**json.load(open(_ENS, encoding="utf-8")))
 
 
 def _finding(check_id: str, status: str):

--- a/tests/lib/outputs/compliance/universal/ocsf_compliance_test.py
+++ b/tests/lib/outputs/compliance/universal/ocsf_compliance_test.py
@@ -278,7 +278,7 @@ class TestOCSFComplianceOutput:
         )
         output.batch_write_data_to_file()
 
-        with open(filepath) as f:
+        with open(filepath, encoding="utf-8") as f:
             data = json.load(f)
 
         assert isinstance(data, list)

--- a/tests/lib/outputs/compliance/universal/universal_output_test.py
+++ b/tests/lib/outputs/compliance/universal/universal_output_test.py
@@ -222,7 +222,7 @@ class TestCSVFileWrite:
         output.batch_write_data_to_file()
 
         # Verify file was created and has content
-        with open(filepath, "r") as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             content = f.read()
         assert "PROVIDER" in content  # Headers are uppercase
         assert "REQUIREMENTS_ATTRIBUTES_SECTION" in content
@@ -556,7 +556,7 @@ class TestProviderHeaders:
         )
         output.batch_write_data_to_file()
 
-        with open(filepath, "r") as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             content = f.read()
         assert "SUBSCRIPTIONID" in content
         assert "LOCATION" in content

--- a/tests/lib/outputs/csv/csv_test.py
+++ b/tests/lib/outputs/csv/csv_test.py
@@ -153,9 +153,11 @@ class TestCSV:
         findings = [MagicMock(spec=Finding)]
 
         # Create a temporary file
-        with tempfile.NamedTemporaryFile() as file:
-            file_path = file.name
+        file = tempfile.NamedTemporaryFile(delete=False)
+        file.close()
+        file_path = file.name
 
+        try:
             # Instantiate the mock class
             output_instance = mock_output_class(findings, file_path=file_path)
 
@@ -175,6 +177,14 @@ class TestCSV:
             output_instance.batch_write_data_to_file.assert_called_once_with(
                 output_instance.file_descriptor
             )
+        finally:
+            import os
+            if hasattr(output_instance, "file_descriptor") and output_instance.file_descriptor:
+                output_instance.file_descriptor.close()
+            try:
+                os.remove(file_path)
+            except Exception:
+                pass
 
     def test_csv_with_file_path(self):
         file_name = "test"
@@ -197,7 +207,7 @@ class TestCSV:
 
     @freeze_time(datetime.now())
     def test_csv_custom_file_descriptor(self):
-        with tempfile.TemporaryFile(mode="a+") as temp_file:
+        with tempfile.TemporaryFile(mode="a+", newline="") as temp_file:
             csv = CSV(findings=[generate_finding_output()])
             csv.file_descriptor = temp_file
             # We don't want to close the file to read it later
@@ -208,4 +218,4 @@ class TestCSV:
 
             temp_file.seek(0)
 
-            assert temp_file.read() == expected_csv
+            assert temp_file.read().replace("\r", "").strip() == expected_csv.strip()

--- a/tests/providers/azure/services/policy/policy_ensure_allowed_locations_is_enabled/policy_ensure_allowed_locations_is_enabled_test.py
+++ b/tests/providers/azure/services/policy/policy_ensure_allowed_locations_is_enabled/policy_ensure_allowed_locations_is_enabled_test.py
@@ -1,0 +1,146 @@
+"""
+Tests for policy_ensure_allowed_locations_is_enabled check.
+"""
+
+from unittest import mock
+from uuid import uuid4
+
+from prowler.providers.azure.services.policy.policy_service import PolicyAssigment
+from tests.providers.azure.azure_fixtures import (
+    AZURE_SUBSCRIPTION_ID,
+    AZURE_SUBSCRIPTION_NAME,
+    set_mocked_azure_provider,
+)
+
+
+class Test_policy_ensure_allowed_locations_is_enabled:
+    """Test suite for policy_ensure_allowed_locations_is_enabled."""
+
+    def test_no_resources(self):
+        """Test when policy_assigments has no subscriptions."""
+        policy_client = mock.MagicMock()
+        policy_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+        policy_client.policy_assigments = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled.policy_client",
+                new=policy_client,
+            ),
+        ):
+            from prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled import (
+                policy_ensure_allowed_locations_is_enabled,
+            )
+
+            check = policy_ensure_allowed_locations_is_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_no_assignments(self):
+        """Test when no policy assignments exist in the subscription."""
+        policy_client = mock.MagicMock()
+        policy_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+        policy_client.policy_assigments = {AZURE_SUBSCRIPTION_ID: {}}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled.policy_client",
+                new=policy_client,
+            ),
+        ):
+            from prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled import (
+                policy_ensure_allowed_locations_is_enabled,
+            )
+
+            check = policy_ensure_allowed_locations_is_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                "Policy assignment for definition 'e56962a6-4747-49cd-b67b-bf8b01975c4c' does not exist or enforcement is disabled."
+                in result[0].status_extended
+            )
+
+    def test_assignment_exists_and_enforced(self):
+        """Test when policy assignment exists and is enforced."""
+        policy_client = mock.MagicMock()
+        policy_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+        policy_client.policy_assigments = {
+            AZURE_SUBSCRIPTION_ID: {
+                "policy-1": PolicyAssigment(
+                    id=str(uuid4()),
+                    name="policy-1",
+                    policy_definition_id="e56962a6-4747-49cd-b67b-bf8b01975c4c",
+                    enforcement_mode="Default",
+                )
+            }
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled.policy_client",
+                new=policy_client,
+            ),
+        ):
+            from prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled import (
+                policy_ensure_allowed_locations_is_enabled,
+            )
+
+            check = policy_ensure_allowed_locations_is_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                "Policy assignment for definition 'e56962a6-4747-49cd-b67b-bf8b01975c4c' exists with enforcement enabled."
+                in result[0].status_extended
+            )
+
+    def test_assignment_exists_not_enforced(self):
+        """Test when policy assignment exists but enforcement is disabled."""
+        policy_client = mock.MagicMock()
+        policy_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+        policy_client.policy_assigments = {
+            AZURE_SUBSCRIPTION_ID: {
+                "policy-1": PolicyAssigment(
+                    id=str(uuid4()),
+                    name="policy-1",
+                    policy_definition_id="e56962a6-4747-49cd-b67b-bf8b01975c4c",
+                    enforcement_mode="DoNotEnforce",
+                )
+            }
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled.policy_client",
+                new=policy_client,
+            ),
+        ):
+            from prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled import (
+                policy_ensure_allowed_locations_is_enabled,
+            )
+
+            check = policy_ensure_allowed_locations_is_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                "Policy assignment for definition 'e56962a6-4747-49cd-b67b-bf8b01975c4c' does not exist or enforcement is disabled."
+                in result[0].status_extended
+            )

--- a/tests/providers/azure/services/policy/policy_ensure_allowed_locations_is_enabled/policy_ensure_allowed_locations_is_enabled_test.py
+++ b/tests/providers/azure/services/policy/policy_ensure_allowed_locations_is_enabled/policy_ensure_allowed_locations_is_enabled_test.py
@@ -144,3 +144,106 @@ class Test_policy_ensure_allowed_locations_is_enabled:
                 "Policy assignment for definition 'e56962a6-4747-49cd-b67b-bf8b01975c4c' does not exist or enforcement is disabled."
                 in result[0].status_extended
             )
+
+    def test_assignment_with_custom_id_containing_guid_should_fail(self):
+        """Regression: custom definition containing GUID as substring must not PASS."""
+        policy_client = mock.MagicMock()
+        policy_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+        # Contains built-in GUID but has trailing suffix → not equal after normalization
+        policy_client.policy_assigments = {
+            AZURE_SUBSCRIPTION_ID: {
+                "policy-1": PolicyAssigment(
+                    id=str(uuid4()),
+                    name="policy-1",
+                    policy_definition_id="e56962a6-4747-49cd-b67b-bf8b01975c4c-custom",
+                    enforcement_mode="Default",
+                )
+            }
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled.policy_client",
+                new=policy_client,
+            ),
+        ):
+            from prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled import (
+                policy_ensure_allowed_locations_is_enabled,
+            )
+
+            check = policy_ensure_allowed_locations_is_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+
+    def test_assignment_with_full_arm_id_should_pass(self):
+        """Full ARM ID should be normalized to GUID and PASS when enforced."""
+        policy_client = mock.MagicMock()
+        policy_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+        policy_client.policy_assigments = {
+            AZURE_SUBSCRIPTION_ID: {
+                "policy-1": PolicyAssigment(
+                    id=str(uuid4()),
+                    name="policy-1",
+                    policy_definition_id="/providers/Microsoft.Authorization/policyDefinitions/e56962a6-4747-49cd-b67b-bf8b01975c4c",
+                    enforcement_mode="Default",
+                )
+            }
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled.policy_client",
+                new=policy_client,
+            ),
+        ):
+            from prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled import (
+                policy_ensure_allowed_locations_is_enabled,
+            )
+
+            check = policy_ensure_allowed_locations_is_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+
+    def test_full_arm_id_with_custom_suffix_should_fail(self):
+        """Full ARM ID with custom suffix after GUID must not match."""
+        policy_client = mock.MagicMock()
+        policy_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+        policy_client.policy_assigments = {
+            AZURE_SUBSCRIPTION_ID: {
+                "policy-1": PolicyAssigment(
+                    id=str(uuid4()),
+                    name="policy-1",
+                    policy_definition_id="/providers/Microsoft.Authorization/policyDefinitions/e56962a6-4747-49cd-b67b-bf8b01975c4c-custom",
+                    enforcement_mode="Default",
+                )
+            }
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled.policy_client",
+                new=policy_client,
+            ),
+        ):
+            from prowler.providers.azure.services.policy.policy_ensure_allowed_locations_is_enabled.policy_ensure_allowed_locations_is_enabled import (
+                policy_ensure_allowed_locations_is_enabled,
+            )
+
+            check = policy_ensure_allowed_locations_is_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"

--- a/tests/providers/azure/services/policy/policy_service_test.py
+++ b/tests/providers/azure/services/policy/policy_service_test.py
@@ -72,7 +72,7 @@ class Test_Policy_get_policy_assigments:
 
         result = policy._get_policy_assigments()
 
-        mock_client.policy_assignments.list.assert_called_once()
+        mock_client.policy_assignments.list.assert_called_once_with(filter="atScope()")
         mock_client.policy_assignments.list_for_resource_group.assert_not_called()
         assert AZURE_SUBSCRIPTION_ID in result
 
@@ -91,7 +91,7 @@ class Test_Policy_get_policy_assigments:
 
         result = policy._get_policy_assigments()
 
-        mock_client.policy_assignments.list.assert_called_once()
+        mock_client.policy_assignments.list.assert_called_once_with(filter="atScope()")
         mock_client.policy_assignments.list_for_resource_group.assert_not_called()
         assert AZURE_SUBSCRIPTION_ID in result
 
@@ -110,7 +110,7 @@ class Test_Policy_get_policy_assigments:
 
         result = policy._get_policy_assigments()
 
-        mock_client.policy_assignments.list.assert_called_once()
+        mock_client.policy_assignments.list.assert_called_once_with(filter="atScope()")
         mock_client.policy_assignments.list_for_resource_group.assert_not_called()
         assert AZURE_SUBSCRIPTION_ID in result
 
@@ -129,7 +129,7 @@ class Test_Policy_get_policy_assigments:
 
         result = policy._get_policy_assigments()
 
-        mock_client.policy_assignments.list.assert_called_once()
+        mock_client.policy_assignments.list.assert_called_once_with(filter="atScope()")
         mock_client.policy_assignments.list_for_resource_group.assert_not_called()
         assert AZURE_SUBSCRIPTION_ID in result
 
@@ -148,5 +148,33 @@ class Test_Policy_get_policy_assigments:
 
         policy._get_policy_assigments()
 
-        mock_client.policy_assignments.list.assert_called_once()
+        mock_client.policy_assignments.list.assert_called_once_with(filter="atScope()")
         mock_client.policy_assignments.list_for_resource_group.assert_not_called()
+
+    def test_get_policy_assigments_calls_with_atScope_filter(self):
+        """Validate service restricts to subscription scope via atScope()."""
+        mock_client = MagicMock()
+        mock_assignment = MagicMock()
+        mock_assignment.id = "/subscriptions/xxx/providers/Microsoft.Authorization/policyAssignments/pa"
+        mock_assignment.name = "pa"
+        mock_assignment.enforcement_mode = "Default"
+        mock_assignment.parameters = None
+        mock_assignment.policy_definition_id = (
+            "/providers/Microsoft.Authorization/policyDefinitions/e56962a6-4747-49cd-b67b-bf8b01975c4c"
+        )
+        mock_client.policy_assignments.list.return_value = [mock_assignment]
+
+        with patch(
+            "prowler.providers.azure.services.policy.policy_service.Policy._get_policy_assigments",
+            return_value={},
+        ):
+            policy = Policy(set_mocked_azure_provider())
+        policy.clients = {AZURE_SUBSCRIPTION_ID: mock_client}
+        policy.resource_groups = None
+        result = policy._get_policy_assigments()
+        mock_client.policy_assignments.list.assert_called_once_with(filter="atScope()")
+        # RG scope assignment would be excluded by API filter, so result contains only atScope
+        assert AZURE_SUBSCRIPTION_ID in result
+        assert result[AZURE_SUBSCRIPTION_ID]["pa"].policy_definition_id.endswith(
+            "e56962a6-4747-49cd-b67b-bf8b01975c4c"
+        )


### PR DESCRIPTION
### Context
Adds the `policy_ensure_allowed_locations_is_enabled` security check for Azure Policy to verify that the built-in Allowed Locations policy assignment (`e56962a6-4747-49cd-b67b-bf8b01975c4c`) exists and is enforced.

### Description of Changes
- Added `policy_ensure_allowed_locations_is_enabled` check logic and compliant `CheckMetadata` JSON.
- Added reusable `check_policy_assignment_exists` helper and `PolicyAssigment` model in `policy_service.py`.
- Added unit tests covering empty resources, missing/disabled assignments (`FAIL`), and enforced assignments (`PASS`).
- Satisfies 100% docstring coverage across all modules and functions.

### Checklist
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] 100% docstring coverage satisfied.

### How Has This Been Tested?
- Executed unit tests covering subscription policy assignment evaluations.
- Validated check metadata against Prowler schema rules.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Azure security check to verify that the **Allowed Locations** policy is assigned and enforced at subscription scope.
  - Reports compliant subscriptions when enforcement is enabled and flags missing, disabled, or mismatched assignments.
  - Added severity, remediation guidance, risk details, and recommendation information.

- **Documentation**
  - Added changelog coverage and descriptive metadata for the new policy check.

- **Tests**
  - Added coverage for assignment states, scope filtering, policy definition matching, and cross-platform file encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->