### PR TITLE
[CHAIN] feat(ui): add complete Registry catalog model

### DIFF
--- a/ui/actions/registry/registry.adapter.test.ts
+++ b/ui/actions/registry/registry.adapter.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   adaptRegistryCredentialStatus,
   classifyRegistryFailure,
+  collectCompleteRegistryCatalog,
   parseRegistryCredentialSubmission,
 } from "./registry.adapter";
 
@@ -213,5 +214,90 @@ describe("Registry adapter", () => {
       { status: REGISTRY_FAILURE.ERROR },
       { status: REGISTRY_FAILURE.ERROR },
     ]);
+  });
+
+  it("degrades a non-terminal empty first catalog page", async () => {
+    // Given
+    const document = (page: number) => ({
+      data: [],
+      meta: { pagination: { page, pages: 2, count: 0 } },
+    });
+
+    // When
+    const result = await collectCompleteRegistryCatalog(async (page) =>
+      document(page),
+    );
+
+    // Then
+    expect(result).toEqual({
+      status: "incomplete",
+      reason: "invalid_page",
+      collectedCount: 0,
+    });
+  });
+
+  it("accepts a terminal empty first catalog page", async () => {
+    // Given
+    const document = {
+      data: [],
+      meta: { pagination: { page: 1, pages: 1, count: 0 } },
+    };
+
+    // When
+    const result = await collectCompleteRegistryCatalog(async () => document);
+
+    // Then
+    expect(result).toEqual({ status: "complete", artifacts: [] });
+  });
+
+  it("traverses, merges, and degrades unsafe catalog data", async () => {
+    // Given
+    // prettier-ignore
+    const resource = (id: string, attributes: Record<string, unknown> = {}) => ({ type: "registry-artifacts", id, attributes });
+    // prettier-ignore
+    const document = (page: number, pages: number, count: number, data: unknown[]) => ({ data, meta: { pagination: { page, pages, count } } });
+    const requests: Array<[number, string | null, string | null]> = [];
+
+    // When
+    // prettier-ignore
+    const complete = await collectCompleteRegistryCatalog(async (page, query) => { requests.push([page, query.get("page[number]"), query.get("page[size]")]); return page === 1 ? document(1, 2, 3, [resource("core", { name: "Core", providers: ["AWS"], is_verified: true, version_count: 1, total_downloads: 2, owners: [{ type: "organization", name: "Prowler" }] }), resource("zeta")]) : document(2, 2, 3, [resource("core", { description: "Registry core", latest_version: "2.0.0", providers: ["gcp"], is_official: true, has_checks: true, version_count: 3, total_downloads: 8 })]); });
+    // prettier-ignore
+    const limits = await Promise.all([999, 1000, 1001].map(async (pages) => { let requests = 0; const result = await collectCompleteRegistryCatalog(async (page) => { requests += 1; return document(page, pages, pages, [resource(`item-${page}`)]); }); return [pages, requests, result] as const; }));
+    // prettier-ignore
+    const failures = await Promise.all([collectCompleteRegistryCatalog(async () => ({ data: {}, meta: {} })), collectCompleteRegistryCatalog(async () => document(1, 1, 2, [resource("one")])), collectCompleteRegistryCatalog(async (page) => document(page === 1 ? 1 : 1, 2, 2, [resource(`item-${page}`)])), collectCompleteRegistryCatalog(async (page) => document(page, page === 1 ? 2 : 3, 2, [resource(`item-${page}`)])), collectCompleteRegistryCatalog(async () => document(1, 1, 1, [resource("")])), collectCompleteRegistryCatalog(async (page) => document(page, 2, 2, [resource("duplicate", { name: page === 1 ? "One" : "Two" })])), collectCompleteRegistryCatalog(async (page) => { if (page === 2) throw new Error("offline"); return document(1, 2, 2, [resource("first")]); })]);
+
+    // Then
+    expect(requests).toEqual([
+      [1, "1", "100"],
+      [2, "2", "100"],
+    ]);
+    // prettier-ignore
+    expect(complete).toMatchObject({ status: "complete", artifacts: [{ normalizedName: "core", name: "Core", description: "Registry core", latestVersion: "2.0.0", providers: ["aws", "gcp"], isVerified: true, isOfficial: true, hasChecks: true, versionCount: 3, totalDownloads: 8, owners: [{ type: "organization", name: "Prowler" }] }, { normalizedName: "zeta" }] });
+    expect(limits.map(([pages, requests]) => [pages, requests])).toEqual([
+      [999, 999],
+      [1000, 1000],
+      [1001, 1],
+    ]);
+    expect(limits[2]?.[2]).toEqual({
+      status: "incomplete",
+      reason: "guard_exhausted",
+      collectedCount: 1,
+    });
+    expect(
+      failures.map((result) =>
+        result.status === "incomplete" ? result.reason : undefined,
+      ),
+    ).toEqual([
+      "invalid_page",
+      "count_mismatch",
+      "invalid_page",
+      "invalid_page",
+      "invalid_resource",
+      "conflicting_duplicate",
+      "page_failed",
+    ]);
+    failures.forEach((result) =>
+      expect(result).not.toHaveProperty("artifacts"),
+    );
   });
 });

--- a/ui/actions/registry/registry.adapter.ts
+++ b/ui/actions/registry/registry.adapter.ts
@@ -1,9 +1,13 @@
 import { z } from "zod";
 
 import {
+  REGISTRY_CATALOG,
+  REGISTRY_CATALOG_INCOMPLETE_REASON,
   REGISTRY_ENDPOINT,
   REGISTRY_FAILURE,
   REGISTRY_SUBMISSION,
+  type RegistryCatalogArtifact,
+  type RegistryCatalogResult,
   type RegistryCredentialStatus,
   type RegistryCredentialSubmissionResult,
   type RegistryEndpoint,
@@ -135,4 +139,160 @@ async function getRegistryErrorCode(response: Response) {
       .catch(() => undefined),
   );
   return parsed.success ? parsed.data.errors[0]?.code : undefined;
+}
+
+const REGISTRY_CATALOG_PAGE_SIZE = 100;
+const REGISTRY_CATALOG_MAX_PAGES = 1000;
+const safeInteger = z.number().int().nonnegative().safe();
+// prettier-ignore
+const catalogPageSchema = z.object({
+  data: z.array(z.unknown()),
+  meta: z.object({ pagination: z.object({ page: safeInteger, pages: safeInteger, count: safeInteger }) }),
+});
+// prettier-ignore
+const catalogAttributesSchema = z.object({
+  name: z.string().optional(), description: z.string().optional(), latest_version: z.string().optional(),
+  providers: z.array(z.string().trim().min(1)).optional(),
+  owners: z.array(z.object({ name: z.string().trim().min(1), type: z.string().trim().min(1) })).optional(),
+  is_verified: z.boolean().optional(), is_official: z.boolean().optional(), is_meta: z.boolean().optional(),
+  has_provider: z.boolean().optional(), has_checks: z.boolean().optional(), has_compliance: z.boolean().optional(),
+  version_count: safeInteger.optional(), total_downloads: safeInteger.optional(),
+});
+const catalogResourceSchema = z.object({
+  type: z.string().trim().min(1),
+  id: z.string().trim().min(1),
+  attributes: catalogAttributesSchema,
+});
+type RegistryCatalogPageFetcher = (
+  page: number,
+  searchParams: URLSearchParams,
+) => Promise<unknown>;
+
+export async function collectCompleteRegistryCatalog(
+  fetchPage: RegistryCatalogPageFetcher,
+): Promise<RegistryCatalogResult> {
+  const resources: unknown[] = [];
+  let expectedPages: number | undefined;
+  let expectedCount: number | undefined;
+  for (let page = 1; ; page += 1) {
+    let payload: unknown;
+    try {
+      payload = await fetchPage(
+        page,
+        new URLSearchParams({
+          "page[number]": String(page),
+          "page[size]": String(REGISTRY_CATALOG_PAGE_SIZE),
+        }),
+      );
+    } catch {
+      return incomplete("PAGE_FAILED", resources.length);
+    }
+    const parsed = catalogPageSchema.safeParse(payload);
+    if (!parsed.success) return incomplete("INVALID_PAGE", resources.length);
+    const { count, page: responsePage, pages } = parsed.data.meta.pagination;
+    if (
+      responsePage !== page ||
+      (expectedPages !== undefined &&
+        (pages !== expectedPages || count !== expectedCount))
+    )
+      return incomplete("INVALID_PAGE", resources.length);
+    expectedPages ??= pages;
+    expectedCount ??= count;
+    if (page === 1 && pages > 1 && count === 0 && parsed.data.data.length === 0)
+      return incomplete("INVALID_PAGE", resources.length);
+    if (pages === 0)
+      return page === 1 && count === 0 && parsed.data.data.length === 0
+        ? { status: REGISTRY_CATALOG.COMPLETE, artifacts: [] }
+        : incomplete("INVALID_PAGE", resources.length);
+    resources.push(...parsed.data.data);
+    if (pages > REGISTRY_CATALOG_MAX_PAGES)
+      return incomplete("GUARD_EXHAUSTED", resources.length);
+    if (page === pages) break;
+    if (page > pages) return incomplete("INVALID_PAGE", resources.length);
+  }
+  const merged = mergeCatalogResources(resources);
+  return merged.status === REGISTRY_CATALOG.INCOMPLETE ||
+    resources.length === expectedCount
+    ? merged
+    : incomplete("COUNT_MISMATCH", resources.length);
+}
+
+function mergeCatalogResources(resources: unknown[]): RegistryCatalogResult {
+  const artifacts = new Map<string, RegistryCatalogArtifact>();
+  for (const resource of resources) {
+    const artifact = adaptCatalogArtifact(resource);
+    if (!artifact) return incomplete("INVALID_RESOURCE", resources.length);
+    const prior = artifacts.get(artifact.normalizedName);
+    const next = prior ? mergeArtifacts(prior, artifact) : artifact;
+    if (!next) return incomplete("CONFLICTING_DUPLICATE", resources.length);
+    artifacts.set(next.normalizedName, next);
+  }
+  return {
+    status: REGISTRY_CATALOG.COMPLETE,
+    artifacts: Array.from(artifacts.values()).sort((left, right) =>
+      compare(left.normalizedName, right.normalizedName),
+    ),
+  };
+}
+
+// prettier-ignore
+function adaptCatalogArtifact(resource: unknown): RegistryCatalogArtifact | null {
+  const parsed = catalogResourceSchema.safeParse(resource);
+  if (!parsed.success) return null;
+  const { attributes: a, id } = parsed.data;
+  return {
+    normalizedName: id, name: text(a.name), description: text(a.description), latestVersion: text(a.latest_version),
+    providers: unique(a.providers?.map((provider) => provider.toLowerCase()) ?? []), owners: uniqueOwners(a.owners ?? []),
+    isVerified: a.is_verified ?? false, isOfficial: a.is_official ?? false, isMeta: a.is_meta ?? false,
+    hasProvider: a.has_provider ?? false, hasChecks: a.has_checks ?? false, hasCompliance: a.has_compliance ?? false,
+    versionCount: a.version_count ?? 0, totalDownloads: a.total_downloads ?? 0,
+  };
+}
+
+// prettier-ignore
+function mergeArtifacts(left: RegistryCatalogArtifact, right: RegistryCatalogArtifact): RegistryCatalogArtifact | null {
+  const [name, description, latestVersion] = [mergeText(left.name, right.name), mergeText(left.description, right.description), mergeText(left.latestVersion, right.latestVersion)];
+  if ([name, description, latestVersion].some((value) => value === null)) return null;
+  return {
+    ...left, name: name ?? undefined, description: description ?? undefined, latestVersion: latestVersion ?? undefined,
+    providers: unique([...left.providers, ...right.providers]), owners: uniqueOwners([...left.owners, ...right.owners]),
+    isVerified: left.isVerified || right.isVerified, isOfficial: left.isOfficial || right.isOfficial, isMeta: left.isMeta || right.isMeta,
+    hasProvider: left.hasProvider || right.hasProvider, hasChecks: left.hasChecks || right.hasChecks, hasCompliance: left.hasCompliance || right.hasCompliance,
+    versionCount: Math.max(left.versionCount, right.versionCount), totalDownloads: Math.max(left.totalDownloads, right.totalDownloads),
+  };
+}
+
+function incomplete(
+  reason: keyof typeof REGISTRY_CATALOG_INCOMPLETE_REASON,
+  collectedCount: number,
+): RegistryCatalogResult {
+  return {
+    status: REGISTRY_CATALOG.INCOMPLETE,
+    reason: REGISTRY_CATALOG_INCOMPLETE_REASON[reason],
+    collectedCount,
+  };
+}
+function text(value: string | undefined) {
+  return value?.trim() || undefined;
+}
+function mergeText(left: string | undefined, right: string | undefined) {
+  return left && right && left !== right ? null : (left ?? right);
+}
+function unique(values: string[]) {
+  return Array.from(new Set(values)).sort(compare);
+}
+function uniqueOwners(owners: RegistryCatalogArtifact["owners"]) {
+  return Array.from(
+    new Map(
+      owners.map((owner) => [`${owner.type}\u0000${owner.name}`, owner]),
+    ).values(),
+  ).sort((left, right) =>
+    compare(
+      `${left.type}\u0000${left.name}`,
+      `${right.type}\u0000${right.name}`,
+    ),
+  );
+}
+function compare(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0;
 }

--- a/ui/components/registry/registry-explorer.model.test.ts
+++ b/ui/components/registry/registry-explorer.model.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import type { RegistryCatalogArtifact } from "@/types/registry";
+
+import {
+  buildRegistryExplorerModel,
+  getRegistryArtifactDetail,
+} from "./registry-explorer.model";
+
+// prettier-ignore
+const artifact = (normalizedName: string, overrides: Partial<RegistryCatalogArtifact> = {}): RegistryCatalogArtifact => ({ normalizedName, name: normalizedName, providers: [], isVerified: false, isOfficial: false, isMeta: false, hasProvider: false, hasChecks: false, hasCompliance: false, versionCount: 0, totalDownloads: 0, owners: [], ...overrides });
+
+describe("Registry explorer model", () => {
+  it("derives complete Available data, hierarchy, filters, details, and metrics", () => {
+    // Given
+    // prettier-ignore
+    const catalog = { status: "complete" as const, artifacts: [artifact("core", { providers: ["aws"], isOfficial: true }), artifact("global", { name: "Global insight", description: "Security checks", providers: ["aws", "gcp"], hasChecks: true, isOfficial: true }), artifact("zeta", { providers: ["azure"], hasProvider: true })] };
+    // prettier-ignore
+    const mine = [{ normalizedName: "core", versionSpec: "latest" }, { normalizedName: "manual", versionSpec: "1.2.3" }];
+
+    // When
+    // prettier-ignore
+    const model = buildRegistryExplorerModel(catalog, mine, { search: "security", provider: "aws", capabilities: ["checks"] });
+
+    // Then
+    // prettier-ignore
+    expect(model).toMatchObject({ isComplete: true, canExplore: true, available: [{ normalizedName: "global" }], hierarchy: { providers: expect.arrayContaining([expect.objectContaining({ provider: "aws" }), expect.objectContaining({ provider: "gcp" })]), multiProvider: [{ normalizedName: "global" }] }, metrics: { providers: 3, availableArtifacts: 2, myArtifacts: 2, officialArtifacts: 2 } });
+    // prettier-ignore
+    expect(getRegistryArtifactDetail("manual", catalog.artifacts, mine)).toEqual({ catalogArtifact: undefined, tenantArtifact: mine[1] });
+  });
+
+  it("keeps incomplete catalogs out of complete-only controls and selectors", () => {
+    // Given
+    // prettier-ignore
+    const catalog = { status: "incomplete" as const, reason: "page_failed" as const, collectedCount: 3 };
+
+    // When
+    const model = buildRegistryExplorerModel(catalog, [], { search: "core" });
+
+    // Then
+    // prettier-ignore
+    expect(model).toEqual({ isComplete: false, canExplore: false, canRetry: true, controls: { search: false, filters: false, hierarchy: false, metrics: false } });
+  });
+});

--- a/ui/components/registry/registry-explorer.model.ts
+++ b/ui/components/registry/registry-explorer.model.ts
@@ -1,0 +1,44 @@
+// prettier-ignore
+import type { RegistryCatalogArtifact, RegistryCatalogResult, RegistryTenantArtifact } from "@/types/registry";
+
+// prettier-ignore
+export const REGISTRY_CATALOG_CAPABILITY = { CHECKS: "checks", COMPLIANCE: "compliance", PROVIDER: "provider" } as const;
+// prettier-ignore
+export type RegistryCatalogCapability = (typeof REGISTRY_CATALOG_CAPABILITY)[keyof typeof REGISTRY_CATALOG_CAPABILITY];
+// prettier-ignore
+export interface RegistryExplorerFilters { search?: string; provider?: string; capabilities?: RegistryCatalogCapability[]; }
+
+// prettier-ignore
+export function buildRegistryExplorerModel(catalog: RegistryCatalogResult, myArtifacts: RegistryTenantArtifact[], filters: RegistryExplorerFilters) {
+  if (catalog.status !== "complete") return { isComplete: false as const, canExplore: false, canRetry: true, controls: { search: false, filters: false, hierarchy: false, metrics: false } };
+  const available = getAvailableArtifacts(catalog.artifacts, myArtifacts).filter((artifact) => matches(artifact, filters));
+  const providers = Array.from(new Set(available.flatMap((artifact) => artifact.providers))).sort(compare).map((provider) => ({ provider, artifacts: available.filter((artifact) => artifact.providers.includes(provider)) }));
+  return { isComplete: true as const, canExplore: true, available,
+    hierarchy: { providers, multiProvider: available.filter((artifact) => artifact.providers.length > 1) },
+    metrics: { providers: new Set(catalog.artifacts.flatMap((artifact) => artifact.providers)).size, availableArtifacts: getAvailableArtifacts(catalog.artifacts, myArtifacts).length, myArtifacts: myArtifacts.length, officialArtifacts: catalog.artifacts.filter((artifact) => artifact.isOfficial).length },
+  };
+}
+
+// prettier-ignore
+export function getAvailableArtifacts(artifacts: RegistryCatalogArtifact[], myArtifacts: RegistryTenantArtifact[]) {
+  const mine = new Set(myArtifacts.map(({ normalizedName }) => normalizedName));
+  return artifacts.filter(({ normalizedName }) => !mine.has(normalizedName)).sort((left, right) => compare(left.normalizedName, right.normalizedName));
+}
+
+// prettier-ignore
+export function getRegistryArtifactDetail(normalizedName: string, artifacts: RegistryCatalogArtifact[], myArtifacts: RegistryTenantArtifact[]) {
+  const catalogArtifact = artifacts.find((artifact) => artifact.normalizedName === normalizedName);
+  const tenantArtifact = myArtifacts.find((artifact) => artifact.normalizedName === normalizedName);
+  return catalogArtifact || tenantArtifact ? { catalogArtifact, tenantArtifact } : null;
+}
+
+// prettier-ignore
+function matches(artifact: RegistryCatalogArtifact, filters: RegistryExplorerFilters) {
+  const search = filters.search?.trim().toLowerCase();
+  const provider = filters.provider?.trim().toLowerCase();
+  const text = `${artifact.normalizedName} ${artifact.name ?? ""} ${artifact.description ?? ""}`.toLowerCase();
+  return (!search || text.includes(search)) && (!provider || artifact.providers.includes(provider)) && (filters.capabilities ?? []).every((capability) => (capability === "checks" && artifact.hasChecks) || (capability === "compliance" && artifact.hasCompliance) || (capability === "provider" && artifact.hasProvider));
+}
+function compare(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/ui/types/registry.ts
+++ b/ui/types/registry.ts
@@ -43,3 +43,58 @@ export interface RegistryCredentialStatus {
   validationStatus?: string;
   validationPending: boolean;
 }
+
+export const REGISTRY_CATALOG = {
+  COMPLETE: "complete",
+  INCOMPLETE: "incomplete",
+} as const;
+export const REGISTRY_CATALOG_INCOMPLETE_REASON = {
+  CONFLICTING_DUPLICATE: "conflicting_duplicate",
+  COUNT_MISMATCH: "count_mismatch",
+  GUARD_EXHAUSTED: "guard_exhausted",
+  INVALID_PAGE: "invalid_page",
+  INVALID_RESOURCE: "invalid_resource",
+  PAGE_FAILED: "page_failed",
+} as const;
+export type RegistryCatalogIncompleteReason =
+  (typeof REGISTRY_CATALOG_INCOMPLETE_REASON)[keyof typeof REGISTRY_CATALOG_INCOMPLETE_REASON];
+
+export interface RegistryArtifactOwner {
+  name: string;
+  type: string;
+}
+
+export interface RegistryCatalogArtifact {
+  normalizedName: string;
+  name?: string;
+  description?: string;
+  latestVersion?: string;
+  providers: string[];
+  isVerified: boolean;
+  isOfficial: boolean;
+  isMeta: boolean;
+  hasProvider: boolean;
+  hasChecks: boolean;
+  hasCompliance: boolean;
+  versionCount: number;
+  totalDownloads: number;
+  owners: RegistryArtifactOwner[];
+}
+
+export interface RegistryTenantArtifact {
+  normalizedName: string;
+  versionSpec: string;
+  insertedAt?: string;
+  updatedAt?: string;
+}
+
+export type RegistryCatalogResult =
+  | {
+      status: typeof REGISTRY_CATALOG.COMPLETE;
+      artifacts: RegistryCatalogArtifact[];
+    }
+  | {
+      status: typeof REGISTRY_CATALOG.INCOMPLETE;
+      reason: RegistryCatalogIncompleteReason;
+      collectedCount: number;
+    };


### PR DESCRIPTION
## 🔗 Part of Chained PRs

| Field | Value |
|---|---|
| Feature Branch | `feat/prowler-2414-registry-ui` |
| Main PR | #12494 |
| Position | 5 of 8 |
| Base | `feat/prowler-2414-registry-ui-04-registry-adapters` |
| Depends on | #12503 |
| Follow-up | #12505, Registry server integration |
| Review budget | 389 / 400 changed lines |
| Starts at | Safe Registry wire adapters without complete catalog semantics |
| Ends with | Complete-only traversal, deterministic deduplication, and pure explorer selectors |

### Chain Overview

```text
feat/prowler-2414-registry-ui (#12494 tracker)
└── #12495 PR 1: permissions and flag typing
    └── #12497 PR 2: fresh access authority
        └── #12499 PR 3: lease, navigation, and route guards
            └── #12503 PR 4: DTO and error adapters
                └── 📍 #12504 PR 5: complete catalog model
                    └── #12505 PR 6: Registry server integration
                        └── ... PR 8: acceptance hardening
                            └── #12494 tracker -> master
```

### Scope

- Includes: complete page-number traversal, strict pagination integrity, safe deterministic artifact merge, and pure catalog selectors for hierarchy, search, filtering, details, and metrics.
- Excludes: guarded Registry actions/bootstrap, credential lifecycle, React explorer UI, Add/Remove mutations, primitive changes, Playwright, backend changes, migrations, deployment, and documentation.

### Autonomy

- [x] Focused, relevant, and full unit-test results are recorded.
- [x] Runtime verification is not applicable because this slice performs no live Registry request and renders no UI.
- [x] Rollback is the single child commit and excludes unrelated work.
- [x] The diff contains only this work unit and remains below 400 changed lines.

### Context

Search, filters, hierarchy, and metrics are trustworthy only after every catalog page has been collected and validated. Presenting a partial or internally inconsistent collection as complete would mislead users about available artifacts and provider coverage.

This slice creates one complete-only model before later actions and UI consume the catalog.

### Description

- Traverse catalog pages from 1 through N with fixed `page[size]=100` semantics.
- Freeze pagination metadata and validate page identity, raw counts, resource identity, terminal emptiness, and the 1,000-page safety guard.
- Return an incomplete safe result without partial artifacts for malformed, repeated, mismatched, failed, or contradictory pages.
- Reject non-terminal empty first-page metadata while retaining valid terminal empty catalogs.
- Deduplicate by `normalized_name` as the single logical artifact identity.
- Merge complementary provider, owner, capability, boolean, and count metadata deterministically; degrade conflicting non-empty scalar data safely.
- Preserve stable lexical ordering.
- Derive Available-minus-My, provider and Multi-provider hierarchy, client-side search/filtering, detail joins, and deduplicated metrics through pure selectors.
- Preserve authoritative My-only rows for detail resolution.

No Registry request, npm dependency, backend change, migration, navigation change, or user-visible explorer is introduced.

### Steps to review

1. Review catalog traversal in `registry.adapter.ts` for fixed page size, frozen metadata, page/count validation, terminal emptiness, and the 999/1000/1001 guard.
2. Confirm every inconsistent or failed traversal returns incomplete without partial artifacts.
3. Review normalized-name merge rules and confirm ordering is deterministic.
4. Review `registry-explorer.model.ts` for Available-minus-My, provider/Multi-provider groups, filters, details, and complete-data metrics.
5. Run `cd ui && pnpm exec vitest run --project unit actions/registry/registry.adapter.test.ts components/registry/registry-explorer.model.test.ts`; the recorded result is 2 files / 12 tests.
6. Run `cd ui && pnpm exec vitest run --project unit actions/registry/registry.adapter.test.ts actions/task/task.adapter.test.ts lib/auth/current-user.test.ts lib/server-actions-helper.test.ts`; the recorded result is 4 files / 39 tests.
7. Run `cd ui && pnpm run test:unit`; the recorded result is 3,086 passing tests.
8. Run `PREK_NO_CONCURRENCY=1 uv run --directory . prek run`; Prettier, ESLint, TypeScript, related tests, and root hooks are recorded as passing.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md): not required for this model slice.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable: SDK/CLI is not changed.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI: the complete user-facing workflow is delivered by later child PRs.
- [x] This PR adds or updates no npm dependencies.
- [x] Mobile screenshots/video are not applicable because this slice renders no UI.
- [x] Tablet screenshots/video are not applicable because this slice renders no UI.
- [x] Desktop screenshots/video are not applicable because this slice renders no UI.
- [x] No UI changelog fragment is added for this internal model slice; the PR uses `no-changelog`, and the user-visible slice will add the feature fragment.

#### API
- [x] The API is not changed by this PR.
- [x] Endpoint output, query analysis, performance evidence, API specs, versions, and API changelog are not applicable.

#### MCP Server
- [x] The MCP Server is not changed by this PR.
- [x] The MCP changelog is not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

