### PR TITLE
feat(ui): let alert rules target authorized Slack channels

### DIFF
--- a/ui/__tests__/msw/handlers/alerts.fixtures.ts
+++ b/ui/__tests__/msw/handlers/alerts.fixtures.ts
@@ -1,31 +1,38 @@
 /**
  * Fixture data for the alerts handlers. The alert-rule shapes mirror the API
- * the alerts UI already consumes; the Slack-channel shapes follow the working
- * assumptions in `openspec/changes/add-slack-alert-channels/design.md` (D3) —
- * every assumed wire name carries a `TODO(Josema)` in `./alerts.ts` until the
- * contract is signed off.
+ * the alerts UI already consumes; the Slack-channel shapes follow the signed
+ * contract (`openspec/changes/add-slack-alert-channels/contract/`), and what
+ * the contract still leaves open carries a `TODO(Josema)`.
  *
  * The disabled/empty channel states are driven by what the fixture OMITS
- * (no integration, no authorized channels), never by handing the UI a
- * pre-disabled state (design D9).
+ * (no integration, no configured channels, no confirmations), never by
+ * handing the UI a pre-disabled state (design D9).
  */
 
-/** A Slack channel as the alerts surfaces know one: id, name, privacy. */
+/** A Slack channel configured on the integration. */
 export interface AlertsSlackChannelFixture {
   id: string;
   name: string;
   isPrivate: boolean;
+  /**
+   * Null until the connection check posts its one-time confirmation. Only a
+   * confirmed channel is eligible as an alert destination, and a
+   * same-workspace reinstall resets every timestamp.
+   */
+  confirmationSentAt: string | null;
 }
 
 /**
- * The connected Slack integration as the alert form reads it — only the
- * authorized destination set matters on this page. `slackIntegration: null`
- * is the no-workspace-connected tenant.
+ * The tenant's Slack integration. `slackIntegration: null` is the tenant with
+ * no workspace connected at all.
  */
 export interface AlertsSlackIntegrationFixture {
   id: string;
   workspaceName: string;
-  authorizedChannels: AlertsSlackChannelFixture[];
+  /** Null until a connection check has run; a reinstall resets it. */
+  connected: boolean | null;
+  /** The channels authorized on the integration. */
+  channels: AlertsSlackChannelFixture[];
 }
 
 export const ALERT_RULE_TRIGGERS = {
@@ -47,11 +54,11 @@ export interface AlertRuleFixture {
   condition: Record<string, unknown>;
   recipientEmails: string[];
   /**
-   * Stored destinations with resolved name and privacy. May include channels
-   * absent from the integration's authorized set — the stale-channel
-   * scenario, which the UI must keep visible rather than silently drop.
+   * Stored destinations, by channel id — all the mapping table holds. The
+   * read enriches them from the integration, so an id its workspace no longer
+   * carries simply disappears, exactly as the server-side cascade leaves it.
    */
-  slackChannels: AlertsSlackChannelFixture[];
+  slackChannelIds: string[];
 }
 
 export const ALERT_RECIPIENT_STATUSES = {
@@ -82,6 +89,8 @@ export const ALERTS_SLACK_INTEGRATION_ID =
   "7c9e6a1b-2d3f-4e5a-8b6c-9d0e1f2a3b4c";
 export const ALERT_RULE_ID = "1f6d3c2b-8a4e-4b7d-9c5f-0e1a2b3c4d5e";
 
+const CONFIRMED_AT = "2026-08-18T10:15:00Z";
+
 /**
  * The channel ids and names match the Slack fixtures' workspace so an
  * end-to-end reading of both pages tells one story, without importing from
@@ -91,22 +100,17 @@ export const ALERTS_PUBLIC_CHANNEL: AlertsSlackChannelFixture = {
   id: "C0123AB",
   name: "security",
   isPrivate: false,
+  confirmationSentAt: CONFIRMED_AT,
 };
 
 export const ALERTS_PRIVATE_CHANNEL: AlertsSlackChannelFixture = {
   id: "C0456CD",
   name: "security-alerts",
   isPrivate: true,
+  confirmationSentAt: CONFIRMED_AT,
 };
 
-/** Offered by the workspace but NOT authorized: stale-channel material. */
-export const ALERTS_UNAUTHORIZED_CHANNEL: AlertsSlackChannelFixture = {
-  id: "C0789EF",
-  name: "platform",
-  isPrivate: false,
-};
-
-export const ALERTS_AUTHORIZED_CHANNELS: AlertsSlackChannelFixture[] = [
+export const ALERTS_CONFIGURED_CHANNELS: AlertsSlackChannelFixture[] = [
   ALERTS_PUBLIC_CHANNEL,
   ALERTS_PRIVATE_CHANNEL,
 ];
@@ -114,17 +118,23 @@ export const ALERTS_AUTHORIZED_CHANNELS: AlertsSlackChannelFixture[] = [
 /**
  * Refusal wire values for the rule-write validation, spelled out rather than
  * imported from any UI mapping: a rename on our side must fail these tests.
- * TODO(Josema): status/code of both refusals pending contract sign-off (D3).
+ * TODO(Josema): the refusal's HTTP status and error codes are the one thing
+ * the signed contract leaves open (D3, Validation row); these stay the
+ * working assumption until it answers.
  */
+export const ALERTS_SLACK_NOT_CONNECTED_CODE = "slack_not_connected";
 export const ALERTS_CHANNEL_NOT_AUTHORIZED_CODE =
   "slack_channel_not_authorized";
-export const ALERTS_SLACK_NOT_CONNECTED_CODE = "slack_not_connected";
+export const ALERTS_CHANNEL_NOT_CONFIRMED_CODE = "slack_channel_not_confirmed";
 
 export const ALERTS_SLACK_NOT_CONNECTED_DETAIL =
   "Slack must be connected before an alert rule can name channel destinations.";
 
 export const alertsChannelNotAuthorizedDetail = (channelId: string): string =>
-  `Channel ${channelId} is not in the Slack integration's authorized channels.`;
+  `Channel ${channelId} is not configured on the Slack integration.`;
+
+export const alertsChannelNotConfirmedDetail = (channelId: string): string =>
+  `Channel ${channelId} has not been confirmed yet. Run the Slack connection check first.`;
 
 export const ALERTS_LIST_SERVER_ERROR_DETAIL = "A server error occurred.";
 
@@ -142,13 +152,13 @@ export const alertRuleFixture = (
     value: 1,
   },
   recipientEmails: ["security@example.com"],
-  slackChannels: [],
+  slackChannelIds: [],
   ...overrides,
 });
 
 /**
- * The baseline tenant: a connected workspace with two authorized channels
- * (one private) and one email-only rule to edit.
+ * The baseline tenant: a connected workspace with two confirmed channels (one
+ * private) and one email-only rule to edit.
  */
 export const alertsFixture = (
   overrides: Partial<AlertsFixture> = {},
@@ -164,9 +174,8 @@ export const alertsFixture = (
   slackIntegration: {
     id: ALERTS_SLACK_INTEGRATION_ID,
     workspaceName: "Prowler HQ",
-    authorizedChannels: ALERTS_AUTHORIZED_CHANNELS.map((channel) => ({
-      ...channel,
-    })),
+    connected: true,
+    channels: ALERTS_CONFIGURED_CHANNELS.map((channel) => ({ ...channel })),
   },
   listServerError: false,
   ...overrides,
@@ -185,26 +194,33 @@ export const emptyChannelPoolAlertsFixture = (
     slackIntegration: {
       id: ALERTS_SLACK_INTEGRATION_ID,
       workspaceName: "Prowler HQ",
-      authorizedChannels: [],
+      connected: true,
+      channels: [],
     },
     ...overrides,
   });
 
 /**
- * A rule that stored a channel the integration no longer authorizes: the
- * stored value must stay visible and selected, and a re-save keeping it must
- * be refused by the ⊆ validation.
+ * A same-workspace reinstall: the channels and the rules' mappings survive,
+ * every confirmation and the connection state are reset. The only way the API
+ * can still hand the form a stored channel it does not offer.
  */
-export const staleChannelAlertsFixture = (
+export const reinstalledWorkspaceAlertsFixture = (
   overrides: Partial<AlertsFixture> = {},
 ): AlertsFixture =>
   alertsFixture({
+    slackIntegration: {
+      id: ALERTS_SLACK_INTEGRATION_ID,
+      workspaceName: "Prowler HQ",
+      connected: null,
+      channels: ALERTS_CONFIGURED_CHANNELS.map((channel) => ({
+        ...channel,
+        confirmationSentAt: null,
+      })),
+    },
     rules: [
       alertRuleFixture({
-        slackChannels: [
-          { ...ALERTS_PUBLIC_CHANNEL },
-          { ...ALERTS_UNAUTHORIZED_CHANNEL },
-        ],
+        slackChannelIds: [ALERTS_PUBLIC_CHANNEL.id, ALERTS_PRIVATE_CHANNEL.id],
       }),
     ],
     ...overrides,

--- a/ui/__tests__/msw/handlers/alerts.fixtures.ts
+++ b/ui/__tests__/msw/handlers/alerts.fixtures.ts
@@ -1,8 +1,8 @@
 /**
  * Fixture data for the alerts handlers. The alert-rule shapes mirror the API
  * the alerts UI already consumes; the Slack-channel shapes follow the signed
- * contract (`openspec/changes/add-slack-alert-channels/contract/`), and what
- * the contract still leaves open carries a `TODO(Josema)`.
+ * contract (`openspec/changes/add-slack-alert-channels/contract/`), addendum
+ * section 6 included — it leaves nothing open.
  *
  * The disabled/empty channel states are driven by what the fixture OMITS
  * (no integration, no configured channels, no confirmations), never by
@@ -116,16 +116,13 @@ export const ALERTS_CONFIGURED_CHANNELS: AlertsSlackChannelFixture[] = [
 ];
 
 /**
- * Refusal wire values for the rule-write validation, spelled out rather than
- * imported from any UI mapping: a rename on our side must fail these tests.
- * TODO(Josema): the refusal's HTTP status and error codes are the one thing
- * the signed contract leaves open (D3, Validation row); these stay the
- * working assumption until it answers.
+ * The signed refusal code for the rule-write validation (contract section 6.1):
+ * one code, and a 400, for every ineligible condition — only the human
+ * `detail` says which one refused. Spelled out rather than imported from any
+ * UI mapping: a rename on our side must fail these tests.
  */
-export const ALERTS_SLACK_NOT_CONNECTED_CODE = "slack_not_connected";
-export const ALERTS_CHANNEL_NOT_AUTHORIZED_CODE =
-  "slack_channel_not_authorized";
-export const ALERTS_CHANNEL_NOT_CONFIRMED_CODE = "slack_channel_not_confirmed";
+export const ALERTS_SLACK_CHANNEL_NOT_ELIGIBLE_CODE =
+  "slack_channel_not_eligible";
 
 export const ALERTS_SLACK_NOT_CONNECTED_DETAIL =
   "Slack must be connected before an alert rule can name channel destinations.";

--- a/ui/__tests__/msw/handlers/alerts.fixtures.ts
+++ b/ui/__tests__/msw/handlers/alerts.fixtures.ts
@@ -91,7 +91,9 @@ export interface AlertsFixture {
   /**
    * A failure status for `GET /alerts/slack-channels`, or null to serve it.
    * The two statuses reach the UI by different routes: a `5xx` throws out of
-   * `handleApiResponse`, a `403` comes back as an error payload.
+   * `handleApiResponse`, a `403` comes back as an error payload. A refused read
+   * is also the only route to an empty pool on a connected workspace: served,
+   * the pool of a `connected: true` install always holds its confirmed set.
    */
   channelsReadError: number | null;
   /**
@@ -225,34 +227,6 @@ export const noAuthorizedChannelsAlertsFixture = (
       connected: null,
       channels: [],
     },
-    ...overrides,
-  });
-
-/**
- * A connected workspace whose channels are all still unconfirmed, with a rule
- * that already stores them: the eligible pool is empty while the rule's own
- * channels read back in full. The read model enriches from what is CONFIGURED,
- * the pool offers only what is CONFIRMED — so the empty-pool state and stored
- * channels are not mutually exclusive, whatever an empty pool suggests.
- */
-export const unconfirmedChannelPoolAlertsFixture = (
-  overrides: Partial<AlertsFixture> = {},
-): AlertsFixture =>
-  alertsFixture({
-    slackIntegration: {
-      id: ALERTS_SLACK_INTEGRATION_ID,
-      workspaceName: "Prowler HQ",
-      connected: true,
-      channels: ALERTS_CONFIGURED_CHANNELS.map((channel) => ({
-        ...channel,
-        confirmationSentAt: null,
-      })),
-    },
-    rules: [
-      alertRuleFixture({
-        slackChannelIds: [ALERTS_PUBLIC_CHANNEL.id, ALERTS_PRIVATE_CHANNEL.id],
-      }),
-    ],
     ...overrides,
   });
 

--- a/ui/__tests__/msw/handlers/alerts.fixtures.ts
+++ b/ui/__tests__/msw/handlers/alerts.fixtures.ts
@@ -1,0 +1,211 @@
+/**
+ * Fixture data for the alerts handlers. The alert-rule shapes mirror the API
+ * the alerts UI already consumes; the Slack-channel shapes follow the working
+ * assumptions in `openspec/changes/add-slack-alert-channels/design.md` (D3) —
+ * every assumed wire name carries a `TODO(Josema)` in `./alerts.ts` until the
+ * contract is signed off.
+ *
+ * The disabled/empty channel states are driven by what the fixture OMITS
+ * (no integration, no authorized channels), never by handing the UI a
+ * pre-disabled state (design D9).
+ */
+
+/** A Slack channel as the alerts surfaces know one: id, name, privacy. */
+export interface AlertsSlackChannelFixture {
+  id: string;
+  name: string;
+  isPrivate: boolean;
+}
+
+/**
+ * The connected Slack integration as the alert form reads it — only the
+ * authorized destination set matters on this page. `slackIntegration: null`
+ * is the no-workspace-connected tenant.
+ */
+export interface AlertsSlackIntegrationFixture {
+  id: string;
+  workspaceName: string;
+  authorizedChannels: AlertsSlackChannelFixture[];
+}
+
+export const ALERT_RULE_TRIGGERS = {
+  AFTER_SCAN: "after_scan",
+  DAILY: "daily",
+  BOTH: "both",
+} as const;
+
+export type AlertRuleTriggerFixture =
+  (typeof ALERT_RULE_TRIGGERS)[keyof typeof ALERT_RULE_TRIGGERS];
+
+export interface AlertRuleFixture {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  trigger: AlertRuleTriggerFixture;
+  /** The condition DSL travels through the UI opaquely. */
+  condition: Record<string, unknown>;
+  recipientEmails: string[];
+  /**
+   * Stored destinations with resolved name and privacy. May include channels
+   * absent from the integration's authorized set — the stale-channel
+   * scenario, which the UI must keep visible rather than silently drop.
+   */
+  slackChannels: AlertsSlackChannelFixture[];
+}
+
+export const ALERT_RECIPIENT_STATUSES = {
+  PENDING: "pending",
+  CONFIRMED: "confirmed",
+  UNSUBSCRIBED: "unsubscribed",
+  BOUNCED: "bounced",
+} as const;
+
+export type AlertRecipientStatusFixture =
+  (typeof ALERT_RECIPIENT_STATUSES)[keyof typeof ALERT_RECIPIENT_STATUSES];
+
+export interface AlertRecipientFixture {
+  email: string;
+  status: AlertRecipientStatusFixture;
+}
+
+export interface AlertsFixture {
+  rules: AlertRuleFixture[];
+  recipients: AlertRecipientFixture[];
+  slackIntegration: AlertsSlackIntegrationFixture | null;
+  /** The rules list read answers `500`. */
+  listServerError: boolean;
+}
+
+/** UUIDs, as the API's ids are. */
+export const ALERTS_SLACK_INTEGRATION_ID =
+  "7c9e6a1b-2d3f-4e5a-8b6c-9d0e1f2a3b4c";
+export const ALERT_RULE_ID = "1f6d3c2b-8a4e-4b7d-9c5f-0e1a2b3c4d5e";
+
+/**
+ * The channel ids and names match the Slack fixtures' workspace so an
+ * end-to-end reading of both pages tells one story, without importing from
+ * `slack.fixtures.ts` (that file belongs to the integrations lane).
+ */
+export const ALERTS_PUBLIC_CHANNEL: AlertsSlackChannelFixture = {
+  id: "C0123AB",
+  name: "security",
+  isPrivate: false,
+};
+
+export const ALERTS_PRIVATE_CHANNEL: AlertsSlackChannelFixture = {
+  id: "C0456CD",
+  name: "security-alerts",
+  isPrivate: true,
+};
+
+/** Offered by the workspace but NOT authorized: stale-channel material. */
+export const ALERTS_UNAUTHORIZED_CHANNEL: AlertsSlackChannelFixture = {
+  id: "C0789EF",
+  name: "platform",
+  isPrivate: false,
+};
+
+export const ALERTS_AUTHORIZED_CHANNELS: AlertsSlackChannelFixture[] = [
+  ALERTS_PUBLIC_CHANNEL,
+  ALERTS_PRIVATE_CHANNEL,
+];
+
+/**
+ * Refusal wire values for the rule-write validation, spelled out rather than
+ * imported from any UI mapping: a rename on our side must fail these tests.
+ * TODO(Josema): status/code of both refusals pending contract sign-off (D3).
+ */
+export const ALERTS_CHANNEL_NOT_AUTHORIZED_CODE =
+  "slack_channel_not_authorized";
+export const ALERTS_SLACK_NOT_CONNECTED_CODE = "slack_not_connected";
+
+export const ALERTS_SLACK_NOT_CONNECTED_DETAIL =
+  "Slack must be connected before an alert rule can name channel destinations.";
+
+export const alertsChannelNotAuthorizedDetail = (channelId: string): string =>
+  `Channel ${channelId} is not in the Slack integration's authorized channels.`;
+
+export const ALERTS_LIST_SERVER_ERROR_DETAIL = "A server error occurred.";
+
+export const alertRuleFixture = (
+  overrides: Partial<AlertRuleFixture> = {},
+): AlertRuleFixture => ({
+  id: ALERT_RULE_ID,
+  name: "Critical findings",
+  description: "Notify security when critical findings land.",
+  enabled: true,
+  trigger: ALERT_RULE_TRIGGERS.AFTER_SCAN,
+  condition: {
+    op: "count_gte",
+    filter: { severity: ["critical"] },
+    value: 1,
+  },
+  recipientEmails: ["security@example.com"],
+  slackChannels: [],
+  ...overrides,
+});
+
+/**
+ * The baseline tenant: a connected workspace with two authorized channels
+ * (one private) and one email-only rule to edit.
+ */
+export const alertsFixture = (
+  overrides: Partial<AlertsFixture> = {},
+): AlertsFixture => ({
+  rules: [alertRuleFixture()],
+  recipients: [
+    {
+      email: "security@example.com",
+      status: ALERT_RECIPIENT_STATUSES.CONFIRMED,
+    },
+    { email: "ops@example.com", status: ALERT_RECIPIENT_STATUSES.CONFIRMED },
+  ],
+  slackIntegration: {
+    id: ALERTS_SLACK_INTEGRATION_ID,
+    workspaceName: "Prowler HQ",
+    authorizedChannels: ALERTS_AUTHORIZED_CHANNELS.map((channel) => ({
+      ...channel,
+    })),
+  },
+  listServerError: false,
+  ...overrides,
+});
+
+/** No Slack workspace connected: the channel destination must say why (D9). */
+export const noSlackAlertsFixture = (
+  overrides: Partial<AlertsFixture> = {},
+): AlertsFixture => alertsFixture({ slackIntegration: null, ...overrides });
+
+/** Workspace connected, nothing authorized yet: the empty-pool state (D9). */
+export const emptyChannelPoolAlertsFixture = (
+  overrides: Partial<AlertsFixture> = {},
+): AlertsFixture =>
+  alertsFixture({
+    slackIntegration: {
+      id: ALERTS_SLACK_INTEGRATION_ID,
+      workspaceName: "Prowler HQ",
+      authorizedChannels: [],
+    },
+    ...overrides,
+  });
+
+/**
+ * A rule that stored a channel the integration no longer authorizes: the
+ * stored value must stay visible and selected, and a re-save keeping it must
+ * be refused by the ⊆ validation.
+ */
+export const staleChannelAlertsFixture = (
+  overrides: Partial<AlertsFixture> = {},
+): AlertsFixture =>
+  alertsFixture({
+    rules: [
+      alertRuleFixture({
+        slackChannels: [
+          { ...ALERTS_PUBLIC_CHANNEL },
+          { ...ALERTS_UNAUTHORIZED_CHANNEL },
+        ],
+      }),
+    ],
+    ...overrides,
+  });

--- a/ui/__tests__/msw/handlers/alerts.fixtures.ts
+++ b/ui/__tests__/msw/handlers/alerts.fixtures.ts
@@ -29,7 +29,13 @@ export interface AlertsSlackChannelFixture {
 export interface AlertsSlackIntegrationFixture {
   id: string;
   workspaceName: string;
-  /** Null until a connection check has run; a reinstall resets it. */
+  /**
+   * Null until a connection check has run; a reinstall or a changed channel
+   * set resets it. `true` therefore implies a non-empty set with every channel
+   * on it confirmed: the check requires "at least one configured channel" and
+   * the integration "is connected only when every check and required
+   * confirmation succeeds" (contract, Connection).
+   */
   connected: boolean | null;
   /** The channels authorized on the integration. */
   channels: AlertsSlackChannelFixture[];
@@ -202,15 +208,21 @@ export const noSlackAlertsFixture = (
   overrides: Partial<AlertsFixture> = {},
 ): AlertsFixture => alertsFixture({ slackIntegration: null, ...overrides });
 
-/** Workspace connected, nothing authorized yet: the empty-pool state (D9). */
-export const emptyChannelPoolAlertsFixture = (
+/**
+ * A workspace approved with nothing authorized on it: a new install, or one
+ * whose channel set was cleared. `connected` is `null`, never `true` — a check
+ * needs at least one configured channel, so none can have run, and clearing the
+ * set resets the connection state anyway (contract, Connection and PATCH). The
+ * Slack lane models the same tenant in `connectedSlackFixture`.
+ */
+export const noAuthorizedChannelsAlertsFixture = (
   overrides: Partial<AlertsFixture> = {},
 ): AlertsFixture =>
   alertsFixture({
     slackIntegration: {
       id: ALERTS_SLACK_INTEGRATION_ID,
       workspaceName: "Prowler HQ",
-      connected: true,
+      connected: null,
       channels: [],
     },
     ...overrides,

--- a/ui/__tests__/msw/handlers/alerts.fixtures.ts
+++ b/ui/__tests__/msw/handlers/alerts.fixtures.ts
@@ -82,6 +82,19 @@ export interface AlertsFixture {
   slackIntegration: AlertsSlackIntegrationFixture | null;
   /** The rules list read answers `500`. */
   listServerError: boolean;
+  /**
+   * A failure status for `GET /alerts/slack-channels`, or null to serve it.
+   * The two statuses reach the UI by different routes: a `5xx` throws out of
+   * `handleApiResponse`, a `403` comes back as an error payload.
+   */
+  channelsReadError: number | null;
+  /**
+   * A failure status for `GET /integrations`, or null to serve it. `403` is
+   * the everyday one: the endpoint gates even reads behind
+   * `MANAGE_INTEGRATIONS`, which is off by default, while `/alerts` is not
+   * gated at all — so a non-admin editing an alert rule always lands here.
+   */
+  integrationsReadError: number | null;
 }
 
 /** UUIDs, as the API's ids are. */
@@ -135,6 +148,10 @@ export const alertsChannelNotConfirmedDetail = (channelId: string): string =>
 
 export const ALERTS_LIST_SERVER_ERROR_DETAIL = "A server error occurred.";
 
+/** DRF's own refusal body, what a read the caller may not perform answers. */
+export const ALERTS_READ_FORBIDDEN_DETAIL =
+  "You do not have permission to perform this action.";
+
 export const alertRuleFixture = (
   overrides: Partial<AlertRuleFixture> = {},
 ): AlertRuleFixture => ({
@@ -175,6 +192,8 @@ export const alertsFixture = (
     channels: ALERTS_CONFIGURED_CHANNELS.map((channel) => ({ ...channel })),
   },
   listServerError: false,
+  channelsReadError: null,
+  integrationsReadError: null,
   ...overrides,
 });
 
@@ -194,6 +213,34 @@ export const emptyChannelPoolAlertsFixture = (
       connected: true,
       channels: [],
     },
+    ...overrides,
+  });
+
+/**
+ * A connected workspace whose channels are all still unconfirmed, with a rule
+ * that already stores them: the eligible pool is empty while the rule's own
+ * channels read back in full. The read model enriches from what is CONFIGURED,
+ * the pool offers only what is CONFIRMED — so the empty-pool state and stored
+ * channels are not mutually exclusive, whatever an empty pool suggests.
+ */
+export const unconfirmedChannelPoolAlertsFixture = (
+  overrides: Partial<AlertsFixture> = {},
+): AlertsFixture =>
+  alertsFixture({
+    slackIntegration: {
+      id: ALERTS_SLACK_INTEGRATION_ID,
+      workspaceName: "Prowler HQ",
+      connected: true,
+      channels: ALERTS_CONFIGURED_CHANNELS.map((channel) => ({
+        ...channel,
+        confirmationSentAt: null,
+      })),
+    },
+    rules: [
+      alertRuleFixture({
+        slackChannelIds: [ALERTS_PUBLIC_CHANNEL.id, ALERTS_PRIVATE_CHANNEL.id],
+      }),
+    ],
     ...overrides,
   });
 

--- a/ui/__tests__/msw/handlers/alerts.fixtures.ts
+++ b/ui/__tests__/msw/handlers/alerts.fixtures.ts
@@ -1,43 +1,33 @@
 /**
- * Fixture data for the alerts handlers. The alert-rule shapes mirror the API
- * the alerts UI already consumes; the Slack-channel shapes follow the signed
- * contract (`openspec/changes/add-slack-alert-channels/contract/`), addendum
- * section 6 included — it leaves nothing open.
+ * Fixture data for the alerts handlers. The Slack-channel shapes follow the
+ * signed contract (`openspec/changes/add-slack-alert-channels/contract/`).
  *
  * The disabled/empty channel states are driven by what the fixture OMITS
  * (no integration, no configured channels, no confirmations), never by
  * handing the UI a pre-disabled state (design D9).
  */
 
-/** A Slack channel configured on the integration. */
 export interface AlertsSlackChannelFixture {
   id: string;
   name: string;
   isPrivate: boolean;
   /**
-   * Null until the connection check posts its one-time confirmation. Only a
-   * confirmed channel is eligible as an alert destination, and a
-   * same-workspace reinstall resets every timestamp.
+   * Null until the connection check posts its confirmation; a same-workspace
+   * reinstall resets every timestamp. Only a confirmed channel is eligible.
    */
   confirmationSentAt: string | null;
 }
 
-/**
- * The tenant's Slack integration. `slackIntegration: null` is the tenant with
- * no workspace connected at all.
- */
+/** `slackIntegration: null` is a tenant with no workspace connected at all. */
 export interface AlertsSlackIntegrationFixture {
   id: string;
   workspaceName: string;
   /**
    * Null until a connection check has run; a reinstall or a changed channel
    * set resets it. `true` therefore implies a non-empty set with every channel
-   * on it confirmed: the check requires "at least one configured channel" and
-   * the integration "is connected only when every check and required
-   * confirmation succeeds" (contract, Connection).
+   * on it confirmed (contract, Connection).
    */
   connected: boolean | null;
-  /** The channels authorized on the integration. */
   channels: AlertsSlackChannelFixture[];
 }
 
@@ -59,11 +49,7 @@ export interface AlertRuleFixture {
   /** The condition DSL travels through the UI opaquely. */
   condition: Record<string, unknown>;
   recipientEmails: string[];
-  /**
-   * Stored destinations, by channel id — all the mapping table holds. The
-   * read enriches them from the integration, so an id its workspace no longer
-   * carries simply disappears, exactly as the server-side cascade leaves it.
-   */
+  /** Ids only; the read enriches them from the integration. */
   slackChannelIds: string[];
 }
 
@@ -89,23 +75,20 @@ export interface AlertsFixture {
   /** The rules list read answers `500`. */
   listServerError: boolean;
   /**
-   * A failure status for `GET /alerts/slack-channels`, or null to serve it.
-   * The two statuses reach the UI by different routes: a `5xx` throws out of
-   * `handleApiResponse`, a `403` comes back as an error payload. A refused read
-   * is also the only route to an empty pool on a connected workspace: served,
-   * the pool of a `connected: true` install always holds its confirmed set.
+   * A failure status for `GET /alerts/slack-channels`, or null to serve it. A
+   * refused read is the only route to an empty pool on a connected workspace:
+   * served, a `connected: true` install always holds its confirmed set.
    */
   channelsReadError: number | null;
   /**
    * A failure status for `GET /integrations`, or null to serve it. `403` is
    * the everyday one: the endpoint gates even reads behind
-   * `MANAGE_INTEGRATIONS`, which is off by default, while `/alerts` is not
-   * gated at all — so a non-admin editing an alert rule always lands here.
+   * `MANAGE_INTEGRATIONS`, off by default, while `/alerts` is not gated — a
+   * non-admin editing an alert rule always lands here.
    */
   integrationsReadError: number | null;
 }
 
-/** UUIDs, as the API's ids are. */
 export const ALERTS_SLACK_INTEGRATION_ID =
   "7c9e6a1b-2d3f-4e5a-8b6c-9d0e1f2a3b4c";
 export const ALERT_RULE_ID = "1f6d3c2b-8a4e-4b7d-9c5f-0e1a2b3c4d5e";
@@ -113,9 +96,8 @@ export const ALERT_RULE_ID = "1f6d3c2b-8a4e-4b7d-9c5f-0e1a2b3c4d5e";
 const CONFIRMED_AT = "2026-08-18T10:15:00Z";
 
 /**
- * The channel ids and names match the Slack fixtures' workspace so an
- * end-to-end reading of both pages tells one story, without importing from
- * `slack.fixtures.ts` (that file belongs to the integrations lane).
+ * Ids and names match the Slack fixtures' workspace, deliberately without
+ * importing from `slack.fixtures.ts` (the integrations lane owns that file).
  */
 export const ALERTS_PUBLIC_CHANNEL: AlertsSlackChannelFixture = {
   id: "C0123AB",
@@ -137,10 +119,10 @@ export const ALERTS_CONFIGURED_CHANNELS: AlertsSlackChannelFixture[] = [
 ];
 
 /**
- * The signed refusal code for the rule-write validation (contract section 6.1):
- * one code, and a 400, for every ineligible condition — only the human
- * `detail` says which one refused. Spelled out rather than imported from any
- * UI mapping: a rename on our side must fail these tests.
+ * One code, and a 400, for every ineligible condition (contract section 6.1) —
+ * only the human `detail` says which one refused. Code and details are spelled
+ * out here rather than imported from the UI: a rename on our side must fail
+ * these tests.
  */
 export const ALERTS_SLACK_CHANNEL_NOT_ELIGIBLE_CODE =
   "slack_channel_not_eligible";
@@ -156,7 +138,7 @@ export const alertsChannelNotConfirmedDetail = (channelId: string): string =>
 
 export const ALERTS_LIST_SERVER_ERROR_DETAIL = "A server error occurred.";
 
-/** DRF's own refusal body, what a read the caller may not perform answers. */
+/** DRF's own refusal body. */
 export const ALERTS_READ_FORBIDDEN_DETAIL =
   "You do not have permission to perform this action.";
 
@@ -179,8 +161,8 @@ export const alertRuleFixture = (
 });
 
 /**
- * The baseline tenant: a connected workspace with two confirmed channels (one
- * private) and one email-only rule to edit.
+ * The baseline tenant: a connected workspace with two confirmed channels and
+ * one email-only rule.
  */
 export const alertsFixture = (
   overrides: Partial<AlertsFixture> = {},
@@ -211,11 +193,10 @@ export const noSlackAlertsFixture = (
 ): AlertsFixture => alertsFixture({ slackIntegration: null, ...overrides });
 
 /**
- * A workspace approved with nothing authorized on it: a new install, or one
- * whose channel set was cleared. `connected` is `null`, never `true` — a check
- * needs at least one configured channel, so none can have run, and clearing the
- * set resets the connection state anyway (contract, Connection and PATCH). The
- * Slack lane models the same tenant in `connectedSlackFixture`.
+ * A workspace approved with nothing authorized on it. `connected` is `null`,
+ * never `true`: a check needs at least one configured channel, so none can
+ * have run, and clearing the set resets the connection state anyway
+ * (contract, Connection and PATCH).
  */
 export const noAuthorizedChannelsAlertsFixture = (
   overrides: Partial<AlertsFixture> = {},
@@ -232,8 +213,8 @@ export const noAuthorizedChannelsAlertsFixture = (
 
 /**
  * A same-workspace reinstall: the channels and the rules' mappings survive,
- * every confirmation and the connection state are reset. The only way the API
- * can still hand the form a stored channel it does not offer.
+ * every confirmation and the connection state are reset — the only way the API
+ * can hand the form a stored channel it does not offer.
  */
 export const reinstalledWorkspaceAlertsFixture = (
   overrides: Partial<AlertsFixture> = {},

--- a/ui/__tests__/msw/handlers/alerts.fixtures.ts
+++ b/ui/__tests__/msw/handlers/alerts.fixtures.ts
@@ -87,6 +87,8 @@ export interface AlertsFixture {
    * non-admin editing an alert rule always lands here.
    */
   integrationsReadError: number | null;
+  /** Whether `GET /integrations` rejects at the transport layer. */
+  integrationsNetworkError: boolean;
 }
 
 export const ALERTS_SLACK_INTEGRATION_ID =
@@ -184,6 +186,7 @@ export const alertsFixture = (
   listServerError: false,
   channelsReadError: null,
   integrationsReadError: null,
+  integrationsNetworkError: false,
   ...overrides,
 });
 

--- a/ui/__tests__/msw/handlers/alerts.ts
+++ b/ui/__tests__/msw/handlers/alerts.ts
@@ -6,7 +6,7 @@
  *
  * The Slack shapes follow the signed contract
  * (`openspec/changes/add-slack-alert-channels/contract/slack-alerts-api.md`,
- * section 2); what it leaves open carries a `TODO(Josema)`.
+ * section 2 and the section 6 addendum, which closed every open point).
  *
  * State is per-call: a create is visible to the next rules read. Wire them
  * per test via `worker.use(...handlersForAlerts(fx))`.
@@ -15,10 +15,8 @@
 import { http, HttpResponse } from "msw";
 
 import {
-  ALERTS_CHANNEL_NOT_AUTHORIZED_CODE,
-  ALERTS_CHANNEL_NOT_CONFIRMED_CODE,
   ALERTS_LIST_SERVER_ERROR_DETAIL,
-  ALERTS_SLACK_NOT_CONNECTED_CODE,
+  ALERTS_SLACK_CHANNEL_NOT_ELIGIBLE_CODE,
   ALERTS_SLACK_NOT_CONNECTED_DETAIL,
   alertsChannelNotAuthorizedDetail,
   alertsChannelNotConfirmedDetail,
@@ -101,11 +99,9 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
     );
 
   /**
-   * What `GET /alerts/slack-channels` offers: the enabled and connected
-   * integration's channels.
-   * TODO(Josema): the contract does not literally say the listing filters to
-   * *confirmed* channels (D3, Eligibility row). Assumed here — the rule write
-   * refuses unconfirmed ones, so offering them would offer a refusal.
+   * What `GET /alerts/slack-channels` offers, as signed (section 6.2): only
+   * the confirmed channels of the enabled and connected integration. An
+   * unconfirmed one would just be an offer of a refusal.
    */
   const eligibleChannels = (): AlertsSlackChannelFixture[] =>
     isConnected
@@ -114,52 +110,40 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
         )
       : [];
 
+  /** Every ineligible condition answers the one signed pair (section 6.1). */
+  const notEligible = (detail: string): Response =>
+    HttpResponse.json(
+      errorBody(detail, 400, ALERTS_SLACK_CHANNEL_NOT_ELIGIBLE_CODE),
+      { status: 400 },
+    );
+
   /**
-   * The rule-write validation the contract signs: an enabled and connected
-   * integration, the channel configured on it, and a non-null
-   * `confirmation_sent_at`. Answered before any write lands, so a refusal
-   * leaves the stored rule unchanged.
-   * TODO(Josema): whether PATCH re-validates channels a rule already stores is
-   * open (tasks 7.14). The supplied list is validated on both writes here —
-   * the literal reading — and the UI only surfaces what comes back.
+   * The rule-write validation the contract signs: every channel a write ADDS
+   * needs an enabled and connected integration, the channel configured on it,
+   * and a non-null `confirmation_sent_at`. Only newly added channels are
+   * validated (section 6.3), so ids the rule already stores never block an
+   * edit — a same-workspace reinstall that reset their confirmations does not
+   * freeze the rule. Answered before any write lands, so a refusal leaves the
+   * stored rule unchanged.
    */
   const refuseInvalidChannels = (
     channelIds: string[] | undefined,
+    retainedIds: readonly string[] = [],
   ): Response | null => {
-    if (!channelIds || channelIds.length === 0) return null;
+    const added = (channelIds ?? []).filter(
+      (channelId) => !retainedIds.includes(channelId),
+    );
+    if (added.length === 0) return null;
 
-    if (!isConnected) {
-      return HttpResponse.json(
-        errorBody(
-          ALERTS_SLACK_NOT_CONNECTED_DETAIL,
-          400,
-          ALERTS_SLACK_NOT_CONNECTED_CODE,
-        ),
-        { status: 400 },
-      );
-    }
+    if (!isConnected) return notEligible(ALERTS_SLACK_NOT_CONNECTED_DETAIL);
 
-    for (const channelId of channelIds) {
+    for (const channelId of added) {
       const channel = configuredChannel(channelId);
       if (!channel) {
-        return HttpResponse.json(
-          errorBody(
-            alertsChannelNotAuthorizedDetail(channelId),
-            400,
-            ALERTS_CHANNEL_NOT_AUTHORIZED_CODE,
-          ),
-          { status: 400 },
-        );
+        return notEligible(alertsChannelNotAuthorizedDetail(channelId));
       }
       if (channel.confirmationSentAt === null) {
-        return HttpResponse.json(
-          errorBody(
-            alertsChannelNotConfirmedDetail(channelId),
-            400,
-            ALERTS_CHANNEL_NOT_CONFIRMED_CODE,
-          ),
-          { status: 400 },
-        );
+        return notEligible(alertsChannelNotConfirmedDetail(channelId));
       }
     }
 
@@ -285,6 +269,7 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
     http.post(`${API}/alerts/rules`, async ({ request }) => {
       const attributes = await parseRuleAttributes(request);
       const written = storedIds(attributes.slack_channels ?? []);
+      // A create retains nothing: everything supplied is newly added.
       const refusal = refuseInvalidChannels(written);
       if (refusal) return refusal;
 
@@ -330,7 +315,8 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
         const written = attributes.slack_channels
           ? storedIds(attributes.slack_channels)
           : undefined;
-        const refusal = refuseInvalidChannels(written);
+        // Retained ids are the rule's stored selection: never re-validated.
+        const refusal = refuseInvalidChannels(written, rule.slackChannelIds);
         if (refusal) return refusal;
 
         if (attributes.name !== undefined) rule.name = attributes.name;

--- a/ui/__tests__/msw/handlers/alerts.ts
+++ b/ui/__tests__/msw/handlers/alerts.ts
@@ -1,12 +1,12 @@
 /**
- * MSW handlers for the alerts pages: rules CRUD, recipients, the Slack
- * integration read the channel field depends on, and the sibling reads the
+ * MSW handlers for the alerts pages: rules CRUD, recipients, the eligible
+ * Slack channels the destination field offers, the integration read that
+ * tells an empty pool from no workspace at all, and the sibling reads the
  * alerts page issues on mount (providers, scans, findings metadata).
  *
- * The Slack-channel wire names are D3 working assumptions
- * (`openspec/changes/add-slack-alert-channels/design.md`) — each carries a
- * `TODO(Josema)` until the contract is signed off; a rename lands here and in
- * the adapter only.
+ * The Slack shapes follow the signed contract
+ * (`openspec/changes/add-slack-alert-channels/contract/slack-alerts-api.md`,
+ * section 2); what it leaves open carries a `TODO(Josema)`.
  *
  * State is per-call: a create is visible to the next rules read. Wire them
  * per test via `worker.use(...handlersForAlerts(fx))`.
@@ -16,10 +16,12 @@ import { http, HttpResponse } from "msw";
 
 import {
   ALERTS_CHANNEL_NOT_AUTHORIZED_CODE,
+  ALERTS_CHANNEL_NOT_CONFIRMED_CODE,
   ALERTS_LIST_SERVER_ERROR_DETAIL,
   ALERTS_SLACK_NOT_CONNECTED_CODE,
   ALERTS_SLACK_NOT_CONNECTED_DETAIL,
   alertsChannelNotAuthorizedDetail,
+  alertsChannelNotConfirmedDetail,
 } from "./alerts.fixtures";
 import type {
   AlertRuleFixture,
@@ -45,30 +47,6 @@ const errorBody = (detail: string, status: number, code?: string) => ({
   ],
 });
 
-const channelAttribute = (channel: AlertsSlackChannelFixture) => ({
-  id: channel.id,
-  name: channel.name,
-  is_private: channel.isPrivate,
-});
-
-const ruleResource = (rule: AlertRuleFixture) => ({
-  id: rule.id,
-  type: "alert-rules",
-  attributes: {
-    name: rule.name,
-    description: rule.description,
-    enabled: rule.enabled,
-    trigger: rule.trigger,
-    condition: rule.condition,
-    schema_version: 1,
-    recipient_emails: rule.recipientEmails,
-    // TODO(Josema): `slack_channels` read shape pending contract sign-off (D3).
-    slack_channels: rule.slackChannels.map(channelAttribute),
-    inserted_at: TS,
-    updated_at: TS,
-  },
-});
-
 const collection = (data: unknown[]) => ({
   data,
   meta: {
@@ -77,28 +55,11 @@ const collection = (data: unknown[]) => ({
   },
 });
 
-const integrationResource = (
-  integration: NonNullable<AlertsFixture["slackIntegration"]>,
-) => ({
-  id: integration.id,
-  type: "integrations",
-  attributes: {
-    inserted_at: TS,
-    updated_at: TS,
-    enabled: true,
-    connected: true,
-    connection_last_checked_at: TS,
-    integration_type: "slack",
-    configuration: {
-      team_id: "T01PROWLER",
-      team_name: integration.workspaceName,
-      bot_user_id: "U01PROWLERBOT",
-      // TODO(Josema): plural stored shape pending contract sign-off (D3) —
-      // supersedes the singular `channel_id` / `channel_name`.
-      channels: integration.authorizedChannels.map(channelAttribute),
-    },
-  },
-  links: { self: `${API}/integrations/${integration.id}` },
+/** The rule read's channel shape: resolved name and privacy, no Slack call. */
+const storedChannelAttribute = (channel: AlertsSlackChannelFixture) => ({
+  id: channel.id,
+  name: channel.name,
+  is_private: channel.isPrivate,
 });
 
 interface RuleWriteAttributes {
@@ -108,8 +69,8 @@ interface RuleWriteAttributes {
   trigger?: AlertRuleFixture["trigger"];
   condition?: AlertRuleFixture["condition"];
   recipient_emails?: string[];
-  // TODO(Josema): `slack_channels` write attribute pending contract sign-off (D3).
-  slack_channels?: string[];
+  /** Objects carrying only `id`; name and privacy are server-derived. */
+  slack_channels?: { id: string }[];
 }
 
 const parseRuleAttributes = async (
@@ -126,21 +87,48 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
   const rules: AlertRuleFixture[] = fx.rules.map((rule) => ({
     ...rule,
     recipientEmails: [...rule.recipientEmails],
-    slackChannels: rule.slackChannels.map((channel) => ({ ...channel })),
+    slackChannelIds: [...rule.slackChannelIds],
   }));
   let createdCount = 0;
 
+  const isConnected = fx.slackIntegration?.connected === true;
+
+  const configuredChannel = (
+    channelId: string,
+  ): AlertsSlackChannelFixture | undefined =>
+    fx.slackIntegration?.channels.find(
+      (candidate) => candidate.id === channelId,
+    );
+
   /**
-   * The rule-write validation the contract promises: channels only while a
-   * workspace is connected, and each within the authorized set. Answered
-   * before any write lands, so a refusal leaves the stored rule unchanged.
+   * What `GET /alerts/slack-channels` offers: the enabled and connected
+   * integration's channels.
+   * TODO(Josema): the contract does not literally say the listing filters to
+   * *confirmed* channels (D3, Eligibility row). Assumed here — the rule write
+   * refuses unconfirmed ones, so offering them would offer a refusal.
+   */
+  const eligibleChannels = (): AlertsSlackChannelFixture[] =>
+    isConnected
+      ? (fx.slackIntegration?.channels ?? []).filter(
+          (channel) => channel.confirmationSentAt !== null,
+        )
+      : [];
+
+  /**
+   * The rule-write validation the contract signs: an enabled and connected
+   * integration, the channel configured on it, and a non-null
+   * `confirmation_sent_at`. Answered before any write lands, so a refusal
+   * leaves the stored rule unchanged.
+   * TODO(Josema): whether PATCH re-validates channels a rule already stores is
+   * open (tasks 7.14). The supplied list is validated on both writes here —
+   * the literal reading — and the UI only surfaces what comes back.
    */
   const refuseInvalidChannels = (
     channelIds: string[] | undefined,
   ): Response | null => {
     if (!channelIds || channelIds.length === 0) return null;
 
-    if (!fx.slackIntegration) {
+    if (!isConnected) {
       return HttpResponse.json(
         errorBody(
           ALERTS_SLACK_NOT_CONNECTED_DETAIL,
@@ -151,32 +139,91 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
       );
     }
 
-    const authorized = new Set(
-      fx.slackIntegration.authorizedChannels.map((channel) => channel.id),
-    );
-    const outside = channelIds.find((id) => !authorized.has(id));
-    if (outside) {
-      return HttpResponse.json(
-        errorBody(
-          alertsChannelNotAuthorizedDetail(outside),
-          400,
-          ALERTS_CHANNEL_NOT_AUTHORIZED_CODE,
-        ),
-        { status: 400 },
-      );
+    for (const channelId of channelIds) {
+      const channel = configuredChannel(channelId);
+      if (!channel) {
+        return HttpResponse.json(
+          errorBody(
+            alertsChannelNotAuthorizedDetail(channelId),
+            400,
+            ALERTS_CHANNEL_NOT_AUTHORIZED_CODE,
+          ),
+          { status: 400 },
+        );
+      }
+      if (channel.confirmationSentAt === null) {
+        return HttpResponse.json(
+          errorBody(
+            alertsChannelNotConfirmedDetail(channelId),
+            400,
+            ALERTS_CHANNEL_NOT_CONFIRMED_CODE,
+          ),
+          { status: 400 },
+        );
+      }
     }
 
     return null;
   };
 
-  /** Total by construction: ids were validated against the same set. */
-  const resolveChannels = (channelIds: string[]): AlertsSlackChannelFixture[] =>
-    channelIds.flatMap((id) => {
-      const channel = fx.slackIntegration?.authorizedChannels.find(
-        (candidate) => candidate.id === id,
-      );
-      return channel ? [{ ...channel }] : [];
-    });
+  /** Deduplicated, as the contract requires of every Slack id list. */
+  const storedIds = (written: { id: string }[]): string[] =>
+    Array.from(new Set(written.map((channel) => channel.id)));
+
+  /**
+   * The read enriches the mapping's ids from the integration — the mapping
+   * table holds no metadata — so a channel the workspace no longer carries is
+   * simply absent, exactly as the cascade leaves it.
+   */
+  const ruleResource = (rule: AlertRuleFixture) => ({
+    id: rule.id,
+    type: "alert-rules",
+    attributes: {
+      name: rule.name,
+      description: rule.description,
+      enabled: rule.enabled,
+      trigger: rule.trigger,
+      condition: rule.condition,
+      schema_version: 1,
+      recipient_emails: rule.recipientEmails,
+      slack_channels: rule.slackChannelIds.flatMap((channelId) => {
+        const channel = configuredChannel(channelId);
+        return channel ? [storedChannelAttribute(channel)] : [];
+      }),
+      inserted_at: TS,
+      updated_at: TS,
+    },
+  });
+
+  const integrationResource = (
+    integration: NonNullable<AlertsFixture["slackIntegration"]>,
+  ) => ({
+    id: integration.id,
+    type: "integrations",
+    attributes: {
+      inserted_at: TS,
+      updated_at: TS,
+      enabled: true,
+      connected: integration.connected,
+      connection_last_checked_at: integration.connected === null ? null : TS,
+      integration_type: "slack",
+      configuration: {
+        team_id: "T01PROWLER",
+        team_name: integration.workspaceName,
+        bot_user_id: "U01PROWLERBOT",
+        channels: integration.channels.map((channel) => ({
+          ...storedChannelAttribute(channel),
+          confirmation_sent_at: channel.confirmationSentAt,
+        })),
+        verification: {
+          task_id: null,
+          started_at: null,
+          finished_at: integration.connected === null ? null : TS,
+        },
+      },
+    },
+    links: { self: `${API}/integrations/${integration.id}` },
+  });
 
   return [
     // --- Rules -------------------------------------------------------------
@@ -237,7 +284,8 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
 
     http.post(`${API}/alerts/rules`, async ({ request }) => {
       const attributes = await parseRuleAttributes(request);
-      const refusal = refuseInvalidChannels(attributes.slack_channels);
+      const written = storedIds(attributes.slack_channels ?? []);
+      const refusal = refuseInvalidChannels(written);
       if (refusal) return refusal;
 
       createdCount += 1;
@@ -249,7 +297,8 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
         trigger: attributes.trigger ?? "after_scan",
         condition: attributes.condition ?? {},
         recipientEmails: attributes.recipient_emails ?? [],
-        slackChannels: resolveChannels(attributes.slack_channels ?? []),
+        // Omission defaults both destination lists to empty.
+        slackChannelIds: written,
       };
       rules.push(created);
 
@@ -278,7 +327,10 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
         }
 
         const attributes = await parseRuleAttributes(request);
-        const refusal = refuseInvalidChannels(attributes.slack_channels);
+        const written = attributes.slack_channels
+          ? storedIds(attributes.slack_channels)
+          : undefined;
+        const refusal = refuseInvalidChannels(written);
         if (refusal) return refusal;
 
         if (attributes.name !== undefined) rule.name = attributes.name;
@@ -293,10 +345,10 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
         if (attributes.recipient_emails !== undefined) {
           rule.recipientEmails = attributes.recipient_emails;
         }
-        // Replace-not-additive, like `recipient_emails`; omitting the key
-        // leaves the stored channels — stale ones included — untouched.
-        if (attributes.slack_channels !== undefined) {
-          rule.slackChannels = resolveChannels(attributes.slack_channels);
+        // A supplied list replaces the whole Slack selection atomically, `[]`
+        // clears it, and omitting the key leaves it untouched.
+        if (written !== undefined) {
+          rule.slackChannelIds = written;
         }
 
         return HttpResponse.json({ data: ruleResource(rule) });
@@ -311,6 +363,17 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
       rules.splice(index, 1);
       return new HttpResponse(null, { status: 204 });
     }),
+
+    // --- The channels the alert form offers ---------------------------------
+    http.get(`${API}/alerts/slack-channels`, () =>
+      HttpResponse.json({
+        data: eligibleChannels().map((channel) => ({
+          type: "slack-channels",
+          id: channel.id,
+          attributes: { name: channel.name, is_private: channel.isPrivate },
+        })),
+      }),
+    ),
 
     // --- Recipients ---------------------------------------------------------
     http.get(`${API}/alerts/recipients`, () =>
@@ -330,7 +393,7 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
       ),
     ),
 
-    // --- The Slack integration the channel field reads ----------------------
+    // --- The integration read that tells the two empty states apart ---------
     http.get(`${API}/integrations`, ({ request }) => {
       const type = new URL(request.url).searchParams.get(
         "filter[integration_type]",

--- a/ui/__tests__/msw/handlers/alerts.ts
+++ b/ui/__tests__/msw/handlers/alerts.ts
@@ -1,0 +1,365 @@
+/**
+ * MSW handlers for the alerts pages: rules CRUD, recipients, the Slack
+ * integration read the channel field depends on, and the sibling reads the
+ * alerts page issues on mount (providers, scans, findings metadata).
+ *
+ * The Slack-channel wire names are D3 working assumptions
+ * (`openspec/changes/add-slack-alert-channels/design.md`) — each carries a
+ * `TODO(Josema)` until the contract is signed off; a rename lands here and in
+ * the adapter only.
+ *
+ * State is per-call: a create is visible to the next rules read. Wire them
+ * per test via `worker.use(...handlersForAlerts(fx))`.
+ */
+
+import { http, HttpResponse } from "msw";
+
+import {
+  ALERTS_CHANNEL_NOT_AUTHORIZED_CODE,
+  ALERTS_LIST_SERVER_ERROR_DETAIL,
+  ALERTS_SLACK_NOT_CONNECTED_CODE,
+  ALERTS_SLACK_NOT_CONNECTED_DETAIL,
+  alertsChannelNotAuthorizedDetail,
+} from "./alerts.fixtures";
+import type {
+  AlertRuleFixture,
+  AlertsFixture,
+  AlertsSlackChannelFixture,
+} from "./alerts.fixtures";
+
+const API = process.env.UI_API_BASE_URL;
+const TS = "2026-08-20T09:00:00Z";
+
+/**
+ * `status` is a string, per the JSON:API spec — same taxonomy the Slack
+ * handlers answer with, since the validation is about Slack state.
+ */
+const errorBody = (detail: string, status: number, code?: string) => ({
+  errors: [
+    {
+      status: String(status),
+      ...(code ? { code } : {}),
+      detail,
+      source: { pointer: "/data" },
+    },
+  ],
+});
+
+const channelAttribute = (channel: AlertsSlackChannelFixture) => ({
+  id: channel.id,
+  name: channel.name,
+  is_private: channel.isPrivate,
+});
+
+const ruleResource = (rule: AlertRuleFixture) => ({
+  id: rule.id,
+  type: "alert-rules",
+  attributes: {
+    name: rule.name,
+    description: rule.description,
+    enabled: rule.enabled,
+    trigger: rule.trigger,
+    condition: rule.condition,
+    schema_version: 1,
+    recipient_emails: rule.recipientEmails,
+    // TODO(Josema): `slack_channels` read shape pending contract sign-off (D3).
+    slack_channels: rule.slackChannels.map(channelAttribute),
+    inserted_at: TS,
+    updated_at: TS,
+  },
+});
+
+const collection = (data: unknown[]) => ({
+  data,
+  meta: {
+    version: "v1",
+    pagination: { page: 1, pages: 1, count: data.length },
+  },
+});
+
+const integrationResource = (
+  integration: NonNullable<AlertsFixture["slackIntegration"]>,
+) => ({
+  id: integration.id,
+  type: "integrations",
+  attributes: {
+    inserted_at: TS,
+    updated_at: TS,
+    enabled: true,
+    connected: true,
+    connection_last_checked_at: TS,
+    integration_type: "slack",
+    configuration: {
+      team_id: "T01PROWLER",
+      team_name: integration.workspaceName,
+      bot_user_id: "U01PROWLERBOT",
+      // TODO(Josema): plural stored shape pending contract sign-off (D3) —
+      // supersedes the singular `channel_id` / `channel_name`.
+      channels: integration.authorizedChannels.map(channelAttribute),
+    },
+  },
+  links: { self: `${API}/integrations/${integration.id}` },
+});
+
+interface RuleWriteAttributes {
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+  trigger?: AlertRuleFixture["trigger"];
+  condition?: AlertRuleFixture["condition"];
+  recipient_emails?: string[];
+  // TODO(Josema): `slack_channels` write attribute pending contract sign-off (D3).
+  slack_channels?: string[];
+}
+
+const parseRuleAttributes = async (
+  request: Request,
+): Promise<RuleWriteAttributes> => {
+  const body = (await request.json().catch(() => null)) as {
+    data?: { attributes?: RuleWriteAttributes };
+  } | null;
+  return body?.data?.attributes ?? {};
+};
+
+export const handlersForAlerts = (fx: AlertsFixture) => {
+  // Mutable copies: writes must not reach through to the caller's fixture.
+  const rules: AlertRuleFixture[] = fx.rules.map((rule) => ({
+    ...rule,
+    recipientEmails: [...rule.recipientEmails],
+    slackChannels: rule.slackChannels.map((channel) => ({ ...channel })),
+  }));
+  let createdCount = 0;
+
+  /**
+   * The rule-write validation the contract promises: channels only while a
+   * workspace is connected, and each within the authorized set. Answered
+   * before any write lands, so a refusal leaves the stored rule unchanged.
+   */
+  const refuseInvalidChannels = (
+    channelIds: string[] | undefined,
+  ): Response | null => {
+    if (!channelIds || channelIds.length === 0) return null;
+
+    if (!fx.slackIntegration) {
+      return HttpResponse.json(
+        errorBody(
+          ALERTS_SLACK_NOT_CONNECTED_DETAIL,
+          400,
+          ALERTS_SLACK_NOT_CONNECTED_CODE,
+        ),
+        { status: 400 },
+      );
+    }
+
+    const authorized = new Set(
+      fx.slackIntegration.authorizedChannels.map((channel) => channel.id),
+    );
+    const outside = channelIds.find((id) => !authorized.has(id));
+    if (outside) {
+      return HttpResponse.json(
+        errorBody(
+          alertsChannelNotAuthorizedDetail(outside),
+          400,
+          ALERTS_CHANNEL_NOT_AUTHORIZED_CODE,
+        ),
+        { status: 400 },
+      );
+    }
+
+    return null;
+  };
+
+  /** Total by construction: ids were validated against the same set. */
+  const resolveChannels = (channelIds: string[]): AlertsSlackChannelFixture[] =>
+    channelIds.flatMap((id) => {
+      const channel = fx.slackIntegration?.authorizedChannels.find(
+        (candidate) => candidate.id === id,
+      );
+      return channel ? [{ ...channel }] : [];
+    });
+
+  return [
+    // --- Rules -------------------------------------------------------------
+    http.get(`${API}/alerts/rules`, () => {
+      if (fx.listServerError) {
+        return HttpResponse.json(
+          errorBody(ALERTS_LIST_SERVER_ERROR_DETAIL, 500),
+          { status: 500 },
+        );
+      }
+      return HttpResponse.json(collection(rules.map(ruleResource)));
+    }),
+
+    /**
+     * Registered before the `:id` routes so the literal paths win. The seed
+     * echoes the filter bag back as a leaf condition — the UI treats the DSL
+     * opaquely, so the exact translation is this fixture's business alone.
+     */
+    http.post(`${API}/alerts/rules/seed`, async ({ request }) => {
+      const body = (await request.json().catch(() => null)) as {
+        data?: { attributes?: { filter_bag?: Record<string, unknown> } };
+      } | null;
+      const bag = body?.data?.attributes?.filter_bag ?? {};
+      const severity = bag["filter[severity__in]"];
+      const severityValues = Array.isArray(severity)
+        ? severity
+        : typeof severity === "string"
+          ? severity.split(",")
+          : ["critical"];
+
+      return HttpResponse.json({
+        data: {
+          id: "seeded-rule",
+          type: "alert-rule-seedings",
+          attributes: {
+            condition: {
+              op: "count_gte",
+              filter: { severity: severityValues },
+              value: 1,
+            },
+          },
+        },
+      });
+    }),
+
+    http.post(`${API}/alerts/rules/preview`, () =>
+      HttpResponse.json({
+        data: {
+          id: "preview",
+          type: "alert-rule-previews",
+          attributes: {
+            summary: { finding_count_total: 3, top_severity: "critical" },
+            evaluation_failed: false,
+          },
+        },
+      }),
+    ),
+
+    http.post(`${API}/alerts/rules`, async ({ request }) => {
+      const attributes = await parseRuleAttributes(request);
+      const refusal = refuseInvalidChannels(attributes.slack_channels);
+      if (refusal) return refusal;
+
+      createdCount += 1;
+      const created: AlertRuleFixture = {
+        id: `created-rule-${createdCount}`,
+        name: attributes.name ?? "",
+        description: attributes.description ?? "",
+        enabled: attributes.enabled ?? true,
+        trigger: attributes.trigger ?? "after_scan",
+        condition: attributes.condition ?? {},
+        recipientEmails: attributes.recipient_emails ?? [],
+        slackChannels: resolveChannels(attributes.slack_channels ?? []),
+      };
+      rules.push(created);
+
+      return HttpResponse.json(
+        { data: ruleResource(created) },
+        { status: 201 },
+      );
+    }),
+
+    http.get<{ id: string }>(`${API}/alerts/rules/:id`, ({ params }) => {
+      const rule = rules.find((candidate) => candidate.id === params.id);
+      if (!rule) {
+        return HttpResponse.json(errorBody("Not found.", 404), { status: 404 });
+      }
+      return HttpResponse.json({ data: ruleResource(rule) });
+    }),
+
+    http.patch<{ id: string }>(
+      `${API}/alerts/rules/:id`,
+      async ({ params, request }) => {
+        const rule = rules.find((candidate) => candidate.id === params.id);
+        if (!rule) {
+          return HttpResponse.json(errorBody("Not found.", 404), {
+            status: 404,
+          });
+        }
+
+        const attributes = await parseRuleAttributes(request);
+        const refusal = refuseInvalidChannels(attributes.slack_channels);
+        if (refusal) return refusal;
+
+        if (attributes.name !== undefined) rule.name = attributes.name;
+        if (attributes.description !== undefined) {
+          rule.description = attributes.description;
+        }
+        if (attributes.enabled !== undefined) rule.enabled = attributes.enabled;
+        if (attributes.trigger !== undefined) rule.trigger = attributes.trigger;
+        if (attributes.condition !== undefined) {
+          rule.condition = attributes.condition;
+        }
+        if (attributes.recipient_emails !== undefined) {
+          rule.recipientEmails = attributes.recipient_emails;
+        }
+        // Replace-not-additive, like `recipient_emails`; omitting the key
+        // leaves the stored channels — stale ones included — untouched.
+        if (attributes.slack_channels !== undefined) {
+          rule.slackChannels = resolveChannels(attributes.slack_channels);
+        }
+
+        return HttpResponse.json({ data: ruleResource(rule) });
+      },
+    ),
+
+    http.delete<{ id: string }>(`${API}/alerts/rules/:id`, ({ params }) => {
+      const index = rules.findIndex((candidate) => candidate.id === params.id);
+      if (index === -1) {
+        return HttpResponse.json(errorBody("Not found.", 404), { status: 404 });
+      }
+      rules.splice(index, 1);
+      return new HttpResponse(null, { status: 204 });
+    }),
+
+    // --- Recipients ---------------------------------------------------------
+    http.get(`${API}/alerts/recipients`, () =>
+      HttpResponse.json(
+        collection(
+          fx.recipients.map((recipient, index) => ({
+            id: `recipient-${index + 1}`,
+            type: "alert-recipients",
+            attributes: {
+              email: recipient.email,
+              status: recipient.status,
+              inserted_at: TS,
+              updated_at: TS,
+            },
+          })),
+        ),
+      ),
+    ),
+
+    // --- The Slack integration the channel field reads ----------------------
+    http.get(`${API}/integrations`, ({ request }) => {
+      const type = new URL(request.url).searchParams.get(
+        "filter[integration_type]",
+      );
+      // An unfiltered read would pull every type into the alert form.
+      const install =
+        type === "slack" && fx.slackIntegration ? fx.slackIntegration : null;
+      return HttpResponse.json(
+        collection(install ? [integrationResource(install)] : []),
+      );
+    }),
+
+    // --- Sibling reads the alerts page issues on mount -----------------------
+    http.get(`${API}/providers`, () => HttpResponse.json(collection([]))),
+    http.get(`${API}/scans`, () => HttpResponse.json(collection([]))),
+    http.get(`${API}/findings/metadata/latest`, () =>
+      HttpResponse.json({
+        data: {
+          id: "latest",
+          type: "findings-metadata",
+          attributes: {
+            regions: [],
+            services: [],
+            resource_types: [],
+            categories: [],
+            groups: [],
+          },
+        },
+      }),
+    ),
+  ];
+};

--- a/ui/__tests__/msw/handlers/alerts.ts
+++ b/ui/__tests__/msw/handlers/alerts.ts
@@ -16,6 +16,7 @@ import { http, HttpResponse } from "msw";
 
 import {
   ALERTS_LIST_SERVER_ERROR_DETAIL,
+  ALERTS_READ_FORBIDDEN_DETAIL,
   ALERTS_SLACK_CHANNEL_NOT_ELIGIBLE_CODE,
   ALERTS_SLACK_NOT_CONNECTED_DETAIL,
   alertsChannelNotAuthorizedDetail,
@@ -44,6 +45,22 @@ const errorBody = (detail: string, status: number, code?: string) => ({
     },
   ],
 });
+
+/**
+ * A read the fixture asks to fail. The status is the whole point: a `5xx`
+ * throws out of `handleApiResponse` and rejects the caller's promise, a `4xx`
+ * comes back as an error payload — two routes into the UI, not one.
+ */
+const readFailure = (status: number): Response =>
+  HttpResponse.json(
+    errorBody(
+      status >= 500
+        ? ALERTS_LIST_SERVER_ERROR_DETAIL
+        : ALERTS_READ_FORBIDDEN_DETAIL,
+      status,
+    ),
+    { status },
+  );
 
 const collection = (data: unknown[]) => ({
   data,
@@ -351,15 +368,16 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
     }),
 
     // --- The channels the alert form offers ---------------------------------
-    http.get(`${API}/alerts/slack-channels`, () =>
-      HttpResponse.json({
+    http.get(`${API}/alerts/slack-channels`, () => {
+      if (fx.channelsReadError) return readFailure(fx.channelsReadError);
+      return HttpResponse.json({
         data: eligibleChannels().map((channel) => ({
           type: "slack-channels",
           id: channel.id,
           attributes: { name: channel.name, is_private: channel.isPrivate },
         })),
-      }),
-    ),
+      });
+    }),
 
     // --- Recipients ---------------------------------------------------------
     http.get(`${API}/alerts/recipients`, () =>
@@ -381,6 +399,8 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
 
     // --- The integration read that tells the two empty states apart ---------
     http.get(`${API}/integrations`, ({ request }) => {
+      if (fx.integrationsReadError)
+        return readFailure(fx.integrationsReadError);
       const type = new URL(request.url).searchParams.get(
         "filter[integration_type]",
       );

--- a/ui/__tests__/msw/handlers/alerts.ts
+++ b/ui/__tests__/msw/handlers/alerts.ts
@@ -372,6 +372,7 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
 
     // Read so the form can tell "no workspace" from "no eligible channels".
     http.get(`${API}/integrations`, ({ request }) => {
+      if (fx.integrationsNetworkError) return HttpResponse.error();
       if (fx.integrationsReadError)
         return readFailure(fx.integrationsReadError);
       const type = new URL(request.url).searchParams.get(

--- a/ui/__tests__/msw/handlers/alerts.ts
+++ b/ui/__tests__/msw/handlers/alerts.ts
@@ -1,12 +1,7 @@
 /**
- * MSW handlers for the alerts pages: rules CRUD, recipients, the eligible
- * Slack channels the destination field offers, the integration read that
- * tells an empty pool from no workspace at all, and the sibling reads the
- * alerts page issues on mount (providers, scans, findings metadata).
- *
- * The Slack shapes follow the signed contract
- * (`openspec/changes/add-slack-alert-channels/contract/slack-alerts-api.md`,
- * section 2 and the section 6 addendum, which closed every open point).
+ * MSW handlers for the alerts pages. The Slack shapes follow the signed
+ * contract, section 2 and the section 6 addendum
+ * (`openspec/changes/add-slack-alert-channels/contract/slack-alerts-api.md`).
  *
  * State is per-call: a create is visible to the next rules read. Wire them
  * per test via `worker.use(...handlersForAlerts(fx))`.
@@ -31,10 +26,7 @@ import type {
 const API = process.env.UI_API_BASE_URL;
 const TS = "2026-08-20T09:00:00Z";
 
-/**
- * `status` is a string, per the JSON:API spec — same taxonomy the Slack
- * handlers answer with, since the validation is about Slack state.
- */
+/** `status` is a string, per the JSON:API spec. */
 const errorBody = (detail: string, status: number, code?: string) => ({
   errors: [
     {
@@ -46,11 +38,7 @@ const errorBody = (detail: string, status: number, code?: string) => ({
   ],
 });
 
-/**
- * A read the fixture asks to fail. The status is the whole point: a `5xx`
- * throws out of `handleApiResponse` and rejects the caller's promise, a `4xx`
- * comes back as an error payload — two routes into the UI, not one.
- */
+/** `5xx` throws out of `handleApiResponse`; `4xx` returns an error payload. */
 const readFailure = (status: number): Response =>
   HttpResponse.json(
     errorBody(
@@ -70,7 +58,6 @@ const collection = (data: unknown[]) => ({
   },
 });
 
-/** The rule read's channel shape: resolved name and privacy, no Slack call. */
 const storedChannelAttribute = (channel: AlertsSlackChannelFixture) => ({
   id: channel.id,
   name: channel.name,
@@ -84,7 +71,7 @@ interface RuleWriteAttributes {
   trigger?: AlertRuleFixture["trigger"];
   condition?: AlertRuleFixture["condition"];
   recipient_emails?: string[];
-  /** Objects carrying only `id`; name and privacy are server-derived. */
+  /** Ids only; name and privacy are server-derived. */
   slack_channels?: { id: string }[];
 }
 
@@ -116,9 +103,8 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
     );
 
   /**
-   * What `GET /alerts/slack-channels` offers, as signed (section 6.2): only
-   * the confirmed channels of the enabled and connected integration. An
-   * unconfirmed one would just be an offer of a refusal.
+   * Only the confirmed channels of the enabled and connected integration
+   * (section 6.2).
    */
   const eligibleChannels = (): AlertsSlackChannelFixture[] =>
     isConnected
@@ -135,13 +121,10 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
     );
 
   /**
-   * The rule-write validation the contract signs: every channel a write ADDS
-   * needs an enabled and connected integration, the channel configured on it,
-   * and a non-null `confirmation_sent_at`. Only newly added channels are
-   * validated (section 6.3), so ids the rule already stores never block an
-   * edit — a same-workspace reinstall that reset their confirmations does not
-   * freeze the rule. Answered before any write lands, so a refusal leaves the
-   * stored rule unchanged.
+   * An added channel needs an enabled and connected integration, the channel
+   * configured on it, and a non-null `confirmation_sent_at`. Only NEWLY added
+   * ids are validated (section 6.3) — retained ids never block an edit — and
+   * the refusal is answered before any write lands.
    */
   const refuseInvalidChannels = (
     channelIds: string[] | undefined,
@@ -172,9 +155,8 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
     Array.from(new Set(written.map((channel) => channel.id)));
 
   /**
-   * The read enriches the mapping's ids from the integration — the mapping
-   * table holds no metadata — so a channel the workspace no longer carries is
-   * simply absent, exactly as the cascade leaves it.
+   * The mapping table holds ids only, so the read enriches them from the
+   * integration — a channel the workspace no longer carries is simply absent.
    */
   const ruleResource = (rule: AlertRuleFixture) => ({
     id: rule.id,
@@ -227,7 +209,6 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
   });
 
   return [
-    // --- Rules -------------------------------------------------------------
     http.get(`${API}/alerts/rules`, () => {
       if (fx.listServerError) {
         return HttpResponse.json(
@@ -238,11 +219,7 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
       return HttpResponse.json(collection(rules.map(ruleResource)));
     }),
 
-    /**
-     * Registered before the `:id` routes so the literal paths win. The seed
-     * echoes the filter bag back as a leaf condition — the UI treats the DSL
-     * opaquely, so the exact translation is this fixture's business alone.
-     */
+    /** Registered before the `:id` routes so the literal paths win. */
     http.post(`${API}/alerts/rules/seed`, async ({ request }) => {
       const body = (await request.json().catch(() => null)) as {
         data?: { attributes?: { filter_bag?: Record<string, unknown> } };
@@ -299,7 +276,6 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
         trigger: attributes.trigger ?? "after_scan",
         condition: attributes.condition ?? {},
         recipientEmails: attributes.recipient_emails ?? [],
-        // Omission defaults both destination lists to empty.
         slackChannelIds: written,
       };
       rules.push(created);
@@ -332,7 +308,6 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
         const written = attributes.slack_channels
           ? storedIds(attributes.slack_channels)
           : undefined;
-        // Retained ids are the rule's stored selection: never re-validated.
         const refusal = refuseInvalidChannels(written, rule.slackChannelIds);
         if (refusal) return refusal;
 
@@ -348,8 +323,8 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
         if (attributes.recipient_emails !== undefined) {
           rule.recipientEmails = attributes.recipient_emails;
         }
-        // A supplied list replaces the whole Slack selection atomically, `[]`
-        // clears it, and omitting the key leaves it untouched.
+        // A supplied list replaces the whole selection; omitting the key
+        // leaves it untouched.
         if (written !== undefined) {
           rule.slackChannelIds = written;
         }
@@ -367,7 +342,6 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
       return new HttpResponse(null, { status: 204 });
     }),
 
-    // --- The channels the alert form offers ---------------------------------
     http.get(`${API}/alerts/slack-channels`, () => {
       if (fx.channelsReadError) return readFailure(fx.channelsReadError);
       return HttpResponse.json({
@@ -379,7 +353,6 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
       });
     }),
 
-    // --- Recipients ---------------------------------------------------------
     http.get(`${API}/alerts/recipients`, () =>
       HttpResponse.json(
         collection(
@@ -397,7 +370,7 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
       ),
     ),
 
-    // --- The integration read that tells the two empty states apart ---------
+    // Read so the form can tell "no workspace" from "no eligible channels".
     http.get(`${API}/integrations`, ({ request }) => {
       if (fx.integrationsReadError)
         return readFailure(fx.integrationsReadError);
@@ -412,7 +385,7 @@ export const handlersForAlerts = (fx: AlertsFixture) => {
       );
     }),
 
-    // --- Sibling reads the alerts page issues on mount -----------------------
+    // Sibling reads the alerts page issues on mount.
     http.get(`${API}/providers`, () => HttpResponse.json(collection([]))),
     http.get(`${API}/scans`, () => HttpResponse.json(collection([]))),
     http.get(`${API}/findings/metadata/latest`, () =>

--- a/ui/actions/integrations/integrations.ts
+++ b/ui/actions/integrations/integrations.ts
@@ -37,8 +37,7 @@ export const getIntegrations = async (searchParams?: URLSearchParams) => {
 
     return handleApiResponse(response);
   } catch (error) {
-    console.error("Error fetching integrations:", error);
-    return { data: [], meta: { pagination: { count: 0 } } };
+    return handleApiError(error);
   }
 };
 

--- a/ui/app/(prowler)/alerts/_actions/alerts.ts
+++ b/ui/app/(prowler)/alerts/_actions/alerts.ts
@@ -25,9 +25,8 @@ export interface AlertPayload {
    */
   recipientEmails?: string[];
   /**
-   * Slack channel ids from the eligible set. Replace-not-additive like
-   * `recipientEmails`: a supplied list replaces the whole Slack selection,
-   * `[]` clears it, and omitting the key leaves it unchanged.
+   * Replace-not-additive like `recipientEmails`: `[]` clears the selection,
+   * omitting the key leaves it unchanged.
    */
   slackChannels?: string[];
 }

--- a/ui/app/(prowler)/alerts/_actions/alerts.ts
+++ b/ui/app/(prowler)/alerts/_actions/alerts.ts
@@ -24,6 +24,12 @@ export interface AlertPayload {
    * emails. Recipient IDs are NOT used by the rule write path.
    */
   recipientEmails?: string[];
+  /**
+   * Slack channel ids from the integration's authorized set. Replace-not-
+   * additive like `recipientEmails`; omitting the key leaves the rule's
+   * channels unchanged.
+   */
+  slackChannels?: string[];
 }
 
 const buildRuleEnvelope = (payload: AlertPayload, alertId?: string) => ({
@@ -39,6 +45,11 @@ const buildRuleEnvelope = (payload: AlertPayload, alertId?: string) => ({
       schema_version: ALERT_SCHEMA_VERSION,
       ...(payload.recipientEmails !== undefined
         ? { recipient_emails: payload.recipientEmails }
+        : {}),
+      // TODO(Josema): `slack_channels` write attribute pending contract
+      // sign-off (D3) — ids only, the API derives name and privacy.
+      ...(payload.slackChannels !== undefined
+        ? { slack_channels: payload.slackChannels }
         : {}),
     },
   },

--- a/ui/app/(prowler)/alerts/_actions/alerts.ts
+++ b/ui/app/(prowler)/alerts/_actions/alerts.ts
@@ -25,9 +25,9 @@ export interface AlertPayload {
    */
   recipientEmails?: string[];
   /**
-   * Slack channel ids from the integration's authorized set. Replace-not-
-   * additive like `recipientEmails`; omitting the key leaves the rule's
-   * channels unchanged.
+   * Slack channel ids from the eligible set. Replace-not-additive like
+   * `recipientEmails`: a supplied list replaces the whole Slack selection,
+   * `[]` clears it, and omitting the key leaves it unchanged.
    */
   slackChannels?: string[];
 }
@@ -46,10 +46,9 @@ const buildRuleEnvelope = (payload: AlertPayload, alertId?: string) => ({
       ...(payload.recipientEmails !== undefined
         ? { recipient_emails: payload.recipientEmails }
         : {}),
-      // TODO(Josema): `slack_channels` write attribute pending contract
-      // sign-off (D3) — ids only, the API derives name and privacy.
+      // Objects carrying only `id`; the API derives name and privacy.
       ...(payload.slackChannels !== undefined
-        ? { slack_channels: payload.slackChannels }
+        ? { slack_channels: payload.slackChannels.map((id) => ({ id })) }
         : {}),
     },
   },

--- a/ui/app/(prowler)/alerts/_actions/slack-channels.test.ts
+++ b/ui/app/(prowler)/alerts/_actions/slack-channels.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  fetchMock,
+  getAuthHeadersMock,
+  handleApiErrorMock,
+  handleApiResponseMock,
+} = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  getAuthHeadersMock: vi.fn(),
+  handleApiErrorMock: vi.fn(),
+  handleApiResponseMock: vi.fn(),
+}));
+
+vi.mock("@/lib", () => ({
+  apiBaseUrl: "https://api.test/api/v1",
+  getAuthHeaders: getAuthHeadersMock,
+  getErrorMessage: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+}));
+
+vi.mock("@/lib/server-actions-helper", () => ({
+  handleApiError: handleApiErrorMock,
+  handleApiResponse: handleApiResponseMock,
+}));
+
+import { getAlertSlackChannels } from "./slack-channels";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockResolvedValue(
+    new Response(JSON.stringify({ data: [] }), {
+      status: 200,
+      headers: { "Content-Type": "application/vnd.api+json" },
+    }),
+  );
+  getAuthHeadersMock.mockResolvedValue({
+    Accept: "application/vnd.api+json",
+    Authorization: "Bearer test-token",
+  });
+  handleApiResponseMock.mockResolvedValue({ data: [] });
+  handleApiErrorMock.mockReturnValue({ error: "Unexpected error." });
+});
+
+describe("getAlertSlackChannels", () => {
+  it("requests a page large enough for the whole eligible pool", async () => {
+    await getAlertSlackChannels();
+    const [url] = fetchMock.mock.calls.at(-1) ?? [""];
+    expect(String(url)).toContain("page%5Bsize%5D=100");
+  });
+
+  it("returns whatever handleApiResponse returns", async () => {
+    handleApiResponseMock.mockResolvedValue({
+      data: [
+        {
+          id: "C1",
+          type: "alert-slack-channels",
+          attributes: { name: "#security" },
+        },
+      ],
+    });
+    const result = await getAlertSlackChannels();
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].attributes.name).toBe("#security");
+  });
+});

--- a/ui/app/(prowler)/alerts/_actions/slack-channels.test.ts
+++ b/ui/app/(prowler)/alerts/_actions/slack-channels.test.ts
@@ -44,10 +44,15 @@ beforeEach(() => {
 });
 
 describe("getAlertSlackChannels", () => {
-  it("requests a page large enough for the whole eligible pool", async () => {
+  it("requests the unpaginated endpoint", async () => {
+    // Given - The endpoint rejects unsupported pagination parameters
+
+    // When
     await getAlertSlackChannels();
+
+    // Then
     const [url] = fetchMock.mock.calls.at(-1) ?? [""];
-    expect(String(url)).toContain("page%5Bsize%5D=100");
+    expect(String(url)).toBe("https://api.test/api/v1/alerts/slack-channels");
   });
 
   it("returns whatever handleApiResponse returns", async () => {

--- a/ui/app/(prowler)/alerts/_actions/slack-channels.ts
+++ b/ui/app/(prowler)/alerts/_actions/slack-channels.ts
@@ -7,11 +7,9 @@ const ALERT_SLACK_CHANNELS_PATH = "/alerts/slack-channels";
 const CHANNELS_PAGE_SIZE = "100";
 
 /**
- * The channels eligible as alert destinations, from the tenant's enabled and
- * connected Slack integration. Server-side only: no Slack round-trip, so no
- * cursor pagination. The page size is still sent because the API paginates
- * collections by default and the picker reads `data` flat, so a default page
- * would truncate the pool silently.
+ * The channels eligible as alert destinations. A page size is sent because the
+ * API paginates collections by default and the picker reads `data` flat, so a
+ * default page could truncate the pool silently.
  */
 export const getAlertSlackChannels = async () => {
   const headers = await getAuthHeaders({ contentType: false });

--- a/ui/app/(prowler)/alerts/_actions/slack-channels.ts
+++ b/ui/app/(prowler)/alerts/_actions/slack-channels.ts
@@ -4,15 +4,19 @@ import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { handleApiError, handleApiResponse } from "@/lib/server-actions-helper";
 
 const ALERT_SLACK_CHANNELS_PATH = "/alerts/slack-channels";
+const CHANNELS_PAGE_SIZE = "100";
 
 /**
  * The channels eligible as alert destinations, from the tenant's enabled and
- * connected Slack integration. Server-side only: no Slack round-trip, so the
- * alert form has neither pagination nor a listing-failure state.
+ * connected Slack integration. Server-side only: no Slack round-trip, so no
+ * cursor pagination. The page size is still sent because the API paginates
+ * collections by default and the picker reads `data` flat, so a default page
+ * would truncate the pool silently.
  */
 export const getAlertSlackChannels = async () => {
   const headers = await getAuthHeaders({ contentType: false });
   const url = new URL(`${apiBaseUrl}${ALERT_SLACK_CHANNELS_PATH}`);
+  url.searchParams.append("page[size]", CHANNELS_PAGE_SIZE);
 
   try {
     const response = await fetch(url.toString(), { headers });

--- a/ui/app/(prowler)/alerts/_actions/slack-channels.ts
+++ b/ui/app/(prowler)/alerts/_actions/slack-channels.ts
@@ -4,17 +4,11 @@ import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { handleApiError, handleApiResponse } from "@/lib/server-actions-helper";
 
 const ALERT_SLACK_CHANNELS_PATH = "/alerts/slack-channels";
-const CHANNELS_PAGE_SIZE = "100";
 
-/**
- * The channels eligible as alert destinations. A page size is sent because the
- * API paginates collections by default and the picker reads `data` flat, so a
- * default page could truncate the pool silently.
- */
+/** The channels eligible as alert destinations. */
 export const getAlertSlackChannels = async () => {
   const headers = await getAuthHeaders({ contentType: false });
   const url = new URL(`${apiBaseUrl}${ALERT_SLACK_CHANNELS_PATH}`);
-  url.searchParams.append("page[size]", CHANNELS_PAGE_SIZE);
 
   try {
     const response = await fetch(url.toString(), { headers });

--- a/ui/app/(prowler)/alerts/_actions/slack-channels.ts
+++ b/ui/app/(prowler)/alerts/_actions/slack-channels.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { handleApiError, handleApiResponse } from "@/lib/server-actions-helper";
+
+const ALERT_SLACK_CHANNELS_PATH = "/alerts/slack-channels";
+
+/**
+ * The channels eligible as alert destinations, from the tenant's enabled and
+ * connected Slack integration. Server-side only: no Slack round-trip, so the
+ * alert form has neither pagination nor a listing-failure state.
+ */
+export const getAlertSlackChannels = async () => {
+  const headers = await getAuthHeaders({ contentType: false });
+  const url = new URL(`${apiBaseUrl}${ALERT_SLACK_CHANNELS_PATH}`);
+
+  try {
+    const response = await fetch(url.toString(), { headers });
+    return handleApiResponse(response);
+  } catch (error) {
+    return handleApiError(error);
+  }
+};

--- a/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
@@ -30,15 +30,24 @@ const integrationsActionMocks = vi.hoisted(() => ({
   getIntegrations: vi.fn(),
 }));
 
+const slackChannelsActionMocks = vi.hoisted(() => ({
+  getAlertSlackChannels: vi.fn(),
+}));
+
 vi.mock(
   "@/app/(prowler)/alerts/_actions/recipients",
   () => recipientsActionMocks,
 );
 
-// The channels field reads the Slack integration on mount; its behavior is
-// covered by the page integration tests (no-overlap rule), so the unit lane
-// only keeps the fetch from escaping jsdom.
+// The channels field reads the eligible channels and the Slack integration on
+// mount; its behavior is covered by the page integration tests (no-overlap
+// rule), so the unit lane only keeps the fetches from escaping jsdom.
 vi.mock("@/actions/integrations/integrations", () => integrationsActionMocks);
+
+vi.mock(
+  "@/app/(prowler)/alerts/_actions/slack-channels",
+  () => slackChannelsActionMocks,
+);
 
 vi.mock("@/app/(prowler)/alerts/_actions", () => alertsActionMocks);
 
@@ -257,9 +266,13 @@ describe("AlertFormModal", () => {
       new Promise(() => {}),
     );
     integrationsActionMocks.getIntegrations.mockReset();
-    // Never resolves, like the recipients read above: the channels field's
+    slackChannelsActionMocks.getAlertSlackChannels.mockReset();
+    // Never resolve, like the recipients read above: the channels field's
     // settled states are integration-tested; the unit lane keeps it loading.
     integrationsActionMocks.getIntegrations.mockReturnValue(
+      new Promise(() => {}),
+    );
+    slackChannelsActionMocks.getAlertSlackChannels.mockReturnValue(
       new Promise(() => {}),
     );
     alertsActionMocks.previewAlertCondition.mockReset();

--- a/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
@@ -39,9 +39,6 @@ vi.mock(
   () => recipientsActionMocks,
 );
 
-// The channels field reads the eligible channels and the Slack integration on
-// mount; its behavior is covered by the page integration tests (no-overlap
-// rule), so the unit lane only keeps the fetches from escaping jsdom.
 vi.mock("@/actions/integrations/integrations", () => integrationsActionMocks);
 
 vi.mock(
@@ -267,8 +264,8 @@ describe("AlertFormModal", () => {
     );
     integrationsActionMocks.getIntegrations.mockReset();
     slackChannelsActionMocks.getAlertSlackChannels.mockReset();
-    // Never resolve, like the recipients read above: the channels field's
-    // settled states are integration-tested; the unit lane keeps it loading.
+    // Never resolve, like the recipients read above: the field's settled
+    // states are integration-tested, so the unit lane keeps it loading.
     integrationsActionMocks.getIntegrations.mockReturnValue(
       new Promise(() => {}),
     );

--- a/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
@@ -476,6 +476,28 @@ describe("AlertFormModal", () => {
     expect(errorMessage).toHaveClass("text-text-error-primary");
   });
 
+  it("should surface a form error when a field without its own error slot fails validation", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onSubmit = vi
+      .fn()
+      .mockResolvedValue({ ok: true, alertId: "alert-1" });
+    mockRecipientsList();
+    renderCreateModal({ onSubmit });
+
+    // When: paste in one event instead of 2001 keystrokes
+    await user.click(screen.getByLabelText(/^description$/i));
+    await user.paste("x".repeat(2001));
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    // Then
+    const errorMessage = await screen.findByText(
+      "Fix alert fields before saving.",
+    );
+    expect(errorMessage).toHaveClass("text-text-error-primary");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it("should reset form defaults when opening a different alert", () => {
     // Given
     const { rerender } = render(

--- a/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
@@ -26,10 +26,19 @@ const alertsActionMocks = vi.hoisted(() => ({
   seedAlertRule: vi.fn(),
 }));
 
+const integrationsActionMocks = vi.hoisted(() => ({
+  getIntegrations: vi.fn(),
+}));
+
 vi.mock(
   "@/app/(prowler)/alerts/_actions/recipients",
   () => recipientsActionMocks,
 );
+
+// The channels field reads the Slack integration on mount; its behavior is
+// covered by the page integration tests (no-overlap rule), so the unit lane
+// only keeps the fetch from escaping jsdom.
+vi.mock("@/actions/integrations/integrations", () => integrationsActionMocks);
 
 vi.mock("@/app/(prowler)/alerts/_actions", () => alertsActionMocks);
 
@@ -247,6 +256,12 @@ describe("AlertFormModal", () => {
     recipientsActionMocks.listAlertRecipients.mockReturnValue(
       new Promise(() => {}),
     );
+    integrationsActionMocks.getIntegrations.mockReset();
+    // Never resolves, like the recipients read above: the channels field's
+    // settled states are integration-tested; the unit lane keeps it loading.
+    integrationsActionMocks.getIntegrations.mockReturnValue(
+      new Promise(() => {}),
+    );
     alertsActionMocks.previewAlertCondition.mockReset();
     alertsActionMocks.seedAlertRule.mockReset();
     alertsActionMocks.seedAlertRule.mockResolvedValue({
@@ -279,7 +294,8 @@ describe("AlertFormModal", () => {
     expect(screen.getByLabelText(/^description$/i)).toBeVisible();
     expect(screen.getByLabelText(/^frequency$/i)).toBeVisible();
     expect(screen.getByLabelText(/^recipients$/i)).toBeVisible();
-    expect(screen.getAllByRole("combobox")).toHaveLength(2);
+    // Frequency, Recipients, and the Slack destination channels trigger.
+    expect(screen.getAllByRole("combobox")).toHaveLength(3);
     expect(screen.queryByText("Alert criteria")).not.toBeInTheDocument();
     expect(screen.queryByText(/delivery settings/i)).not.toBeInTheDocument();
     expect(

--- a/ui/app/(prowler)/alerts/_components/__tests__/alerts-manager.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alerts-manager.test.tsx
@@ -112,13 +112,13 @@ vi.mock("../alert-form-modal", () => ({
       const result = await onSubmit({
         name: "Updated alert",
         description: "",
-        method: "email",
         frequency: ALERT_TRIGGER_KINDS.AFTER_SCAN,
         condition: {
           op: ALERT_AGGREGATE_OPS.ANY,
           filter: { severity: ["critical"] },
         },
         recipientEmails: [],
+        slackChannels: [],
         enabled: true,
       });
       setError(result.ok ? null : (result.error ?? null));

--- a/ui/app/(prowler)/alerts/_components/__tests__/seed-from-findings-button.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/seed-from-findings-button.test.tsx
@@ -79,13 +79,13 @@ vi.mock("@/app/(prowler)/alerts/_components/alert-form-modal", () => ({
             onSubmit({
               name: defaultName ?? "Findings filter alert",
               description: "",
-              method: "email",
               frequency: "after_scan",
               condition: seededCondition ?? {
                 op: "any",
                 filter: { severity: ["critical"] },
               },
               recipientEmails: ["security@example.com"],
+              slackChannels: [],
               enabled: true,
             })
           }

--- a/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
+++ b/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
@@ -61,6 +61,8 @@ import type {
   AlertFormValues,
 } from "../_types/alert-form";
 
+import { SlackChannelsField } from "./slack-channels-field";
+
 interface AlertFormModalProps {
   open: boolean;
   defaultFrequency: AlertTriggerKind;
@@ -368,6 +370,10 @@ const AlertFormModalContent = ({
   const [selectedRecipientEmails, setSelectedRecipientEmails] = useState(
     () => new Set(defaults.recipientEmails.map(normalizeEmail)),
   );
+  // Local state needed: channel picks are buffered until the form submits.
+  const [selectedSlackChannels, setSelectedSlackChannels] = useState<string[]>(
+    defaults.slackChannels,
+  );
   const [errors, setErrors] = useState<FormErrors>({});
   const [saving, setSaving] = useState(false);
   const [previewLoading, setPreviewLoading] = useState(false);
@@ -397,10 +403,7 @@ const AlertFormModalContent = ({
     frequency,
     condition,
     recipientEmails: getRecipientEmails(selectedRecipientEmails),
-    // Stored channels round-trip untouched until the channels field lands:
-    // the write is replace-not-additive, so omitting them would wipe a rule's
-    // destinations on every edit.
-    slackChannels: defaults.slackChannels,
+    slackChannels: selectedSlackChannels,
     enabled: defaults.enabled,
   });
 
@@ -555,6 +558,13 @@ const AlertFormModalContent = ({
           {errors.recipientEmails && (
             <FieldError>{errors.recipientEmails}</FieldError>
           )}
+        </Field>
+        <Field>
+          <SlackChannelsField
+            selectedChannelIds={selectedSlackChannels}
+            storedChannels={editingAlert?.attributes.slack_channels ?? []}
+            onValuesChange={setSelectedSlackChannels}
+          />
         </Field>
         {editingAlert && (
           <div className="flex flex-col gap-3">

--- a/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
+++ b/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
@@ -85,6 +85,7 @@ interface AlertFormModalProps {
 interface FormErrors {
   name?: string;
   recipientEmails?: string;
+  slackChannels?: string;
   root?: string;
 }
 
@@ -109,6 +110,8 @@ const ALERT_FREQUENCY_OPTIONS = [
 ] as const;
 
 const ALERT_SEED_ERROR = "Apply at least one alert-compatible Findings filter.";
+
+const ALERT_FORM_ERROR = "Fix alert fields before saving.";
 
 const serializeCondition = (condition: AlertCondition | null): string =>
   condition ? JSON.stringify(condition) : "none";
@@ -470,10 +473,18 @@ const AlertFormModalContent = ({
     const parsed = alertFormSchema.safeParse(values);
     if (!parsed.success) {
       const fieldErrors = parsed.error.flatten().fieldErrors;
-      setErrors({
+      const fieldScoped: FormErrors = {
         name: fieldErrors.name?.[0],
         recipientEmails: fieldErrors.recipientEmails?.[0],
-      });
+        slackChannels: fieldErrors.slackChannels?.[0],
+      };
+      // Fields with no slot of their own must still surface something, or the
+      // parse failure leaves Save a silent no-op.
+      setErrors(
+        Object.values(fieldScoped).some(Boolean)
+          ? fieldScoped
+          : { ...fieldScoped, root: ALERT_FORM_ERROR },
+      );
       return;
     }
 
@@ -565,6 +576,9 @@ const AlertFormModalContent = ({
             storedChannels={editingAlert?.attributes.slack_channels ?? []}
             onValuesChange={setSelectedSlackChannels}
           />
+          {errors.slackChannels && (
+            <FieldError>{errors.slackChannels}</FieldError>
+          )}
         </Field>
         {editingAlert && (
           <div className="flex flex-col gap-3">

--- a/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
+++ b/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
@@ -373,7 +373,6 @@ const AlertFormModalContent = ({
   const [selectedRecipientEmails, setSelectedRecipientEmails] = useState(
     () => new Set(defaults.recipientEmails.map(normalizeEmail)),
   );
-  // Local state needed: channel picks are buffered until the form submits.
   const [selectedSlackChannels, setSelectedSlackChannels] = useState<string[]>(
     defaults.slackChannels,
   );
@@ -478,8 +477,7 @@ const AlertFormModalContent = ({
         recipientEmails: fieldErrors.recipientEmails?.[0],
         slackChannels: fieldErrors.slackChannels?.[0],
       };
-      // Fields with no slot of their own must still surface something, or the
-      // parse failure leaves Save a silent no-op.
+      // A field with no error slot of its own would leave Save a silent no-op.
       setErrors(
         Object.values(fieldScoped).some(Boolean)
           ? fieldScoped

--- a/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
+++ b/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
@@ -60,7 +60,6 @@ import type {
   AlertFormSubmitResult,
   AlertFormValues,
 } from "../_types/alert-form";
-import { ALERT_NOTIFICATION_METHODS } from "../_types/alert-form";
 
 interface AlertFormModalProps {
   open: boolean;
@@ -395,10 +394,13 @@ const AlertFormModalContent = ({
   const buildCurrentValues = (condition: AlertCondition): AlertFormValues => ({
     name,
     description,
-    method: ALERT_NOTIFICATION_METHODS.EMAIL,
     frequency,
     condition,
     recipientEmails: getRecipientEmails(selectedRecipientEmails),
+    // Stored channels round-trip untouched until the channels field lands:
+    // the write is replace-not-additive, so omitting them would wipe a rule's
+    // destinations on every edit.
+    slackChannels: defaults.slackChannels,
     enabled: defaults.enabled,
   });
 

--- a/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
+++ b/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 
 import { getIntegrations } from "@/actions/integrations/integrations";
+import { getAlertSlackChannels } from "@/app/(prowler)/alerts/_actions/slack-channels";
 import { SlackChannelMultiSelect } from "@/components/integrations/slack/slack-channel-multi-select";
 import {
   Button,
@@ -27,10 +28,8 @@ const SLACK_INTEGRATION_HREF = "/integrations/slack";
 
 const NO_INTEGRATION_COPY =
   "Posting alerts to Slack channels needs a connected Slack workspace.";
-const NO_INTEGRATION_WITH_STORED_COPY =
-  "Channel delivery is unavailable until a Slack workspace is connected.";
 const EMPTY_POOL_COPY =
-  "No channels are authorized yet. Authorize channels on the Slack integration to offer them here.";
+  "No channels are ready yet. Authorize channels on the Slack integration and run its connection check to offer them here.";
 
 /**
  * The three presentations the spec allows (design D2/D4). Read by the page
@@ -44,26 +43,38 @@ const FIELD_STATE = {
 
 type FieldState = (typeof FIELD_STATE)[keyof typeof FIELD_STATE];
 
+/** `GET /alerts/slack-channels` — id is the channel id (contract section 2). */
+interface EligibleChannelResource {
+  id: string;
+  attributes: { name: string; is_private: boolean };
+}
+
 interface SlackChannelsFieldProps {
   selectedChannelIds: string[];
   /**
-   * The rule's stored channels from the read model (id, name, privacy), so a
-   * channel missing from the authorized set — or the whole workspace being
-   * gone — never blanks the stored selection.
+   * The rule's stored channels from the read model (id, name, privacy). They
+   * are merged into the options so a channel that is configured but not yet
+   * confirmed — what a same-workspace reinstall leaves behind — still renders
+   * by name and privacy instead of blanking the stored selection.
    */
   storedChannels: SlackChannelOption[];
   onValuesChange: (channelIds: string[]) => void;
 }
 
-/**
- * The authorized set is the pool; the stored selection is merged in so a
- * de-authorized channel stays visible and selected until the user removes it.
- */
+const toChannelOptions = (data: unknown): SlackChannelOption[] =>
+  Array.isArray(data)
+    ? (data as EligibleChannelResource[]).map((resource) => ({
+        id: resource.id,
+        name: resource.attributes.name,
+        is_private: resource.attributes.is_private,
+      }))
+    : [];
+
 const mergeOptions = (
-  authorized: SlackChannelOption[],
+  eligible: SlackChannelOption[],
   stored: SlackChannelOption[],
 ): SlackChannelOption[] => {
-  const byId = new Map(authorized.map((channel) => [channel.id, channel]));
+  const byId = new Map(eligible.map((channel) => [channel.id, channel]));
   stored.forEach((channel) => {
     if (!byId.has(channel.id)) byId.set(channel.id, channel);
   });
@@ -87,10 +98,11 @@ const FieldNotice = ({ copy }: { copy: string }) => (
 );
 
 /**
- * Slack channel destinations for an alert rule (design D4): reads the
- * tenant's Slack integration on mount — never the workspace listing (D2), so
- * there is no pagination and no listing-failure state — and offers exactly
- * the integration's authorized channels.
+ * Slack channel destinations for an alert rule (design D2/D4): the options
+ * come from the dedicated eligible-channels endpoint — never the workspace
+ * listing, so there is no pagination and no listing-failure state — and the
+ * integration is read only to tell an empty pool from no workspace at all,
+ * which an empty collection cannot say on its own.
  */
 export const SlackChannelsField = ({
   selectedChannelIds,
@@ -98,35 +110,45 @@ export const SlackChannelsField = ({
   onValuesChange,
 }: SlackChannelsFieldProps) => {
   const [loading, setLoading] = useState(true);
-  const [authorizedChannels, setAuthorizedChannels] = useState<
+  const [eligibleChannels, setEligibleChannels] = useState<
     SlackChannelOption[]
   >([]);
-  const [connected, setConnected] = useState(false);
+  const [integrationUsable, setIntegrationUsable] = useState(false);
 
   useMountEffect(() => {
-    getIntegrations(
-      new URLSearchParams({ "filter[integration_type]": "slack" }),
-    ).then((result) => {
+    Promise.all([
+      getAlertSlackChannels(),
+      getIntegrations(
+        new URLSearchParams({ "filter[integration_type]": "slack" }),
+      ),
+    ]).then(([channelsResult, integrationsResult]) => {
       setLoading(false);
-      // A failed read collapses to the disconnected presentation: the spec
-      // allows exactly three states, and the integration page is where a
-      // read problem gets diagnosed.
-      if (result?.error) return;
-      const integration = (result?.data as IntegrationProps[] | undefined)?.[0];
-      if (!integration) return;
-      setConnected(true);
-      setAuthorizedChannels(
-        integration.attributes.configuration.channels ?? [],
+      // A failed read collapses to the disabled presentation: the spec allows
+      // exactly three states, and the integration page is where a read
+      // problem gets diagnosed.
+      if (!channelsResult?.error) {
+        setEligibleChannels(toChannelOptions(channelsResult?.data));
+      }
+      if (integrationsResult?.error) return;
+      const integration = (
+        integrationsResult?.data as IntegrationProps[] | undefined
+      )?.[0];
+      setIntegrationUsable(
+        Boolean(integration?.attributes.enabled) &&
+          integration?.attributes.connected === true,
       );
     });
   });
 
-  const options = mergeOptions(authorizedChannels, storedChannels);
-  const state: FieldState = connected
-    ? authorizedChannels.length > 0
+  const options = mergeOptions(eligibleChannels, storedChannels);
+  // Eligibility decides the state; the merged stored channels only decide what
+  // an already-saved rule renders.
+  const state: FieldState =
+    eligibleChannels.length > 0
       ? FIELD_STATE.POPULATED
-      : FIELD_STATE.EMPTY_POOL
-    : FIELD_STATE.NO_INTEGRATION;
+      : integrationUsable
+        ? FIELD_STATE.EMPTY_POOL
+        : FIELD_STATE.NO_INTEGRATION;
 
   if (loading) {
     return (
@@ -145,9 +167,10 @@ export const SlackChannelsField = ({
   if (state === FIELD_STATE.NO_INTEGRATION) {
     return (
       <div data-alert-channels-state={state} className="flex flex-col gap-2">
-        {storedChannels.length > 0 ? (
-          // The stored selection stays visible and identified; only a
-          // connected workspace makes it editable again.
+        {options.length > 0 ? (
+          // A rule keeps its channels while its workspace is unverified — a
+          // reinstall resets the confirmations, not the mappings — so the
+          // stored selection stays readable until the check runs again.
           <SlackChannelMultiSelect
             options={options}
             values={selectedChannelIds}
@@ -177,18 +200,12 @@ export const SlackChannelsField = ({
             </Tooltip>
           </>
         )}
-        <FieldNotice
-          copy={
-            storedChannels.length > 0
-              ? NO_INTEGRATION_WITH_STORED_COPY
-              : NO_INTEGRATION_COPY
-          }
-        />
+        <FieldNotice copy={NO_INTEGRATION_COPY} />
       </div>
     );
   }
 
-  if (state === FIELD_STATE.EMPTY_POOL && options.length === 0) {
+  if (state === FIELD_STATE.EMPTY_POOL) {
     return (
       <div data-alert-channels-state={state} className="flex flex-col gap-2">
         <Label>Destination channels</Label>
@@ -204,9 +221,6 @@ export const SlackChannelsField = ({
         values={selectedChannelIds}
         onChange={onValuesChange}
       />
-      {state === FIELD_STATE.EMPTY_POOL && (
-        <FieldNotice copy={EMPTY_POOL_COPY} />
-      )}
     </div>
   );
 };

--- a/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
+++ b/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
@@ -170,7 +170,8 @@ export const SlackChannelsField = ({
         {options.length > 0 ? (
           // A rule keeps its channels while its workspace is unverified — a
           // reinstall resets the confirmations, not the mappings — so the
-          // stored selection stays readable until the check runs again.
+          // stored selection stays readable, and retained ids never refuse a
+          // save: only channels just added are validated (contract 6.3).
           <SlackChannelMultiSelect
             options={options}
             values={selectedChannelIds}

--- a/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
+++ b/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
@@ -27,11 +27,7 @@ import {
 
 const SLACK_INTEGRATION_HREF = "/integrations/slack";
 
-/**
- * The notice is what explains a disabled picker, so the picker points at it
- * rather than leaving the reason to adjacency. Only one notice renders per
- * state, so the id stays unique.
- */
+// Only one notice renders per state, so a shared id stays unique.
 const CHANNELS_NOTICE_ID = "alert-slack-channels-notice";
 
 const NO_INTEGRATION_COPY =
@@ -43,10 +39,7 @@ const EMPTY_POOL_COPY =
 const UNKNOWN_COPY =
   "The Slack workspace status could not be checked. Its channels may still be available on the Slack integration.";
 
-/**
- * The three presentations the spec allows (design D2/D4). Read by the page
- * harness off `data-alert-channels-state`.
- */
+// Read by the page harness off `data-alert-channels-state`.
 const FIELD_STATE = {
   NO_INTEGRATION: "no-integration",
   EMPTY_POOL: "empty-pool",
@@ -56,15 +49,14 @@ const FIELD_STATE = {
 type FieldState = (typeof FIELD_STATE)[keyof typeof FIELD_STATE];
 
 /**
- * What the mount reads could establish about the workspace. Only the copy
- * reads it, never the presentation: a read that failed must not be told as a
- * workspace that is missing. `/integrations` gates even reads behind
- * `MANAGE_INTEGRATIONS`, so every non-admin gets a 403 there while
- * `/alerts/slack-channels` answers them normally.
+ * Read only by the notice copy, never by the presentation: a failed read must
+ * not be told as a missing workspace. `/integrations` gates even reads behind
+ * `MANAGE_INTEGRATIONS`, so non-admins get a 403 there while
+ * `/alerts/slack-channels` answers them.
  */
 const WORKSPACE = {
   READY: "ready",
-  /** A workspace is there; it is disabled, or no check has confirmed it. */
+  /** Present, but disabled or not confirmed by a check. */
   UNVERIFIED: "unverified",
   MISSING: "missing",
   UNKNOWN: "unknown",
@@ -82,21 +74,12 @@ const WORKSPACE_COPY: Record<Workspace, string> = {
 
 interface SlackChannelsFieldProps {
   selectedChannelIds: string[];
-  /**
-   * The rule's stored channels from the read model (id, name, privacy). They
-   * are merged into the options so a channel that is configured but not yet
-   * confirmed — what a same-workspace reinstall leaves behind — still renders
-   * by name and privacy instead of blanking the stored selection.
-   */
+  /** Merged into the options, so channels outside the pool still render. */
   storedChannels: SlackChannelOption[];
   onValuesChange: (channelIds: string[]) => void;
 }
 
-/**
- * `GET /alerts/slack-channels` — id is the channel id (contract section 2).
- * Mapped per resource, as the workspace listing is: one malformed element
- * would otherwise empty the whole picker.
- */
+// Skips malformed resources: one bad element would otherwise empty the picker.
 const toChannelOptions = (data: unknown): SlackChannelOption[] => {
   if (!Array.isArray(data)) return [];
 
@@ -107,8 +90,7 @@ const toChannelOptions = (data: unknown): SlackChannelOption[] => {
     const name = resource?.attributes?.name;
     channels.push({
       id: channelId,
-      // The picker sorts on `name` through `localeCompare`, which anything
-      // but a string takes the whole list down with.
+      // The shared picker sorts `name` with `localeCompare`; non-strings throw.
       name: typeof name === "string" ? name : "",
       is_private: Boolean(resource?.attributes?.is_private),
     });
@@ -150,10 +132,7 @@ interface StoredChannelsPickerProps {
   onChange: (channelIds: string[]) => void;
 }
 
-/**
- * The rule's own channels, readable but not editable against a pool it left.
- * Only rendered alongside a notice, so it always has a reason to point at.
- */
+// Only rendered alongside a notice, so `describedBy` always has a target.
 const StoredChannelsPicker = ({
   options,
   values,
@@ -169,12 +148,8 @@ const StoredChannelsPicker = ({
 );
 
 /**
- * Slack channel destinations for an alert rule (design D2/D4): the options
- * come from the dedicated eligible-channels endpoint rather than the Slack
- * workspace listing, so the field makes no Slack round-trip and carries none
- * of the cursor paging that listing needs. The integration is read only to
- * tell an empty pool from no workspace at all, which an empty collection
- * cannot say on its own — and, when a read fails, neither can the field.
+ * The integration is read only to tell an empty pool from no workspace at
+ * all, which an empty channel collection cannot say on its own.
  */
 export const SlackChannelsField = ({
   selectedChannelIds,
@@ -202,8 +177,7 @@ export const SlackChannelsField = ({
           setChannelsReadable(true);
           setEligibleChannels(toChannelOptions(channelsResult?.data));
         }
-        // A read that failed leaves the workspace unknown, so nothing below
-        // claims the tenant has no Slack at all.
+        // A failed read leaves the workspace unknown, not "no Slack at all".
         if (integrationsResult?.error) return;
 
         const integration = (
@@ -220,16 +194,14 @@ export const SlackChannelsField = ({
             : WORKSPACE.UNVERIFIED,
         );
       })
-      // `handleApiResponse` throws on a 5xx and both actions return it
-      // unawaited, so the rejection lands here. Sentry already captured it;
-      // what matters is that the field leaves its loading skeleton.
+      // A >= 500 answer throws past the action's own catch; without this the
+      // field never leaves its loading skeleton.
       .catch(() => undefined)
       .finally(() => setLoading(false));
   });
 
   const options = mergeOptions(eligibleChannels, storedChannels);
-  // Eligibility decides the state; the merged stored channels only decide what
-  // an already-saved rule renders.
+  // Eligibility decides the state, not the merged stored channels.
   const state: FieldState =
     eligibleChannels.length > 0
       ? FIELD_STATE.POPULATED
@@ -237,12 +209,13 @@ export const SlackChannelsField = ({
         ? FIELD_STATE.EMPTY_POOL
         : FIELD_STATE.NO_INTEGRATION;
 
-  // A pool that could not be read tells nothing about the workspace either,
-  // so it drops back to the copy that claims nothing.
+  // An unreadable pool says nothing about the workspace either.
   const noticeCopy = channelsReadable
     ? WORKSPACE_COPY[workspace]
     : UNKNOWN_COPY;
 
+  // No `data-alert-channels-state` here: its absence is what makes the page
+  // harness wait for a settled state instead of latching this one.
   if (loading) {
     return (
       <div className="flex flex-col gap-2">
@@ -261,10 +234,8 @@ export const SlackChannelsField = ({
     return (
       <div data-alert-channels-state={state} className="flex flex-col gap-2">
         {options.length > 0 ? (
-          // A rule keeps its channels while its workspace is unverified — a
-          // reinstall resets the confirmations, not the mappings — so the
-          // stored selection stays readable, and retained ids never refuse a
-          // save: only channels just added are validated (contract 6.3).
+          // Retained ids never refuse a save: only channels just added are
+          // validated (contract 6.3).
           <StoredChannelsPicker
             options={options}
             values={selectedChannelIds}
@@ -280,8 +251,8 @@ export const SlackChannelsField = ({
                     <MultiSelectTrigger
                       id="slack-channels"
                       aria-label="Destination channels"
-                      // Why it cannot be used travels with the control: the
-                      // tooltip only reaches a pointer or the wrapper's focus.
+                      // The reason must travel with the control; the tooltip
+                      // only reaches a pointer or the wrapper's focus.
                       aria-describedby={CHANNELS_NOTICE_ID}
                       disabled
                     >
@@ -305,9 +276,6 @@ export const SlackChannelsField = ({
     return (
       <div data-alert-channels-state={state} className="flex flex-col gap-2">
         {options.length > 0 ? (
-          // The read model enriches from what is configured, the pool offers
-          // only what is confirmed, so a rule can hold channels an empty pool
-          // does not offer. Rendering the notice alone would hide them.
           <StoredChannelsPicker
             options={options}
             values={selectedChannelIds}

--- a/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
+++ b/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
@@ -27,6 +27,13 @@ import {
 
 const SLACK_INTEGRATION_HREF = "/integrations/slack";
 
+/**
+ * The notice is what explains a disabled picker, so the picker points at it
+ * rather than leaving the reason to adjacency. Only one notice renders per
+ * state, so the id stays unique.
+ */
+const CHANNELS_NOTICE_ID = "alert-slack-channels-notice";
+
 const NO_INTEGRATION_COPY =
   "Posting alerts to Slack channels needs a connected Slack workspace.";
 const UNVERIFIED_COPY =
@@ -128,6 +135,7 @@ const ManageIntegrationLink = () => (
 
 const FieldNotice = ({ copy }: { copy: string }) => (
   <p
+    id={CHANNELS_NOTICE_ID}
     data-alert-channels-notice
     className="text-text-neutral-secondary flex flex-wrap items-center gap-1 text-xs"
   >
@@ -142,7 +150,10 @@ interface StoredChannelsPickerProps {
   onChange: (channelIds: string[]) => void;
 }
 
-/** The rule's own channels, readable but not editable against a pool it left. */
+/**
+ * The rule's own channels, readable but not editable against a pool it left.
+ * Only rendered alongside a notice, so it always has a reason to point at.
+ */
 const StoredChannelsPicker = ({
   options,
   values,
@@ -152,6 +163,7 @@ const StoredChannelsPicker = ({
     options={options}
     values={values}
     onChange={onChange}
+    describedBy={CHANNELS_NOTICE_ID}
     disabled
   />
 );
@@ -268,6 +280,9 @@ export const SlackChannelsField = ({
                     <MultiSelectTrigger
                       id="slack-channels"
                       aria-label="Destination channels"
+                      // Why it cannot be used travels with the control: the
+                      // tooltip only reaches a pointer or the wrapper's focus.
+                      aria-describedby={CHANNELS_NOTICE_ID}
                       disabled
                     >
                       <MultiSelectValue placeholder="No channels available" />

--- a/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
+++ b/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
@@ -19,9 +19,10 @@ import {
   MultiSelectValue,
 } from "@/components/shadcn/select/multiselect";
 import { useMountEffect } from "@/hooks/use-mount-effect";
-import type {
-  IntegrationProps,
-  SlackChannelOption,
+import {
+  INTEGRATION_TYPE,
+  type IntegrationProps,
+  type SlackChannelOption,
 } from "@/types/integrations";
 
 const SLACK_INTEGRATION_HREF = "/integrations/slack";
@@ -179,7 +180,9 @@ export const SlackChannelsField = ({
     Promise.all([
       getAlertSlackChannels(),
       getIntegrations(
-        new URLSearchParams({ "filter[integration_type]": "slack" }),
+        new URLSearchParams({
+          "filter[integration_type]": INTEGRATION_TYPE.SLACK,
+        }),
       ),
     ])
       .then(([channelsResult, integrationsResult]) => {

--- a/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
+++ b/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
@@ -74,7 +74,7 @@ const WORKSPACE_COPY: Record<Workspace, string> = {
 
 interface SlackChannelsFieldProps {
   selectedChannelIds: string[];
-  /** Merged into the options, so channels outside the pool still render. */
+  /** Merged into the options while selected, so stored channels still render. */
   storedChannels: SlackChannelOption[];
   onValuesChange: (channelIds: string[]) => void;
 }
@@ -101,10 +101,15 @@ const toChannelOptions = (data: unknown): SlackChannelOption[] => {
 const mergeOptions = (
   eligible: SlackChannelOption[],
   stored: SlackChannelOption[],
+  selectedIds: string[],
 ): SlackChannelOption[] => {
   const byId = new Map(eligible.map((channel) => [channel.id, channel]));
+  // A stored channel outside the pool is kept only while it stays selected:
+  // deselecting it must not leave it offered for a pick the write refuses.
   stored.forEach((channel) => {
-    if (!byId.has(channel.id)) byId.set(channel.id, channel);
+    if (!byId.has(channel.id) && selectedIds.includes(channel.id)) {
+      byId.set(channel.id, channel);
+    }
   });
   return Array.from(byId.values());
 };
@@ -200,7 +205,11 @@ export const SlackChannelsField = ({
       .finally(() => setLoading(false));
   });
 
-  const options = mergeOptions(eligibleChannels, storedChannels);
+  const options = mergeOptions(
+    eligibleChannels,
+    storedChannels,
+    selectedChannelIds,
+  );
   // Eligibility decides the state, not the merged stored channels.
   const state: FieldState =
     eligibleChannels.length > 0

--- a/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
+++ b/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
@@ -28,8 +28,12 @@ const SLACK_INTEGRATION_HREF = "/integrations/slack";
 
 const NO_INTEGRATION_COPY =
   "Posting alerts to Slack channels needs a connected Slack workspace.";
+const UNVERIFIED_COPY =
+  "The Slack workspace has not passed a connection check yet. Run it on the Slack integration to offer its channels here.";
 const EMPTY_POOL_COPY =
   "No channels are ready yet. Authorize channels on the Slack integration and run its connection check to offer them here.";
+const UNKNOWN_COPY =
+  "The Slack workspace status could not be checked. Its channels may still be available on the Slack integration.";
 
 /**
  * The three presentations the spec allows (design D2/D4). Read by the page
@@ -43,11 +47,30 @@ const FIELD_STATE = {
 
 type FieldState = (typeof FIELD_STATE)[keyof typeof FIELD_STATE];
 
-/** `GET /alerts/slack-channels` — id is the channel id (contract section 2). */
-interface EligibleChannelResource {
-  id: string;
-  attributes: { name: string; is_private: boolean };
-}
+/**
+ * What the mount reads could establish about the workspace. Only the copy
+ * reads it, never the presentation: a read that failed must not be told as a
+ * workspace that is missing. `/integrations` gates even reads behind
+ * `MANAGE_INTEGRATIONS`, so every non-admin gets a 403 there while
+ * `/alerts/slack-channels` answers them normally.
+ */
+const WORKSPACE = {
+  READY: "ready",
+  /** A workspace is there; it is disabled, or no check has confirmed it. */
+  UNVERIFIED: "unverified",
+  MISSING: "missing",
+  UNKNOWN: "unknown",
+} as const;
+
+type Workspace = (typeof WORKSPACE)[keyof typeof WORKSPACE];
+
+/** A ready workspace only ever explains itself when its pool came back empty. */
+const WORKSPACE_COPY: Record<Workspace, string> = {
+  [WORKSPACE.READY]: EMPTY_POOL_COPY,
+  [WORKSPACE.UNVERIFIED]: UNVERIFIED_COPY,
+  [WORKSPACE.MISSING]: NO_INTEGRATION_COPY,
+  [WORKSPACE.UNKNOWN]: UNKNOWN_COPY,
+};
 
 interface SlackChannelsFieldProps {
   selectedChannelIds: string[];
@@ -61,14 +84,29 @@ interface SlackChannelsFieldProps {
   onValuesChange: (channelIds: string[]) => void;
 }
 
-const toChannelOptions = (data: unknown): SlackChannelOption[] =>
-  Array.isArray(data)
-    ? (data as EligibleChannelResource[]).map((resource) => ({
-        id: resource.id,
-        name: resource.attributes.name,
-        is_private: resource.attributes.is_private,
-      }))
-    : [];
+/**
+ * `GET /alerts/slack-channels` — id is the channel id (contract section 2).
+ * Mapped per resource, as the workspace listing is: one malformed element
+ * would otherwise empty the whole picker.
+ */
+const toChannelOptions = (data: unknown): SlackChannelOption[] => {
+  if (!Array.isArray(data)) return [];
+
+  const channels: SlackChannelOption[] = [];
+  for (const resource of data) {
+    const channelId = resource?.id;
+    if (typeof channelId !== "string" || channelId.length === 0) continue;
+    const name = resource?.attributes?.name;
+    channels.push({
+      id: channelId,
+      // The picker sorts on `name` through `localeCompare`, which anything
+      // but a string takes the whole list down with.
+      name: typeof name === "string" ? name : "",
+      is_private: Boolean(resource?.attributes?.is_private),
+    });
+  }
+  return channels;
+};
 
 const mergeOptions = (
   eligible: SlackChannelOption[],
@@ -97,12 +135,33 @@ const FieldNotice = ({ copy }: { copy: string }) => (
   </p>
 );
 
+interface StoredChannelsPickerProps {
+  options: SlackChannelOption[];
+  values: string[];
+  onChange: (channelIds: string[]) => void;
+}
+
+/** The rule's own channels, readable but not editable against a pool it left. */
+const StoredChannelsPicker = ({
+  options,
+  values,
+  onChange,
+}: StoredChannelsPickerProps) => (
+  <SlackChannelMultiSelect
+    options={options}
+    values={values}
+    onChange={onChange}
+    disabled
+  />
+);
+
 /**
  * Slack channel destinations for an alert rule (design D2/D4): the options
- * come from the dedicated eligible-channels endpoint — never the workspace
- * listing, so there is no pagination and no listing-failure state — and the
- * integration is read only to tell an empty pool from no workspace at all,
- * which an empty collection cannot say on its own.
+ * come from the dedicated eligible-channels endpoint rather than the Slack
+ * workspace listing, so the field makes no Slack round-trip and carries none
+ * of the cursor paging that listing needs. The integration is read only to
+ * tell an empty pool from no workspace at all, which an empty collection
+ * cannot say on its own — and, when a read fails, neither can the field.
  */
 export const SlackChannelsField = ({
   selectedChannelIds,
@@ -113,7 +172,8 @@ export const SlackChannelsField = ({
   const [eligibleChannels, setEligibleChannels] = useState<
     SlackChannelOption[]
   >([]);
-  const [integrationUsable, setIntegrationUsable] = useState(false);
+  const [channelsReadable, setChannelsReadable] = useState(false);
+  const [workspace, setWorkspace] = useState<Workspace>(WORKSPACE.UNKNOWN);
 
   useMountEffect(() => {
     Promise.all([
@@ -121,23 +181,35 @@ export const SlackChannelsField = ({
       getIntegrations(
         new URLSearchParams({ "filter[integration_type]": "slack" }),
       ),
-    ]).then(([channelsResult, integrationsResult]) => {
-      setLoading(false);
-      // A failed read collapses to the disabled presentation: the spec allows
-      // exactly three states, and the integration page is where a read
-      // problem gets diagnosed.
-      if (!channelsResult?.error) {
-        setEligibleChannels(toChannelOptions(channelsResult?.data));
-      }
-      if (integrationsResult?.error) return;
-      const integration = (
-        integrationsResult?.data as IntegrationProps[] | undefined
-      )?.[0];
-      setIntegrationUsable(
-        Boolean(integration?.attributes.enabled) &&
-          integration?.attributes.connected === true,
-      );
-    });
+    ])
+      .then(([channelsResult, integrationsResult]) => {
+        if (!channelsResult?.error) {
+          setChannelsReadable(true);
+          setEligibleChannels(toChannelOptions(channelsResult?.data));
+        }
+        // A read that failed leaves the workspace unknown, so nothing below
+        // claims the tenant has no Slack at all.
+        if (integrationsResult?.error) return;
+
+        const integration = (
+          integrationsResult?.data as IntegrationProps[] | undefined
+        )?.[0];
+        if (!integration) {
+          setWorkspace(WORKSPACE.MISSING);
+          return;
+        }
+        setWorkspace(
+          integration.attributes.enabled &&
+            integration.attributes.connected === true
+            ? WORKSPACE.READY
+            : WORKSPACE.UNVERIFIED,
+        );
+      })
+      // `handleApiResponse` throws on a 5xx and both actions return it
+      // unawaited, so the rejection lands here. Sentry already captured it;
+      // what matters is that the field leaves its loading skeleton.
+      .catch(() => undefined)
+      .finally(() => setLoading(false));
   });
 
   const options = mergeOptions(eligibleChannels, storedChannels);
@@ -146,9 +218,15 @@ export const SlackChannelsField = ({
   const state: FieldState =
     eligibleChannels.length > 0
       ? FIELD_STATE.POPULATED
-      : integrationUsable
+      : workspace === WORKSPACE.READY
         ? FIELD_STATE.EMPTY_POOL
         : FIELD_STATE.NO_INTEGRATION;
+
+  // A pool that could not be read tells nothing about the workspace either,
+  // so it drops back to the copy that claims nothing.
+  const noticeCopy = channelsReadable
+    ? WORKSPACE_COPY[workspace]
+    : UNKNOWN_COPY;
 
   if (loading) {
     return (
@@ -172,11 +250,10 @@ export const SlackChannelsField = ({
           // reinstall resets the confirmations, not the mappings — so the
           // stored selection stays readable, and retained ids never refuse a
           // save: only channels just added are validated (contract 6.3).
-          <SlackChannelMultiSelect
+          <StoredChannelsPicker
             options={options}
             values={selectedChannelIds}
             onChange={onValuesChange}
-            disabled
           />
         ) : (
           <>
@@ -190,18 +267,18 @@ export const SlackChannelsField = ({
                       aria-label="Destination channels"
                       disabled
                     >
-                      <MultiSelectValue placeholder="Requires a connected Slack workspace" />
+                      <MultiSelectValue placeholder="No channels available" />
                     </MultiSelectTrigger>
                   </MultiSelect>
                 </span>
               </TooltipTrigger>
               <TooltipContent side="top" className="max-w-xs">
-                {NO_INTEGRATION_COPY}
+                {noticeCopy}
               </TooltipContent>
             </Tooltip>
           </>
         )}
-        <FieldNotice copy={NO_INTEGRATION_COPY} />
+        <FieldNotice copy={noticeCopy} />
       </div>
     );
   }
@@ -209,8 +286,19 @@ export const SlackChannelsField = ({
   if (state === FIELD_STATE.EMPTY_POOL) {
     return (
       <div data-alert-channels-state={state} className="flex flex-col gap-2">
-        <Label>Destination channels</Label>
-        <FieldNotice copy={EMPTY_POOL_COPY} />
+        {options.length > 0 ? (
+          // The read model enriches from what is configured, the pool offers
+          // only what is confirmed, so a rule can hold channels an empty pool
+          // does not offer. Rendering the notice alone would hide them.
+          <StoredChannelsPicker
+            options={options}
+            values={selectedChannelIds}
+            onChange={onValuesChange}
+          />
+        ) : (
+          <Label>Destination channels</Label>
+        )}
+        <FieldNotice copy={noticeCopy} />
       </div>
     );
   }

--- a/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
+++ b/ui/app/(prowler)/alerts/_components/slack-channels-field.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import { getIntegrations } from "@/actions/integrations/integrations";
+import { SlackChannelMultiSelect } from "@/components/integrations/slack/slack-channel-multi-select";
+import {
+  Button,
+  Label,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/shadcn";
+import {
+  MultiSelect,
+  MultiSelectTrigger,
+  MultiSelectValue,
+} from "@/components/shadcn/select/multiselect";
+import { useMountEffect } from "@/hooks/use-mount-effect";
+import type {
+  IntegrationProps,
+  SlackChannelOption,
+} from "@/types/integrations";
+
+const SLACK_INTEGRATION_HREF = "/integrations/slack";
+
+const NO_INTEGRATION_COPY =
+  "Posting alerts to Slack channels needs a connected Slack workspace.";
+const NO_INTEGRATION_WITH_STORED_COPY =
+  "Channel delivery is unavailable until a Slack workspace is connected.";
+const EMPTY_POOL_COPY =
+  "No channels are authorized yet. Authorize channels on the Slack integration to offer them here.";
+
+/**
+ * The three presentations the spec allows (design D2/D4). Read by the page
+ * harness off `data-alert-channels-state`.
+ */
+const FIELD_STATE = {
+  NO_INTEGRATION: "no-integration",
+  EMPTY_POOL: "empty-pool",
+  POPULATED: "populated",
+} as const;
+
+type FieldState = (typeof FIELD_STATE)[keyof typeof FIELD_STATE];
+
+interface SlackChannelsFieldProps {
+  selectedChannelIds: string[];
+  /**
+   * The rule's stored channels from the read model (id, name, privacy), so a
+   * channel missing from the authorized set — or the whole workspace being
+   * gone — never blanks the stored selection.
+   */
+  storedChannels: SlackChannelOption[];
+  onValuesChange: (channelIds: string[]) => void;
+}
+
+/**
+ * The authorized set is the pool; the stored selection is merged in so a
+ * de-authorized channel stays visible and selected until the user removes it.
+ */
+const mergeOptions = (
+  authorized: SlackChannelOption[],
+  stored: SlackChannelOption[],
+): SlackChannelOption[] => {
+  const byId = new Map(authorized.map((channel) => [channel.id, channel]));
+  stored.forEach((channel) => {
+    if (!byId.has(channel.id)) byId.set(channel.id, channel);
+  });
+  return Array.from(byId.values());
+};
+
+const ManageIntegrationLink = () => (
+  <Button variant="link" size="link-sm" className="h-auto p-0" asChild>
+    <Link href={SLACK_INTEGRATION_HREF}>Manage the Slack integration</Link>
+  </Button>
+);
+
+const FieldNotice = ({ copy }: { copy: string }) => (
+  <p
+    data-alert-channels-notice
+    className="text-text-neutral-secondary flex flex-wrap items-center gap-1 text-xs"
+  >
+    <span>{copy}</span>
+    <ManageIntegrationLink />
+  </p>
+);
+
+/**
+ * Slack channel destinations for an alert rule (design D4): reads the
+ * tenant's Slack integration on mount — never the workspace listing (D2), so
+ * there is no pagination and no listing-failure state — and offers exactly
+ * the integration's authorized channels.
+ */
+export const SlackChannelsField = ({
+  selectedChannelIds,
+  storedChannels,
+  onValuesChange,
+}: SlackChannelsFieldProps) => {
+  const [loading, setLoading] = useState(true);
+  const [authorizedChannels, setAuthorizedChannels] = useState<
+    SlackChannelOption[]
+  >([]);
+  const [connected, setConnected] = useState(false);
+
+  useMountEffect(() => {
+    getIntegrations(
+      new URLSearchParams({ "filter[integration_type]": "slack" }),
+    ).then((result) => {
+      setLoading(false);
+      // A failed read collapses to the disconnected presentation: the spec
+      // allows exactly three states, and the integration page is where a
+      // read problem gets diagnosed.
+      if (result?.error) return;
+      const integration = (result?.data as IntegrationProps[] | undefined)?.[0];
+      if (!integration) return;
+      setConnected(true);
+      setAuthorizedChannels(
+        integration.attributes.configuration.channels ?? [],
+      );
+    });
+  });
+
+  const options = mergeOptions(authorizedChannels, storedChannels);
+  const state: FieldState = connected
+    ? authorizedChannels.length > 0
+      ? FIELD_STATE.POPULATED
+      : FIELD_STATE.EMPTY_POOL
+    : FIELD_STATE.NO_INTEGRATION;
+
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-2">
+        <SlackChannelMultiSelect
+          options={options}
+          values={selectedChannelIds}
+          onChange={onValuesChange}
+          isLoading
+          disabled
+        />
+      </div>
+    );
+  }
+
+  if (state === FIELD_STATE.NO_INTEGRATION) {
+    return (
+      <div data-alert-channels-state={state} className="flex flex-col gap-2">
+        {storedChannels.length > 0 ? (
+          // The stored selection stays visible and identified; only a
+          // connected workspace makes it editable again.
+          <SlackChannelMultiSelect
+            options={options}
+            values={selectedChannelIds}
+            onChange={onValuesChange}
+            disabled
+          />
+        ) : (
+          <>
+            <Label>Destination channels</Label>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex w-full" tabIndex={0}>
+                  <MultiSelect values={[]} onValuesChange={() => undefined}>
+                    <MultiSelectTrigger
+                      id="slack-channels"
+                      aria-label="Destination channels"
+                      disabled
+                    >
+                      <MultiSelectValue placeholder="Requires a connected Slack workspace" />
+                    </MultiSelectTrigger>
+                  </MultiSelect>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="max-w-xs">
+                {NO_INTEGRATION_COPY}
+              </TooltipContent>
+            </Tooltip>
+          </>
+        )}
+        <FieldNotice
+          copy={
+            storedChannels.length > 0
+              ? NO_INTEGRATION_WITH_STORED_COPY
+              : NO_INTEGRATION_COPY
+          }
+        />
+      </div>
+    );
+  }
+
+  if (state === FIELD_STATE.EMPTY_POOL && options.length === 0) {
+    return (
+      <div data-alert-channels-state={state} className="flex flex-col gap-2">
+        <Label>Destination channels</Label>
+        <FieldNotice copy={EMPTY_POOL_COPY} />
+      </div>
+    );
+  }
+
+  return (
+    <div data-alert-channels-state={state} className="flex flex-col gap-2">
+      <SlackChannelMultiSelect
+        options={options}
+        values={selectedChannelIds}
+        onChange={onValuesChange}
+      />
+      {state === FIELD_STATE.EMPTY_POOL && (
+        <FieldNotice copy={EMPTY_POOL_COPY} />
+      )}
+    </div>
+  );
+};

--- a/ui/app/(prowler)/alerts/_lib/__tests__/alert-adapter.test.ts
+++ b/ui/app/(prowler)/alerts/_lib/__tests__/alert-adapter.test.ts
@@ -23,10 +23,10 @@ const condition: AlertCondition = {
 const baseValues = {
   name: "  Critical findings  ",
   description: "  Notify security  ",
-  method: "email",
   frequency: ALERT_TRIGGER_KINDS.DAILY,
   condition,
   recipientEmails: [" Security@Example.COM ", "ops@example.com"],
+  slackChannels: [" C0123AB ", "C0123AB", ""],
   enabled: true,
 } satisfies AlertFormValues;
 
@@ -65,6 +65,7 @@ describe("simple alert adapter", () => {
       trigger: ALERT_TRIGGER_KINDS.DAILY,
       condition,
       recipientEmails: ["security@example.com", "ops@example.com"],
+      slackChannels: ["C0123AB"],
     });
     expect(payload.condition).toBe(condition);
     expect(payload).not.toHaveProperty("method");
@@ -78,10 +79,10 @@ describe("simple alert adapter", () => {
     expect(defaults).toEqual({
       name: "Existing alert",
       description: "Existing description",
-      method: "email",
       frequency: ALERT_TRIGGER_KINDS.BOTH,
       condition,
       recipientEmails: ["alerts@example.com"],
+      slackChannels: [],
       enabled: false,
     });
   });

--- a/ui/app/(prowler)/alerts/_lib/alert-adapter.ts
+++ b/ui/app/(prowler)/alerts/_lib/alert-adapter.ts
@@ -55,7 +55,6 @@ export const getAlertFormDefaults = (alert: AlertRule): AlertFormValues => ({
   frequency: alert.attributes.trigger,
   condition: alert.attributes.condition,
   recipientEmails: alert.attributes.recipient_emails ?? [],
-  // TODO(Josema): `slack_channels` read shape pending contract sign-off (D3).
   slackChannels: (alert.attributes.slack_channels ?? []).map(
     (channel) => channel.id,
   ),

--- a/ui/app/(prowler)/alerts/_lib/alert-adapter.ts
+++ b/ui/app/(prowler)/alerts/_lib/alert-adapter.ts
@@ -8,10 +8,7 @@ import {
   type AlertRule,
 } from "@/app/(prowler)/alerts/_types";
 
-import {
-  ALERT_NOTIFICATION_METHODS,
-  type AlertFormValues,
-} from "../_types/alert-form";
+import type { AlertFormValues } from "../_types/alert-form";
 
 const DEFAULT_CONDITION: AlertCondition = {
   op: ALERT_AGGREGATE_OPS.COUNT_GTE,
@@ -24,6 +21,11 @@ const normalizeRecipientEmails = (emails: string[]): string[] =>
     .map((email) => email.trim().toLowerCase())
     .filter((email) => email.length > 0);
 
+const normalizeSlackChannels = (channelIds: string[]): string[] =>
+  Array.from(
+    new Set(channelIds.map((id) => id.trim()).filter((id) => id.length > 0)),
+  );
+
 export const toAlertPayload = (values: AlertFormValues): AlertPayload => ({
   name: values.name.trim(),
   description: values.description.trim(),
@@ -31,6 +33,7 @@ export const toAlertPayload = (values: AlertFormValues): AlertPayload => ({
   trigger: values.frequency,
   condition: values.condition,
   recipientEmails: normalizeRecipientEmails(values.recipientEmails),
+  slackChannels: normalizeSlackChannels(values.slackChannels),
 });
 
 export const getEmptyAlertFormDefaults = (
@@ -39,20 +42,23 @@ export const getEmptyAlertFormDefaults = (
 ): AlertFormValues => ({
   name: "",
   description: "",
-  method: ALERT_NOTIFICATION_METHODS.EMAIL,
   frequency,
   condition,
   recipientEmails: [],
+  slackChannels: [],
   enabled: true,
 });
 
 export const getAlertFormDefaults = (alert: AlertRule): AlertFormValues => ({
   name: alert.attributes.name,
   description: alert.attributes.description,
-  method: ALERT_NOTIFICATION_METHODS.EMAIL,
   frequency: alert.attributes.trigger,
   condition: alert.attributes.condition,
   recipientEmails: alert.attributes.recipient_emails ?? [],
+  // TODO(Josema): `slack_channels` read shape pending contract sign-off (D3).
+  slackChannels: (alert.attributes.slack_channels ?? []).map(
+    (channel) => channel.id,
+  ),
   enabled: alert.attributes.enabled,
 });
 

--- a/ui/app/(prowler)/alerts/_lib/alert-form-schema.ts
+++ b/ui/app/(prowler)/alerts/_lib/alert-form-schema.ts
@@ -5,8 +5,6 @@ import {
   type AlertCondition,
 } from "@/app/(prowler)/alerts/_types";
 
-import { ALERT_NOTIFICATION_METHODS } from "../_types/alert-form";
-
 const alertConditionSchema = z.custom<AlertCondition>(
   (value) => typeof value === "object" && value !== null,
   "Alert condition is required.",
@@ -15,11 +13,11 @@ const alertConditionSchema = z.custom<AlertCondition>(
 export const alertFormSchema = z.object({
   name: z.string().trim().min(1, { error: "Name is required." }).max(120),
   description: z.string().trim().max(2000).default(""),
-  method: z.literal(ALERT_NOTIFICATION_METHODS.EMAIL),
   frequency: z.enum(ALERT_TRIGGER_KIND_VALUES),
   condition: alertConditionSchema,
   recipientEmails: z
     .array(z.email({ error: "Enter a valid email address." }))
     .default([]),
+  slackChannels: z.array(z.string().trim().min(1)).default([]),
   enabled: z.boolean(),
 });

--- a/ui/app/(prowler)/alerts/_types/alert-form.ts
+++ b/ui/app/(prowler)/alerts/_types/alert-form.ts
@@ -3,20 +3,14 @@ import type {
   AlertTriggerKind,
 } from "@/app/(prowler)/alerts/_types";
 
-export const ALERT_NOTIFICATION_METHODS = {
-  EMAIL: "email",
-} as const;
-
-export type AlertNotificationMethod =
-  (typeof ALERT_NOTIFICATION_METHODS)[keyof typeof ALERT_NOTIFICATION_METHODS];
-
 export interface AlertFormValues {
   name: string;
   description: string;
-  method: AlertNotificationMethod;
   frequency: AlertTriggerKind;
   condition: AlertCondition;
   recipientEmails: string[];
+  /** Slack channel ids drawn from the integration's authorized set. */
+  slackChannels: string[];
   enabled: boolean;
 }
 

--- a/ui/app/(prowler)/alerts/_types/alert-form.ts
+++ b/ui/app/(prowler)/alerts/_types/alert-form.ts
@@ -9,7 +9,6 @@ export interface AlertFormValues {
   frequency: AlertTriggerKind;
   condition: AlertCondition;
   recipientEmails: string[];
-  /** Slack channel ids drawn from the integration's authorized set. */
   slackChannels: string[];
   enabled: boolean;
 }

--- a/ui/app/(prowler)/alerts/_types/index.ts
+++ b/ui/app/(prowler)/alerts/_types/index.ts
@@ -148,11 +148,7 @@ export interface AlertRuleAttributes {
    * `recipient_emails` attribute), not as a JSON:API relationships block.
    */
   recipient_emails?: string[];
-  /**
-   * Slack channel destinations, resolved by the API to id + name + privacy so
-   * the UI renders stored channels without a Slack round-trip. The write side
-   * takes ids only.
-   */
+  /** Resolved by the API; the write side takes ids only. */
   slack_channels?: SlackChannelOption[];
   created_by?: string | null;
   inserted_at: string;

--- a/ui/app/(prowler)/alerts/_types/index.ts
+++ b/ui/app/(prowler)/alerts/_types/index.ts
@@ -150,8 +150,8 @@ export interface AlertRuleAttributes {
   recipient_emails?: string[];
   /**
    * Slack channel destinations, resolved by the API to id + name + privacy so
-   * the UI renders stored channels without a Slack round-trip.
-   * TODO(Josema): attribute name and shape pending contract sign-off (D3).
+   * the UI renders stored channels without a Slack round-trip. The write side
+   * takes ids only.
    */
   slack_channels?: SlackChannelOption[];
   created_by?: string | null;

--- a/ui/app/(prowler)/alerts/_types/index.ts
+++ b/ui/app/(prowler)/alerts/_types/index.ts
@@ -1,3 +1,4 @@
+import type { SlackChannelOption } from "@/types/integrations";
 import { SEVERITY_LEVELS } from "@/types/severities";
 
 // Canonical DSL vocabulary and resource types for the Alerts UI.
@@ -147,6 +148,12 @@ export interface AlertRuleAttributes {
    * `recipient_emails` attribute), not as a JSON:API relationships block.
    */
   recipient_emails?: string[];
+  /**
+   * Slack channel destinations, resolved by the API to id + name + privacy so
+   * the UI renders stored channels without a Slack round-trip.
+   * TODO(Josema): attribute name and shape pending contract sign-off (D3).
+   */
+  slack_channels?: SlackChannelOption[];
   created_by?: string | null;
   inserted_at: string;
   updated_at: string;

--- a/ui/app/(prowler)/alerts/alerts-page.harness.ts
+++ b/ui/app/(prowler)/alerts/alerts-page.harness.ts
@@ -8,8 +8,8 @@
  * The channel-destination readers are the harness side of the S2 contract:
  * the alert form's channels field renders a wrapper carrying
  * `data-alert-channels-state` (`no-integration` | `empty-pool` | `populated`),
- * its explanatory copy under `data-alert-channels-notice`, and its
- * multi-select trigger as `#alert-slack-channels`.
+ * its explanatory copy under `data-alert-channels-notice`, and the shared
+ * multi-select's trigger as `#slack-channels`.
  */
 
 import { createElement } from "react";
@@ -206,52 +206,129 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
   }
 
   /**
-   * Open the channel picker and hand back its options. Mirrors the Slack
-   * harness: a re-render landing mid-gesture makes Radix drop the open state,
-   * so re-open from the keyboard when nothing mounted.
+   * The options inside the popover THIS trigger controls, or null. Correlated
+   * through `aria-controls`: two pickers share the page (channels,
+   * recipients) and the MultiSelect also keeps a hidden mirror of its items,
+   * so any unscoped `[role="option"]` query can answer for the wrong picker.
    */
-  private async openChannelPicker(): Promise<HTMLElement[]> {
-    const mounted = (): HTMLElement[] | null => {
-      const options = Array.from(
-        document.querySelectorAll<HTMLElement>('[role="option"]'),
-      );
-      return options.length > 0 ? options : null;
-    };
+  private static optionsControlledBy(
+    trigger: HTMLElement,
+  ): HTMLElement[] | null {
+    const contentId = trigger.getAttribute("aria-controls");
+    const content = contentId ? document.getElementById(contentId) : null;
+    if (!content || content.getAttribute("data-state") !== "open") return null;
+    const options = Array.from(
+      content.querySelectorAll<HTMLElement>('[role="option"]'),
+    );
+    return options.length > 0 ? options : null;
+  }
+
+  private async openPicker(triggerSelector: string): Promise<HTMLElement[]> {
+    const trigger = await this.waitFor<HTMLElement>(
+      () => this.q(triggerSelector),
+      10000,
+      `the ${triggerSelector} picker`,
+    );
+    const mounted = () => AlertsPageHarness.optionsControlledBy(trigger);
 
     const alreadyOpen = mounted();
     if (alreadyOpen) return alreadyOpen;
 
-    const trigger = await this.waitFor<HTMLElement>(
-      () => this.q("#alert-slack-channels"),
-      10000,
-      "the channel picker",
-    );
     await this.clickElement(trigger, { fallbackToDomClick: true });
 
-    let options = await this.waitForOrNull(
-      mounted,
-      2000,
-      "the channel options",
-    );
+    let options = await this.waitForOrNull(mounted, 2000, "the picker options");
     if (!options) {
       await this.user.keyboard("{Enter}");
-      options = await this.waitForOrNull(mounted, 8000, "the channel options");
+      options = await this.waitForOrNull(mounted, 8000, "the picker options");
     }
     if (!options) {
-      throw new Error("openChannelPicker: the channel picker offered nothing");
+      throw new Error(`openPicker: ${triggerSelector} offered nothing`);
     }
     return options;
   }
 
-  private async closeChannelPicker(): Promise<void> {
-    await this.user.keyboard("{Escape}");
+  private async openChannelPicker(): Promise<HTMLElement[]> {
+    return this.openPicker("#slack-channels");
+  }
+
+  /** Whether the channel picker is rendered but refuses interaction. */
+  async channelPickerDisabled(): Promise<boolean> {
+    const trigger = await this.waitFor(
+      () => this.q("#slack-channels"),
+      10000,
+      "the channel picker trigger",
+    );
+    return (
+      (trigger as HTMLButtonElement).disabled ||
+      trigger.getAttribute("aria-disabled") === "true" ||
+      trigger.hasAttribute("disabled")
+    );
+  }
+
+  /**
+   * Toggle the named recipient emails in the recipients picker, verifying
+   * each pick against its chip like `pickChannels` does.
+   */
+  async pickRecipients(emails: string[]): Promise<void> {
+    for (const email of emails) {
+      let picked = false;
+      for (let attempt = 0; attempt < 3 && !picked; attempt += 1) {
+        const options = await this.openPicker("#alert-recipients");
+        const option = options.find((candidate) =>
+          (candidate.textContent ?? "").includes(email),
+        );
+        if (!option) {
+          await this.closePicker("#alert-recipients");
+          throw new Error(`pickRecipients: no recipient "${email}" is offered`);
+        }
+        await this.clickElement(option, { fallbackToDomClick: true });
+        picked =
+          (await this.waitForOrNull(
+            () => this.chipContaining(email),
+            2000,
+            `the ${email} chip`,
+          )) !== null;
+      }
+      if (!picked) {
+        throw new Error(`pickRecipients: ${email} never showed as selected`);
+      }
+    }
+    await this.closePicker("#alert-recipients");
+  }
+
+  /**
+   * Close an open picker by clicking a neutral spot inside the dialog (its
+   * title). Not a bare Escape — with focus outside the popover it reaches the
+   * dialog and closes the whole modal. Not the trigger either — its chips
+   * remove-on-click, so a click landing on one silently drops a selection.
+   */
+  private async closePicker(triggerSelector: string): Promise<void> {
+    const trigger = this.q(triggerSelector);
+    const isOpen = () => {
+      const contentId = trigger?.getAttribute("aria-controls");
+      const content = contentId ? document.getElementById(contentId) : null;
+      return content?.getAttribute("data-state") === "open";
+    };
+    if (trigger && isOpen()) {
+      const neutral =
+        this.dialog()?.querySelector<HTMLElement>("h2") ?? trigger;
+      await this.clickElement(neutral, { fallbackToDomClick: true });
+      await this.waitForOrNull(() => !isOpen(), 2000, "the picker to close");
+    }
     await this.waitForTransition();
+  }
+
+  private async closeChannelPicker(): Promise<void> {
+    await this.closePicker("#slack-channels");
   }
 
   private static optionChannelName(option: HTMLElement): string {
     return (
       option.getAttribute("data-channel") ??
-      (option.textContent ?? "").replace(/Private/g, "").trim()
+      (option.textContent ?? "")
+        .replace(/Private/g, "")
+        .trim()
+        .replace(/^#/, "")
     );
   }
 
@@ -273,18 +350,46 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     return /Private/.test(option?.textContent ?? "");
   }
 
-  /** Toggle the named channels in the picker, then close it. */
+  /** A visible chip whose text contains `text`, anywhere in the open form. */
+  private chipContaining(text: string): HTMLElement | null {
+    return (
+      Array.from(
+        document.querySelectorAll<HTMLElement>("[data-selected-item]"),
+      ).find((chip) => (chip.textContent ?? "").includes(text)) ?? null
+    );
+  }
+
+  /**
+   * Toggle the named channels in the picker, then close it. Each pick is
+   * verified against the chip the user sees and retried when the click
+   * landed on a node the selection re-render had already replaced.
+   */
   async pickChannels(names: string[]): Promise<void> {
     for (const name of names) {
-      const options = await this.openChannelPicker();
-      const option = options.find(
-        (candidate) => AlertsPageHarness.optionChannelName(candidate) === name,
-      );
-      if (!option) {
-        await this.closeChannelPicker();
-        throw new Error(`pickChannels: no channel named "${name}" is offered`);
+      let picked = false;
+      for (let attempt = 0; attempt < 3 && !picked; attempt += 1) {
+        const options = await this.openChannelPicker();
+        const option = options.find(
+          (candidate) =>
+            AlertsPageHarness.optionChannelName(candidate) === name,
+        );
+        if (!option) {
+          await this.closeChannelPicker();
+          throw new Error(
+            `pickChannels: no channel named "${name}" is offered`,
+          );
+        }
+        await this.clickElement(option, { fallbackToDomClick: true });
+        picked =
+          (await this.waitForOrNull(
+            () => this.chipContaining(`#${name}`),
+            2000,
+            `the #${name} chip`,
+          )) !== null;
       }
-      await this.clickElement(option, { fallbackToDomClick: true });
+      if (!picked) {
+        throw new Error(`pickChannels: #${name} never showed as selected`);
+      }
     }
     await this.closeChannelPicker();
   }
@@ -306,7 +411,11 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
       const text = (chip.textContent ?? "").replace(/\s+/g, " ").trim();
       return {
         isPrivate: /Private/.test(text),
-        name: text.replace(/Private/g, "").trim(),
+        // The chip renders `#name` with an sr-only "Private" marker.
+        name: text
+          .replace(/Private/g, "")
+          .trim()
+          .replace(/^#/, ""),
       };
     });
   }

--- a/ui/app/(prowler)/alerts/alerts-page.harness.ts
+++ b/ui/app/(prowler)/alerts/alerts-page.harness.ts
@@ -108,9 +108,9 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
   }
 
   async saveRule(): Promise<void> {
-    await this.submitModal();
+    const submittedDialog = await this.submitModal();
     await this.waitFor(
-      () => this.dialog() === null,
+      () => !submittedDialog.isConnected,
       10000,
       "the alert modal to close after saving",
     );
@@ -134,7 +134,7 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     );
   }
 
-  private async submitModal(): Promise<void> {
+  private async submitModal(): Promise<HTMLElement> {
     const dialog = this.dialog();
     if (!dialog) throw new Error("submitModal: no alert modal is open");
     const submit = await this.waitFor(
@@ -143,6 +143,7 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
       "the modal submit button",
     );
     await this.clickElement(submit, { fallbackToDomClick: true });
+    return dialog;
   }
 
   private modalErrorText(): string | null {

--- a/ui/app/(prowler)/alerts/alerts-page.harness.ts
+++ b/ui/app/(prowler)/alerts/alerts-page.harness.ts
@@ -25,11 +25,11 @@ import { SeedFromFindingsButton } from "./_components/seed-from-findings-button"
 import AlertsPage from "./page";
 
 export const CHANNEL_FIELD_STATE = {
-  /** No Slack workspace connected: visible, disabled, explains itself. */
+  /** No enabled and connected Slack workspace: visible, disabled, explains itself. */
   NO_INTEGRATION: "no-integration",
-  /** Workspace connected, nothing authorized yet. */
+  /** Workspace connected, no channel eligible yet. */
   EMPTY_POOL: "empty-pool",
-  /** The authorized set is on offer. */
+  /** The eligible channels are on offer. */
   POPULATED: "populated",
 } as const;
 
@@ -151,7 +151,10 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     return text.length > 0 ? text : null;
   }
 
-  /** The channel ids the last rule write actually submitted. */
+  /**
+   * The channel ids the last rule write actually submitted, read off the
+   * contract's `[{id}, …]` write shape.
+   */
   async savedRuleChannels(): Promise<string[] | undefined> {
     const method =
       this.countRequests("POST", "/alerts/rules") >
@@ -159,9 +162,9 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
         ? "POST"
         : "PATCH";
     const body = await this.lastRequestBody<{
-      data?: { attributes?: { slack_channels?: string[] } };
+      data?: { attributes?: { slack_channels?: { id: string }[] } };
     }>(method, "/alerts/rules");
-    return body?.data?.attributes?.slack_channels;
+    return body?.data?.attributes?.slack_channels?.map((channel) => channel.id);
   }
 
   // --- The channel destination field ---------------------------------------

--- a/ui/app/(prowler)/alerts/alerts-page.harness.ts
+++ b/ui/app/(prowler)/alerts/alerts-page.harness.ts
@@ -2,14 +2,7 @@
  * Page-level test harness for the Alerts page (Vitest Browser Mode).
  *
  * A client renderer cannot render an async server component, so the page is
- * called and the element it returns is what gets rendered — the providers and
- * Slack harnesses' pattern.
- *
- * The channel-destination readers are the harness side of the S2 contract:
- * the alert form's channels field renders a wrapper carrying
- * `data-alert-channels-state` (`no-integration` | `empty-pool` | `populated`),
- * its explanatory copy under `data-alert-channels-notice`, and the shared
- * multi-select's trigger as `#slack-channels`.
+ * called and the element it returns is what gets rendered.
  */
 
 import { createElement } from "react";
@@ -25,24 +18,21 @@ import { SeedFromFindingsButton } from "./_components/seed-from-findings-button"
 import AlertsPage from "./page";
 
 export const CHANNEL_FIELD_STATE = {
-  /** No enabled and connected Slack workspace: visible, disabled, explains itself. */
+  /** No Slack workspace both enabled and connected. */
   NO_INTEGRATION: "no-integration",
   /** Workspace connected, no channel eligible yet. */
   EMPTY_POOL: "empty-pool",
-  /** The eligible channels are on offer. */
   POPULATED: "populated",
 } as const;
 
 export type ChannelFieldState =
   (typeof CHANNEL_FIELD_STATE)[keyof typeof CHANNEL_FIELD_STATE];
 
-/** A selected channel as the user reads it off the closed field. */
 export interface SelectedChannelChip {
   name: string;
   isPrivate: boolean;
 }
 
-/** A channel as a rule write submits it — the contract's `[{id}, …]` shape. */
 interface RuleWriteChannel {
   id: string;
 }
@@ -57,7 +47,6 @@ interface RuleWriteData {
   attributes?: RuleWriteAttributes;
 }
 
-/** The envelope an alert rule create or update submits. */
 interface RuleWriteEnvelope {
   data?: RuleWriteData;
 }
@@ -74,7 +63,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
 
   // --- Mounting -----------------------------------------------------------
 
-  /** Open the alerts page, the way a visit does. */
   async mount(
     searchParams: Record<string, string | undefined> = {},
   ): Promise<void> {
@@ -85,10 +73,7 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     await this.waitForText(/Get notified when findings match/);
   }
 
-  /**
-   * Mount the creation entry as the findings page composes it — the alerts
-   * page itself only edits; rules are created from Findings (seed flow).
-   */
+  /** Rules are created from Findings (seed flow), never from the alerts page. */
   mountCreateEntry(
     filterBag: AlertsFilterBag = DEFAULT_CREATE_FILTER_BAG,
   ): void {
@@ -104,13 +89,11 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     return document.querySelector<HTMLElement>('[role="dialog"]');
   }
 
-  /** Seed from the mounted create entry and wait for the modal. */
   async openCreateModal(): Promise<void> {
     await this.clickButton(/Create Alert/);
     await this.waitFor(() => this.dialog(), 10000, "the create alert modal");
   }
 
-  /** Open a listed rule for editing, by its name. */
   async openEditModal(ruleName: string): Promise<void> {
     const nameButton = await this.waitFor(
       () =>
@@ -124,7 +107,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     await this.waitFor(() => this.dialog(), 10000, "the edit alert modal");
   }
 
-  /** Submit the open modal (Create or Save) and wait for it to close. */
   async saveRule(): Promise<void> {
     await this.submitModal();
     await this.waitFor(
@@ -135,9 +117,7 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
   }
 
   /**
-   * Submit the open modal expecting a refusal, and hand back what the user is
-   * told. A save that closes the modal fails the test rather than timing out.
-   * Only newly added channels are validated (contract section 6.3), so a
+   * Only newly added channels are validated (contract 6.3), so provoking a
    * channel refusal needs options that went stale mid-edit.
    */
   async refusedRuleSave(): Promise<string> {
@@ -168,11 +148,8 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
   private modalErrorText(): string | null {
     const dialog = this.dialog();
     if (!dialog) return null;
-    // The error class is shared, and first-in-DOM-order wins: the recipients
-    // read failure and the preview error both render one ABOVE the form-level
-    // message and would shadow it. Only the form-level one is a `div` — every
-    // field-scoped error is a `p` — so prefer that, and keep the broad query
-    // as the fallback for a refusal that never reaches the form level.
+    // The error class is shared and first-in-DOM-order wins, so prefer the
+    // form-level error: it is the only `div`, every field-scoped one is a `p`.
     const error =
       dialog.querySelector<HTMLElement>("div.text-text-error-primary") ??
       dialog.querySelector<HTMLElement>(".text-text-error-primary");
@@ -180,23 +157,15 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     return text.length > 0 ? text : null;
   }
 
-  /**
-   * The channel ids the last rule write actually submitted, read off the
-   * contract's `[{id}, …]` write shape.
-   */
   async savedRuleChannels(): Promise<string[] | undefined> {
     const body = await this.lastRuleWriteBody();
     return body?.data?.attributes?.slack_channels?.map((channel) => channel.id);
   }
 
   /**
-   * The most recent rule write in the request log, picked by payload rather
-   * than by method or path: `/alerts/rules` is a prefix of the seed and
-   * preview endpoints, so a path match — and the POST-vs-PATCH counting it
-   * invites — can resolve to a request that carries no channels. Seed and
-   * preview envelopes declare their own `type`; the enable/disable toggle
-   * reuses both the write's URL and its type, and only a real write carries
-   * `schema_version`.
+   * Matched by payload, not by method or path: `/alerts/rules` prefixes the
+   * seed and preview endpoints, and the enable/disable toggle reuses both the
+   * write's URL and its type — only a real write carries `schema_version`.
    */
   private async lastRuleWriteBody(): Promise<RuleWriteEnvelope | null> {
     for (const entry of [...this.requestLog].reverse()) {
@@ -211,7 +180,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     return null;
   }
 
-  /** A request with no body, or one that is not JSON, is not a rule write. */
   private static async parsedBody(
     request: Request,
   ): Promise<RuleWriteEnvelope | null> {
@@ -228,7 +196,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     return document.querySelector<HTMLElement>("[data-alert-channels-state]");
   }
 
-  /** Which of its three states the channel destination is presenting. */
   async channelFieldState(): Promise<ChannelFieldState> {
     const field = await this.waitFor(
       () => this.channelField(),
@@ -238,7 +205,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     return field.getAttribute("data-alert-channels-state") as ChannelFieldState;
   }
 
-  /** The copy explaining a degraded state, wherever the field renders it. */
   async channelFieldNotice(): Promise<string> {
     const notice = await this.waitFor(
       () => document.querySelector<HTMLElement>("[data-alert-channels-notice]"),
@@ -248,7 +214,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     return (notice.textContent ?? "").replace(/\s+/g, " ").trim();
   }
 
-  /** The affordance a degraded state offers toward the integration page. */
   integrationAffordanceHref(): string | null {
     const scopes: (ParentNode | null)[] = [
       document.querySelector("[data-alert-channels-notice]"),
@@ -264,10 +229,10 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
   }
 
   /**
-   * The options inside the popover THIS trigger controls, or null. Correlated
-   * through `aria-controls`: two pickers share the page (channels,
-   * recipients) and the MultiSelect also keeps a hidden mirror of its items,
-   * so any unscoped `[role="option"]` query can answer for the wrong picker.
+   * The options inside the popover THIS trigger controls, correlated through
+   * `aria-controls`: two pickers share the page and the MultiSelect keeps a
+   * hidden mirror of its items, so an unscoped `[role="option"]` query can
+   * answer for the wrong one.
    */
   private static optionsControlledBy(
     trigger: HTMLElement,
@@ -309,7 +274,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     return this.openPicker("#slack-channels");
   }
 
-  /** Whether the channel picker is rendered but refuses interaction. */
   async channelPickerDisabled(): Promise<boolean> {
     const trigger = await this.waitFor(
       () => this.q("#slack-channels"),
@@ -323,17 +287,13 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     );
   }
 
-  /**
-   * Toggle the named recipient emails in the recipients picker, verifying
-   * each pick against its chip like `pickChannels` does.
-   */
   async pickRecipients(emails: string[]): Promise<void> {
     for (const email of emails) {
       let picked = false;
       for (let attempt = 0; attempt < 3 && !picked; attempt += 1) {
         const options = await this.openPicker("#alert-recipients");
-        // The picker stays open between attempts, so a retry clicking an item
-        // the previous attempt did select would toggle it back off.
+        // The picker stays open between attempts: re-clicking an item the last
+        // attempt did select would toggle it back off.
         if (this.isRecipientSelected(email)) {
           picked = true;
           break;
@@ -361,10 +321,9 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
   }
 
   /**
-   * Close an open picker by clicking a neutral spot inside the dialog (its
-   * title). Not a bare Escape — with focus outside the popover it reaches the
-   * dialog and closes the whole modal. Not the trigger either — its chips
-   * remove-on-click, so a click landing on one silently drops a selection.
+   * Closed by clicking the dialog title. Not Escape — with focus outside the
+   * popover it reaches the dialog and closes the whole modal. Not the trigger
+   * — its chips remove on click, silently dropping a selection.
    */
   private async closePicker(triggerSelector: string): Promise<void> {
     const trigger = this.q(triggerSelector);
@@ -396,7 +355,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     );
   }
 
-  /** The channels offered for the rule, in the order the picker lists them. */
   async offeredChannels(): Promise<string[]> {
     const options = await this.openChannelPicker();
     const names = options.map(AlertsPageHarness.optionChannelName);
@@ -404,7 +362,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     return names;
   }
 
-  /** Whether the channel offered under `name` is presented as private. */
   async isChannelOfferedAsPrivate(name: string): Promise<boolean> {
     const options = await this.openChannelPicker();
     const option = options.find(
@@ -415,11 +372,10 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
   }
 
   /**
-   * The text of every selected chip inside `scope`, as the user reads it.
-   * Always scoped to one field: two pickers share the open form, and a
-   * document-wide substring test answers for the wrong one — a private
-   * channel's chip reads `Private#security-alerts`, which contains
-   * `#security`, the name of the other fixture channel.
+   * Always scoped to one field and matched exactly, never document-wide: two
+   * pickers share the open form, and a private chip reads
+   * `Private#security-alerts`, which contains `#security` — the other fixture
+   * channel.
    */
   private static chipTexts(scope: ParentNode): string[] {
     return Array.from(
@@ -438,7 +394,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     };
   }
 
-  /** Whether the closed field already shows `name` among its chips. */
   private isChannelSelected(name: string): boolean {
     const field = this.channelField();
     if (!field) return false;
@@ -447,7 +402,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
       .some((chip) => chip.name === name);
   }
 
-  /** Whether the recipients field already shows `email` among its chips. */
   private isRecipientSelected(email: string): boolean {
     const trigger = this.q("#alert-recipients");
     return (
@@ -456,17 +410,17 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
   }
 
   /**
-   * Toggle the named channels in the picker, then close it. Each pick is
-   * verified against the chip the user sees and retried when the click
-   * landed on a node the selection re-render had already replaced.
+   * Each pick is verified against the chip the user sees, then re-resolved and
+   * re-clicked: the click can land on a node the selection re-render already
+   * replaced, and a native click on a detached node never reaches React.
    */
   async pickChannels(names: string[]): Promise<void> {
     for (const name of names) {
       let picked = false;
       for (let attempt = 0; attempt < 3 && !picked; attempt += 1) {
         const options = await this.openChannelPicker();
-        // The picker stays open between attempts, so a retry clicking an item
-        // the previous attempt did select would toggle it back off.
+        // The picker stays open between attempts: re-clicking an item the last
+        // attempt did select would toggle it back off.
         if (this.isChannelSelected(name)) {
           picked = true;
           break;
@@ -496,10 +450,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     await this.closeChannelPicker();
   }
 
-  /**
-   * The rule's selected channels as the closed field shows them — name and
-   * privacy read from the chip the user sees.
-   */
   async selectedChannelChips(): Promise<SelectedChannelChip[]> {
     const field = await this.waitFor(
       () => this.channelField(),
@@ -514,8 +464,8 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
   // --- The alerts list ------------------------------------------------------
 
   /**
-   * The destinations summary the list shows for a rule, without opening it —
-   * the Destinations column once S3 lands (Recipients until then).
+   * No caller on this branch: the Destinations column lands in S3
+   * (`feature/alerts-destinations-column`), which consumes this. Not dead code.
    */
   async ruleDestinationsSummary(ruleName: string): Promise<string> {
     const headers = Array.from(

--- a/ui/app/(prowler)/alerts/alerts-page.harness.ts
+++ b/ui/app/(prowler)/alerts/alerts-page.harness.ts
@@ -1,0 +1,359 @@
+/**
+ * Page-level test harness for the Alerts page (Vitest Browser Mode).
+ *
+ * A client renderer cannot render an async server component, so the page is
+ * called and the element it returns is what gets rendered — the providers and
+ * Slack harnesses' pattern.
+ *
+ * The channel-destination readers are the harness side of the S2 contract:
+ * the alert form's channels field renders a wrapper carrying
+ * `data-alert-channels-state` (`no-integration` | `empty-pool` | `populated`),
+ * its explanatory copy under `data-alert-channels-notice`, and its
+ * multi-select trigger as `#alert-slack-channels`.
+ */
+
+import { createElement } from "react";
+
+import { BrowserHarness } from "@/__tests__/browser-harness";
+import { handlersForAlerts } from "@/__tests__/msw/handlers/alerts";
+import type { AlertsFixture } from "@/__tests__/msw/handlers/alerts.fixtures";
+import { worker } from "@/__tests__/msw/worker";
+import { render } from "@/__tests__/render-browser";
+import type { AlertsFilterBag } from "@/app/(prowler)/alerts/_types";
+
+import { SeedFromFindingsButton } from "./_components/seed-from-findings-button";
+import AlertsPage from "./page";
+
+export const CHANNEL_FIELD_STATE = {
+  /** No Slack workspace connected: visible, disabled, explains itself. */
+  NO_INTEGRATION: "no-integration",
+  /** Workspace connected, nothing authorized yet. */
+  EMPTY_POOL: "empty-pool",
+  /** The authorized set is on offer. */
+  POPULATED: "populated",
+} as const;
+
+export type ChannelFieldState =
+  (typeof CHANNEL_FIELD_STATE)[keyof typeof CHANNEL_FIELD_STATE];
+
+/** A selected channel as the user reads it off the closed field. */
+export interface SelectedChannelChip {
+  name: string;
+  isPrivate: boolean;
+}
+
+const DEFAULT_CREATE_FILTER_BAG: AlertsFilterBag = {
+  "filter[severity__in]": ["critical"],
+};
+
+export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
+  private wireHandlers(): void {
+    worker.use(...handlersForAlerts(this.fixture));
+    this.trackRequests(worker);
+  }
+
+  // --- Mounting -----------------------------------------------------------
+
+  /** Open the alerts page, the way a visit does. */
+  async mount(
+    searchParams: Record<string, string | undefined> = {},
+  ): Promise<void> {
+    window.history.replaceState(null, "", "/alerts");
+    this.wireHandlers();
+
+    render(await AlertsPage({ searchParams: Promise.resolve(searchParams) }));
+    await this.waitForText(/Get notified when findings match/);
+  }
+
+  /**
+   * Mount the creation entry as the findings page composes it — the alerts
+   * page itself only edits; rules are created from Findings (seed flow).
+   */
+  mountCreateEntry(
+    filterBag: AlertsFilterBag = DEFAULT_CREATE_FILTER_BAG,
+  ): void {
+    window.history.replaceState(null, "", "/findings");
+    this.wireHandlers();
+
+    render(createElement(SeedFromFindingsButton, { filterBag }));
+  }
+
+  // --- The alert modal ------------------------------------------------------
+
+  private dialog(): HTMLElement | null {
+    return document.querySelector<HTMLElement>('[role="dialog"]');
+  }
+
+  /** Seed from the mounted create entry and wait for the modal. */
+  async openCreateModal(): Promise<void> {
+    await this.clickButton(/Create Alert/);
+    await this.waitFor(() => this.dialog(), 10000, "the create alert modal");
+  }
+
+  /** Open a listed rule for editing, by its name. */
+  async openEditModal(ruleName: string): Promise<void> {
+    const nameButton = await this.waitFor(
+      () =>
+        Array.from(
+          this.container.querySelectorAll<HTMLButtonElement>("button"),
+        ).find((button) => (button.textContent ?? "").trim() === ruleName),
+      10000,
+      `the listed rule "${ruleName}"`,
+    );
+    await this.clickElement(nameButton, { fallbackToDomClick: true });
+    await this.waitFor(() => this.dialog(), 10000, "the edit alert modal");
+  }
+
+  /** Submit the open modal (Create or Save) and wait for it to close. */
+  async saveRule(): Promise<void> {
+    await this.submitModal();
+    await this.waitFor(
+      () => this.dialog() === null,
+      10000,
+      "the alert modal to close after saving",
+    );
+  }
+
+  /**
+   * Submit the open modal expecting a refusal, and hand back what the user is
+   * told. A save that closes the modal fails the test rather than timing out.
+   */
+  async refusedRuleSave(): Promise<string> {
+    await this.submitModal();
+    return this.waitFor(
+      () => {
+        if (this.dialog() === null) {
+          throw new Error("refusedRuleSave: the save landed, not refused");
+        }
+        return this.modalErrorText();
+      },
+      10000,
+      "the refused rule save",
+    );
+  }
+
+  private async submitModal(): Promise<void> {
+    const dialog = this.dialog();
+    if (!dialog) throw new Error("submitModal: no alert modal is open");
+    const submit = await this.waitFor(
+      () => this.buttonByText(/^(Create|Save)$/, dialog),
+      5000,
+      "the modal submit button",
+    );
+    await this.clickElement(submit, { fallbackToDomClick: true });
+  }
+
+  private modalErrorText(): string | null {
+    const dialog = this.dialog();
+    if (!dialog) return null;
+    const error = dialog.querySelector<HTMLElement>(".text-text-error-primary");
+    const text = (error?.textContent ?? "").trim();
+    return text.length > 0 ? text : null;
+  }
+
+  /** The channel ids the last rule write actually submitted. */
+  async savedRuleChannels(): Promise<string[] | undefined> {
+    const method =
+      this.countRequests("POST", "/alerts/rules") >
+      this.countRequests("PATCH", "/alerts/rules")
+        ? "POST"
+        : "PATCH";
+    const body = await this.lastRequestBody<{
+      data?: { attributes?: { slack_channels?: string[] } };
+    }>(method, "/alerts/rules");
+    return body?.data?.attributes?.slack_channels;
+  }
+
+  // --- The channel destination field ---------------------------------------
+
+  private channelField(): HTMLElement | null {
+    return document.querySelector<HTMLElement>("[data-alert-channels-state]");
+  }
+
+  /** Which of its three states the channel destination is presenting. */
+  async channelFieldState(): Promise<ChannelFieldState> {
+    const field = await this.waitFor(
+      () => this.channelField(),
+      10000,
+      "the channel destination field",
+    );
+    return field.getAttribute("data-alert-channels-state") as ChannelFieldState;
+  }
+
+  /** The copy explaining a degraded state, wherever the field renders it. */
+  async channelFieldNotice(): Promise<string> {
+    const notice = await this.waitFor(
+      () => document.querySelector<HTMLElement>("[data-alert-channels-notice]"),
+      10000,
+      "the channel destination notice",
+    );
+    return (notice.textContent ?? "").replace(/\s+/g, " ").trim();
+  }
+
+  /** The affordance a degraded state offers toward the integration page. */
+  integrationAffordanceHref(): string | null {
+    const scopes: (ParentNode | null)[] = [
+      document.querySelector("[data-alert-channels-notice]"),
+      this.channelField(),
+    ];
+    for (const scope of scopes) {
+      const link = scope?.querySelector<HTMLAnchorElement>(
+        'a[href="/integrations/slack"]',
+      );
+      if (link) return link.getAttribute("href");
+    }
+    return null;
+  }
+
+  /**
+   * Open the channel picker and hand back its options. Mirrors the Slack
+   * harness: a re-render landing mid-gesture makes Radix drop the open state,
+   * so re-open from the keyboard when nothing mounted.
+   */
+  private async openChannelPicker(): Promise<HTMLElement[]> {
+    const mounted = (): HTMLElement[] | null => {
+      const options = Array.from(
+        document.querySelectorAll<HTMLElement>('[role="option"]'),
+      );
+      return options.length > 0 ? options : null;
+    };
+
+    const alreadyOpen = mounted();
+    if (alreadyOpen) return alreadyOpen;
+
+    const trigger = await this.waitFor<HTMLElement>(
+      () => this.q("#alert-slack-channels"),
+      10000,
+      "the channel picker",
+    );
+    await this.clickElement(trigger, { fallbackToDomClick: true });
+
+    let options = await this.waitForOrNull(
+      mounted,
+      2000,
+      "the channel options",
+    );
+    if (!options) {
+      await this.user.keyboard("{Enter}");
+      options = await this.waitForOrNull(mounted, 8000, "the channel options");
+    }
+    if (!options) {
+      throw new Error("openChannelPicker: the channel picker offered nothing");
+    }
+    return options;
+  }
+
+  private async closeChannelPicker(): Promise<void> {
+    await this.user.keyboard("{Escape}");
+    await this.waitForTransition();
+  }
+
+  private static optionChannelName(option: HTMLElement): string {
+    return (
+      option.getAttribute("data-channel") ??
+      (option.textContent ?? "").replace(/Private/g, "").trim()
+    );
+  }
+
+  /** The channels offered for the rule, in the order the picker lists them. */
+  async offeredChannels(): Promise<string[]> {
+    const options = await this.openChannelPicker();
+    const names = options.map(AlertsPageHarness.optionChannelName);
+    await this.closeChannelPicker();
+    return names;
+  }
+
+  /** Whether the channel offered under `name` is presented as private. */
+  async isChannelOfferedAsPrivate(name: string): Promise<boolean> {
+    const options = await this.openChannelPicker();
+    const option = options.find(
+      (candidate) => AlertsPageHarness.optionChannelName(candidate) === name,
+    );
+    await this.closeChannelPicker();
+    return /Private/.test(option?.textContent ?? "");
+  }
+
+  /** Toggle the named channels in the picker, then close it. */
+  async pickChannels(names: string[]): Promise<void> {
+    for (const name of names) {
+      const options = await this.openChannelPicker();
+      const option = options.find(
+        (candidate) => AlertsPageHarness.optionChannelName(candidate) === name,
+      );
+      if (!option) {
+        await this.closeChannelPicker();
+        throw new Error(`pickChannels: no channel named "${name}" is offered`);
+      }
+      await this.clickElement(option, { fallbackToDomClick: true });
+    }
+    await this.closeChannelPicker();
+  }
+
+  /**
+   * The rule's selected channels as the closed field shows them — name and
+   * privacy read from the chip the user sees.
+   */
+  async selectedChannelChips(): Promise<SelectedChannelChip[]> {
+    const field = await this.waitFor(
+      () => this.channelField(),
+      10000,
+      "the channel destination field",
+    );
+    const chips = Array.from(
+      field.querySelectorAll<HTMLElement>("[data-selected-item]"),
+    );
+    return chips.map((chip) => {
+      const text = (chip.textContent ?? "").replace(/\s+/g, " ").trim();
+      return {
+        isPrivate: /Private/.test(text),
+        name: text.replace(/Private/g, "").trim(),
+      };
+    });
+  }
+
+  // --- The alerts list ------------------------------------------------------
+
+  /** The names of the listed rules, in table order. */
+  async listedRules(): Promise<string[]> {
+    const rows = await this.waitFor(
+      () => {
+        const found = Array.from(
+          this.container.querySelectorAll<HTMLTableRowElement>("tbody tr"),
+        );
+        return found.length > 0 ? found : null;
+      },
+      10000,
+      "the alerts list",
+    );
+    return rows.map((row) =>
+      (row.querySelector("button")?.textContent ?? "").trim(),
+    );
+  }
+
+  /**
+   * The destinations summary the list shows for a rule, without opening it —
+   * the Destinations column once S3 lands (Recipients until then).
+   */
+  async ruleDestinationsSummary(ruleName: string): Promise<string> {
+    const headers = Array.from(
+      this.container.querySelectorAll<HTMLElement>("thead th"),
+    );
+    const columnIndex = headers.findIndex((header) =>
+      /Destinations|Recipients/.test(header.textContent ?? ""),
+    );
+    if (columnIndex === -1) {
+      throw new Error("ruleDestinationsSummary: no destinations column");
+    }
+
+    const row = await this.waitFor(
+      () =>
+        Array.from(
+          this.container.querySelectorAll<HTMLTableRowElement>("tbody tr"),
+        ).find((candidate) => (candidate.textContent ?? "").includes(ruleName)),
+      10000,
+      `the listed rule "${ruleName}"`,
+    );
+    const cell = row.querySelectorAll("td")[columnIndex];
+    return (cell?.textContent ?? "").replace(/\s+/g, " ").trim();
+  }
+}

--- a/ui/app/(prowler)/alerts/alerts-page.harness.ts
+++ b/ui/app/(prowler)/alerts/alerts-page.harness.ts
@@ -148,7 +148,14 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
   private modalErrorText(): string | null {
     const dialog = this.dialog();
     if (!dialog) return null;
-    const error = dialog.querySelector<HTMLElement>(".text-text-error-primary");
+    // The error class is shared, and first-in-DOM-order wins: the recipients
+    // read failure and the preview error both render one ABOVE the form-level
+    // message and would shadow it. Only the form-level one is a `div` — every
+    // field-scoped error is a `p` — so prefer that, and keep the broad query
+    // as the fallback for a refusal that never reaches the form level.
+    const error =
+      dialog.querySelector<HTMLElement>("div.text-text-error-primary") ??
+      dialog.querySelector<HTMLElement>(".text-text-error-primary");
     const text = (error?.textContent ?? "").trim();
     return text.length > 0 ? text : null;
   }
@@ -279,6 +286,12 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
       let picked = false;
       for (let attempt = 0; attempt < 3 && !picked; attempt += 1) {
         const options = await this.openPicker("#alert-recipients");
+        // The picker stays open between attempts, so a retry clicking an item
+        // the previous attempt did select would toggle it back off.
+        if (this.isRecipientSelected(email)) {
+          picked = true;
+          break;
+        }
         const option = options.find((candidate) =>
           (candidate.textContent ?? "").includes(email),
         );
@@ -289,10 +302,10 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
         await this.clickElement(option, { fallbackToDomClick: true });
         picked =
           (await this.waitForOrNull(
-            () => this.chipContaining(email),
+            () => this.isRecipientSelected(email),
             2000,
             `the ${email} chip`,
-          )) !== null;
+          )) ?? false;
       }
       if (!picked) {
         throw new Error(`pickRecipients: ${email} never showed as selected`);
@@ -355,12 +368,44 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
     return /Private/.test(option?.textContent ?? "");
   }
 
-  /** A visible chip whose text contains `text`, anywhere in the open form. */
-  private chipContaining(text: string): HTMLElement | null {
+  /**
+   * The text of every selected chip inside `scope`, as the user reads it.
+   * Always scoped to one field: two pickers share the open form, and a
+   * document-wide substring test answers for the wrong one — a private
+   * channel's chip reads `Private#security-alerts`, which contains
+   * `#security`, the name of the other fixture channel.
+   */
+  private static chipTexts(scope: ParentNode): string[] {
+    return Array.from(
+      scope.querySelectorAll<HTMLElement>("[data-selected-item]"),
+    ).map((chip) => (chip.textContent ?? "").replace(/\s+/g, " ").trim());
+  }
+
+  /** The chip renders `#name` with an sr-only "Private" marker. */
+  private static toChannelChip(text: string): SelectedChannelChip {
+    return {
+      isPrivate: /Private/.test(text),
+      name: text
+        .replace(/Private/g, "")
+        .trim()
+        .replace(/^#/, ""),
+    };
+  }
+
+  /** Whether the closed field already shows `name` among its chips. */
+  private isChannelSelected(name: string): boolean {
+    const field = this.channelField();
+    if (!field) return false;
+    return AlertsPageHarness.chipTexts(field)
+      .map(AlertsPageHarness.toChannelChip)
+      .some((chip) => chip.name === name);
+  }
+
+  /** Whether the recipients field already shows `email` among its chips. */
+  private isRecipientSelected(email: string): boolean {
+    const trigger = this.q("#alert-recipients");
     return (
-      Array.from(
-        document.querySelectorAll<HTMLElement>("[data-selected-item]"),
-      ).find((chip) => (chip.textContent ?? "").includes(text)) ?? null
+      trigger !== null && AlertsPageHarness.chipTexts(trigger).includes(email)
     );
   }
 
@@ -374,6 +419,12 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
       let picked = false;
       for (let attempt = 0; attempt < 3 && !picked; attempt += 1) {
         const options = await this.openChannelPicker();
+        // The picker stays open between attempts, so a retry clicking an item
+        // the previous attempt did select would toggle it back off.
+        if (this.isChannelSelected(name)) {
+          picked = true;
+          break;
+        }
         const option = options.find(
           (candidate) =>
             AlertsPageHarness.optionChannelName(candidate) === name,
@@ -387,10 +438,10 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
         await this.clickElement(option, { fallbackToDomClick: true });
         picked =
           (await this.waitForOrNull(
-            () => this.chipContaining(`#${name}`),
+            () => this.isChannelSelected(name),
             2000,
             `the #${name} chip`,
-          )) !== null;
+          )) ?? false;
       }
       if (!picked) {
         throw new Error(`pickChannels: #${name} never showed as selected`);
@@ -409,20 +460,9 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
       10000,
       "the channel destination field",
     );
-    const chips = Array.from(
-      field.querySelectorAll<HTMLElement>("[data-selected-item]"),
+    return AlertsPageHarness.chipTexts(field).map(
+      AlertsPageHarness.toChannelChip,
     );
-    return chips.map((chip) => {
-      const text = (chip.textContent ?? "").replace(/\s+/g, " ").trim();
-      return {
-        isPrivate: /Private/.test(text),
-        // The chip renders `#name` with an sr-only "Private" marker.
-        name: text
-          .replace(/Private/g, "")
-          .trim()
-          .replace(/^#/, ""),
-      };
-    });
   }
 
   // --- The alerts list ------------------------------------------------------

--- a/ui/app/(prowler)/alerts/alerts-page.harness.ts
+++ b/ui/app/(prowler)/alerts/alerts-page.harness.ts
@@ -42,6 +42,26 @@ export interface SelectedChannelChip {
   isPrivate: boolean;
 }
 
+/** A channel as a rule write submits it — the contract's `[{id}, …]` shape. */
+interface RuleWriteChannel {
+  id: string;
+}
+
+interface RuleWriteAttributes {
+  schema_version?: number;
+  slack_channels?: RuleWriteChannel[];
+}
+
+interface RuleWriteData {
+  type?: string;
+  attributes?: RuleWriteAttributes;
+}
+
+/** The envelope an alert rule create or update submits. */
+interface RuleWriteEnvelope {
+  data?: RuleWriteData;
+}
+
 const DEFAULT_CREATE_FILTER_BAG: AlertsFilterBag = {
   "filter[severity__in]": ["critical"],
 };
@@ -165,15 +185,41 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
    * contract's `[{id}, …]` write shape.
    */
   async savedRuleChannels(): Promise<string[] | undefined> {
-    const method =
-      this.countRequests("POST", "/alerts/rules") >
-      this.countRequests("PATCH", "/alerts/rules")
-        ? "POST"
-        : "PATCH";
-    const body = await this.lastRequestBody<{
-      data?: { attributes?: { slack_channels?: { id: string }[] } };
-    }>(method, "/alerts/rules");
+    const body = await this.lastRuleWriteBody();
     return body?.data?.attributes?.slack_channels?.map((channel) => channel.id);
+  }
+
+  /**
+   * The most recent rule write in the request log, picked by payload rather
+   * than by method or path: `/alerts/rules` is a prefix of the seed and
+   * preview endpoints, so a path match — and the POST-vs-PATCH counting it
+   * invites — can resolve to a request that carries no channels. Seed and
+   * preview envelopes declare their own `type`; the enable/disable toggle
+   * reuses both the write's URL and its type, and only a real write carries
+   * `schema_version`.
+   */
+  private async lastRuleWriteBody(): Promise<RuleWriteEnvelope | null> {
+    for (const entry of [...this.requestLog].reverse()) {
+      const body = await AlertsPageHarness.parsedBody(entry.request);
+      if (
+        body?.data?.type === "alert-rules" &&
+        body.data.attributes?.schema_version !== undefined
+      ) {
+        return body;
+      }
+    }
+    return null;
+  }
+
+  /** A request with no body, or one that is not JSON, is not a rule write. */
+  private static async parsedBody(
+    request: Request,
+  ): Promise<RuleWriteEnvelope | null> {
+    try {
+      return (await request.clone().json()) as RuleWriteEnvelope;
+    } catch {
+      return null;
+    }
   }
 
   // --- The channel destination field ---------------------------------------
@@ -466,23 +512,6 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
   }
 
   // --- The alerts list ------------------------------------------------------
-
-  /** The names of the listed rules, in table order. */
-  async listedRules(): Promise<string[]> {
-    const rows = await this.waitFor(
-      () => {
-        const found = Array.from(
-          this.container.querySelectorAll<HTMLTableRowElement>("tbody tr"),
-        );
-        return found.length > 0 ? found : null;
-      },
-      10000,
-      "the alerts list",
-    );
-    return rows.map((row) =>
-      (row.querySelector("button")?.textContent ?? "").trim(),
-    );
-  }
 
   /**
    * The destinations summary the list shows for a rule, without opening it —

--- a/ui/app/(prowler)/alerts/alerts-page.harness.ts
+++ b/ui/app/(prowler)/alerts/alerts-page.harness.ts
@@ -117,6 +117,8 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
   /**
    * Submit the open modal expecting a refusal, and hand back what the user is
    * told. A save that closes the modal fails the test rather than timing out.
+   * Only newly added channels are validated (contract section 6.3), so a
+   * channel refusal needs options that went stale mid-edit.
    */
   async refusedRuleSave(): Promise<string> {
     await this.submitModal();

--- a/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
+++ b/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
@@ -16,6 +16,7 @@ import {
   ALERTS_PRIVATE_CHANNEL,
   ALERTS_PUBLIC_CHANNEL,
   alertRuleFixture,
+  alertsChannelNotConfirmedDetail,
   alertsFixture,
   emptyChannelPoolAlertsFixture,
   noSlackAlertsFixture,
@@ -207,13 +208,45 @@ describe("alert rules target Slack channels", () => {
     ]);
   });
 
-  it("surfaces the refusal when a stored channel is not confirmed and connected", async () => {
+  it("saves an edit that retains channels a reinstall left unconfirmed", async () => {
     const harness = new AlertsPageHarness(reinstalledWorkspaceAlertsFixture());
     await harness.mount();
     await harness.openEditModal(RULE_NAME);
 
+    await harness.saveRule();
+
+    // Only newly added channels are validated, so the retained selection goes
+    // back untouched even though the reinstall confirmed none of it — a rule
+    // never becomes uneditable behind the user's back.
+    expect(await harness.savedRuleChannels()).toEqual([
+      ALERTS_PUBLIC_CHANNEL.id,
+      ALERTS_PRIVATE_CHANNEL.id,
+    ]);
+  });
+
+  it("surfaces the refusal when a channel just added went stale before the save", async () => {
+    const fixture = alertsFixture();
+    const harness = new AlertsPageHarness(fixture);
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+    await harness.pickChannels([ALERTS_PRIVATE_CHANNEL.name]);
+
+    // The picker offered a confirmed channel; the connection state it was
+    // offered on is reset before the submit. Only a channel the user just
+    // added can reach the write ineligible, so this is the one path a refusal
+    // travels.
+    fixture.slackIntegration?.channels.forEach((channel) => {
+      if (channel.id === ALERTS_PRIVATE_CHANNEL.id) {
+        channel.confirmationSentAt = null;
+      }
+    });
+
     const refusal = await harness.refusedRuleSave();
 
-    expect(refusal).toMatch(/Slack must be connected/i);
+    // The modal stays open on the unchanged rule and repeats the API's own
+    // detail, which the UI never parses.
+    expect(refusal).toContain(
+      alertsChannelNotConfirmedDetail(ALERTS_PRIVATE_CHANNEL.id),
+    );
   });
 });

--- a/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
+++ b/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
@@ -191,6 +191,28 @@ describe("alert rules target Slack channels", () => {
     ]);
   });
 
+  it("waits only for the submitted alert modal to close", async () => {
+    // Given
+    const harness = new AlertsPageHarness(alertsFixture());
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+    const unrelatedDialog = document.createElement("div");
+    unrelatedDialog.setAttribute("role", "dialog");
+    unrelatedDialog.setAttribute("aria-label", "Concurrent test dialog");
+    document.body.append(unrelatedDialog);
+
+    try {
+      // When
+      await harness.saveRule();
+
+      // Then
+      expect(await harness.savedRuleChannels()).toEqual([]);
+      expect(unrelatedDialog.isConnected).toBe(true);
+    } finally {
+      unrelatedDialog.remove();
+    }
+  });
+
   it("keeps a stored channel readable after a reinstall reset its confirmation", async () => {
     const harness = new AlertsPageHarness(reinstalledWorkspaceAlertsFixture());
     await harness.mount();

--- a/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
+++ b/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
@@ -21,7 +21,6 @@ import {
   noAuthorizedChannelsAlertsFixture,
   noSlackAlertsFixture,
   reinstalledWorkspaceAlertsFixture,
-  unconfirmedChannelPoolAlertsFixture,
 } from "@/__tests__/msw/handlers/alerts.fixtures";
 
 import { AlertsPageHarness, CHANNEL_FIELD_STATE } from "./alerts-page.harness";
@@ -232,13 +231,26 @@ describe("alert rules target Slack channels", () => {
 
   it("keeps a rule's channels readable when the pool is empty but its own are stored", async () => {
     const harness = new AlertsPageHarness(
-      unconfirmedChannelPoolAlertsFixture(),
+      alertsFixture({
+        // The one reachable route to an empty pool on a connected workspace: a
+        // refused read. A served pool of a `connected: true` install always
+        // holds its confirmed set — the check confirms every channel on it.
+        channelsReadError: 403,
+        rules: [
+          alertRuleFixture({
+            slackChannelIds: [
+              ALERTS_PUBLIC_CHANNEL.id,
+              ALERTS_PRIVATE_CHANNEL.id,
+            ],
+          }),
+        ],
+      }),
     );
     await harness.mount();
     await harness.openEditModal(RULE_NAME);
 
-    // Reachable from backend state alone: the read model enriches from what is
-    // configured, the pool offers only what is confirmed. An empty pool must
+    // The rule's own channels come from the read model, which enriches them
+    // from the integration; the pool is a separate read. An empty pool must
     // not swallow the selection the rule actually holds.
     expect(await harness.channelFieldState()).toBe(
       CHANNEL_FIELD_STATE.EMPTY_POOL,
@@ -248,9 +260,14 @@ describe("alert rules target Slack channels", () => {
       { name: ALERTS_PUBLIC_CHANNEL.name, isPrivate: false },
       { name: ALERTS_PRIVATE_CHANNEL.name, isPrivate: true },
     ]);
-    expect(await harness.channelFieldNotice()).toMatch(/authorize/i);
+    // A refused pool read says nothing about the workspace's channels, so the
+    // copy cannot be the one that asks the user to authorize some.
+    const notice = await harness.channelFieldNotice();
+    expect(notice).toMatch(/could not be checked/i);
+    expect(notice).not.toMatch(/authorize/i);
 
-    // Retained ids are never re-validated, so the unconfirmed pair still saves.
+    // The stored ids reach the write from the disabled picker rather than
+    // being dropped with the pool that no longer offers them.
     await harness.saveRule();
     expect(await harness.savedRuleChannels()).toEqual([
       ALERTS_PUBLIC_CHANNEL.id,
@@ -313,9 +330,11 @@ describe("alert rules target Slack channels", () => {
 
   it("does not claim the workspace is missing when the integration read is refused", async () => {
     // What every non-admin sees: `/integrations` gates even reads behind
-    // `MANAGE_INTEGRATIONS`, off by default, while `/alerts` is not gated.
+    // `MANAGE_INTEGRATIONS`, off by default, while `/alerts` is not gated. On
+    // an unverified workspace, so the pool comes back empty and the field has
+    // to say something about a workspace it could not read.
     const harness = new AlertsPageHarness(
-      unconfirmedChannelPoolAlertsFixture({ integrationsReadError: 403 }),
+      reinstalledWorkspaceAlertsFixture({ integrationsReadError: 403 }),
     );
     await harness.mount();
     await harness.openEditModal(RULE_NAME);

--- a/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
+++ b/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * Browser-mode tests for the Alerts page (`/alerts`) and the alert modal's
+ * Slack channel destinations, driven through `AlertsPageHarness`. MSW answers
+ * from handlers derived from the D3 contract working assumptions
+ * (`openspec/changes/add-slack-alert-channels/design.md`).
+ *
+ * The no-integration and empty-pool states are driven through fixtures that
+ * OMIT the integration or its channels (design D9) — never by handing the UI
+ * a pre-disabled state.
+ */
+
+import { describe, expect } from "vitest";
+
+import { it } from "@/__tests__/fixtures";
+import {
+  ALERTS_PRIVATE_CHANNEL,
+  ALERTS_PUBLIC_CHANNEL,
+  ALERTS_UNAUTHORIZED_CHANNEL,
+  alertRuleFixture,
+  alertsFixture,
+  emptyChannelPoolAlertsFixture,
+  noSlackAlertsFixture,
+  staleChannelAlertsFixture,
+} from "@/__tests__/msw/handlers/alerts.fixtures";
+
+import { AlertsPageHarness, CHANNEL_FIELD_STATE } from "./alerts-page.harness";
+
+const RULE_NAME = "Critical findings";
+
+interface RuleWriteBody {
+  data: { attributes: { recipient_emails?: string[] } };
+}
+
+describe("alert rules target Slack channels", () => {
+  it("creates a rule with channels and an email, keeping both destination kinds", async () => {
+    const harness = new AlertsPageHarness(alertsFixture());
+    harness.mountCreateEntry();
+    await harness.openCreateModal();
+
+    await harness.pickChannels([
+      ALERTS_PUBLIC_CHANNEL.name,
+      ALERTS_PRIVATE_CHANNEL.name,
+    ]);
+    await harness.pickRecipients(["security@example.com"]);
+    await harness.saveRule();
+
+    expect(await harness.savedRuleChannels()).toEqual([
+      ALERTS_PUBLIC_CHANNEL.id,
+      ALERTS_PRIVATE_CHANNEL.id,
+    ]);
+    const body = await harness.lastRequestBody<RuleWriteBody>(
+      "POST",
+      "/alerts/rules",
+    );
+    expect(body?.data.attributes.recipient_emails).toContain(
+      "security@example.com",
+    );
+  });
+
+  it("accepts a rule whose only destinations are channels", async () => {
+    const harness = new AlertsPageHarness(alertsFixture());
+    harness.mountCreateEntry();
+    await harness.openCreateModal();
+
+    await harness.pickChannels([ALERTS_PRIVATE_CHANNEL.name]);
+    await harness.saveRule();
+
+    expect(await harness.savedRuleChannels()).toEqual([
+      ALERTS_PRIVATE_CHANNEL.id,
+    ]);
+    const body = await harness.lastRequestBody<RuleWriteBody>(
+      "POST",
+      "/alerts/rules",
+    );
+    expect(body?.data.attributes.recipient_emails).toEqual([]);
+  });
+
+  it("offers exactly the integration's authorized set", async () => {
+    const harness = new AlertsPageHarness(alertsFixture());
+    harness.mountCreateEntry();
+    await harness.openCreateModal();
+
+    const offered = await harness.offeredChannels();
+
+    expect(offered).toEqual(
+      expect.arrayContaining([
+        ALERTS_PUBLIC_CHANNEL.name,
+        ALERTS_PRIVATE_CHANNEL.name,
+      ]),
+    );
+    expect(offered).toHaveLength(2);
+    expect(offered).not.toContain(ALERTS_UNAUTHORIZED_CHANNEL.name);
+  });
+
+  it("identifies a private channel in the listing and on its chip", async () => {
+    const harness = new AlertsPageHarness(alertsFixture());
+    harness.mountCreateEntry();
+    await harness.openCreateModal();
+
+    expect(
+      await harness.isChannelOfferedAsPrivate(ALERTS_PRIVATE_CHANNEL.name),
+    ).toBe(true);
+    expect(
+      await harness.isChannelOfferedAsPrivate(ALERTS_PUBLIC_CHANNEL.name),
+    ).toBe(false);
+
+    await harness.pickChannels([ALERTS_PRIVATE_CHANNEL.name]);
+
+    expect(await harness.selectedChannelChips()).toEqual([
+      { name: ALERTS_PRIVATE_CHANNEL.name, isPrivate: true },
+    ]);
+  });
+
+  it("says channels must first be authorized when the pool is empty, and still saves", async () => {
+    const harness = new AlertsPageHarness(emptyChannelPoolAlertsFixture());
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+
+    expect(await harness.channelFieldState()).toBe(
+      CHANNEL_FIELD_STATE.EMPTY_POOL,
+    );
+    expect(await harness.channelFieldNotice()).toMatch(/authorized/i);
+    expect(harness.integrationAffordanceHref()).toBe("/integrations/slack");
+
+    // The rule's other fields and destinations still save.
+    await harness.saveRule();
+    expect(await harness.savedRuleChannels()).toEqual([]);
+  });
+
+  it("explains the disabled destination when no workspace is connected", async () => {
+    const harness = new AlertsPageHarness(noSlackAlertsFixture());
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+
+    expect(await harness.channelFieldState()).toBe(
+      CHANNEL_FIELD_STATE.NO_INTEGRATION,
+    );
+    expect(await harness.channelPickerDisabled()).toBe(true);
+    expect(await harness.channelFieldNotice()).toMatch(
+      /connected Slack workspace/i,
+    );
+    expect(harness.integrationAffordanceHref()).toBe("/integrations/slack");
+  });
+
+  it("shows the stored selection, by name and privacy, when editing", async () => {
+    const harness = new AlertsPageHarness(
+      alertsFixture({
+        rules: [
+          alertRuleFixture({
+            slackChannels: [
+              { ...ALERTS_PUBLIC_CHANNEL },
+              { ...ALERTS_PRIVATE_CHANNEL },
+            ],
+          }),
+        ],
+      }),
+    );
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+
+    expect(await harness.channelFieldState()).toBe(
+      CHANNEL_FIELD_STATE.POPULATED,
+    );
+    expect(await harness.selectedChannelChips()).toEqual([
+      { name: ALERTS_PUBLIC_CHANNEL.name, isPrivate: false },
+      { name: ALERTS_PRIVATE_CHANNEL.name, isPrivate: true },
+    ]);
+  });
+
+  it("keeps a rule's channels visible after the workspace is disconnected", async () => {
+    const harness = new AlertsPageHarness(
+      noSlackAlertsFixture({
+        rules: [
+          alertRuleFixture({
+            slackChannels: [
+              { ...ALERTS_PUBLIC_CHANNEL },
+              { ...ALERTS_PRIVATE_CHANNEL },
+            ],
+          }),
+        ],
+      }),
+    );
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+
+    expect(await harness.channelFieldState()).toBe(
+      CHANNEL_FIELD_STATE.NO_INTEGRATION,
+    );
+    expect(await harness.selectedChannelChips()).toEqual([
+      { name: ALERTS_PUBLIC_CHANNEL.name, isPrivate: false },
+      { name: ALERTS_PRIVATE_CHANNEL.name, isPrivate: true },
+    ]);
+    expect(await harness.channelFieldNotice()).toMatch(
+      /unavailable until a Slack workspace is connected/i,
+    );
+  });
+
+  it("keeps a stored channel selected after it leaves the authorized set", async () => {
+    const harness = new AlertsPageHarness(staleChannelAlertsFixture());
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+
+    const chips = await harness.selectedChannelChips();
+    expect(chips.map((chip) => chip.name)).toEqual([
+      ALERTS_PUBLIC_CHANNEL.name,
+      ALERTS_UNAUTHORIZED_CHANNEL.name,
+    ]);
+    // Merged into the options, so deselecting it is the user's explicit act.
+    expect(await harness.offeredChannels()).toContain(
+      ALERTS_UNAUTHORIZED_CHANNEL.name,
+    );
+  });
+
+  it("surfaces the refusal when a saved channel is outside the authorized set", async () => {
+    const harness = new AlertsPageHarness(staleChannelAlertsFixture());
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+
+    const refusal = await harness.refusedRuleSave();
+
+    expect(refusal).toContain(ALERTS_UNAUTHORIZED_CHANNEL.id);
+    expect(refusal).toMatch(/authorized/i);
+  });
+});

--- a/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
+++ b/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
@@ -1,12 +1,12 @@
 /**
  * Browser-mode tests for the Alerts page (`/alerts`) and the alert modal's
  * Slack channel destinations, driven through `AlertsPageHarness`. MSW answers
- * from handlers derived from the D3 contract working assumptions
- * (`openspec/changes/add-slack-alert-channels/design.md`).
+ * from handlers encoding the signed contract
+ * (`openspec/changes/add-slack-alert-channels/contract/slack-alerts-api.md`).
  *
  * The no-integration and empty-pool states are driven through fixtures that
- * OMIT the integration or its channels (design D9) — never by handing the UI
- * a pre-disabled state.
+ * OMIT the integration, its channels or their confirmations (design D9) —
+ * never by handing the UI a pre-disabled state.
  */
 
 import { describe, expect } from "vitest";
@@ -15,12 +15,11 @@ import { it } from "@/__tests__/fixtures";
 import {
   ALERTS_PRIVATE_CHANNEL,
   ALERTS_PUBLIC_CHANNEL,
-  ALERTS_UNAUTHORIZED_CHANNEL,
   alertRuleFixture,
   alertsFixture,
   emptyChannelPoolAlertsFixture,
   noSlackAlertsFixture,
-  staleChannelAlertsFixture,
+  reinstalledWorkspaceAlertsFixture,
 } from "@/__tests__/msw/handlers/alerts.fixtures";
 
 import { AlertsPageHarness, CHANNEL_FIELD_STATE } from "./alerts-page.harness";
@@ -75,7 +74,7 @@ describe("alert rules target Slack channels", () => {
     expect(body?.data.attributes.recipient_emails).toEqual([]);
   });
 
-  it("offers exactly the integration's authorized set", async () => {
+  it("offers exactly the eligible channels", async () => {
     const harness = new AlertsPageHarness(alertsFixture());
     harness.mountCreateEntry();
     await harness.openCreateModal();
@@ -89,7 +88,6 @@ describe("alert rules target Slack channels", () => {
       ]),
     );
     expect(offered).toHaveLength(2);
-    expect(offered).not.toContain(ALERTS_UNAUTHORIZED_CHANNEL.name);
   });
 
   it("identifies a private channel in the listing and on its chip", async () => {
@@ -111,7 +109,7 @@ describe("alert rules target Slack channels", () => {
     ]);
   });
 
-  it("says channels must first be authorized when the pool is empty, and still saves", async () => {
+  it("says channels must be authorized and checked when nothing is eligible, and still saves", async () => {
     const harness = new AlertsPageHarness(emptyChannelPoolAlertsFixture());
     await harness.mount();
     await harness.openEditModal(RULE_NAME);
@@ -119,7 +117,9 @@ describe("alert rules target Slack channels", () => {
     expect(await harness.channelFieldState()).toBe(
       CHANNEL_FIELD_STATE.EMPTY_POOL,
     );
-    expect(await harness.channelFieldNotice()).toMatch(/authorized/i);
+    const notice = await harness.channelFieldNotice();
+    expect(notice).toMatch(/authorize/i);
+    expect(notice).toMatch(/connection check/i);
     expect(harness.integrationAffordanceHref()).toBe("/integrations/slack");
 
     // The rule's other fields and destinations still save.
@@ -136,6 +136,8 @@ describe("alert rules target Slack channels", () => {
       CHANNEL_FIELD_STATE.NO_INTEGRATION,
     );
     expect(await harness.channelPickerDisabled()).toBe(true);
+    // Deleting the workspace deletes the rules' channel mappings with it.
+    expect(await harness.selectedChannelChips()).toEqual([]);
     expect(await harness.channelFieldNotice()).toMatch(
       /connected Slack workspace/i,
     );
@@ -147,9 +149,9 @@ describe("alert rules target Slack channels", () => {
       alertsFixture({
         rules: [
           alertRuleFixture({
-            slackChannels: [
-              { ...ALERTS_PUBLIC_CHANNEL },
-              { ...ALERTS_PRIVATE_CHANNEL },
+            slackChannelIds: [
+              ALERTS_PUBLIC_CHANNEL.id,
+              ALERTS_PRIVATE_CHANNEL.id,
             ],
           }),
         ],
@@ -167,58 +169,51 @@ describe("alert rules target Slack channels", () => {
     ]);
   });
 
-  it("keeps a rule's channels visible after the workspace is disconnected", async () => {
+  it("submits the complete selection, not just the added channel", async () => {
     const harness = new AlertsPageHarness(
-      noSlackAlertsFixture({
+      alertsFixture({
         rules: [
-          alertRuleFixture({
-            slackChannels: [
-              { ...ALERTS_PUBLIC_CHANNEL },
-              { ...ALERTS_PRIVATE_CHANNEL },
-            ],
-          }),
+          alertRuleFixture({ slackChannelIds: [ALERTS_PUBLIC_CHANNEL.id] }),
         ],
       }),
     );
     await harness.mount();
     await harness.openEditModal(RULE_NAME);
 
+    await harness.pickChannels([ALERTS_PRIVATE_CHANNEL.name]);
+    await harness.saveRule();
+
+    expect(await harness.savedRuleChannels()).toEqual([
+      ALERTS_PUBLIC_CHANNEL.id,
+      ALERTS_PRIVATE_CHANNEL.id,
+    ]);
+  });
+
+  it("keeps a stored channel readable after a reinstall reset its confirmation", async () => {
+    const harness = new AlertsPageHarness(reinstalledWorkspaceAlertsFixture());
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+
+    // The workspace still carries both channels, but an unverified install
+    // offers none of them: the options come from the eligible-channels
+    // endpoint, never from the integration's configuration.
     expect(await harness.channelFieldState()).toBe(
       CHANNEL_FIELD_STATE.NO_INTEGRATION,
     );
+    expect(await harness.channelPickerDisabled()).toBe(true);
     expect(await harness.selectedChannelChips()).toEqual([
       { name: ALERTS_PUBLIC_CHANNEL.name, isPrivate: false },
       { name: ALERTS_PRIVATE_CHANNEL.name, isPrivate: true },
     ]);
-    expect(await harness.channelFieldNotice()).toMatch(
-      /unavailable until a Slack workspace is connected/i,
-    );
   });
 
-  it("keeps a stored channel selected after it leaves the authorized set", async () => {
-    const harness = new AlertsPageHarness(staleChannelAlertsFixture());
-    await harness.mount();
-    await harness.openEditModal(RULE_NAME);
-
-    const chips = await harness.selectedChannelChips();
-    expect(chips.map((chip) => chip.name)).toEqual([
-      ALERTS_PUBLIC_CHANNEL.name,
-      ALERTS_UNAUTHORIZED_CHANNEL.name,
-    ]);
-    // Merged into the options, so deselecting it is the user's explicit act.
-    expect(await harness.offeredChannels()).toContain(
-      ALERTS_UNAUTHORIZED_CHANNEL.name,
-    );
-  });
-
-  it("surfaces the refusal when a saved channel is outside the authorized set", async () => {
-    const harness = new AlertsPageHarness(staleChannelAlertsFixture());
+  it("surfaces the refusal when a stored channel is not confirmed and connected", async () => {
+    const harness = new AlertsPageHarness(reinstalledWorkspaceAlertsFixture());
     await harness.mount();
     await harness.openEditModal(RULE_NAME);
 
     const refusal = await harness.refusedRuleSave();
 
-    expect(refusal).toContain(ALERTS_UNAUTHORIZED_CHANNEL.id);
-    expect(refusal).toMatch(/authorized/i);
+    expect(refusal).toMatch(/Slack must be connected/i);
   });
 });

--- a/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
+++ b/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
@@ -362,6 +362,26 @@ describe("alert rules target Slack channels", () => {
     ]);
   });
 
+  it("does not claim the workspace is missing when its integration read rejects", async () => {
+    // Given - The channel read succeeds with an empty eligible pool while the
+    // integration read fails before receiving an HTTP response.
+    const harness = new AlertsPageHarness(
+      reinstalledWorkspaceAlertsFixture({ integrationsNetworkError: true }),
+    );
+    await harness.mount();
+
+    // When
+    await harness.openEditModal(RULE_NAME);
+
+    // Then
+    expect(await harness.channelFieldState()).toBe(
+      CHANNEL_FIELD_STATE.NO_INTEGRATION,
+    );
+    const notice = await harness.channelFieldNotice();
+    expect(notice).toMatch(/could not be checked/i);
+    expect(notice).not.toMatch(/needs a connected Slack workspace/i);
+  });
+
   it("surfaces the refusal when a channel just added went stale before the save", async () => {
     const fixture = alertsFixture();
     const harness = new AlertsPageHarness(fixture);

--- a/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
+++ b/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
@@ -21,6 +21,7 @@ import {
   emptyChannelPoolAlertsFixture,
   noSlackAlertsFixture,
   reinstalledWorkspaceAlertsFixture,
+  unconfirmedChannelPoolAlertsFixture,
 } from "@/__tests__/msw/handlers/alerts.fixtures";
 
 import { AlertsPageHarness, CHANNEL_FIELD_STATE } from "./alerts-page.harness";
@@ -221,6 +222,108 @@ describe("alert rules target Slack channels", () => {
     expect(await harness.savedRuleChannels()).toEqual([
       ALERTS_PUBLIC_CHANNEL.id,
       ALERTS_PRIVATE_CHANNEL.id,
+    ]);
+  });
+
+  it("keeps a rule's channels readable when the pool is empty but its own are stored", async () => {
+    const harness = new AlertsPageHarness(
+      unconfirmedChannelPoolAlertsFixture(),
+    );
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+
+    // Reachable from backend state alone: the read model enriches from what is
+    // configured, the pool offers only what is confirmed. An empty pool must
+    // not swallow the selection the rule actually holds.
+    expect(await harness.channelFieldState()).toBe(
+      CHANNEL_FIELD_STATE.EMPTY_POOL,
+    );
+    expect(await harness.channelPickerDisabled()).toBe(true);
+    expect(await harness.selectedChannelChips()).toEqual([
+      { name: ALERTS_PUBLIC_CHANNEL.name, isPrivate: false },
+      { name: ALERTS_PRIVATE_CHANNEL.name, isPrivate: true },
+    ]);
+    expect(await harness.channelFieldNotice()).toMatch(/authorize/i);
+
+    // Retained ids are never re-validated, so the unconfirmed pair still saves.
+    await harness.saveRule();
+    expect(await harness.savedRuleChannels()).toEqual([
+      ALERTS_PUBLIC_CHANNEL.id,
+      ALERTS_PRIVATE_CHANNEL.id,
+    ]);
+  });
+
+  it("settles, and claims nothing, when the channels read fails outright", async () => {
+    const harness = new AlertsPageHarness(
+      alertsFixture({
+        channelsReadError: 500,
+        rules: [
+          alertRuleFixture({
+            slackChannelIds: [
+              ALERTS_PUBLIC_CHANNEL.id,
+              ALERTS_PRIVATE_CHANNEL.id,
+            ],
+          }),
+        ],
+      }),
+    );
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+
+    // A `5xx` throws out of the action and rejects the mount's read. Reading
+    // the state at all is the assertion: the loading skeleton stamps no
+    // `data-alert-channels-state`, so an unguarded rejection times out here.
+    expect(await harness.channelFieldState()).toBe(
+      CHANNEL_FIELD_STATE.NO_INTEGRATION,
+    );
+    expect(await harness.channelPickerDisabled()).toBe(true);
+    expect(await harness.selectedChannelChips()).toEqual([
+      { name: ALERTS_PUBLIC_CHANNEL.name, isPrivate: false },
+      { name: ALERTS_PRIVATE_CHANNEL.name, isPrivate: true },
+    ]);
+
+    // The tenant's workspace is connected. A read that failed cannot say so
+    // either way, so the copy says neither.
+    const notice = await harness.channelFieldNotice();
+    expect(notice).toMatch(/could not be checked/i);
+    expect(notice).not.toMatch(/needs a connected Slack workspace/i);
+  });
+
+  it("does not blame an empty pool when the channels read was refused", async () => {
+    const harness = new AlertsPageHarness(
+      alertsFixture({ channelsReadError: 403 }),
+    );
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+
+    expect(await harness.channelFieldState()).toBe(
+      CHANNEL_FIELD_STATE.EMPTY_POOL,
+    );
+    // Channels may well be authorized and confirmed — the read never said.
+    const notice = await harness.channelFieldNotice();
+    expect(notice).toMatch(/could not be checked/i);
+    expect(notice).not.toMatch(/authorize/i);
+    expect(harness.integrationAffordanceHref()).toBe("/integrations/slack");
+  });
+
+  it("does not claim the workspace is missing when the integration read is refused", async () => {
+    // What every non-admin sees: `/integrations` gates even reads behind
+    // `MANAGE_INTEGRATIONS`, off by default, while `/alerts` is not gated.
+    const harness = new AlertsPageHarness(
+      unconfirmedChannelPoolAlertsFixture({ integrationsReadError: 403 }),
+    );
+    await harness.mount();
+    await harness.openEditModal(RULE_NAME);
+
+    expect(await harness.channelFieldState()).toBe(
+      CHANNEL_FIELD_STATE.NO_INTEGRATION,
+    );
+    const notice = await harness.channelFieldNotice();
+    expect(notice).toMatch(/could not be checked/i);
+    expect(notice).not.toMatch(/needs a connected Slack workspace/i);
+    expect(await harness.selectedChannelChips()).toEqual([
+      { name: ALERTS_PUBLIC_CHANNEL.name, isPrivate: false },
+      { name: ALERTS_PRIVATE_CHANNEL.name, isPrivate: true },
     ]);
   });
 

--- a/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
+++ b/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
@@ -18,7 +18,7 @@ import {
   alertRuleFixture,
   alertsChannelNotConfirmedDetail,
   alertsFixture,
-  emptyChannelPoolAlertsFixture,
+  noAuthorizedChannelsAlertsFixture,
   noSlackAlertsFixture,
   reinstalledWorkspaceAlertsFixture,
   unconfirmedChannelPoolAlertsFixture,
@@ -111,17 +111,22 @@ describe("alert rules target Slack channels", () => {
     ]);
   });
 
-  it("says channels must be authorized and checked when nothing is eligible, and still saves", async () => {
-    const harness = new AlertsPageHarness(emptyChannelPoolAlertsFixture());
+  it("says the check has not run when the workspace has no channels, and still saves", async () => {
+    const harness = new AlertsPageHarness(noAuthorizedChannelsAlertsFixture());
     await harness.mount();
     await harness.openEditModal(RULE_NAME);
 
+    // A workspace with nothing authorized cannot have passed a check — the
+    // check requires a configured channel — so the field reads as unverified
+    // rather than as a connected workspace whose eligible pool came back empty.
     expect(await harness.channelFieldState()).toBe(
-      CHANNEL_FIELD_STATE.EMPTY_POOL,
+      CHANNEL_FIELD_STATE.NO_INTEGRATION,
     );
+    expect(await harness.channelPickerDisabled()).toBe(true);
     const notice = await harness.channelFieldNotice();
-    expect(notice).toMatch(/authorize/i);
     expect(notice).toMatch(/connection check/i);
+    // The tenant does have a workspace; only the check is missing.
+    expect(notice).not.toMatch(/needs a connected Slack workspace/i);
     expect(harness.integrationAffordanceHref()).toBe("/integrations/slack");
 
     // The rule's other fields and destinations still save.

--- a/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
+++ b/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
@@ -1,12 +1,10 @@
 /**
- * Browser-mode tests for the Alerts page (`/alerts`) and the alert modal's
- * Slack channel destinations, driven through `AlertsPageHarness`. MSW answers
- * from handlers encoding the signed contract
+ * Browser-mode tests for the Alerts page and the alert modal's Slack channel
+ * destinations. MSW answers from the signed contract
  * (`openspec/changes/add-slack-alert-channels/contract/slack-alerts-api.md`).
  *
- * The no-integration and empty-pool states are driven through fixtures that
- * OMIT the integration, its channels or their confirmations (design D9) —
- * never by handing the UI a pre-disabled state.
+ * Degraded states come from fixtures that OMIT the integration, its channels
+ * or their confirmations (design D9) — never from a pre-disabled state.
  */
 
 import { describe, expect } from "vitest";
@@ -115,9 +113,8 @@ describe("alert rules target Slack channels", () => {
     await harness.mount();
     await harness.openEditModal(RULE_NAME);
 
-    // A workspace with nothing authorized cannot have passed a check — the
-    // check requires a configured channel — so the field reads as unverified
-    // rather than as a connected workspace whose eligible pool came back empty.
+    // Nothing authorized means the check cannot have passed (it requires a
+    // configured channel), so the field reads unverified, not empty-pool.
     expect(await harness.channelFieldState()).toBe(
       CHANNEL_FIELD_STATE.NO_INTEGRATION,
     );
@@ -128,7 +125,6 @@ describe("alert rules target Slack channels", () => {
     expect(notice).not.toMatch(/needs a connected Slack workspace/i);
     expect(harness.integrationAffordanceHref()).toBe("/integrations/slack");
 
-    // The rule's other fields and destinations still save.
     await harness.saveRule();
     expect(await harness.savedRuleChannels()).toEqual([]);
   });
@@ -200,9 +196,8 @@ describe("alert rules target Slack channels", () => {
     await harness.mount();
     await harness.openEditModal(RULE_NAME);
 
-    // The workspace still carries both channels, but an unverified install
-    // offers none of them: the options come from the eligible-channels
-    // endpoint, never from the integration's configuration.
+    // An unverified install still carries both channels but offers none: the
+    // options come from the eligible-channels endpoint, not the integration.
     expect(await harness.channelFieldState()).toBe(
       CHANNEL_FIELD_STATE.NO_INTEGRATION,
     );
@@ -221,8 +216,7 @@ describe("alert rules target Slack channels", () => {
     await harness.saveRule();
 
     // Only newly added channels are validated, so the retained selection goes
-    // back untouched even though the reinstall confirmed none of it — a rule
-    // never becomes uneditable behind the user's back.
+    // back untouched even though the reinstall confirmed none of it.
     expect(await harness.savedRuleChannels()).toEqual([
       ALERTS_PUBLIC_CHANNEL.id,
       ALERTS_PRIVATE_CHANNEL.id,
@@ -232,9 +226,8 @@ describe("alert rules target Slack channels", () => {
   it("keeps a rule's channels readable when the pool is empty but its own are stored", async () => {
     const harness = new AlertsPageHarness(
       alertsFixture({
-        // The one reachable route to an empty pool on a connected workspace: a
-        // refused read. A served pool of a `connected: true` install always
-        // holds its confirmed set — the check confirms every channel on it.
+        // The one reachable route to an empty pool on a connected workspace:
+        // a refused read — a served pool always holds its confirmed set.
         channelsReadError: 403,
         rules: [
           alertRuleFixture({
@@ -249,9 +242,8 @@ describe("alert rules target Slack channels", () => {
     await harness.mount();
     await harness.openEditModal(RULE_NAME);
 
-    // The rule's own channels come from the read model, which enriches them
-    // from the integration; the pool is a separate read. An empty pool must
-    // not swallow the selection the rule actually holds.
+    // The rule's own channels come from the read model, enriched from the
+    // integration; the pool is a separate read.
     expect(await harness.channelFieldState()).toBe(
       CHANNEL_FIELD_STATE.EMPTY_POOL,
     );
@@ -260,8 +252,8 @@ describe("alert rules target Slack channels", () => {
       { name: ALERTS_PUBLIC_CHANNEL.name, isPrivate: false },
       { name: ALERTS_PRIVATE_CHANNEL.name, isPrivate: true },
     ]);
-    // A refused pool read says nothing about the workspace's channels, so the
-    // copy cannot be the one that asks the user to authorize some.
+    // A refused read says nothing about the workspace's channels, so the copy
+    // cannot ask the user to authorize some.
     const notice = await harness.channelFieldNotice();
     expect(notice).toMatch(/could not be checked/i);
     expect(notice).not.toMatch(/authorize/i);
@@ -292,9 +284,9 @@ describe("alert rules target Slack channels", () => {
     await harness.mount();
     await harness.openEditModal(RULE_NAME);
 
-    // A `5xx` throws out of the action and rejects the mount's read. Reading
-    // the state at all is the assertion: the loading skeleton stamps no
-    // `data-alert-channels-state`, so an unguarded rejection times out here.
+    // A `5xx` throws out of the action. Reading the state at all is the
+    // assertion: the loading skeleton stamps no `data-alert-channels-state`,
+    // so an unguarded rejection times out here.
     expect(await harness.channelFieldState()).toBe(
       CHANNEL_FIELD_STATE.NO_INTEGRATION,
     );
@@ -304,8 +296,7 @@ describe("alert rules target Slack channels", () => {
       { name: ALERTS_PRIVATE_CHANNEL.name, isPrivate: true },
     ]);
 
-    // The tenant's workspace is connected. A read that failed cannot say so
-    // either way, so the copy says neither.
+    // The workspace is connected, but a failed read cannot say so either way.
     const notice = await harness.channelFieldNotice();
     expect(notice).toMatch(/could not be checked/i);
     expect(notice).not.toMatch(/needs a connected Slack workspace/i);
@@ -321,7 +312,6 @@ describe("alert rules target Slack channels", () => {
     expect(await harness.channelFieldState()).toBe(
       CHANNEL_FIELD_STATE.EMPTY_POOL,
     );
-    // Channels may well be authorized and confirmed — the read never said.
     const notice = await harness.channelFieldNotice();
     expect(notice).toMatch(/could not be checked/i);
     expect(notice).not.toMatch(/authorize/i);
@@ -330,9 +320,8 @@ describe("alert rules target Slack channels", () => {
 
   it("does not claim the workspace is missing when the integration read is refused", async () => {
     // What every non-admin sees: `/integrations` gates even reads behind
-    // `MANAGE_INTEGRATIONS`, off by default, while `/alerts` is not gated. On
-    // an unverified workspace, so the pool comes back empty and the field has
-    // to say something about a workspace it could not read.
+    // `MANAGE_INTEGRATIONS`, off by default, while `/alerts` is not — layered
+    // on an unverified workspace, so the pool comes back empty too.
     const harness = new AlertsPageHarness(
       reinstalledWorkspaceAlertsFixture({ integrationsReadError: 403 }),
     );
@@ -358,10 +347,9 @@ describe("alert rules target Slack channels", () => {
     await harness.openEditModal(RULE_NAME);
     await harness.pickChannels([ALERTS_PRIVATE_CHANNEL.name]);
 
-    // The picker offered a confirmed channel; the connection state it was
-    // offered on is reset before the submit. Only a channel the user just
-    // added can reach the write ineligible, so this is the one path a refusal
-    // travels.
+    // The picker offered a confirmed channel; its confirmation is reset before
+    // the submit. Only a just-added channel can reach the write ineligible, so
+    // this is the one path a refusal travels.
     fixture.slackIntegration?.channels.forEach((channel) => {
       if (channel.id === ALERTS_PRIVATE_CHANNEL.id) {
         channel.confirmationSentAt = null;
@@ -370,8 +358,7 @@ describe("alert rules target Slack channels", () => {
 
     const refusal = await harness.refusedRuleSave();
 
-    // The modal stays open on the unchanged rule and repeats the API's own
-    // detail, which the UI never parses.
+    // The refusal repeats the API's own detail, which the UI never parses.
     expect(refusal).toContain(
       alertsChannelNotConfirmedDetail(ALERTS_PRIVATE_CHANNEL.id),
     );

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
@@ -12,6 +12,7 @@ import { isProwlerFindingNode } from "./_lib";
 import type { PageFixture } from "./attack-paths-page.fixtures";
 
 export class AttackPathPageHarness extends BrowserHarness<PageFixture> {
+  private static readonly FLOW_SEL = ".react-flow";
   private static readonly NODE_SEL = ".react-flow__node";
   private static readonly EDGE_SEL = ".react-flow__edge";
   private static readonly VIEWPORT_SEL = ".react-flow__viewport";
@@ -243,10 +244,9 @@ export class AttackPathPageHarness extends BrowserHarness<PageFixture> {
   }
 
   /**
-   * Inline `transform` of the React Flow viewport element. This is the
-   * pan/zoom matrix React Flow rewrites on every fit/zoom/pan, so comparing
-   * it before vs. after a user action is enough to assert that the viewport
-   * actually moved (or stayed put).
+   * Inline `transform` of the React Flow viewport element. Compare transforms
+   * only when the scenario guarantees different final camera positions; an
+   * unchanged transform does not prove that a fit operation did not run.
    */
   get viewportTransform(): string {
     return this.viewport?.style.transform ?? "";
@@ -258,6 +258,31 @@ export class AttackPathPageHarness extends BrowserHarness<PageFixture> {
     timeoutMs = 2000,
   ): Promise<void> {
     await this.waitFor(() => this.viewportTransform !== previous, timeoutMs);
+  }
+
+  /** Wait until every requested node is fully contained in the graph canvas. */
+  async waitForNodesInViewport(
+    nodeIds: string[],
+    timeoutMs = 2000,
+  ): Promise<void> {
+    await this.waitFor(() => {
+      const canvas = this.q(AttackPathPageHarness.FLOW_SEL);
+      if (!canvas) return false;
+
+      const canvasRect = canvas.getBoundingClientRect();
+      return nodeIds.every((nodeId) => {
+        const node = this.getNodeById(nodeId);
+        if (!node) return false;
+
+        const nodeRect = node.getBoundingClientRect();
+        return (
+          nodeRect.left >= canvasRect.left &&
+          nodeRect.right <= canvasRect.right &&
+          nodeRect.top >= canvasRect.top &&
+          nodeRect.bottom <= canvasRect.bottom
+        );
+      });
+    }, timeoutMs);
   }
 
   /** Wait until exactly `count` edges are highlighted. */

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.integration.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.integration.test.tsx
@@ -446,9 +446,14 @@ describe("exploring the graph", () => {
   test("Back to Full View restores the graph and keeps the expanded findings context fitted", async ({
     mountWith,
   }) => {
-    const graph = await mountWith(fixtures.large(20));
+    const fixture = fixtures.large(20);
+    const graph = await mountWith(fixture);
     await graph.executeQuery();
     await graph.waitForGraphStable(16);
+
+    const fullGraphResourceIds = (fixture.queryResult?.nodes ?? [])
+      .filter((node) => !isProwlerFindingNode(node.labels))
+      .map((node) => node.id);
 
     const expandedResource = await graph.clickFirstResourceNode();
     const expandedResourceId = expandedResource.getAttribute("data-id");
@@ -458,19 +463,21 @@ describe("exploring the graph", () => {
       .map((node) => node.getAttribute("data-id"))
       .filter((id): id is string => id !== null);
     const contextualNodeIds = [expandedResourceId!, ...expandedFindingIds];
+    const expectedVisibleNodeIds = [
+      ...fullGraphResourceIds,
+      ...expandedFindingIds,
+    ].sort();
     expect(graph.findingNodes.length).toBeGreaterThan(0);
 
     await graph.clickFirstFindingNode();
     expect(graph.isInFilteredView).toBe(true);
 
     await graph.exitFilteredView();
-    await graph.waitForGraphStable(16);
+    await graph.waitForGraphStable(expectedVisibleNodeIds.length);
     await graph.waitForNodesInViewport(contextualNodeIds);
 
     expect(graph.isInFilteredView).toBe(false);
-    expect(graph.renderedNodeIds).toEqual(
-      expect.arrayContaining(contextualNodeIds),
-    );
+    expect(graph.renderedNodeIds.sort()).toEqual(expectedVisibleNodeIds);
   });
   test("clicking a resource without findings does nothing", async ({
     mountWith,
@@ -488,21 +495,6 @@ describe("exploring the graph", () => {
     expect(graph.findingNodes.length).toBe(0);
     expect(graph.hasNodeDetailsModal).toBe(false);
     expect(graph.hasNodeActionDialog).toBe(false);
-  });
-
-  test("exiting the filtered view restores the full graph", async ({
-    mountWith,
-  }) => {
-    const graph = await mountWith();
-    await graph.executeQuery();
-    await graph.waitForGraphStable(3);
-    await graph.expandAllFindings();
-
-    const fullNodes = graph.nodes.length;
-    await graph.clickFirstFindingNode();
-    await graph.exitFilteredView();
-    await graph.waitForGraphStable(fullNodes);
-    expect(graph.isInFilteredView).toBe(false);
   });
 
   test("hovering a node highlights its path edges", async ({ mountWith }) => {

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.integration.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.integration.test.tsx
@@ -443,25 +443,34 @@ describe("exploring the graph", () => {
     await graph.waitForViewportChange(expandedViewport);
   });
 
-  test("returning from a finding keeps the expanded findings context fitted", async ({
+  test("Back to Full View restores the graph and keeps the expanded findings context fitted", async ({
     mountWith,
   }) => {
     const graph = await mountWith(fixtures.large(20));
     await graph.executeQuery();
     await graph.waitForGraphStable(16);
 
-    await graph.clickFirstResourceNode();
+    const expandedResource = await graph.clickFirstResourceNode();
+    const expandedResourceId = expandedResource.getAttribute("data-id");
+    expect(expandedResourceId).toBeTruthy();
+
+    const expandedFindingIds = graph.findingNodes
+      .map((node) => node.getAttribute("data-id"))
+      .filter((id): id is string => id !== null);
+    const contextualNodeIds = [expandedResourceId!, ...expandedFindingIds];
     expect(graph.findingNodes.length).toBeGreaterThan(0);
 
     await graph.clickFirstFindingNode();
     expect(graph.isInFilteredView).toBe(true);
 
     await graph.exitFilteredView();
+    await graph.waitForGraphStable(16);
+    await graph.waitForNodesInViewport(contextualNodeIds);
 
     expect(graph.isInFilteredView).toBe(false);
-
-    expect(graph.findingNodes.length).toBeGreaterThan(0);
-    expect(graph.viewportTransform).toBeTruthy();
+    expect(graph.renderedNodeIds).toEqual(
+      expect.arrayContaining(contextualNodeIds),
+    );
   });
   test("clicking a resource without findings does nothing", async ({
     mountWith,
@@ -635,27 +644,6 @@ describe("auto-fitting the viewport", () => {
     await graph.waitForViewportChange(beforeFilter);
 
     expect(graph.viewportTransform).not.toBe(beforeFilter);
-  });
-
-  test("Back to Full View re-fits the viewport for the full graph", async ({
-    mountWith,
-  }) => {
-    const graph = await mountWith();
-    await graph.executeQuery();
-    await graph.waitForGraphStable(3);
-    await graph.expandAllFindings();
-
-    const beforeFilter = graph.viewportTransform;
-    await graph.clickFirstFindingNode();
-    expect(graph.isInFilteredView).toBe(true);
-    await graph.waitForViewportChange(beforeFilter);
-    const filterT = graph.viewportTransform;
-
-    await graph.exitFilteredView();
-    await graph.waitForGraphStable(3);
-    await graph.waitForViewportChange(filterT);
-
-    expect(graph.viewportTransform).not.toBe(filterT);
   });
 });
 

--- a/ui/changelog.d/alert-slack-channel-destinations.added.md
+++ b/ui/changelog.d/alert-slack-channel-destinations.added.md
@@ -1,1 +1,1 @@
-Slack channels from the integration's authorized set as alert rule destinations, selectable in the alert modal alongside email recipients
+Slack channels confirmed on the Slack integration as alert rule destinations, selectable in the alert modal alongside email recipients

--- a/ui/changelog.d/alert-slack-channel-destinations.added.md
+++ b/ui/changelog.d/alert-slack-channel-destinations.added.md
@@ -1,0 +1,1 @@
+Slack channels from the integration's authorized set as alert rule destinations, selectable in the alert modal alongside email recipients

--- a/ui/components/integrations/slack/slack-channel-multi-select.tsx
+++ b/ui/components/integrations/slack/slack-channel-multi-select.tsx
@@ -34,6 +34,8 @@ interface SlackChannelMultiSelectProps {
   onRefresh?: () => void;
   disabled?: boolean;
   id?: string;
+  /** Element explaining the picker — a caller's reason for disabling it. */
+  describedBy?: string;
 }
 
 const chipLabel = (option: SlackChannelOption) => (
@@ -59,6 +61,7 @@ export const SlackChannelMultiSelect = ({
   onRefresh,
   disabled = false,
   id = "slack-channels",
+  describedBy,
 }: SlackChannelMultiSelectProps) => {
   const isEmpty = !isLoading && !error && options.length === 0;
   // `htmlFor` may only name an element that exists, and the trigger is only
@@ -118,6 +121,7 @@ export const SlackChannelMultiSelect = ({
             <MultiSelectTrigger
               id={id}
               aria-label="Destination channels"
+              aria-describedby={describedBy}
               disabled={disabled || isLoading}
             >
               <MultiSelectValue


### PR DESCRIPTION
### Context

Slice S2 of the OpenSpec change `add-slack-alert-channels`. An alert rule can now name Slack channels — drawn from the eligible set of the integration built in #12491 — as destinations, from the same modal where email recipients are chosen. Stacked on #12491; S3 (destinations column) and the docs rework stack on top. Reworked in place to the **signed API contract** (2026-08-20).

### Description

- New `SlackChannelsField` in the alerts feature: options come from the contract's dedicated endpoint via `getAlertSlackChannels` (`GET /api/v1/alerts/slack-channels`, JSON:API `type: "slack-channels"`, no Slack round-trip); the integration read remains only to tell the no-integration disabled state (tooltip + link to `/integrations/slack`) from an empty pool (notice pointing at authorizing channels **and** running the connection check — only confirmed channels are eligible).
- Rule writes send `slack_channels: [{id}, …]` — objects carrying only the id; POST omission defaults to `[]`, PATCH omission leaves the destination unchanged, `[]` clears it, a supplied list replaces the selection atomically.
- Form model per the change's design D5: the `method` literal and `ALERT_NOTIFICATION_METHODS` are removed (destinations are the truth); `slackChannels` joins `AlertFormValues` and the Zod schema.
- Edit path: stored channels shown selected by name and privacy from the rule read. Stale/disconnected leftovers no longer exist — de-authorizing a channel or disconnecting Slack removes it from rules server-side (same transaction) — so those states are gone from UI, fixtures and tests; the one API-producible absence (a stored channel awaiting re-confirmation after a workspace reinstall) still renders from the rule read.
- Refusals on the signed shape (2026-08-21, contract §6 addendum): every ineligible channel selection answers **400** with `code: slack_channel_not_eligible`; rule PATCH validates **only newly added** channels, so a reinstall that reset confirmations never blocks editing a rule that retains them; the eligible listing is confirmed-only by contract. `recipient_emails_out` handling verified absent. No `TODO(Josema)` remains.
- First page-level integration scaffolding for alerts: MSW `alerts.ts` handlers + fixtures (degraded states driven by omission), `alerts-page.harness.ts`, `alerts-page.integration.test.tsx`.

### Steps to review

1. `cd ui && pnpm install && pnpm test alerts-page.integration` and `pnpm test alert-form-modal`.
2. With a connected workspace (MSW/dev): create a rule from Findings → seed alert; pick two channels (one private) plus an email → rule saves with both destination kinds; reopen → channels selected, private one tagged with the listing closed.
3. Remove the Slack integration fixture → the channels field renders disabled with the tooltip and a working `/integrations/slack` affordance; with an integration but no eligible channels → the notice pointing at authorize + connection check.
4. Submit an ineligible channel (fixture) → the refusal is surfaced, stored channels unchanged.

### Checklist

- [x] Review if the code is being covered by tests.
- [ ] Review if backport is needed.
- [x] Ensure a changelog fragment is added under <component>/changelog.d/, if applicable.

#### UI

- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under ui/changelog.d/

Screenshots land before this PR is promoted from draft (stack rule: drafts on non-master bases skip the full check set).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack channel destinations for alert rules alongside email recipients.
  * Added channel selection, validation, and helpful states for unavailable, unauthorized, or unconfirmed Slack channels.
  * Preserved selected Slack channels when editing existing alert rules.

* **Bug Fixes**
  * Improved error handling when integration or channel data cannot be loaded.
  * Prevented invalid, duplicate, or empty channel selections from being submitted.

* **Tests**
  * Added comprehensive coverage for Slack channel selection, integration states, editing, validation, and rejected saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->