### PR TITLE
[CHAIN] feat(ui): add fail-closed Registry access boundaries

### DIFF
--- a/ui/app/(prowler)/layout.tsx
+++ b/ui/app/(prowler)/layout.tsx
@@ -12,6 +12,7 @@ import {
   OnboardingGate,
   OnboardingSequenceBanner,
 } from "@/components/onboarding";
+import { RegistryEligibilityProvider } from "@/components/registry/registry-eligibility-provider";
 import { RuntimePublicConfig } from "@/components/runtime-config/runtime-public-config";
 import { NavigationProgress } from "@/components/shadcn/navigation-progress";
 import { Toaster } from "@/components/shadcn/toast";
@@ -108,7 +109,9 @@ export default async function RootLayout({
               <OnboardingSequenceBanner hasCompletedScan={hasCompletedScan} />
             </>
           )}
-          <MainLayout>{children}</MainLayout>
+          <RegistryEligibilityProvider>
+            <MainLayout>{children}</MainLayout>
+          </RegistryEligibilityProvider>
           {cloudEnabled && <FeedbackSurvey />}
           {/* Always mounted: it hosts the detail (finding/resource) views in
               every deployment; the AI tab inside is cloud-gated on its own. */}

--- a/ui/app/(prowler)/registry/page.tsx
+++ b/ui/app/(prowler)/registry/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from "next/navigation";
+
+import { auth } from "@/auth.config";
+import { RegistryAccessBoundary } from "@/components/registry/registry-access-boundary";
+import { REGISTRY_ACCESS } from "@/lib/registry/access";
+import { evaluateRegistryAccess } from "@/lib/registry/access.server";
+
+export const dynamic = "force-dynamic";
+
+export default async function RegistryPage() {
+  const access = await evaluateRegistryAccess((await auth())?.accessToken);
+  if (access.status !== REGISTRY_ACCESS.ELIGIBLE) redirect("/profile");
+  return (
+    <RegistryAccessBoundary initialLeaseDurationMs={access.leaseDurationMs}>
+      {null}
+    </RegistryAccessBoundary>
+  );
+}

--- a/ui/components/layout/app-sidebar/app-sidebar-content.test.tsx
+++ b/ui/components/layout/app-sidebar/app-sidebar-content.test.tsx
@@ -33,6 +33,10 @@ vi.mock("@/hooks/use-runtime-config", () => ({
   useRuntimeConfig: () => ({ apiDocsUrl: "https://local.example/docs" }),
 }));
 
+vi.mock("@/components/registry/registry-eligibility-provider", () => ({
+  useRegistryEligibility: () => ({ isEligible: true }),
+}));
+
 vi.mock("@/store", () => ({
   useScansStore: (
     selector: (state: {
@@ -87,6 +91,18 @@ describe("AppSidebarContent", () => {
       undefined,
     );
     expect(screen.getAllByText("Cloud").length).toBeGreaterThan(0);
+  });
+
+  it("uses the eligibility lease for Registry navigation", () => {
+    // Given / When
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    render(<AppSidebarContent />);
+
+    // Then
+    expect(screen.getByRole("link", { name: /Registry/ })).toHaveAttribute(
+      "href",
+      "/registry",
+    );
   });
 
   it("keeps the existing Lighthouse chat sidebar in Cloud Chat mode", () => {

--- a/ui/components/layout/app-sidebar/app-sidebar-content.tsx
+++ b/ui/components/layout/app-sidebar/app-sidebar-content.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 
 import { LighthouseV2SidebarChat } from "@/app/(prowler)/lighthouse/_components/navigation";
 import { ProwlerBrand } from "@/components/icons";
+import { useRegistryEligibility } from "@/components/registry/registry-eligibility-provider";
 import { useAuth } from "@/hooks";
 import { useRuntimeConfig } from "@/hooks/use-runtime-config";
 import { isCloud } from "@/lib/shared/env";
@@ -24,6 +25,7 @@ interface AppSidebarContentProps {
 export function AppSidebarContent({ onSelect }: AppSidebarContentProps) {
   const pathname = usePathname();
   const { permissions } = useAuth();
+  const { isEligible: registryEligible } = useRegistryEligibility();
   const { apiDocsUrl, cloudBillingEnabled } = useRuntimeConfig();
   const mode = useAppSidebarMode((state) => state.mode);
   const isCloudEnvironment = isCloud();
@@ -31,6 +33,7 @@ export function AppSidebarContent({ onSelect }: AppSidebarContentProps) {
     pathname,
     apiDocsUrl,
     cloudBillingEnabled,
+    registryEligible,
     permissions,
   });
   const showChat = isCloudEnvironment && mode === APP_SIDEBAR_MODE.CHAT;

--- a/ui/components/layout/app-sidebar/navigation-config.test.ts
+++ b/ui/components/layout/app-sidebar/navigation-config.test.ts
@@ -146,6 +146,25 @@ describe("getNavigationConfig", () => {
     ]);
   });
 
+  it("shows the New Registry link for a fresh eligibility lease", () => {
+    // Given / When
+    vi.stubEnv("UI_CLOUD_ENABLED", "true");
+    const registry = getNavigationConfig({
+      pathname: "/registry",
+      apiDocsUrl: null,
+      registryEligible: true,
+    })
+      .flatMap((section) => section.items)
+      .find((item) => item.label === "Registry");
+
+    // Then
+    expect(registry).toMatchObject({
+      href: "/registry",
+      active: true,
+      highlight: true,
+    });
+  });
+
   it("keeps the Cloud Billing destination for users with billing permission", () => {
     // Given
     vi.stubEnv("UI_CLOUD_ENABLED", "true");

--- a/ui/components/layout/app-sidebar/navigation-config.ts
+++ b/ui/components/layout/app-sidebar/navigation-config.ts
@@ -5,6 +5,7 @@ import {
   GitBranch,
   LayoutGrid,
   MessageCircleQuestion,
+  Package,
   Settings,
   ShieldCheck,
   SquareChartGantt,
@@ -32,6 +33,7 @@ interface NavigationConfigOptions {
   pathname: string;
   apiDocsUrl?: string | null;
   cloudBillingEnabled?: boolean;
+  registryEligible?: boolean;
   permissions?: RolePermissionAttributes;
 }
 
@@ -108,6 +110,7 @@ export function getNavigationConfig({
   pathname,
   apiDocsUrl = null,
   cloudBillingEnabled = false,
+  registryEligible = false,
   permissions,
 }: NavigationConfigOptions): NavigationSection[] {
   const isCloudEnvironment = isCloud();
@@ -180,6 +183,18 @@ export function getNavigationConfig({
           icon: Warehouse,
           active: isRouteActive(pathname, "/resources"),
         },
+        ...(registryEligible
+          ? [
+              {
+                kind: NAVIGATION_ITEM_KIND.LINK,
+                href: "/registry",
+                label: "Registry",
+                icon: Package,
+                active: isRouteActive(pathname, "/registry"),
+                highlight: true,
+              } as const,
+            ]
+          : []),
       ],
     },
     {

--- a/ui/components/registry/registry-access-boundary.integration.test.tsx
+++ b/ui/components/registry/registry-access-boundary.integration.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { render } from "@/__tests__/render-browser";
+
+vi.mock("@/lib/registry/access.server", () => ({
+  refreshRegistryEligibility: () => Promise.resolve({ status: "ineligible" }),
+}));
+
+import { RegistryAccessBoundary } from "./registry-access-boundary";
+import { RegistryEligibilityProvider } from "./registry-eligibility-provider";
+
+describe("RegistryAccessBoundary", () => {
+  it("unmounts protected Registry state after client access denial", async () => {
+    // Given / When
+    await render(
+      <RegistryEligibilityProvider>
+        <RegistryAccessBoundary initialLeaseDurationMs={30_000}>
+          <p>Protected Registry state</p>
+        </RegistryAccessBoundary>
+      </RegistryEligibilityProvider>,
+    );
+
+    // Then
+    await expect
+      .poll(() => document.body.textContent)
+      .not.toContain("Protected Registry state");
+  });
+});

--- a/ui/components/registry/registry-access-boundary.tsx
+++ b/ui/components/registry/registry-access-boundary.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+import { REGISTRY_ACCESS } from "@/lib/registry/access";
+
+import { useRegistryEligibility } from "./registry-eligibility-provider";
+
+export function RegistryAccessBoundary({
+  children,
+  initialLeaseDurationMs,
+}: {
+  children: ReactNode;
+  initialLeaseDurationMs: number;
+}) {
+  const router = useRouter();
+  const { generation, isEligible, status } = useRegistryEligibility();
+  const expiresAt = useRef(Date.now() + initialLeaseDurationMs);
+  const [now, setNow] = useState(Date.now());
+  const allowed =
+    isEligible ||
+    (status === REGISTRY_ACCESS.UNKNOWN &&
+      generation <= 1 &&
+      now < expiresAt.current);
+
+  useEffect(() => {
+    const timer = window.setTimeout(
+      () => setNow(Date.now()),
+      Math.max(0, expiresAt.current - Date.now()),
+    );
+    return () => window.clearTimeout(timer);
+  }, []);
+  useEffect(() => {
+    if (!allowed) router.replace("/profile");
+  }, [allowed, router]);
+
+  return allowed ? children : null;
+}

--- a/ui/components/registry/registry-eligibility-provider.integration.test.tsx
+++ b/ui/components/registry/registry-eligibility-provider.integration.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { render } from "@/__tests__/render-browser";
+
+const { refreshAccessMock } = vi.hoisted(() => ({
+  refreshAccessMock: vi.fn(),
+}));
+vi.mock("@/lib/registry/access.server", () => ({
+  refreshRegistryEligibility: refreshAccessMock,
+}));
+
+import {
+  RegistryEligibilityProvider,
+  useRegistryEligibility,
+} from "./registry-eligibility-provider";
+
+function Probe() {
+  const { isEligible, status } = useRegistryEligibility();
+  return <p>{isEligible ? "eligible" : status}</p>;
+}
+
+const renderProbe = () =>
+  render(
+    <RegistryEligibilityProvider>
+      <Probe />
+    </RegistryEligibilityProvider>,
+  );
+
+describe("RegistryEligibilityProvider", () => {
+  it("requires a server lease, renews visible access, and expires hidden access", async () => {
+    // Given
+    vi.useFakeTimers();
+    refreshAccessMock.mockResolvedValue({
+      status: "eligible",
+      leaseDurationMs: 30_000,
+    });
+    const view = await renderProbe();
+    await expect.element(view.getByText("eligible")).toBeVisible();
+
+    // When
+    await vi.advanceTimersByTimeAsync(15_000);
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    // Then
+    expect(refreshAccessMock).toHaveBeenCalledTimes(2);
+    await expect.element(view.getByText("unknown")).toBeVisible();
+    vi.useRealTimers();
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+  });
+
+  it("rejects a late lease after a newer foreground denial", async () => {
+    // Given
+    let resolveFirst!: (value: unknown) => void;
+    refreshAccessMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<unknown>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ status: "ineligible" });
+    const view = await renderProbe();
+
+    // When
+    window.dispatchEvent(new Event("focus"));
+    resolveFirst!({ status: "eligible", leaseDurationMs: 30_000 });
+
+    // Then
+    await expect.element(view.getByText("ineligible")).toBeVisible();
+  });
+});

--- a/ui/components/registry/registry-eligibility-provider.tsx
+++ b/ui/components/registry/registry-eligibility-provider.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import {
+  createContext,
+  type ReactNode,
+  use,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  REGISTRY_ACCESS,
+  type RegistryAccessStatus,
+} from "@/lib/registry/access";
+import { refreshRegistryEligibility } from "@/lib/registry/access.server";
+
+type RegistryEligibilityState = {
+  status: RegistryAccessStatus;
+  generation: number;
+  leaseExpiresAt?: number;
+};
+
+const RegistryEligibilityContext = createContext<
+  | (RegistryEligibilityState & { isEligible: boolean; invalidate: () => void })
+  | null
+>(null);
+
+export function RegistryEligibilityProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const pathname = usePathname();
+  const generationRef = useRef(0);
+  const [state, setState] = useState<RegistryEligibilityState>({
+    status: REGISTRY_ACCESS.UNKNOWN,
+    generation: 0,
+  });
+  const refresh = useEffectEvent(async (invalidate: boolean) => {
+    const generation = ++generationRef.current;
+    if (invalidate) setState({ status: REGISTRY_ACCESS.UNKNOWN, generation });
+    try {
+      const result = await refreshRegistryEligibility();
+      if (generation !== generationRef.current) return;
+      setState(
+        result.status === REGISTRY_ACCESS.ELIGIBLE
+          ? {
+              status: result.status,
+              generation,
+              leaseExpiresAt: Date.now() + result.leaseDurationMs,
+            }
+          : { status: result.status, generation },
+      );
+    } catch {
+      if (generation === generationRef.current) {
+        setState({ status: REGISTRY_ACCESS.UNKNOWN, generation });
+      }
+    }
+  });
+
+  useEffect(() => void refresh(true), [pathname]);
+  useEffect(() => {
+    const refreshVisible = () => {
+      if (document.visibilityState === "visible") void refresh(true);
+    };
+    const refreshOnline = () => void refresh(true);
+    window.addEventListener("focus", refreshVisible);
+    window.addEventListener("online", refreshOnline);
+    document.addEventListener("visibilitychange", refreshVisible);
+    return () => {
+      window.removeEventListener("focus", refreshVisible);
+      window.removeEventListener("online", refreshOnline);
+      document.removeEventListener("visibilitychange", refreshVisible);
+    };
+  }, []);
+  useEffect(() => {
+    if (state.status !== REGISTRY_ACCESS.ELIGIBLE || !state.leaseExpiresAt)
+      return;
+    const expire = window.setTimeout(
+      () => {
+        setState({
+          status: REGISTRY_ACCESS.UNKNOWN,
+          generation: ++generationRef.current,
+        });
+      },
+      Math.max(0, state.leaseExpiresAt - Date.now()),
+    );
+    const renew = window.setInterval(() => {
+      if (document.visibilityState === "visible") void refresh(false);
+    }, 15_000);
+    return () => {
+      window.clearTimeout(expire);
+      window.clearInterval(renew);
+    };
+  }, [state.leaseExpiresAt, state.status]);
+
+  const isEligible =
+    state.status === REGISTRY_ACCESS.ELIGIBLE &&
+    state.leaseExpiresAt !== undefined &&
+    Date.now() < state.leaseExpiresAt;
+  const invalidate = () =>
+    setState({
+      status: REGISTRY_ACCESS.UNKNOWN,
+      generation: ++generationRef.current,
+    });
+  return (
+    <RegistryEligibilityContext value={{ ...state, isEligible, invalidate }}>
+      {children}
+    </RegistryEligibilityContext>
+  );
+}
+
+export function useRegistryEligibility() {
+  const value = use(RegistryEligibilityContext);
+  if (!value) throw new Error("RegistryEligibilityProvider is required");
+  return value;
+}

--- a/ui/lib/registry/access.server.ts
+++ b/ui/lib/registry/access.server.ts
@@ -16,6 +16,12 @@ const hasEnabledProcessFlags = () =>
   readEnv("UI_CLOUD_ENABLED") === "true" &&
   readEnv("UI_REGISTRY_ENABLED") === "true";
 
+export async function refreshRegistryEligibility(): Promise<RegistryAccessResult> {
+  "use server";
+  const { auth } = await import("@/auth.config");
+  return evaluateRegistryAccess((await auth())?.accessToken);
+}
+
 export async function evaluateRegistryAccess(
   accessToken?: string | null,
 ): Promise<RegistryAccessResult> {

--- a/ui/proxy.test.ts
+++ b/ui/proxy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { evaluateAccessMock } = vi.hoisted(() => ({
+  evaluateAccessMock: vi.fn(),
+}));
+vi.mock("@/auth.config", () => ({ auth: (handler: unknown) => handler }));
+vi.mock("@/lib/csp", () => ({ getCspHeader: () => "default-src 'self'" }));
+vi.mock("@/lib/integrations", () => ({
+  GATED_INTEGRATIONS: { posthog: "posthog" },
+  isGatedIntegrationEnabled: () => false,
+  readGatedEnv: () => null,
+}));
+vi.mock("@/lib/registry/access.server", () => ({
+  evaluateRegistryAccess: evaluateAccessMock,
+}));
+vi.mock("@/lib/runtime-env", () => ({ readEnv: () => null }));
+vi.mock("@/lib/shared/env", () => ({ isCloud: () => true }));
+vi.mock("@/lib/utm", () => ({ copyAttributionParams: vi.fn() }));
+
+import proxy from "./proxy";
+
+const request = {
+  auth: { accessToken: "current-token", user: {} },
+  nextUrl: new URL("http://localhost/registry"),
+  url: "http://localhost/registry",
+};
+
+describe("proxy", () => {
+  it("redirects denied direct Registry requests to profile", async () => {
+    // Given / When
+    evaluateAccessMock.mockResolvedValue({ status: "ineligible" });
+    const response = (await proxy(request as never, {} as never)) as Response;
+
+    // Then
+    expect(evaluateAccessMock).toHaveBeenCalledWith("current-token");
+    expect(response.headers.get("location")).toBe("http://localhost/profile");
+  });
+});

--- a/ui/proxy.ts
+++ b/ui/proxy.ts
@@ -8,6 +8,8 @@ import {
   isGatedIntegrationEnabled,
   readGatedEnv,
 } from "@/lib/integrations";
+import { REGISTRY_ACCESS } from "@/lib/registry/access";
+import { evaluateRegistryAccess } from "@/lib/registry/access.server";
 import { readEnv } from "@/lib/runtime-env";
 import { isCloud } from "@/lib/shared/env";
 import { copyAttributionParams } from "@/lib/utm";
@@ -51,7 +53,7 @@ const redirect = (url: URL): NextResponse =>
   withSecurityHeaders(NextResponse.redirect(url));
 
 // NextAuth's auth() wrapper - renamed from middleware to proxy
-export default auth((req: NextAuthRequest) => {
+export default auth(async (req: NextAuthRequest) => {
   const { pathname } = req.nextUrl;
 
   const user = req.auth?.user;
@@ -80,6 +82,14 @@ export default auth((req: NextAuthRequest) => {
     (!isCloud() ||
       !cloudBillingEnabled ||
       user?.permissions?.manage_billing !== true)
+  ) {
+    return redirect(new URL("/profile", req.url));
+  }
+
+  if (
+    (pathname === "/registry" || pathname.startsWith("/registry/")) &&
+    (await evaluateRegistryAccess(req.auth?.accessToken)).status !==
+      REGISTRY_ACCESS.ELIGIBLE
   ) {
     return redirect(new URL("/profile", req.url));
   }


### PR DESCRIPTION
## 🔗 Part of Chained PRs

| Field | Value |
|---|---|
| Feature Branch | `feat/prowler-2414-registry-ui` |
| Main PR | #12494 |
| Position | 3 of 8 |
| Base | `feat/prowler-2414-registry-ui-02-access-authority` |
| Depends on | #12497 |
| Follow-up | #12503, Registry DTO and documented-error adapters |
| Review budget | 397 / 400 changed lines |
| Starts at | Fresh server authority without Registry discovery or routes |
| Ends with | Bounded in-memory leases, fail-closed navigation, and independently guarded direct routes |

### Chain Overview

```text
feat/prowler-2414-registry-ui (#12494 tracker)
└── #12495 PR 1: permissions and flag typing
    └── #12497 PR 2: fresh access authority
        └── 📍 #12499 PR 3: lease, navigation, and route guards
            └── #12503 PR 4: DTO and error adapters
                └── ... PR 8: acceptance hardening
                    └── #12494 tracker -> master
```

### Scope

- Includes: one in-memory eligibility provider, a Registry access boundary, lease-only sidebar discovery, a New badge, proxy denial, and an independently guarded dynamic `/registry` page.
- Excludes: Registry DTO/adapters/data actions, credential handling, catalog traversal, explorer UI, Add/Remove mutations, shared primitive changes, Playwright, backend changes, migrations, deployment, and rollout documentation.

### Autonomy

- [x] Focused and full unit/integration results are recorded.
- [x] Runtime behavior is covered by browser integration; manual explorer validation remains deferred until the user-facing slices exist.
- [x] Rollback is the single child commit and excludes unrelated work.
- [x] The diff contains only this work unit and remains below 400 changed lines.

### Context

A fresh server permission check is not enough for a long-lived browser session. Registry navigation and protected content must disappear within a bounded interval after permission or flag rollback, while direct requests must independently fail closed before reading Registry data.

This slice adds that access boundary without introducing any Registry API or credential behavior.

### Description

- Add one shared in-memory Registry eligibility provider around the authenticated application shell.
- Start in an unknown state and refresh a server-issued lease without trusting JWT permissions or hydrated runtime configuration.
- Renew visible sessions every 15 seconds and enforce a hard 30-second lease expiry, including while the document is hidden.
- Invalidate before mount, focus, visibility, pathname, and online refreshes, and ignore stale request generations.
- Show the New-badged Registry sidebar entry only while the lease is valid.
- Unmount protected Registry content immediately when eligibility is lost.
- Guard `/registry` independently in both the proxy and dynamic server page, redirecting denial to `/profile` before any Registry read.
- Keep lease and protected state out of browser storage and URLs.

No npm dependency, Registry endpoint call, backend change, migration, deployment change, or complete explorer UI is introduced.

### Steps to review

1. Review `registry-eligibility-provider.tsx` for unknown initialization, 15/30-second bounds, invalidate-before-refresh events, and stale-generation suppression.
2. Confirm sidebar discovery depends only on provider eligibility and that the New badge disappears on lease invalidation.
3. Confirm `registry-access-boundary.tsx` unmounts children when eligibility is not current.
4. Confirm `ui/proxy.ts` and `ui/app/(prowler)/registry/page.tsx` independently evaluate fresh access and redirect to `/profile` before Registry reads.
5. Run `cd ui && pnpm exec vitest run --project unit proxy.test.ts lib/registry/access.server.test.ts components/layout/main-layout/main-layout.test.tsx components/layout/app-sidebar/navigation-config.test.ts components/layout/app-sidebar/app-sidebar-content.test.tsx`; the recorded result is 5 files / 29 tests.
6. Run `cd ui && pnpm exec vitest run --project integration components/registry/registry-eligibility-provider.integration.test.tsx components/registry/registry-access-boundary.integration.test.tsx`; the recorded result is 2 files / 3 tests.
7. Run `cd ui && pnpm run test:unit && pnpm run test:integration`; the recorded results are 3,074 unit and 111 integration tests passing.
8. Run `PREK_NO_CONCURRENCY=1 uv run --directory . prek run`; Prettier, ESLint, TypeScript, related tests, and root hooks are recorded as passing.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md): not required for this access-boundary slice.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable: SDK/CLI is not changed.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI: the complete user-facing workflow is delivered by later child PRs.
- [x] This PR adds or updates no npm dependencies.
- [x] Mobile screenshots/video are deferred because Registry remains default-off and the explorer is not part of this slice.
- [x] Tablet screenshots/video are deferred because Registry remains default-off and the explorer is not part of this slice.
- [x] Desktop screenshots/video are deferred because Registry remains default-off and the explorer is not part of this slice.
- [x] No UI changelog fragment is added for this guarded foundation slice; the PR uses `no-changelog`, and the user-visible slice will add the feature fragment.

#### API
- [x] The API is not changed by this PR.
- [x] Endpoint output, query analysis, performance evidence, API specs, versions, and API changelog are not applicable.

#### MCP Server
- [x] The MCP Server is not changed by this PR.
- [x] The MCP changelog is not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


