### PR TITLE
[CHAIN] feat(ui): add Registry permission support

### DIFF
--- a/ui/actions/auth/auth.test.ts
+++ b/ui/actions/auth/auth.test.ts
@@ -23,7 +23,7 @@ vi.mock("@/lib/sentry-breadcrumbs", () => ({
 
 import { createNewUser, getUserByMe } from "./auth";
 
-const userMeResponse = (roleAttributes: Record<string, boolean>) => ({
+const userMeResponse = (roleAttributes: Record<string, unknown>) => ({
   data: {
     type: "users",
     id: "019b1234-5678-7abc-9def-0123456789ab",
@@ -43,7 +43,7 @@ const userMeResponse = (roleAttributes: Record<string, boolean>) => ({
   ],
 });
 
-const mockUserMe = (roleAttributes: Record<string, boolean>) => {
+const mockUserMe = (roleAttributes: Record<string, unknown>) => {
   fetchMock.mockResolvedValue(
     new Response(JSON.stringify(userMeResponse(roleAttributes)), {
       status: 200,
@@ -154,4 +154,29 @@ describe("auth actions", () => {
     expect(result.permissions.manage_lighthouse_ai_configuration).toBe(false);
     expect(result.permissions.manage_users).toBe(true);
   });
+
+  it("should carry an exact manage_registry permission into the session", async () => {
+    // Given
+    mockUserMe({ manage_registry: true });
+
+    // When
+    const result = await getUserByMe("access-token");
+
+    // Then
+    expect(result.permissions.manage_registry).toBe(true);
+  });
+
+  it.each([undefined, "true", "TRUE", 1])(
+    "should deny a malformed manage_registry value of %j",
+    async (manageRegistry) => {
+      // Given
+      mockUserMe({ manage_registry: manageRegistry });
+
+      // When
+      const result = await getUserByMe("access-token");
+
+      // Then
+      expect(result.permissions.manage_registry).toBe(false);
+    },
+  );
 });

--- a/ui/actions/auth/auth.ts
+++ b/ui/actions/auth/auth.ts
@@ -183,6 +183,7 @@ export const getUserByMe = async (accessToken: string) => {
       manage_alerts: userRole.attributes.manage_alerts || false,
       manage_lighthouse_ai_configuration:
         userRole.attributes.manage_lighthouse_ai_configuration || false,
+      manage_registry: userRole.attributes.manage_registry === true,
       unlimited_visibility: userRole.attributes.unlimited_visibility || false,
     };
 

--- a/ui/actions/roles/roles.test.ts
+++ b/ui/actions/roles/roles.test.ts
@@ -50,6 +50,7 @@ const makeRoleFormData = () => {
   formData.set("manage_scans", "false");
   formData.set("manage_alerts", "true");
   formData.set("manage_lighthouse_ai_configuration", "true");
+  formData.set("manage_registry", "true");
   formData.set("unlimited_visibility", "false");
   return formData;
 };
@@ -71,6 +72,36 @@ describe("role actions", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+  });
+
+  it("includes manage_registry when creating and updating a role in Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+
+    // When
+    await addRole(makeRoleFormData());
+    const createAttributes = lastRequestBody().data.attributes;
+    await updateRole(makeRoleFormData(), "role-1");
+    const updateAttributes = lastRequestBody().data.attributes;
+
+    // Then
+    expect(createAttributes.manage_registry).toBe(true);
+    expect(updateAttributes.manage_registry).toBe(true);
+  });
+
+  it("omits manage_registry when creating and updating a role outside Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+
+    // When
+    await addRole(makeRoleFormData());
+    const createAttributes = lastRequestBody().data.attributes;
+    await updateRole(makeRoleFormData(), "role-1");
+    const updateAttributes = lastRequestBody().data.attributes;
+
+    // Then
+    expect(createAttributes).not.toHaveProperty("manage_registry");
+    expect(updateAttributes).not.toHaveProperty("manage_registry");
   });
 
   it("includes manage_alerts when creating a role in Prowler Cloud", async () => {

--- a/ui/actions/roles/roles.ts
+++ b/ui/actions/roles/roles.ts
@@ -116,6 +116,8 @@ export const addRole = async (formData: FormData) => {
       formData.get("manage_alerts") === "true";
     payload.data.attributes.manage_lighthouse_ai_configuration =
       formData.get("manage_lighthouse_ai_configuration") === "true";
+    payload.data.attributes.manage_registry =
+      formData.get("manage_registry") === "true";
   }
 
   // Add provider groups relationships only if there are items
@@ -175,6 +177,8 @@ export const updateRole = async (formData: FormData, roleId: string) => {
       formData.get("manage_alerts") === "true";
     payload.data.attributes.manage_lighthouse_ai_configuration =
       formData.get("manage_lighthouse_ai_configuration") === "true";
+    payload.data.attributes.manage_registry =
+      formData.get("manage_registry") === "true";
   }
 
   // Add provider groups relationships only if there are items

--- a/ui/auth.config.test.ts
+++ b/ui/auth.config.test.ts
@@ -36,12 +36,14 @@ const RESTRICTED_PERMISSIONS: RolePermissionAttributes = {
   manage_scans: false,
   manage_integrations: false,
   manage_alerts: false,
+  manage_registry: false,
   unlimited_visibility: false,
 };
 
 const ELEVATED_PERMISSIONS: RolePermissionAttributes = {
   ...RESTRICTED_PERMISSIONS,
   manage_users: true,
+  manage_registry: true,
   manage_scans: true,
 };
 
@@ -139,6 +141,25 @@ describe("authConfig JWT callback", () => {
     expect(result.user).toMatchObject({
       permissions: RESTRICTED_PERMISSIONS,
     });
+  });
+
+  it("should default manage_registry to false when a sign-in user omits it", async () => {
+    // Given
+    const jwtCallback = authConfig.callbacks?.jwt;
+    if (!jwtCallback) throw new Error("JWT callback is not configured");
+
+    // When
+    const result = await jwtCallback({
+      token: {},
+      account: {} as Parameters<typeof jwtCallback>[0]["account"],
+      user: {
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+      } as Parameters<typeof jwtCallback>[0]["user"],
+    });
+
+    // Then
+    expect(result.user?.permissions.manage_registry).toBe(false);
   });
 
   it("should report a tenant switch failure while preserving the current session", async () => {

--- a/ui/auth.config.ts
+++ b/ui/auth.config.ts
@@ -55,6 +55,7 @@ const DEFAULT_PERMISSIONS: RolePermissionAttributes = {
   manage_billing: false,
   manage_alerts: false,
   manage_lighthouse_ai_configuration: false,
+  manage_registry: false,
   unlimited_visibility: false,
 };
 

--- a/ui/components/roles/workflow/forms/add-role-form.test.tsx
+++ b/ui/components/roles/workflow/forms/add-role-form.test.tsx
@@ -69,6 +69,11 @@ vi.mock("@/lib", () => ({
         "Allows configuring Lighthouse AI, including its provider credentials, default model and business context",
     },
     {
+      field: "manage_registry",
+      label: "Manage Registry",
+      description: "Allows managing tenant Registry credentials and artifacts",
+    },
+    {
       field: "manage_billing",
       label: "Manage Billing",
       description: "Provides access to billing settings and invoices",
@@ -147,7 +152,23 @@ describe("AddRoleForm", () => {
     // Then
     expect(screen.queryByText("Manage Alerts")).not.toBeInTheDocument();
     expect(screen.queryByText("Manage Lighthouse AI")).not.toBeInTheDocument();
+    expect(screen.queryByText("Manage Registry")).not.toBeInTheDocument();
     expect(screen.queryByText("Manage Billing")).not.toBeInTheDocument();
+  });
+
+  it("submits manage_registry when granted in Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    const user = userEvent.setup();
+    render(<AddRoleForm groups={[]} />);
+
+    // When
+    await user.type(screen.getByPlaceholderText("Enter role name"), "New role");
+    await user.click(screen.getByRole("checkbox", { name: "Manage Registry" }));
+    await user.click(screen.getByRole("button", { name: "Add Role" }));
+
+    // Then
+    expect(submittedFormData().get("manage_registry")).toBe("true");
   });
 
   it("submits manage_lighthouse_ai_configuration when granted in Prowler Cloud", async () => {
@@ -193,6 +214,7 @@ describe("AddRoleForm", () => {
     expect(submittedFormData().has("manage_lighthouse_ai_configuration")).toBe(
       false,
     );
+    expect(submittedFormData().has("manage_registry")).toBe(false);
   });
 
   it("navigates back to roles when cancel is clicked", async () => {

--- a/ui/components/roles/workflow/forms/add-role-form.tsx
+++ b/ui/components/roles/workflow/forms/add-role-form.tsx
@@ -28,6 +28,7 @@ export const AddRoleForm = ({ groups }: { groups: RoleGroupOption[] }) => {
       manage_billing: false,
       manage_alerts: false,
       manage_lighthouse_ai_configuration: false,
+      manage_registry: false,
     }),
   };
 
@@ -56,6 +57,7 @@ export const AddRoleForm = ({ groups }: { groups: RoleGroupOption[] }) => {
         "manage_lighthouse_ai_configuration",
         String(values.manage_lighthouse_ai_configuration),
       );
+      formData.append("manage_registry", String(values.manage_registry));
     }
 
     if (values.groups && values.groups.length > 0) {

--- a/ui/components/roles/workflow/forms/edit-role-form.test.tsx
+++ b/ui/components/roles/workflow/forms/edit-role-form.test.tsx
@@ -69,6 +69,11 @@ vi.mock("@/lib", () => ({
         "Allows configuring Lighthouse AI, including its provider credentials, default model and business context",
     },
     {
+      field: "manage_registry",
+      label: "Manage Registry",
+      description: "Allows managing tenant Registry credentials and artifacts",
+    },
+    {
       field: "manage_billing",
       label: "Manage Billing",
       description: "Provides access to billing settings and invoices",
@@ -97,9 +102,11 @@ beforeAll(() => {
 
 const roleData = ({
   manageProviders = false,
+  manageRegistry = false,
   unlimitedVisibility = false,
 }: {
   manageProviders?: boolean;
+  manageRegistry?: boolean;
   unlimitedVisibility?: boolean;
 } = {}) => ({
   data: {
@@ -109,6 +116,7 @@ const roleData = ({
       manage_account: false,
       manage_providers: manageProviders,
       manage_integrations: false,
+      manage_registry: manageRegistry,
       manage_scans: false,
       unlimited_visibility: unlimitedVisibility,
       groups: [],
@@ -137,6 +145,19 @@ describe("EditRoleForm", () => {
     routerMocks.push.mockClear();
     vi.mocked(updateRole).mockClear();
     vi.unstubAllEnvs();
+  });
+
+  it("retains manage_registry when updating a role in Prowler Cloud", async () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    const user = userEvent.setup();
+    renderEditRoleForm({ manageRegistry: true });
+
+    // When
+    await user.click(screen.getByRole("button", { name: "Update Role" }));
+
+    // Then
+    expect(submittedFormData().get("manage_registry")).toBe("true");
   });
 
   it("submits manage_lighthouse_ai_configuration when granted in Prowler Cloud", async () => {
@@ -186,6 +207,7 @@ describe("EditRoleForm", () => {
     expect(submittedFormData().has("manage_lighthouse_ai_configuration")).toBe(
       false,
     );
+    expect(submittedFormData().has("manage_registry")).toBe(false);
   });
 
   it("shows the subtle Unlimited Visibility description inside Visibility", () => {

--- a/ui/components/roles/workflow/forms/edit-role-form.tsx
+++ b/ui/components/roles/workflow/forms/edit-role-form.tsx
@@ -35,6 +35,9 @@ export const EditRoleForm = ({
 
   const defaultValues: DefaultValues<RoleFormValues> = {
     ...roleData.data.attributes,
+    ...(isCloudEnvironment && {
+      manage_registry: roleData.data.attributes.manage_registry ?? false,
+    }),
     groups:
       roleData.data.relationships?.provider_groups?.data.map((g) => g.id) || [],
   };
@@ -62,6 +65,7 @@ export const EditRoleForm = ({
         updatedFields.manage_alerts = values.manage_alerts;
         updatedFields.manage_lighthouse_ai_configuration =
           values.manage_lighthouse_ai_configuration;
+        updatedFields.manage_registry = values.manage_registry;
       }
 
       if (

--- a/ui/hooks/use-auth.ts
+++ b/ui/hooks/use-auth.ts
@@ -15,6 +15,7 @@ export function useAuth() {
     manage_billing: false,
     manage_alerts: false,
     manage_lighthouse_ai_configuration: false,
+    manage_registry: false,
     unlimited_visibility: false,
   };
 

--- a/ui/lib/helper.test.ts
+++ b/ui/lib/helper.test.ts
@@ -141,6 +141,19 @@ describe("getErrorMessage", () => {
 });
 
 describe("permissionFormFields", () => {
+  it("describes Manage Registry", () => {
+    // Given
+    const field = permissionFormFields.find(
+      ({ field }) => field === "manage_registry",
+    );
+
+    // When / Then
+    expect(field).toMatchObject({
+      label: "Manage Registry",
+      description: expect.stringContaining("Registry"),
+    });
+  });
+
   it("describes Unlimited Visibility as organization-wide", () => {
     // Given
     const field = permissionFormFields.find(

--- a/ui/lib/helper.ts
+++ b/ui/lib/helper.ts
@@ -475,6 +475,11 @@ export const permissionFormFields: PermissionInfo[] = [
     description:
       "Allows configuring Lighthouse AI, including its provider credentials, default model and business context",
   },
+  {
+    field: "manage_registry",
+    label: "Manage Registry",
+    description: "Allows managing tenant Registry credentials and artifacts",
+  },
 
   {
     field: "manage_billing",

--- a/ui/lib/permissions.test.ts
+++ b/ui/lib/permissions.test.ts
@@ -13,12 +13,41 @@ const attributes = {
   manage_billing: false,
   manage_alerts: true,
   manage_lighthouse_ai_configuration: true,
+  manage_registry: true,
   unlimited_visibility: false,
 } satisfies RolePermissionAttributes;
 
 describe("getRolePermissions", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+  });
+
+  it("includes Manage Registry in Prowler Cloud when role attributes provide it", () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+
+    // When
+    const permissions = getRolePermissions(attributes);
+
+    // Then
+    expect(permissions).toContainEqual({
+      key: "manage_registry",
+      label: "Manage Registry",
+      enabled: true,
+    });
+  });
+
+  it("hides Manage Registry outside Prowler Cloud", () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+
+    // When
+    const permissions = getRolePermissions(attributes);
+
+    // Then
+    expect(
+      permissions.some((permission) => permission.key === "manage_registry"),
+    ).toBe(false);
   });
 
   it("includes Manage Alerts in Prowler Cloud when role attributes provide it", () => {

--- a/ui/lib/permissions.ts
+++ b/ui/lib/permissions.ts
@@ -72,6 +72,11 @@ export const getRolePermissions = (attributes: RolePermissionAttributes) => {
             label: "Manage Lighthouse AI",
             enabled: attributes.manage_lighthouse_ai_configuration ?? false,
           },
+          {
+            key: "manage_registry",
+            label: "Manage Registry",
+            enabled: attributes.manage_registry === true,
+          },
         ]
       : []),
     {

--- a/ui/lib/role-permissions.ts
+++ b/ui/lib/role-permissions.ts
@@ -4,6 +4,7 @@ const hiddenOutsideCloudFields = [
   "manage_billing",
   "manage_alerts",
   "manage_lighthouse_ai_configuration",
+  "manage_registry",
 ];
 
 export const getVisiblePermissionFormFields = (isCloudEnvironment: boolean) =>

--- a/ui/lib/runtime-env.test.ts
+++ b/ui/lib/runtime-env.test.ts
@@ -111,6 +111,23 @@ describe("readBoolEnv", () => {
     expect(readBoolEnv("UI_SENTRY_ENABLED")).toBe(false);
   });
 
+  it("defaults UI_REGISTRY_ENABLED to disabled and enables its true value", () => {
+    const cases: Array<[string | undefined, boolean]> = [
+      [undefined, false],
+      ["true", true],
+      ["TRUE", false],
+      ["1", false],
+    ];
+
+    for (const [value, enabled] of cases) {
+      // Given
+      vi.stubEnv("UI_REGISTRY_ENABLED", value);
+
+      // When / Then
+      expect(readBoolEnv("UI_REGISTRY_ENABLED")).toBe(enabled);
+    }
+  });
+
   it('is false for other truthy-looking values ("TRUE", "1", "yes")', () => {
     for (const value of ["TRUE", "1", "yes"]) {
       // Given

--- a/ui/types/env.d.ts
+++ b/ui/types/env.d.ts
@@ -30,6 +30,7 @@ declare global {
 
       // Prowler Cloud deployment flag — runtime read (server env, client island).
       UI_CLOUD_ENABLED?: "true" | "false";
+      UI_REGISTRY_ENABLED?: "true" | "false";
 
       CLOUD_BILLING_ENABLED?: "legacy" | "metronome" | "false";
 

--- a/ui/types/formSchemas.test.ts
+++ b/ui/types/formSchemas.test.ts
@@ -8,6 +8,7 @@ import {
   addCredentialsRoleFormSchema,
   addProviderFormSchema,
   KUBECONFIG_UNSUPPORTED_COMMAND_AUTHENTICATION_ERROR,
+  roleFormSchema,
   samlConfigFormSchema,
 } from "./formSchemas";
 
@@ -19,6 +20,30 @@ const BASE_AWS_ROLE_VALUES = {
   [ProviderCredentialFields.EXTERNAL_ID]: "tenant-123",
   [ProviderCredentialFields.CREDENTIALS_TYPE]: "access-secret-key",
 } as const;
+
+describe("roleFormSchema", () => {
+  it("defaults manage_registry to false", () => {
+    // Given / When
+    const result = roleFormSchema.parse({ name: "Registry manager" });
+
+    // Then
+    expect(result.manage_registry).toBe(false);
+  });
+
+  it.each(["true", 1, null])(
+    "rejects malformed manage_registry values of %j",
+    (manageRegistry) => {
+      // Given / When
+      const result = roleFormSchema.safeParse({
+        name: "Registry manager",
+        manage_registry: manageRegistry,
+      });
+
+      // Then
+      expect(result.success).toBe(false);
+    },
+  );
+});
 
 describe("addCredentialsRoleFormSchema", () => {
   it("accepts AWS role credentials when access and secret keys are present", () => {

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -56,6 +56,7 @@ export const roleFormSchema = z.object({
   manage_scans: z.boolean().default(false),
   manage_alerts: z.boolean().default(false),
   manage_lighthouse_ai_configuration: z.boolean().default(false),
+  manage_registry: z.boolean().default(false),
   unlimited_visibility: z.boolean().default(false),
   groups: z.array(z.string()).optional(),
 });

--- a/ui/types/users.ts
+++ b/ui/types/users.ts
@@ -91,6 +91,7 @@ export const PERMISSION_KEY = {
   MANAGE_BILLING: "manage_billing",
   MANAGE_ALERTS: "manage_alerts",
   MANAGE_LIGHTHOUSE_AI_CONFIGURATION: "manage_lighthouse_ai_configuration",
+  MANAGE_REGISTRY: "manage_registry",
   UNLIMITED_VISIBILITY: "unlimited_visibility",
 } as const;
 
@@ -123,6 +124,7 @@ export interface RoleDetail {
     manage_billing?: boolean;
     manage_alerts?: boolean;
     manage_lighthouse_ai_configuration?: boolean;
+    manage_registry?: boolean;
     unlimited_visibility: boolean;
     permission_state?: string;
     inserted_at?: string;


### PR DESCRIPTION
## 🔗 Part of Chained PRs

| Field | Value |
|---|---|
| Feature Branch | `feat/prowler-2414-registry-ui` |
| Main PR | #12494 |
| Position | 1 of 8 |
| Base | `feat/prowler-2414-registry-ui` |
| Depends on | None |
| Follow-up | #12497, fresh Registry access authority |
| Review budget | 237 / 400 changed lines |
| Starts at | Draft Registry tracker with no feature behavior |
| Ends with | Cloud role and session models represent Registry permission safely |

### Chain Overview

```text
feat/prowler-2414-registry-ui (#12494 tracker)
└── 📍 #12495 PR 1: permissions and flag typing
    └── #12497 PR 2: fresh access authority
        └── ... PR 8: acceptance hardening
            └── #12494 tracker -> master
```

### Scope

- Includes: exact-boolean `manage_registry` propagation through Cloud roles, auth/session models, UI permission metadata, false defaults, and local `UI_REGISTRY_ENABLED` typing.
- Excludes: Registry navigation, routes, eligibility evaluation, runtime-config exposure, API calls, credential handling, catalog UI, backend changes, and deployment changes.

### Autonomy

- [x] Focused tests and exact results are recorded.
- [x] Runtime verification is not applicable because this slice exposes no Registry UI or route.
- [x] Rollback is the single child commit and excludes unrelated work.
- [x] The diff contains only this work unit.

### Context

The Registry UI must fail closed and remain hidden until later slices add fresh Cloud, runtime-flag, and permission checks. This first slice introduces only the permission and configuration representation that those guards will consume.

Keeping this foundation separate makes role/session behavior reviewable before any Registry route or API integration exists.

### Description

- Add `manage_registry` to the existing user, role, auth, and permission models with false defaults.
- Copy the permission from the current role only when its value is exactly `true`.
- Allow Cloud role create and edit flows to grant and retain the permission while non-Cloud payloads omit it.
- Add `UI_REGISTRY_ENABLED` environment typing without enabling or exposing Registry.
- Preserve existing Integrations, Billing, and generic navigation permission behavior.

No npm dependency, backend endpoint, migration, public runtime-config field, Registry route, or user-visible Registry workflow is introduced.

### Steps to review

1. Review the exact-boolean and false-default propagation across auth, roles, schemas, and permission display helpers.
2. Confirm Cloud role create/edit payloads include `manage_registry` and non-Cloud payloads omit it.
3. Confirm `UI_REGISTRY_ENABLED` is typed but is not consumed to expose Registry UI.
4. Run `cd ui && pnpm exec vitest run --project unit actions/auth/auth.test.ts auth.config.test.ts types/formSchemas.test.ts actions/roles/roles.test.ts components/roles/workflow/forms/add-role-form.test.tsx components/roles/workflow/forms/edit-role-form.test.tsx components/layout/app-sidebar/navigation-config.test.ts lib/helper.test.ts lib/permissions.test.ts lib/runtime-env.test.ts` and verify 123 tests pass.
5. Run `cd ui && pnpm run typecheck` and `cd ui && pnpm run test:unit`; the recorded results are PASS and 3,047 passing unit tests.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md): not required for this foundation slice.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable: SDK/CLI is not changed.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI: the complete user-facing workflow is delivered by later child PRs.
- [x] This PR adds or updates no npm dependencies.
- [x] Mobile screenshots/video are not applicable because this slice exposes no UI.
- [x] Tablet screenshots/video are not applicable because this slice exposes no UI.
- [x] Desktop screenshots/video are not applicable because this slice exposes no UI.
- [x] No UI changelog fragment is added for this internal foundation slice; the PR uses `no-changelog`, and the user-visible slice will add the feature fragment.

#### API
- [x] The API is not changed by this PR.
- [x] Endpoint output, query analysis, performance evidence, API specs, versions, and API changelog are not applicable.

#### MCP Server
- [x] The MCP Server is not changed by this PR.
- [x] The MCP changelog is not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


