### PR TITLE
[CHAIN] feat(ui): add non-secret Registry API adapters

### DIFF
--- a/ui/actions/registry/registry.adapter.test.ts
+++ b/ui/actions/registry/registry.adapter.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REGISTRY_ENDPOINT,
+  REGISTRY_FAILURE,
+  REGISTRY_SUBMISSION,
+} from "@/types/registry";
+
+import {
+  adaptRegistryCredentialStatus,
+  classifyRegistryFailure,
+  parseRegistryCredentialSubmission,
+} from "./registry.adapter";
+
+const credentialPayload = {
+  data: {
+    attributes: {
+      configured: true,
+      is_valid: true,
+      scopes: ["catalog:read"],
+      last_validated_at: "2026-03-20T12:00:00Z",
+      validation_status: "valid",
+      validation_pending: false,
+      key: "registry-secret-value",
+      masked_key: "reg_***",
+      pending_key: "queued-secret",
+      arbitrary_backend_detail: "do not expose",
+    },
+  },
+};
+
+const activeCredential = adaptRegistryCredentialStatus(credentialPayload);
+const jsonError = (status: number, code: string) =>
+  new Response(
+    JSON.stringify({ errors: [{ code, detail: "private detail" }] }),
+    {
+      status,
+    },
+  );
+
+describe("Registry adapter", () => {
+  it("maps only documented non-secret credential status fields", () => {
+    // Given
+    const malformedPayload = { data: { attributes: { configured: true } } };
+
+    // When
+    const status = adaptRegistryCredentialStatus(credentialPayload);
+
+    // Then
+    expect(status).toEqual({
+      configured: true,
+      isValid: true,
+      scopes: ["catalog:read"],
+      lastValidatedAt: "2026-03-20T12:00:00Z",
+      validationStatus: "valid",
+      validationPending: false,
+    });
+    expect(adaptRegistryCredentialStatus(malformedPayload)).toBeNull();
+  });
+
+  it("accepts only a matching 202 task and fixed Content-Location path", async () => {
+    // Given
+    const response = new Response(
+      JSON.stringify({ data: { type: "tasks", id: "task-123" } }),
+      {
+        status: 202,
+        headers: { "Content-Location": "/api/v1/tasks/task-123" },
+      },
+    );
+
+    // When
+    const result = await parseRegistryCredentialSubmission(response);
+
+    // Then
+    expect(result).toEqual({
+      status: REGISTRY_SUBMISSION.PENDING,
+      taskId: "task-123",
+    });
+  });
+
+  it("rejects a non-202 response or a mismatched task location", async () => {
+    // Given
+    const task = JSON.stringify({ data: { type: "tasks", id: "task-123" } });
+    const wrongStatus = new Response(task, { status: 201 });
+    const wrongLocation = new Response(task, {
+      status: 202,
+      headers: { "Content-Location": "/api/v1/tasks/other" },
+    });
+
+    // When
+    const results = await Promise.all([
+      parseRegistryCredentialSubmission(wrongStatus),
+      parseRegistryCredentialSubmission(wrongLocation),
+    ]);
+
+    // Then
+    expect(results).toEqual([
+      { status: REGISTRY_SUBMISSION.ERROR },
+      { status: REGISTRY_SUBMISSION.ERROR },
+    ]);
+  });
+
+  it("classifies every Registry 401 or 403 as access denied first", async () => {
+    // Given
+    const responses = [
+      [401, REGISTRY_ENDPOINT.CREDENTIAL],
+      [403, REGISTRY_ENDPOINT.MUTATION],
+      [403, REGISTRY_ENDPOINT.PROVIDERS],
+    ] as const;
+
+    // When
+    const results = await Promise.all(
+      responses.map(([status, endpoint]) =>
+        classifyRegistryFailure(
+          jsonError(status, "registry_key_rejected"),
+          endpoint,
+          activeCredential,
+        ),
+      ),
+    );
+
+    // Then
+    expect(results).toEqual([
+      { status: REGISTRY_FAILURE.ACCESS_DENIED },
+      { status: REGISTRY_FAILURE.ACCESS_DENIED },
+      { status: REGISTRY_FAILURE.ACCESS_DENIED },
+    ]);
+  });
+
+  it("maps only a 409 with an authoritative no-active credential to onboarding", async () => {
+    // Given
+    const noCredential = adaptRegistryCredentialStatus({
+      data: {
+        attributes: {
+          configured: false,
+          is_valid: false,
+          scopes: [],
+          validation_pending: false,
+        },
+      },
+    });
+
+    // When
+    const results = await Promise.all(
+      [noCredential, null].map((credential) =>
+        classifyRegistryFailure(
+          new Response(null, { status: 409 }),
+          REGISTRY_ENDPOINT.AVAILABLE_ARTIFACTS,
+          credential,
+        ),
+      ),
+    );
+
+    // Then
+    expect(results).toEqual([
+      { status: REGISTRY_FAILURE.ONBOARDING },
+      { status: REGISTRY_FAILURE.ERROR },
+    ]);
+  });
+
+  it("maps only exact documented 502 and 503 status-code pairs", async () => {
+    // Given
+    const rejected = jsonError(502, "registry_key_rejected");
+    const unavailable = jsonError(503, "registry_unavailable");
+
+    // When
+    const results = await Promise.all([
+      classifyRegistryFailure(
+        rejected,
+        REGISTRY_ENDPOINT.PROVIDERS,
+        activeCredential,
+      ),
+      classifyRegistryFailure(
+        unavailable,
+        REGISTRY_ENDPOINT.AVAILABLE_ARTIFACTS,
+        activeCredential,
+      ),
+    ]);
+
+    // Then
+    expect(results).toEqual([
+      { status: REGISTRY_FAILURE.RECONNECT },
+      { status: REGISTRY_FAILURE.UNAVAILABLE },
+    ]);
+  });
+
+  it("keeps wrong, malformed, and unrelated failures generic", async () => {
+    // Given
+    const malformed = new Response("<html>key=private</html>", { status: 503 });
+
+    // When
+    const results = await Promise.all([
+      classifyRegistryFailure(
+        jsonError(502, "other_error"),
+        REGISTRY_ENDPOINT.PROVIDERS,
+        activeCredential,
+      ),
+      classifyRegistryFailure(
+        jsonError(502, "registry_unavailable"),
+        REGISTRY_ENDPOINT.PROVIDERS,
+        activeCredential,
+      ),
+      classifyRegistryFailure(
+        malformed,
+        REGISTRY_ENDPOINT.PROVIDERS,
+        activeCredential,
+      ),
+    ]);
+
+    // Then
+    expect(results).toEqual([
+      { status: REGISTRY_FAILURE.ERROR },
+      { status: REGISTRY_FAILURE.ERROR },
+      { status: REGISTRY_FAILURE.ERROR },
+    ]);
+  });
+});

--- a/ui/actions/registry/registry.adapter.ts
+++ b/ui/actions/registry/registry.adapter.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+
+import {
+  REGISTRY_ENDPOINT,
+  REGISTRY_FAILURE,
+  REGISTRY_SUBMISSION,
+  type RegistryCredentialStatus,
+  type RegistryCredentialSubmissionResult,
+  type RegistryEndpoint,
+  type RegistryFailureResult,
+} from "@/types/registry";
+
+const REGISTRY_TASK_PATH_PREFIX = "/api/v1/tasks/";
+const REGISTRY_ERROR_CODE = {
+  KEY_REJECTED: "registry_key_rejected",
+  UNAVAILABLE: "registry_unavailable",
+} as const;
+const registryDiscoveryEndpoints = new Set<RegistryEndpoint>([
+  REGISTRY_ENDPOINT.PROVIDERS,
+  REGISTRY_ENDPOINT.AVAILABLE_ARTIFACTS,
+]);
+
+const credentialStatusSchema = z.object({
+  data: z.object({
+    attributes: z.object({
+      configured: z.boolean(),
+      is_valid: z.boolean(),
+      scopes: z.array(z.string()),
+      last_validated_at: z.string().optional(),
+      validation_status: z.string().optional(),
+      validation_pending: z.boolean(),
+    }),
+  }),
+});
+
+const taskSubmissionSchema = z.object({
+  data: z.object({
+    type: z.literal("tasks"),
+    id: z.string().min(1),
+  }),
+});
+
+const errorDocumentSchema = z.object({
+  errors: z.array(z.object({ code: z.string().min(1) })).min(1),
+});
+
+export function adaptRegistryCredentialStatus(
+  payload: unknown,
+): RegistryCredentialStatus | null {
+  const parsed = credentialStatusSchema.safeParse(payload);
+  if (!parsed.success) return null;
+
+  const { attributes } = parsed.data.data;
+  return {
+    configured: attributes.configured,
+    isValid: attributes.is_valid,
+    scopes: attributes.scopes,
+    lastValidatedAt: attributes.last_validated_at,
+    validationStatus: attributes.validation_status,
+    validationPending: attributes.validation_pending,
+  };
+}
+
+export async function parseRegistryCredentialSubmission(
+  response: Response,
+): Promise<RegistryCredentialSubmissionResult> {
+  if (response.status !== 202) return { status: REGISTRY_SUBMISSION.ERROR };
+
+  const parsed = taskSubmissionSchema.safeParse(
+    await response.json().catch(() => undefined),
+  );
+  const taskId = parsed.success ? parsed.data.data.id : undefined;
+  const location = response.headers.get("Content-Location");
+  if (
+    !taskId ||
+    location !== `${REGISTRY_TASK_PATH_PREFIX}${encodeURIComponent(taskId)}`
+  ) {
+    return { status: REGISTRY_SUBMISSION.ERROR };
+  }
+
+  return { status: REGISTRY_SUBMISSION.PENDING, taskId };
+}
+
+export async function classifyRegistryFailure(
+  response: Response,
+  endpoint: RegistryEndpoint,
+  credentialStatus: RegistryCredentialStatus | null,
+): Promise<RegistryFailureResult> {
+  if (response.status === 401 || response.status === 403) {
+    return { status: REGISTRY_FAILURE.ACCESS_DENIED };
+  }
+
+  if (!isRegistryDiscoveryEndpoint(endpoint)) {
+    return { status: REGISTRY_FAILURE.ERROR };
+  }
+
+  if (
+    response.status === 409 &&
+    credentialStatus !== null &&
+    !hasActiveRegistryCredential(credentialStatus)
+  ) {
+    return { status: REGISTRY_FAILURE.ONBOARDING };
+  }
+
+  const code = await getRegistryErrorCode(response);
+  if (response.status === 502 && code === REGISTRY_ERROR_CODE.KEY_REJECTED) {
+    return { status: REGISTRY_FAILURE.RECONNECT };
+  }
+  if (response.status === 503 && code === REGISTRY_ERROR_CODE.UNAVAILABLE) {
+    return { status: REGISTRY_FAILURE.UNAVAILABLE };
+  }
+
+  return { status: REGISTRY_FAILURE.ERROR };
+}
+
+function isRegistryDiscoveryEndpoint(endpoint: RegistryEndpoint) {
+  return registryDiscoveryEndpoints.has(endpoint);
+}
+
+function hasActiveRegistryCredential(
+  credentialStatus: RegistryCredentialStatus | null,
+) {
+  return Boolean(
+    credentialStatus?.configured &&
+      credentialStatus.isValid &&
+      !credentialStatus.validationPending,
+  );
+}
+
+async function getRegistryErrorCode(response: Response) {
+  const parsed = errorDocumentSchema.safeParse(
+    await response
+      .clone()
+      .json()
+      .catch(() => undefined),
+  );
+  return parsed.success ? parsed.data.errors[0]?.code : undefined;
+}

--- a/ui/types/registry.ts
+++ b/ui/types/registry.ts
@@ -1,0 +1,45 @@
+export const REGISTRY_ENDPOINT = {
+  PROVIDERS: "providers",
+  AVAILABLE_ARTIFACTS: "available_artifacts",
+  CREDENTIAL: "credential",
+  MUTATION: "mutation",
+} as const;
+
+export type RegistryEndpoint =
+  (typeof REGISTRY_ENDPOINT)[keyof typeof REGISTRY_ENDPOINT];
+
+export const REGISTRY_FAILURE = {
+  ACCESS_DENIED: "access_denied",
+  ONBOARDING: "onboarding",
+  RECONNECT: "reconnect",
+  UNAVAILABLE: "unavailable",
+  ERROR: "error",
+} as const;
+
+export type RegistryFailureResult =
+  | { status: typeof REGISTRY_FAILURE.ACCESS_DENIED }
+  | { status: typeof REGISTRY_FAILURE.ONBOARDING }
+  | { status: typeof REGISTRY_FAILURE.RECONNECT }
+  | { status: typeof REGISTRY_FAILURE.UNAVAILABLE }
+  | { status: typeof REGISTRY_FAILURE.ERROR };
+
+export const REGISTRY_SUBMISSION = {
+  PENDING: "pending",
+  ERROR: "error",
+} as const;
+
+export type RegistryCredentialSubmissionResult =
+  | {
+      status: typeof REGISTRY_SUBMISSION.PENDING;
+      taskId: string;
+    }
+  | { status: typeof REGISTRY_SUBMISSION.ERROR };
+
+export interface RegistryCredentialStatus {
+  configured: boolean;
+  isValid: boolean;
+  scopes: string[];
+  lastValidatedAt?: string;
+  validationStatus?: string;
+  validationPending: boolean;
+}


### PR DESCRIPTION
## 🔗 Part of Chained PRs

| Field | Value |
|---|---|
| Feature Branch | `feat/prowler-2414-registry-ui` |
| Main PR | #12494 |
| Position | 4 of 8 |
| Base | `feat/prowler-2414-registry-ui-03-access-boundaries` |
| Depends on | #12499 |
| Follow-up | #12504, complete catalog traversal and model |
| Review budget | 400 / 400 changed lines |
| Starts at | Fresh Registry access boundaries without API contracts |
| Ends with | Non-secret Registry DTOs and authorization-first documented-error classification |

### Chain Overview

```text
feat/prowler-2414-registry-ui (#12494 tracker)
└── #12495 PR 1: permissions and flag typing
    └── #12497 PR 2: fresh access authority
        └── #12499 PR 3: lease, navigation, and route guards
            └── 📍 #12503 PR 4: DTO and error adapters
                └── #12504 PR 5: complete catalog model
                    └── ... PR 8: acceptance hardening
                        └── #12494 tracker -> master
```

### Scope

- Includes: private Registry wire schemas, public camel-case non-secret credential/task/failure DTOs, strict accepted-task binding, and authorization-first failure classification.
- Excludes: guarded Registry actions/bootstrap, complete pagination and catalog modeling, credential lifecycle, explorer UI, Add/Remove mutations, primitive changes, Playwright, backend changes, migrations, deployment, and documentation.

### Autonomy

- [x] Focused and full unit-test results are recorded.
- [x] Runtime verification is not applicable because this slice performs no Registry request and exposes no new workflow.
- [x] Rollback is the single child commit and excludes unrelated work.
- [x] The diff contains only this work unit and is exactly 400 changed lines.

### Context

Registry responses can contain malformed, arbitrary, or secret-shaped fields. Client-facing code needs a deliberately small contract that exposes only documented non-secret state and classifies revoked access before interpreting Registry-specific recovery conditions.

This slice establishes that adapter boundary before later actions begin calling Registry endpoints.

### Description

- Add private snake-case Zod schemas for documented Registry wire responses.
- Expose flat camel-case DTOs containing only allowlisted credential and task fields.
- Discard unknown, secret-shaped, and arbitrary backend details instead of forwarding them.
- Accept credential submission only for HTTP 202 with a matching fixed task `Content-Location`.
- Classify every Registry 401/403 as `access_denied` before body parsing or endpoint-specific recovery.
- Recognize only the documented onboarding, rejected-key, and unavailable-service status/code pairs.
- Return fixed generic failures for wrong status/code combinations, malformed payloads, and unrelated backend errors.

No Registry request, npm dependency, backend endpoint, migration, runtime flag, navigation, or user-visible workflow is introduced.

### Steps to review

1. Review `ui/types/registry.ts` and confirm public DTOs contain no key, secret, arbitrary error detail, or raw wire payload.
2. Review the private schemas and mapping in `registry.adapter.ts` for exact field allowlisting.
3. Confirm 401/403 returns `access_denied` before endpoint branching or body parsing.
4. Confirm only the documented 409, 502, and 503 combinations receive specialized safe-copy results.
5. Confirm accepted task parsing requires both HTTP 202 and the fixed encoded task `Content-Location`.
6. Run `cd ui && pnpm exec vitest run --project unit actions/registry/registry.adapter.test.ts actions/task/task.adapter.test.ts lib/auth/current-user.test.ts lib/server-actions-helper.test.ts`; the recorded result is 4 files / 36 tests.
7. Run `cd ui && pnpm run test:unit`; the recorded result is 3,081 passing tests.
8. Run `PREK_NO_CONCURRENCY=1 uv run --directory . prek run`; Prettier, ESLint, TypeScript, related tests, and root hooks are recorded as passing.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md): not required for this adapter slice.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable: SDK/CLI is not changed.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI: the complete user-facing workflow is delivered by later child PRs.
- [x] This PR adds or updates no npm dependencies.
- [x] Mobile screenshots/video are not applicable because this slice exposes no UI.
- [x] Tablet screenshots/video are not applicable because this slice exposes no UI.
- [x] Desktop screenshots/video are not applicable because this slice exposes no UI.
- [x] No UI changelog fragment is added for this internal adapter slice; the PR uses `no-changelog`, and the user-visible slice will add the feature fragment.

#### API
- [x] The API is not changed by this PR.
- [x] Endpoint output, query analysis, performance evidence, API specs, versions, and API changelog are not applicable.

#### MCP Server
- [x] The MCP Server is not changed by this PR.
- [x] The MCP changelog is not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


