### PR TITLE
[CHAIN] feat(ui): add fresh Registry access authority

### DIFF
--- a/ui/actions/auth/auth.ts
+++ b/ui/actions/auth/auth.ts
@@ -4,6 +4,7 @@ import { AuthError } from "next-auth";
 
 import { signIn, signOut } from "@/auth.config";
 import { apiBaseUrl } from "@/lib";
+import { fetchCurrentUser } from "@/lib/auth/current-user";
 import { addAuthEvent } from "@/lib/sentry-breadcrumbs";
 import type { UtmParams } from "@/lib/utm";
 import type { SignInFormData, SignUpFormData } from "@/types";
@@ -141,62 +142,15 @@ export const getToken = async (formData: SignInFormData) => {
 };
 
 export const getUserByMe = async (accessToken: string) => {
-  const url = new URL(`${apiBaseUrl}/users/me?include=roles`);
+  const currentUser = await fetchCurrentUser(accessToken);
 
-  try {
-    const response = await fetch(url.toString(), {
-      method: "GET",
-      headers: {
-        Accept: "application/vnd.api+json",
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-
-    const parsedResponse = await response.json();
-    if (!response.ok) {
-      // Handle different HTTP error codes
-      switch (response.status) {
-        case 401:
-          throw new Error("Invalid or expired token");
-        case 403:
-          throw new Error(parsedResponse.errors?.[0]?.detail);
-        case 404:
-          throw new Error("User not found");
-        default:
-          throw new Error(
-            parsedResponse.errors?.[0]?.detail || "Unknown error",
-          );
-      }
-    }
-
-    const userRole = parsedResponse.included?.find(
-      (item: any) => item.type === "roles",
-    );
-
-    const permissions = {
-      manage_users: userRole.attributes.manage_users || false,
-      manage_account: userRole.attributes.manage_account || false,
-      manage_providers: userRole.attributes.manage_providers || false,
-      manage_scans: userRole.attributes.manage_scans || false,
-      manage_integrations: userRole.attributes.manage_integrations || false,
-      manage_billing: userRole.attributes.manage_billing || false,
-      manage_alerts: userRole.attributes.manage_alerts || false,
-      manage_lighthouse_ai_configuration:
-        userRole.attributes.manage_lighthouse_ai_configuration || false,
-      manage_registry: userRole.attributes.manage_registry === true,
-      unlimited_visibility: userRole.attributes.unlimited_visibility || false,
-    };
-
-    return {
-      name: parsedResponse.data.attributes.name,
-      email: parsedResponse.data.attributes.email,
-      company: parsedResponse.data.attributes.company_name,
-      dateJoined: parsedResponse.data.attributes.date_joined,
-      permissions,
-    };
-  } catch (error: any) {
-    throw new Error(error.message || "Network error or server unreachable");
-  }
+  return {
+    name: currentUser.name,
+    email: currentUser.email,
+    company: currentUser.company,
+    dateJoined: currentUser.dateJoined,
+    permissions: currentUser.permissions,
+  };
 };
 
 export async function logOut() {

--- a/ui/lib/auth/current-user.test.ts
+++ b/ui/lib/auth/current-user.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }));
+vi.mock("@/lib", () => ({ apiBaseUrl: "https://api.example.com/api/v1" }));
+
+import { fetchCurrentUser } from "./current-user";
+
+const role = (manage_registry: unknown) => ({
+  type: "roles",
+  id: "role-1",
+  attributes: { manage_registry },
+});
+const document = (roles: unknown) => ({
+  data: {
+    type: "users",
+    id: "user-1",
+    attributes: { name: "Jane", email: "jane@example.com" },
+  },
+  included: roles,
+});
+const reply = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status });
+
+describe("fetchCurrentUser", () => {
+  beforeEach(() => vi.stubGlobal("fetch", fetchMock));
+
+  it("accepts one current exact-true role without caching", async () => {
+    // Given
+    fetchMock.mockResolvedValue(reply(document([role(true)])));
+    const controller = new AbortController();
+    // When
+    const result = await fetchCurrentUser("access-token", {
+      signal: controller.signal,
+    });
+    // Then
+    expect(result.manageRegistry).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/api/v1/users/me?include=roles",
+      expect.objectContaining({ cache: "no-store", signal: controller.signal }),
+    );
+  });
+
+  it.each([
+    [false, false],
+    [undefined, undefined],
+    ["true", undefined],
+  ])(
+    "keeps only exact boolean authority for %j",
+    async (permission, expected) => {
+      // Given
+      fetchMock.mockResolvedValue(reply(document([role(permission)])));
+      // When / Then
+      await expect(fetchCurrentUser("access-token")).resolves.toMatchObject({
+        manageRegistry: expected,
+        permissions: { manage_registry: permission === true },
+      });
+    },
+  );
+
+  it.each([
+    [document([]), 200],
+    [document([role(true), role(true)]), 200],
+    [{ data: { type: "users" } }, 200],
+    [document([role(true)]), 401],
+    [document([role(true)]), 403],
+    [document([role(true)]), 500],
+  ])(
+    "rejects absent, ambiguous, malformed, or unsuccessful evidence",
+    async (body, status) => {
+      // Given
+      fetchMock.mockResolvedValue(reply(body, status));
+      // When / Then
+      await expect(fetchCurrentUser("access-token")).rejects.toThrow();
+    },
+  );
+});

--- a/ui/lib/auth/current-user.ts
+++ b/ui/lib/auth/current-user.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+
+import { apiBaseUrl } from "@/lib";
+import { PERMISSION_KEY, type RolePermissionAttributes } from "@/types/users";
+
+const currentUserDocumentSchema = z.object({
+  data: z.object({
+    type: z.literal("users"),
+    id: z.string().min(1),
+    attributes: z.object({
+      name: z.string(),
+      email: z.string(),
+      company_name: z.string().optional(),
+      date_joined: z.string().optional(),
+    }),
+  }),
+  included: z.array(
+    z.object({
+      type: z.literal("roles"),
+      id: z.string().min(1),
+      attributes: z.record(z.string(), z.unknown()),
+    }),
+  ),
+});
+
+export interface CurrentUser {
+  name: string;
+  email: string;
+  company?: string;
+  dateJoined?: string;
+  permissions: RolePermissionAttributes;
+  manageRegistry: true | false | undefined;
+}
+
+const toPermissions = (
+  attributes: Record<string, unknown>,
+): RolePermissionAttributes =>
+  Object.fromEntries(
+    Object.values(PERMISSION_KEY).map((key) => [key, attributes[key] === true]),
+  ) as RolePermissionAttributes;
+
+export async function fetchCurrentUser(
+  accessToken: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<CurrentUser> {
+  if (!accessToken.trim()) throw new Error("Current user token is required");
+
+  let response: Response;
+  try {
+    response = await fetch(`${apiBaseUrl}/users/me?include=roles`, {
+      method: "GET",
+      cache: "no-store",
+      signal: options.signal,
+      headers: {
+        Accept: "application/vnd.api+json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+  } catch {
+    throw new Error("Unable to fetch current user");
+  }
+
+  if (!response.ok) throw new Error("Unable to fetch current user");
+
+  const parsed = currentUserDocumentSchema.safeParse(
+    await response.json().catch(() => undefined),
+  );
+  if (!parsed.success) throw new Error("Malformed current user response");
+
+  const [role] = parsed.data.included;
+  if (parsed.data.included.length !== 1 || !role) {
+    throw new Error("Ambiguous current user role");
+  }
+
+  const attributes = role.attributes;
+  const manageRegistry = attributes.manage_registry;
+  return {
+    name: parsed.data.data.attributes.name,
+    email: parsed.data.data.attributes.email,
+    company: parsed.data.data.attributes.company_name,
+    dateJoined: parsed.data.data.attributes.date_joined,
+    permissions: toPermissions(attributes),
+    manageRegistry:
+      typeof manageRegistry === "boolean" ? manageRegistry : undefined,
+  };
+}

--- a/ui/lib/registry/access.server.test.ts
+++ b/ui/lib/registry/access.server.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchCurrentUserMock } = vi.hoisted(() => ({
+  fetchCurrentUserMock: vi.fn(),
+}));
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/current-user", () => ({
+  fetchCurrentUser: fetchCurrentUserMock,
+}));
+
+import { REGISTRY_ACCESS } from "./access";
+import { evaluateRegistryAccess } from "./access.server";
+
+describe("evaluateRegistryAccess", () => {
+  beforeEach(() => {
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    vi.stubEnv("UI_REGISTRY_ENABLED", "true");
+    fetchCurrentUserMock.mockResolvedValue({ manageRegistry: true });
+  });
+
+  it("allows a fresh exact-true current permission with a five-second signal", async () => {
+    // Given / When
+    const result = await evaluateRegistryAccess("access-token");
+    // Then
+    expect(result.status).toBe(REGISTRY_ACCESS.ELIGIBLE);
+  });
+
+  it.each([
+    [" true", "true", "access-token", true, REGISTRY_ACCESS.INELIGIBLE, 0],
+    [undefined, "true", "access-token", true, REGISTRY_ACCESS.INELIGIBLE, 0],
+    ["true", "false", "access-token", true, REGISTRY_ACCESS.INELIGIBLE, 0],
+    ["true", "true", "access-token", false, REGISTRY_ACCESS.INELIGIBLE, 1],
+    ["true", "true", "access-token", undefined, REGISTRY_ACCESS.UNKNOWN, 1],
+    ["true", "true", "", true, REGISTRY_ACCESS.INELIGIBLE, 0],
+  ])(
+    "fails closed without trusting stale JWT authority",
+    async (cloud, flag, token, permission, expected, calls) => {
+      // Given
+      vi.stubEnv("UI_CLOUD_ENABLED", cloud);
+      vi.stubEnv("UI_REGISTRY_ENABLED", flag);
+      fetchCurrentUserMock.mockResolvedValue({ manageRegistry: permission });
+      // When / Then
+      await expect(evaluateRegistryAccess(token)).resolves.toMatchObject({
+        status: expected,
+      });
+      expect(fetchCurrentUserMock).toHaveBeenCalledTimes(calls);
+    },
+  );
+
+  it("returns unknown for malformed, network, abort, and timeout evidence", async () => {
+    // Given
+    fetchCurrentUserMock
+      .mockResolvedValueOnce({ manageRegistry: undefined })
+      .mockRejectedValueOnce(new Error("network"))
+      .mockRejectedValueOnce(new DOMException("aborted", "AbortError"))
+      .mockImplementationOnce(
+        (_token, { signal }) =>
+          new Promise((_, reject) => signal.addEventListener("abort", reject)),
+      );
+    // When / Then
+    const expectUnknown = () =>
+      expect(evaluateRegistryAccess("access-token")).resolves.toMatchObject({
+        status: REGISTRY_ACCESS.UNKNOWN,
+      });
+    await expectUnknown();
+    await expectUnknown();
+    await expectUnknown();
+    vi.useFakeTimers();
+    const result = evaluateRegistryAccess("access-token");
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(result).resolves.toMatchObject({
+      status: REGISTRY_ACCESS.UNKNOWN,
+    });
+    vi.useRealTimers();
+  });
+});

--- a/ui/lib/registry/access.server.ts
+++ b/ui/lib/registry/access.server.ts
@@ -1,0 +1,46 @@
+import "server-only";
+
+import { fetchCurrentUser } from "@/lib/auth/current-user";
+import { readEnv } from "@/lib/runtime-env";
+
+import {
+  isRegistryEligible,
+  REGISTRY_ACCESS,
+  registryAccessResult,
+  type RegistryAccessResult,
+} from "./access";
+
+const CURRENT_USER_TIMEOUT_MS = 5_000;
+
+const hasEnabledProcessFlags = () =>
+  readEnv("UI_CLOUD_ENABLED") === "true" &&
+  readEnv("UI_REGISTRY_ENABLED") === "true";
+
+export async function evaluateRegistryAccess(
+  accessToken?: string | null,
+): Promise<RegistryAccessResult> {
+  if (!hasEnabledProcessFlags() || !accessToken?.trim()) {
+    return registryAccessResult(REGISTRY_ACCESS.INELIGIBLE);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CURRENT_USER_TIMEOUT_MS);
+
+  try {
+    const currentUser = await fetchCurrentUser(accessToken, {
+      signal: controller.signal,
+    });
+    if (currentUser.manageRegistry === undefined) {
+      return registryAccessResult(REGISTRY_ACCESS.UNKNOWN);
+    }
+    return registryAccessResult(
+      isRegistryEligible(true, true, currentUser.manageRegistry)
+        ? REGISTRY_ACCESS.ELIGIBLE
+        : REGISTRY_ACCESS.INELIGIBLE,
+    );
+  } catch {
+    return registryAccessResult(REGISTRY_ACCESS.UNKNOWN);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/ui/lib/registry/access.test.ts
+++ b/ui/lib/registry/access.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { isRegistryEligible } from "./access";
+describe("Registry access", () => {
+  it.each([
+    [true, true, true, true],
+    [false, true, true, false],
+    [true, false, true, false],
+    [true, true, false, false],
+    [true, true, undefined, false],
+    [true, true, "true", false],
+  ])(
+    "allows only exact current authority",
+    (cloud, flag, permission, expected) => {
+      expect(isRegistryEligible(cloud, flag, permission)).toBe(expected);
+    },
+  );
+});

--- a/ui/lib/registry/access.ts
+++ b/ui/lib/registry/access.ts
@@ -1,0 +1,32 @@
+export const REGISTRY_ACCESS = {
+  ELIGIBLE: "eligible",
+  INELIGIBLE: "ineligible",
+  UNKNOWN: "unknown",
+} as const;
+
+export type RegistryAccessStatus =
+  (typeof REGISTRY_ACCESS)[keyof typeof REGISTRY_ACCESS];
+
+export const REGISTRY_ACCESS_LEASE_MS = 30_000;
+
+export type RegistryAccessResult =
+  | {
+      status: typeof REGISTRY_ACCESS.ELIGIBLE;
+      leaseDurationMs: typeof REGISTRY_ACCESS_LEASE_MS;
+    }
+  | { status: typeof REGISTRY_ACCESS.INELIGIBLE }
+  | { status: typeof REGISTRY_ACCESS.UNKNOWN };
+
+export const isRegistryEligible = (
+  cloudEnabled: unknown,
+  registryEnabled: unknown,
+  manageRegistry: unknown,
+) =>
+  cloudEnabled === true && registryEnabled === true && manageRegistry === true;
+
+export const registryAccessResult = (
+  status: RegistryAccessStatus,
+): RegistryAccessResult =>
+  status === REGISTRY_ACCESS.ELIGIBLE
+    ? { status, leaseDurationMs: REGISTRY_ACCESS_LEASE_MS }
+    : { status };


### PR DESCRIPTION
## 🔗 Part of Chained PRs

| Field | Value |
|---|---|
| Feature Branch | `feat/prowler-2414-registry-ui` |
| Main PR | #12494 |
| Position | 2 of 8 |
| Base | `feat/prowler-2414-registry-ui-01-permissions` |
| Depends on | #12495 |
| Follow-up | #12499, Registry lease, navigation, and route guards |
| Review budget | 400 / 400 changed lines |
| Starts at | Registry permission and flag representation without authorization behavior |
| Ends with | Fresh fail-closed Registry access authority without exposing a route or UI |

### Chain Overview

```text
feat/prowler-2414-registry-ui (#12494 tracker)
└── #12495 PR 1: permissions and flag typing
    └── 📍 #12497 PR 2: fresh access authority
        └── #12499 PR 3: lease, navigation, and route guards
            └── ... PR 8: acceptance hardening
                └── #12494 tracker -> master
```

### Scope

- Includes: strict no-store current-user adaptation, exact-boolean permission evaluation, pure Registry access discriminants, and a server-only eligibility evaluator with a five-second timeout.
- Excludes: client leases, navigation, sidebar changes, proxy guards, Registry routes, Registry API calls, credential handling, catalog UI, backend changes, and deployment changes.

### Autonomy

- [x] Focused and full unit-test results are recorded.
- [x] Runtime verification is not applicable because this slice exposes no Registry UI or route.
- [x] Rollback is the single child commit and excludes unrelated work.
- [x] The diff contains only this work unit and is exactly 400 changed lines.

### Context

Registry authorization cannot trust stale JWT permissions or client-hydrated configuration. Before any route or navigation is exposed, the UI needs a fresh server-side authority that denies access when current-user evidence, runtime flags, or process state are missing, malformed, stale, or unavailable.

This slice establishes that boundary independently so later Registry UI work can consume one small, reviewable eligibility contract.

### Description

- Extract the existing `/users/me?include=roles` request into a strict current-user adapter using `cache: "no-store"`.
- Require one unambiguous role and adapt `manage_registry` only when its wire value is exactly `true`.
- Keep existing sign-in and tenant-switch behavior by delegating `getUserByMe` to the adapter.
- Add pure `eligible`, `ineligible`, and `unknown` Registry access results.
- Evaluate current process flags with exact `"true"` semantics and deny when the token or authority evidence is unavailable.
- Abort current-user evaluation after five seconds and never cache an allow result.
- Cover false, missing, malformed, ambiguous, non-200, network, abort, timeout, and stale-JWT denial cases.

No npm dependency, backend endpoint, migration, public runtime configuration, Registry route, or user-visible Registry workflow is introduced.

### Steps to review

1. Review `ui/lib/auth/current-user.ts` for strict JSON:API parsing, role ambiguity rejection, exact-boolean adaptation, and `cache: "no-store"`.
2. Confirm `ui/actions/auth/auth.ts` preserves existing callers by delegating to the current-user adapter.
3. Review `ui/lib/registry/access.ts` and `access.server.ts` for exact Cloud/feature/permission checks, five-second abort behavior, and fail-closed results.
4. Run `cd ui && pnpm exec vitest run --project unit lib/auth/current-user.test.ts lib/registry/access.test.ts lib/registry/access.server.test.ts actions/auth/auth.test.ts auth.config.test.ts`; the recorded result is 37 passing tests.
5. Run `cd ui && pnpm exec vitest run --project unit`; the recorded result is 3,071 passing tests.
6. Run `PREK_NO_CONCURRENCY=1 uv run --directory . prek run`; Prettier, ESLint, TypeScript, related tests, and root hooks are recorded as passing.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md): not required for this internal authorization slice.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable: SDK/CLI is not changed.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI: the complete user-facing workflow is delivered by later child PRs.
- [x] This PR adds or updates no npm dependencies.
- [x] Mobile screenshots/video are not applicable because this slice exposes no UI.
- [x] Tablet screenshots/video are not applicable because this slice exposes no UI.
- [x] Desktop screenshots/video are not applicable because this slice exposes no UI.
- [x] No UI changelog fragment is added for this internal foundation slice; the PR uses `no-changelog`, and the user-visible slice will add the feature fragment.

#### API
- [x] The API is not changed by this PR.
- [x] Endpoint output, query analysis, performance evidence, API specs, versions, and API changelog are not applicable.

#### MCP Server
- [x] The MCP Server is not changed by this PR.
- [x] The MCP changelog is not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


