### PR TITLE
feat(ui): show a rule's destinations in the alerts list

### DIFF
--- a/ui/app/(prowler)/alerts/_components/alerts-table.tsx
+++ b/ui/app/(prowler)/alerts/_components/alerts-table.tsx
@@ -35,10 +35,7 @@ const summarize = (first: string, count: number): string | null => {
   return `${first} +${count - 1} more`;
 };
 
-/**
- * One compact answer to "where does this go?" (design D6): the email summary
- * and the channel summary side by side, either omitted when empty.
- */
+/** Both destination kinds share one compact cell (design D6). */
 const formatDestinations = (alert: AlertRule): string => {
   const recipients = alert.attributes.recipient_emails ?? [];
   const channels = alert.attributes.slack_channels ?? [];

--- a/ui/app/(prowler)/alerts/_components/alerts-table.tsx
+++ b/ui/app/(prowler)/alerts/_components/alerts-table.tsx
@@ -29,11 +29,26 @@ const TRIGGER_LABELS = {
   both: "After scan and daily",
 } as const satisfies Record<AlertRule["attributes"]["trigger"], string>;
 
-const formatRecipients = (alert: AlertRule): string => {
+const summarize = (first: string, count: number): string | null => {
+  if (count === 0) return null;
+  if (count === 1) return first;
+  return `${first} +${count - 1} more`;
+};
+
+/**
+ * One compact answer to "where does this go?" (design D6): the email summary
+ * and the channel summary side by side, either omitted when empty.
+ */
+const formatDestinations = (alert: AlertRule): string => {
   const recipients = alert.attributes.recipient_emails ?? [];
-  if (recipients.length === 0) return "No recipients";
-  if (recipients.length === 1) return recipients[0];
-  return `${recipients[0]} +${recipients.length - 1} more`;
+  const channels = alert.attributes.slack_channels ?? [];
+
+  const summaries = [
+    summarize(recipients[0], recipients.length),
+    summarize(channels[0] ? `#${channels[0].name}` : "", channels.length),
+  ].filter((summary): summary is string => summary !== null);
+
+  return summaries.length > 0 ? summaries.join(" · ") : "No destinations";
 };
 
 interface GetAlertsTableColumnsOptions {
@@ -148,14 +163,14 @@ const getAlertsTableColumns = ({
     cell: ({ row }) => TRIGGER_LABELS[row.original.attributes.trigger],
   },
   {
-    id: "recipients",
+    id: "destinations",
     size: 220,
     minSize: 180,
-    accessorFn: (alert) => formatRecipients(alert),
+    accessorFn: (alert) => formatDestinations(alert),
     header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Recipients" />
+      <DataTableColumnHeader column={column} title="Destinations" />
     ),
-    cell: ({ row }) => formatRecipients(row.original),
+    cell: ({ row }) => formatDestinations(row.original),
   },
   {
     id: "inserted_at",

--- a/ui/app/(prowler)/alerts/_components/alerts-table.tsx
+++ b/ui/app/(prowler)/alerts/_components/alerts-table.tsx
@@ -166,6 +166,7 @@ const getAlertsTableColumns = ({
     id: "destinations",
     size: 220,
     minSize: 180,
+    enableSorting: false,
     accessorFn: (alert) => formatDestinations(alert),
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Destinations" />

--- a/ui/app/(prowler)/alerts/alerts-page.harness.ts
+++ b/ui/app/(prowler)/alerts/alerts-page.harness.ts
@@ -473,14 +473,16 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
       /Destinations/.test(header.textContent ?? ""),
     );
     if (columnIndex === -1) {
-      throw new Error("ruleDestinationsSummary: no destinations column");
+      throw new Error("ruleDestinationsSummary: no alerts table");
     }
 
     const row = await this.waitFor(
       () =>
         Array.from(
-          this.container.querySelectorAll<HTMLTableRowElement>("tbody tr"),
-        ).find((candidate) => (candidate.textContent ?? "").includes(ruleName)),
+          this.container.querySelectorAll<HTMLButtonElement>("tbody tr button"),
+        )
+          .find((button) => (button.textContent ?? "").trim() === ruleName)
+          ?.closest("tr") ?? null,
       10000,
       `the listed rule "${ruleName}"`,
     );

--- a/ui/app/(prowler)/alerts/alerts-page.harness.ts
+++ b/ui/app/(prowler)/alerts/alerts-page.harness.ts
@@ -464,16 +464,13 @@ export class AlertsPageHarness extends BrowserHarness<AlertsFixture> {
 
   // --- The alerts list ------------------------------------------------------
 
-  /**
-   * No caller on this branch: the Destinations column lands in S3
-   * (`feature/alerts-destinations-column`), which consumes this. Not dead code.
-   */
+  /** The destinations summary the list shows for a rule, without opening it. */
   async ruleDestinationsSummary(ruleName: string): Promise<string> {
     const headers = Array.from(
       this.container.querySelectorAll<HTMLElement>("thead th"),
     );
     const columnIndex = headers.findIndex((header) =>
-      /Destinations|Recipients/.test(header.textContent ?? ""),
+      /Destinations/.test(header.textContent ?? ""),
     );
     if (columnIndex === -1) {
       throw new Error("ruleDestinationsSummary: no destinations column");

--- a/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
+++ b/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
@@ -413,9 +413,9 @@ describe("the alerts list shows destinations", () => {
       alertsFixture({
         rules: [
           alertRuleFixture({
-            slackChannels: [
-              { ...ALERTS_PUBLIC_CHANNEL },
-              { ...ALERTS_PRIVATE_CHANNEL },
+            slackChannelIds: [
+              ALERTS_PUBLIC_CHANNEL.id,
+              ALERTS_PRIVATE_CHANNEL.id,
             ],
           }),
         ],
@@ -437,7 +437,7 @@ describe("the alerts list shows destinations", () => {
             id: "rule-channels",
             name: "Channels only",
             recipientEmails: [],
-            slackChannels: [{ ...ALERTS_PRIVATE_CHANNEL }],
+            slackChannelIds: [ALERTS_PRIVATE_CHANNEL.id],
           }),
           alertRuleFixture({
             id: "rule-none",

--- a/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
+++ b/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
@@ -428,7 +428,7 @@ describe("the alerts list shows destinations", () => {
     );
   });
 
-  it("reads correctly for emails-only, channels-only and empty rules", async () => {
+  it("reads correctly for emails-only, channels-only, both-kinds and empty rules", async () => {
     const harness = new AlertsPageHarness(
       alertsFixture({
         rules: [
@@ -438,6 +438,15 @@ describe("the alerts list shows destinations", () => {
             name: "Channels only",
             recipientEmails: [],
             slackChannelIds: [ALERTS_PRIVATE_CHANNEL.id],
+          }),
+          alertRuleFixture({
+            id: "rule-both",
+            name: "Both kinds",
+            recipientEmails: ["security@example.com", "ops@example.com"],
+            slackChannelIds: [
+              ALERTS_PUBLIC_CHANNEL.id,
+              ALERTS_PRIVATE_CHANNEL.id,
+            ],
           }),
           alertRuleFixture({
             id: "rule-none",
@@ -454,6 +463,9 @@ describe("the alerts list shows destinations", () => {
     );
     expect(await harness.ruleDestinationsSummary("Channels only")).toBe(
       `#${ALERTS_PRIVATE_CHANNEL.name}`,
+    );
+    expect(await harness.ruleDestinationsSummary("Both kinds")).toBe(
+      `security@example.com +1 more · #${ALERTS_PUBLIC_CHANNEL.name} +1 more`,
     );
     expect(await harness.ruleDestinationsSummary("No destinations yet")).toBe(
       "No destinations",

--- a/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
+++ b/ui/app/(prowler)/alerts/alerts-page.integration.test.tsx
@@ -406,3 +406,57 @@ describe("alert rules target Slack channels", () => {
     );
   });
 });
+
+describe("the alerts list shows destinations", () => {
+  it("shows a rule's channels by name alongside its emails, without opening it", async () => {
+    const harness = new AlertsPageHarness(
+      alertsFixture({
+        rules: [
+          alertRuleFixture({
+            slackChannels: [
+              { ...ALERTS_PUBLIC_CHANNEL },
+              { ...ALERTS_PRIVATE_CHANNEL },
+            ],
+          }),
+        ],
+      }),
+    );
+    await harness.mount();
+
+    expect(await harness.ruleDestinationsSummary(RULE_NAME)).toBe(
+      `security@example.com · #${ALERTS_PUBLIC_CHANNEL.name} +1 more`,
+    );
+  });
+
+  it("reads correctly for emails-only, channels-only and empty rules", async () => {
+    const harness = new AlertsPageHarness(
+      alertsFixture({
+        rules: [
+          alertRuleFixture({ id: "rule-emails", name: "Emails only" }),
+          alertRuleFixture({
+            id: "rule-channels",
+            name: "Channels only",
+            recipientEmails: [],
+            slackChannels: [{ ...ALERTS_PRIVATE_CHANNEL }],
+          }),
+          alertRuleFixture({
+            id: "rule-none",
+            name: "No destinations yet",
+            recipientEmails: [],
+          }),
+        ],
+      }),
+    );
+    await harness.mount();
+
+    expect(await harness.ruleDestinationsSummary("Emails only")).toBe(
+      "security@example.com",
+    );
+    expect(await harness.ruleDestinationsSummary("Channels only")).toBe(
+      `#${ALERTS_PRIVATE_CHANNEL.name}`,
+    );
+    expect(await harness.ruleDestinationsSummary("No destinations yet")).toBe(
+      "No destinations",
+    );
+  });
+});

--- a/ui/changelog.d/alerts-destinations-column.changed.md
+++ b/ui/changelog.d/alerts-destinations-column.changed.md
@@ -1,0 +1,1 @@
+Alerts list Recipients column becomes Destinations, summarizing a rule's email recipients and Slack channels at a glance


### PR DESCRIPTION
### Context

Slice S3 of the OpenSpec change `add-slack-alert-channels`. With alert rules now targeting Slack channels (#12492), the alerts list surfaces each rule's channel destinations alongside its email recipients — at a glance, without opening the rule. Stacked on #12492; the docs rework stacks on top.

### Description

- The alerts table's Recipients column becomes **Destinations** (design D6): one column with the existing email summary (`a@b.com +N more`) and a channel summary (`#name +N more`) joined with `·`, each omitted when empty, and `No destinations` when both are.
- Names only at list altitude — privacy badges stay in the form.
- Column id `recipients` → `destinations`. The column is now explicitly unsortable: it carries an
  accessor but no sort param, so the header rendered as a sort control and clicking it sent
  `sort=undefined`, which the API rejects with a 400 ("Failed to load alerts") — the same shape the
  old Recipients header had. No filter impact.
- `alerts-page.integration.test.tsx` extended: channels visible by name without opening the rule; emails-only, channels-only, both-kinds (each side overflowing) and no-destination rules each read correctly.
- `ruleDestinationsSummary` now resolves a rule by its name button instead of by substring over the whole row, which could return a neighbour's cell.

### Steps to review

1. `cd ui && pnpm install && pnpm test alerts-page.integration` (13 scenarios).
2. With rules seeded (MSW/dev): a rule with both destination kinds reads `security@example.com · #security +1 more` in the Destinations column; an emails-only rule shows only the email summary; a channels-only rule only the channel summary; a rule with neither shows `No destinations`.

### Checklist

- [x] Review if the code is being covered by tests.
- [ ] Review if backport is needed.
- [x] Ensure a changelog fragment is added under <component>/changelog.d/, if applicable.

#### UI

- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under ui/changelog.d/

Screenshots land before this PR is promoted from draft (stack rule: drafts on non-master bases skip the full check set).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Renamed the Alerts list’s “Recipients” column to “Destinations.”
  - Destinations now show email recipients and Slack channels together.
  - Added concise overflow indicators for long destination lists.
  - Displays “No destinations” when no email recipients or Slack channels are configured.

- **Documentation**
  - Updated the changelog to reflect the new Destinations column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
