### PR TITLE
[CHAIN] feat(ui): add guarded Registry server integration

### DIFF
--- a/ui/actions/registry/registry.adapter.ts
+++ b/ui/actions/registry/registry.adapter.ts
@@ -12,6 +12,7 @@ import {
   type RegistryCredentialSubmissionResult,
   type RegistryEndpoint,
   type RegistryFailureResult,
+  type RegistryTenantArtifact,
 } from "@/types/registry";
 
 const REGISTRY_TASK_PATH_PREFIX = "/api/v1/tasks/";
@@ -44,6 +45,21 @@ const taskSubmissionSchema = z.object({
   }),
 });
 
+const registryCollectionSchema = z.object({ data: z.array(z.unknown()) });
+const tenantArtifactsSchema = z.object({
+  data: z.array(
+    z.object({
+      type: z.string().trim().min(1),
+      id: z.string().trim().min(1),
+      attributes: z.object({
+        version_spec: z.string().trim().min(1),
+        inserted_at: z.string().optional(),
+        updated_at: z.string().optional(),
+      }),
+    }),
+  ),
+});
+
 const errorDocumentSchema = z.object({
   errors: z.array(z.object({ code: z.string().min(1) })).min(1),
 });
@@ -63,6 +79,30 @@ export function adaptRegistryCredentialStatus(
     validationStatus: attributes.validation_status,
     validationPending: attributes.validation_pending,
   };
+}
+
+export function adaptRegistryTenantArtifacts(
+  payload: unknown,
+): RegistryTenantArtifact[] | null {
+  const parsed = tenantArtifactsSchema.safeParse(payload);
+  if (!parsed.success) return null;
+
+  return parsed.data.data.map(({ attributes, id }) => ({
+    normalizedName: id,
+    versionSpec: attributes.version_spec,
+    insertedAt: attributes.inserted_at,
+    updatedAt: attributes.updated_at,
+  }));
+}
+
+export function isRegistryCollection(payload: unknown) {
+  return registryCollectionSchema.safeParse(payload).success;
+}
+
+export class RegistryCatalogPageError extends Error {
+  constructor(readonly failure: RegistryFailureResult) {
+    super("Registry catalog page request failed");
+  }
 }
 
 export async function parseRegistryCredentialSubmission(
@@ -184,7 +224,8 @@ export async function collectCompleteRegistryCatalog(
           "page[size]": String(REGISTRY_CATALOG_PAGE_SIZE),
         }),
       );
-    } catch {
+    } catch (error) {
+      if (error instanceof RegistryCatalogPageError) throw error;
       return incomplete("PAGE_FAILED", resources.length);
     }
     const parsed = catalogPageSchema.safeParse(payload);

--- a/ui/actions/registry/registry.test.ts
+++ b/ui/actions/registry/registry.test.ts
@@ -1,0 +1,676 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  authMock,
+  evaluateAccessMock,
+  fetchMock,
+  pollTaskUntilSettledMock,
+  refreshEligibilityMock,
+} = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  evaluateAccessMock: vi.fn(),
+  fetchMock: vi.fn(),
+  pollTaskUntilSettledMock: vi.fn(),
+  refreshEligibilityMock: vi.fn(),
+}));
+
+vi.mock("@/auth.config", () => ({ auth: authMock }));
+vi.mock("@/lib", () => ({ apiBaseUrl: "https://api.test/api/v1" }));
+vi.mock("@/actions/task/poll", () => ({
+  pollTaskUntilSettled: pollTaskUntilSettledMock,
+}));
+vi.mock("@/lib/registry/access.server", () => ({
+  evaluateRegistryAccess: evaluateAccessMock,
+  refreshRegistryEligibility: refreshEligibilityMock,
+}));
+
+import {
+  disconnectRegistryCredential,
+  getRegistryBootstrap,
+  refreshRegistryCollections,
+  refreshRegistryCredential,
+  refreshRegistryEligibility,
+  submitRegistryCredential,
+} from "./registry";
+
+const activeCredential = {
+  configured: true,
+  isValid: true,
+  scopes: ["catalog:read"],
+  validationPending: false,
+};
+const noCredential = {
+  configured: false,
+  isValid: false,
+  scopes: [],
+  validationPending: false,
+};
+const pendingCredential = {
+  configured: true,
+  isValid: false,
+  scopes: [],
+  validationPending: true,
+};
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/vnd.api+json" },
+  });
+const credentialResponse = (credential = activeCredential) =>
+  jsonResponse({
+    data: {
+      attributes: {
+        configured: credential.configured,
+        is_valid: credential.isValid,
+        scopes: credential.scopes,
+        validation_pending: credential.validationPending,
+      },
+    },
+  });
+const tenantArtifactsResponse = () =>
+  jsonResponse({
+    data: [
+      {
+        type: "registry-tenant-artifacts",
+        id: "prowler-aws",
+        attributes: {
+          version_spec: "latest",
+          inserted_at: "2026-03-20T12:00:00Z",
+        },
+      },
+    ],
+  });
+const providersResponse = () => jsonResponse({ data: [] });
+const catalogResponse = () =>
+  jsonResponse({
+    data: [
+      {
+        type: "registry-artifacts",
+        id: "prowler-aws",
+        attributes: { name: "Prowler AWS", providers: ["aws"] },
+      },
+    ],
+    meta: { pagination: { page: 1, pages: 1, count: 1 } },
+  });
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  authMock.mockResolvedValue({ accessToken: "access-token" });
+  evaluateAccessMock.mockResolvedValue({
+    status: "eligible",
+    leaseDurationMs: 30_000,
+  });
+  refreshEligibilityMock.mockResolvedValue({
+    status: "eligible",
+    leaseDurationMs: 30_000,
+  });
+  fetchMock.mockReset();
+  pollTaskUntilSettledMock.mockReset();
+});
+
+describe("Registry guarded reads", () => {
+  it("denies every Registry data action before any Registry endpoint call", async () => {
+    // Given
+    evaluateAccessMock.mockResolvedValue({ status: "ineligible" });
+    const actions = [
+      getRegistryBootstrap,
+      refreshRegistryCredential,
+      refreshRegistryCollections,
+      () => submitRegistryCredential("registry-test-key"),
+      disconnectRegistryCredential,
+    ];
+
+    // When
+    const results = await Promise.all(actions.map((action) => action()));
+
+    // Then
+    expect(results).toEqual([
+      { status: "access_denied" },
+      { status: "access_denied" },
+      { status: "access_denied" },
+      { status: "access_denied" },
+      { status: "access_denied" },
+    ]);
+    expect(evaluateAccessMock).toHaveBeenCalledTimes(5);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["unknown", "ineligible"])(
+    "denies Registry reads without calls when access is %s",
+    async (status) => {
+      // Given
+      evaluateAccessMock.mockResolvedValue({ status });
+
+      // When
+      const results = await Promise.all([
+        getRegistryBootstrap(),
+        refreshRegistryCredential(),
+        refreshRegistryCollections(),
+      ]);
+
+      // Then
+      expect(results).toEqual([
+        { status: "access_denied" },
+        { status: "access_denied" },
+        { status: "access_denied" },
+      ]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("returns only the current eligibility result without Registry I/O", async () => {
+    // Given
+    const access = { status: "unknown" } as const;
+    refreshEligibilityMock.mockResolvedValue(access);
+
+    // When
+    const result = await refreshRegistryEligibility();
+
+    // Then
+    expect(result).toEqual(access);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("bootstraps in credential, tenant-artifact, providers, then complete-catalog order", async () => {
+    // Given
+    fetchMock
+      .mockResolvedValueOnce(credentialResponse())
+      .mockResolvedValueOnce(tenantArtifactsResponse())
+      .mockResolvedValueOnce(providersResponse())
+      .mockResolvedValueOnce(catalogResponse());
+
+    // When
+    const result = await getRegistryBootstrap();
+
+    // Then
+    expect(result).toEqual({
+      status: "ready",
+      leaseDurationMs: 30_000,
+      state: {
+        status: "ready",
+        credential: activeCredential,
+        catalog: {
+          status: "complete",
+          artifacts: [
+            expect.objectContaining({ normalizedName: "prowler-aws" }),
+          ],
+        },
+        tenantArtifacts: [
+          {
+            normalizedName: "prowler-aws",
+            versionSpec: "latest",
+            insertedAt: "2026-03-20T12:00:00Z",
+          },
+        ],
+      },
+    });
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "https://api.test/api/v1/registry/credential",
+      "https://api.test/api/v1/registry/my-artifacts",
+      "https://api.test/api/v1/registry/providers",
+      "https://api.test/api/v1/registry/available-artifacts?page%5Bnumber%5D=1&page%5Bsize%5D=100",
+    ]);
+    fetchMock.mock.calls.forEach(([, options]) => {
+      expect(options).toMatchObject({
+        cache: "no-store",
+        headers: {
+          Accept: "application/vnd.api+json",
+          Authorization: "Bearer access-token",
+        },
+      });
+    });
+  });
+
+  it.each([
+    [noCredential, "onboarding"],
+    [pendingCredential, "validation_pending"],
+  ] as const)(
+    "blocks catalog bootstrap as %s credential is authoritative",
+    async (credential, expectedStatus) => {
+      // Given
+      fetchMock
+        .mockResolvedValueOnce(credentialResponse(credential))
+        .mockResolvedValueOnce(tenantArtifactsResponse());
+
+      // When
+      const result = await getRegistryBootstrap();
+
+      // Then
+      expect(result).toEqual({
+        status: "ready",
+        leaseDurationMs: 30_000,
+        state: {
+          status: expectedStatus,
+          credential,
+          tenantArtifacts: [
+            {
+              normalizedName: "prowler-aws",
+              versionSpec: "latest",
+              insertedAt: "2026-03-20T12:00:00Z",
+            },
+          ],
+        },
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("returns only a non-secret status read after a fresh guard", async () => {
+    // Given
+    fetchMock.mockResolvedValueOnce(credentialResponse());
+
+    // When
+    const result = await refreshRegistryCredential();
+
+    // Then
+    expect(result).toEqual({ status: "status", credential: activeCredential });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.test/api/v1/registry/credential",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+  });
+
+  it("returns fresh complete collections without accepting a client lease", async () => {
+    // Given
+    fetchMock
+      .mockResolvedValueOnce(providersResponse())
+      .mockResolvedValueOnce(catalogResponse())
+      .mockResolvedValueOnce(tenantArtifactsResponse());
+
+    // When
+    const result = await refreshRegistryCollections();
+
+    // Then
+    expect(result).toEqual({
+      status: "complete",
+      catalog: {
+        status: "complete",
+        artifacts: [expect.objectContaining({ normalizedName: "prowler-aws" })],
+      },
+      tenantArtifacts: [
+        {
+          normalizedName: "prowler-aws",
+          versionSpec: "latest",
+          insertedAt: "2026-03-20T12:00:00Z",
+        },
+      ],
+    });
+    expect(evaluateAccessMock).toHaveBeenCalledWith("access-token");
+  });
+
+  it("maps a discovery 409 to onboarding after an authoritative no-credential read", async () => {
+    // Given
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ errors: [] }, 409))
+      .mockResolvedValueOnce(credentialResponse(noCredential));
+
+    // When
+    const result = await refreshRegistryCollections();
+
+    // Then
+    expect(result).toEqual({ status: "onboarding" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps documented read recovery without exposing retained or partial catalog data", async () => {
+    // Given
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ errors: [{ code: "registry_key_rejected" }] }, 502),
+    );
+
+    // When
+    const reconnect = await refreshRegistryCollections();
+
+    // Then
+    expect(reconnect).toEqual({ status: "reconnect" });
+
+    // Given
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ errors: [{ code: "registry_unavailable" }] }, 503),
+    );
+
+    // When
+    const unavailable = await refreshRegistryCollections();
+
+    // Then
+    expect(unavailable).toEqual({ status: "unavailable" });
+    expect(unavailable).not.toHaveProperty("catalog");
+
+    // Given
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ errors: [{ code: "other_failure" }] }, 502),
+    );
+
+    // When
+    const generic = await refreshRegistryCollections();
+
+    // Then
+    expect(generic).toEqual({ status: "error" });
+  });
+
+  it("maps Registry 401 and 403 to access denial before any recovery classification", async () => {
+    // Given
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ errors: [{ code: "registry_key_rejected" }] }, 401),
+    );
+
+    // When
+    const credential = await refreshRegistryCredential();
+
+    // Then
+    expect(credential).toEqual({ status: "access_denied" });
+
+    // Given
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ errors: [{ code: "registry_unavailable" }] }, 403),
+    );
+
+    // When
+    const collections = await refreshRegistryCollections();
+
+    // Then
+    expect(collections).toEqual({ status: "access_denied" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rechecks access between separate actions after permission revocation", async () => {
+    // Given
+    evaluateAccessMock
+      .mockResolvedValueOnce({ status: "eligible", leaseDurationMs: 30_000 })
+      .mockResolvedValueOnce({ status: "ineligible" });
+    fetchMock.mockResolvedValueOnce(credentialResponse());
+
+    // When
+    const first = await refreshRegistryCredential();
+    const second = await refreshRegistryCollections();
+
+    // Then
+    expect(first).toEqual({ status: "status", credential: activeCredential });
+    expect(second).toEqual({ status: "access_denied" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(evaluateAccessMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a matching credential task as pending until status confirms connection", async () => {
+    // Given
+    const key = "registry-test-key";
+    pollTaskUntilSettledMock.mockResolvedValue({
+      ok: true,
+      state: "completed",
+      task: { attributes: { result: { key } } },
+      result: { key },
+    });
+    fetchMock
+      .mockResolvedValueOnce(credentialResponse(noCredential))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { type: "tasks", id: "task-123" } }),
+          {
+            status: 202,
+            headers: { "Content-Location": "/api/v1/tasks/task-123" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(credentialResponse());
+
+    // When
+    const result = await submitRegistryCredential(key);
+
+    // Then
+    expect(result).toEqual({
+      status: "connected",
+      credential: activeCredential,
+    });
+    expect(pollTaskUntilSettledMock).toHaveBeenCalledWith("task-123", {
+      maxAttempts: 20,
+      delayMs: 3000,
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.test/api/v1/registry/credential",
+      expect.objectContaining({
+        body: JSON.stringify({
+          data: {
+            type: "registry-credentials",
+            attributes: { api_key: key },
+          },
+        }),
+        cache: "no-store",
+        method: "POST",
+      }),
+    );
+    expect(JSON.stringify(result)).not.toContain(key);
+    expect(result).not.toHaveProperty("taskId");
+    expect(result).not.toHaveProperty("result");
+    expect(result).not.toHaveProperty("task");
+  });
+
+  it("re-reads credential and preserves authoritative My artifacts after disconnect", async () => {
+    // Given
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(credentialResponse(noCredential))
+      .mockResolvedValueOnce(tenantArtifactsResponse());
+
+    // When
+    const result = await disconnectRegistryCredential();
+
+    // Then
+    expect(result).toEqual({
+      status: "disconnected",
+      credential: noCredential,
+      tenantArtifacts: [
+        {
+          normalizedName: "prowler-aws",
+          versionSpec: "latest",
+          insertedAt: "2026-03-20T12:00:00Z",
+        },
+      ],
+    });
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "https://api.test/api/v1/registry/credential",
+      "https://api.test/api/v1/registry/credential",
+      "https://api.test/api/v1/registry/my-artifacts",
+    ]);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.test/api/v1/registry/credential",
+      expect.objectContaining({ cache: "no-store", method: "DELETE" }),
+    );
+  });
+
+  it("re-reads authoritatively after a task-binding mismatch without returning the key", async () => {
+    // Given
+    const key = "registry-test-key";
+    fetchMock
+      .mockResolvedValueOnce(credentialResponse(noCredential))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { type: "tasks", id: "task-123" } }),
+          {
+            status: 202,
+            headers: { "Content-Location": "/api/v1/tasks/other-task" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(credentialResponse(pendingCredential));
+
+    // When
+    const result = await submitRegistryCredential(key);
+
+    // Then
+    expect(result).toEqual({ status: "error" });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(JSON.stringify(result)).not.toContain(key);
+  });
+
+  it("re-reads authoritatively after malformed accepted task data", async () => {
+    // Given
+    fetchMock
+      .mockResolvedValueOnce(credentialResponse(noCredential))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { type: "not-a-task", id: "task-123" } }),
+          {
+            status: 202,
+            headers: { "Content-Location": "/api/v1/tasks/task-123" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(credentialResponse(noCredential));
+
+    // When
+    const result = await submitRegistryCredential("registry-test-key");
+
+    // Then
+    expect(result).toEqual({ status: "error" });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves an active credential after a rejected replacement", async () => {
+    // Given
+    const key = "registry-replacement-key";
+    fetchMock
+      .mockResolvedValueOnce(credentialResponse(activeCredential))
+      .mockResolvedValueOnce(jsonResponse({ errors: [] }, 500))
+      .mockResolvedValueOnce(credentialResponse(activeCredential));
+
+    // When
+    const result = await submitRegistryCredential(key);
+
+    // Then
+    expect(result).toEqual({
+      status: "replacement_failed",
+      credential: activeCredential,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(JSON.stringify(result)).not.toContain(key);
+  });
+
+  it("keeps an initial validation timeout pending after the authoritative re-read", async () => {
+    // Given
+    const key = "registry-test-key";
+    pollTaskUntilSettledMock.mockResolvedValue({
+      ok: false,
+      error: "Task timeout",
+      task: { attributes: { result: { key } } },
+      result: { key },
+    });
+    fetchMock
+      .mockResolvedValueOnce(credentialResponse(noCredential))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { type: "tasks", id: "task-123" } }),
+          {
+            status: 202,
+            headers: { "Content-Location": "/api/v1/tasks/task-123" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(credentialResponse(pendingCredential));
+
+    // When
+    const result = await submitRegistryCredential(key);
+
+    // Then
+    expect(result).toEqual({
+      status: "pending",
+      credential: pendingCredential,
+    });
+    expect(JSON.stringify(result)).not.toContain(key);
+  });
+
+  it("does not promote a cancelled replacement despite an active credential re-read", async () => {
+    // Given
+    const key = "registry-replacement-key";
+    pollTaskUntilSettledMock.mockResolvedValue({
+      ok: true,
+      state: "cancelled",
+      task: { attributes: { result: { key } } },
+      result: { key },
+    });
+    fetchMock
+      .mockResolvedValueOnce(credentialResponse(activeCredential))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { type: "tasks", id: "task-123" } }),
+          {
+            status: 202,
+            headers: { "Content-Location": "/api/v1/tasks/task-123" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(credentialResponse(activeCredential));
+
+    // When
+    const result = await submitRegistryCredential(key);
+
+    // Then
+    expect(result).toEqual({
+      status: "replacement_failed",
+      credential: activeCredential,
+    });
+    expect(JSON.stringify(result)).not.toContain(key);
+  });
+
+  it("keeps a completed task generic when authoritative status is not active", async () => {
+    // Given
+    pollTaskUntilSettledMock.mockResolvedValue({
+      ok: true,
+      state: "completed",
+    });
+    fetchMock
+      .mockResolvedValueOnce(credentialResponse(noCredential))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { type: "tasks", id: "task-123" } }),
+          {
+            status: 202,
+            headers: { "Content-Location": "/api/v1/tasks/task-123" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(credentialResponse(noCredential));
+
+    // When
+    const result = await submitRegistryCredential("registry-test-key");
+
+    // Then
+    expect(result).toEqual({ status: "invalid", credential: noCredential });
+  });
+
+  it("handles malformed authoritative status and action authorization failures safely", async () => {
+    // Given
+    pollTaskUntilSettledMock.mockResolvedValue({
+      ok: true,
+      state: "completed",
+    });
+    fetchMock
+      .mockResolvedValueOnce(credentialResponse(noCredential))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { type: "tasks", id: "task-123" } }),
+          {
+            status: 202,
+            headers: { "Content-Location": "/api/v1/tasks/task-123" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(jsonResponse({ data: { attributes: {} } }))
+      .mockResolvedValueOnce(credentialResponse(activeCredential))
+      .mockResolvedValueOnce(jsonResponse({ errors: [] }, 401))
+      .mockResolvedValueOnce(jsonResponse({ errors: [] }, 403));
+
+    // When
+    const malformed = await submitRegistryCredential("registry-test-key");
+    const rejected = await submitRegistryCredential("registry-test-key");
+    const disconnected = await disconnectRegistryCredential();
+
+    // Then
+    expect(malformed).toEqual({ status: "error" });
+    expect(rejected).toEqual({ status: "access_denied" });
+    expect(disconnected).toEqual({ status: "access_denied" });
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+});

--- a/ui/actions/registry/registry.ts
+++ b/ui/actions/registry/registry.ts
@@ -1,0 +1,388 @@
+"use server";
+
+import { pollTaskUntilSettled } from "@/actions/task/poll";
+import { auth } from "@/auth.config";
+import { apiBaseUrl } from "@/lib";
+import { REGISTRY_ACCESS } from "@/lib/registry/access";
+import { evaluateRegistryAccess } from "@/lib/registry/access.server";
+import {
+  REGISTRY_BOOTSTRAP_STATE,
+  REGISTRY_CATALOG,
+  REGISTRY_CREDENTIAL_ACTION,
+  REGISTRY_CREDENTIAL_READ,
+  REGISTRY_ENDPOINT,
+  REGISTRY_FAILURE,
+  type RegistryBootstrapResult,
+  type RegistryBootstrapState,
+  type RegistryCollectionsResult,
+  type RegistryCredentialActionResult,
+  type RegistryCredentialReadResult,
+  type RegistryCredentialStatus,
+  type RegistryFailureResult,
+} from "@/types/registry";
+
+import {
+  adaptRegistryCredentialStatus,
+  adaptRegistryTenantArtifacts,
+  classifyRegistryFailure,
+  collectCompleteRegistryCatalog,
+  isRegistryCollection,
+  parseRegistryCredentialSubmission,
+  RegistryCatalogPageError,
+} from "./registry.adapter";
+
+type GuardedRegistryAccess = { accessToken: string; leaseDurationMs: number };
+
+async function getRegistryAccess(): Promise<GuardedRegistryAccess | null> {
+  const accessToken = (await auth())?.accessToken;
+  const access = await evaluateRegistryAccess(accessToken);
+  return access.status === REGISTRY_ACCESS.ELIGIBLE && accessToken?.trim()
+    ? { accessToken, leaseDurationMs: access.leaseDurationMs }
+    : null;
+}
+
+async function readRegistryResponse(
+  accessToken: string,
+  resource: string,
+  endpoint: (typeof REGISTRY_ENDPOINT)[keyof typeof REGISTRY_ENDPOINT],
+  credential: RegistryCredentialStatus | null = null,
+  searchParams?: URLSearchParams,
+): Promise<Response | RegistryFailureResult> {
+  const url = new URL(`${apiBaseUrl}/registry/${resource}`);
+  if (searchParams) url.search = searchParams.toString();
+
+  let response: Response;
+  try {
+    response = await fetch(url.toString(), {
+      cache: "no-store",
+      headers: {
+        Accept: "application/vnd.api+json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+  } catch {
+    return { status: REGISTRY_FAILURE.ERROR };
+  }
+  if (response.ok) return response;
+
+  return endpoint === REGISTRY_ENDPOINT.PROVIDERS ||
+    endpoint === REGISTRY_ENDPOINT.AVAILABLE_ARTIFACTS
+    ? classifyDiscoveryFailure(response, endpoint, accessToken, credential)
+    : classifyRegistryFailure(response, endpoint, credential);
+}
+
+async function readRegistryCredential(accessToken: string) {
+  const result = await readRegistryResponse(
+    accessToken,
+    "credential",
+    REGISTRY_ENDPOINT.CREDENTIAL,
+  );
+  if (!(result instanceof Response)) return result;
+
+  const credential = adaptRegistryCredentialStatus(
+    await result.json().catch(() => undefined),
+  );
+  return credential
+    ? { status: REGISTRY_CREDENTIAL_READ.STATUS, credential }
+    : { status: REGISTRY_FAILURE.ERROR };
+}
+
+async function readRegistryTenantArtifacts(accessToken: string) {
+  const result = await readRegistryResponse(
+    accessToken,
+    "my-artifacts",
+    REGISTRY_ENDPOINT.MUTATION,
+  );
+  if (!(result instanceof Response)) return result;
+
+  const tenantArtifacts = adaptRegistryTenantArtifacts(
+    await result.json().catch(() => undefined),
+  );
+  return tenantArtifacts
+    ? { status: "ready" as const, tenantArtifacts }
+    : { status: REGISTRY_FAILURE.ERROR };
+}
+
+async function classifyDiscoveryFailure(
+  response: Response,
+  endpoint:
+    | typeof REGISTRY_ENDPOINT.PROVIDERS
+    | typeof REGISTRY_ENDPOINT.AVAILABLE_ARTIFACTS,
+  accessToken: string,
+  credential: RegistryCredentialStatus | null,
+) {
+  if (response.status === 409 && credential === null) {
+    const currentCredential = await readRegistryCredential(accessToken);
+    if (currentCredential.status === REGISTRY_FAILURE.ACCESS_DENIED) {
+      return currentCredential;
+    }
+    credential =
+      currentCredential.status === REGISTRY_CREDENTIAL_READ.STATUS
+        ? currentCredential.credential
+        : null;
+  }
+  return classifyRegistryFailure(response, endpoint, credential);
+}
+
+async function readRegistryProviders(
+  accessToken: string,
+  credential: RegistryCredentialStatus | null,
+) {
+  const result = await readRegistryResponse(
+    accessToken,
+    "providers",
+    REGISTRY_ENDPOINT.PROVIDERS,
+    credential,
+  );
+  if (!(result instanceof Response)) return result;
+  return isRegistryCollection(await result.json().catch(() => undefined))
+    ? { status: "ready" as const }
+    : { status: REGISTRY_FAILURE.ERROR };
+}
+
+async function readCompleteRegistryCatalog(
+  accessToken: string,
+  credential: RegistryCredentialStatus | null,
+) {
+  try {
+    return await collectCompleteRegistryCatalog(async (_page, searchParams) => {
+      const result = await readRegistryResponse(
+        accessToken,
+        "available-artifacts",
+        REGISTRY_ENDPOINT.AVAILABLE_ARTIFACTS,
+        credential,
+        searchParams,
+      );
+      if (!(result instanceof Response))
+        throw new RegistryCatalogPageError(result);
+      return result.json();
+    });
+  } catch (error) {
+    return error instanceof RegistryCatalogPageError
+      ? error.failure
+      : { status: REGISTRY_FAILURE.ERROR };
+  }
+}
+
+const hasActiveRegistryCredential = (credential: RegistryCredentialStatus) =>
+  credential.configured && credential.isValid && !credential.validationPending;
+
+async function credentialTaskCompleted(taskId: string) {
+  const { ok, state } = await pollTaskUntilSettled(taskId, {
+    maxAttempts: 20,
+    delayMs: 3000,
+  });
+  return ok && state === "completed";
+}
+
+function credentialActionResult(
+  priorCredential: RegistryCredentialStatus,
+  credential: RegistryCredentialStatus,
+  taskAccepted: boolean,
+  taskCompleted: boolean,
+): RegistryCredentialActionResult {
+  if (taskCompleted && hasActiveRegistryCredential(credential)) {
+    return { status: REGISTRY_CREDENTIAL_ACTION.CONNECTED, credential };
+  }
+  if (taskAccepted && credential.validationPending) {
+    return { status: REGISTRY_CREDENTIAL_ACTION.PENDING, credential };
+  }
+  if (priorCredential.configured) {
+    return {
+      status: REGISTRY_CREDENTIAL_ACTION.REPLACEMENT_FAILED,
+      credential,
+    };
+  }
+  return taskAccepted
+    ? { status: REGISTRY_CREDENTIAL_ACTION.INVALID, credential }
+    : { status: REGISTRY_FAILURE.ERROR };
+}
+
+function bootstrapReady(
+  access: GuardedRegistryAccess,
+  state: RegistryBootstrapState,
+): RegistryBootstrapResult {
+  return {
+    status: REGISTRY_BOOTSTRAP_STATE.READY,
+    leaseDurationMs: access.leaseDurationMs,
+    state,
+  };
+}
+
+function bootstrapFailure(
+  access: GuardedRegistryAccess,
+  failure: RegistryFailureResult,
+): RegistryBootstrapResult {
+  if (failure.status === REGISTRY_FAILURE.ACCESS_DENIED) {
+    return { status: REGISTRY_FAILURE.ACCESS_DENIED };
+  }
+  return bootstrapReady(access, {
+    status:
+      failure.status === REGISTRY_FAILURE.ONBOARDING
+        ? REGISTRY_BOOTSTRAP_STATE.ERROR
+        : failure.status,
+  });
+}
+
+export { refreshRegistryEligibility } from "@/lib/registry/access.server";
+
+export async function getRegistryBootstrap(): Promise<RegistryBootstrapResult> {
+  const access = await getRegistryAccess();
+  if (!access) return { status: REGISTRY_FAILURE.ACCESS_DENIED };
+
+  const credentialRead = await readRegistryCredential(access.accessToken);
+  if (credentialRead.status !== REGISTRY_CREDENTIAL_READ.STATUS) {
+    return bootstrapFailure(access, credentialRead);
+  }
+  const tenantArtifactsRead = await readRegistryTenantArtifacts(
+    access.accessToken,
+  );
+  if (tenantArtifactsRead.status !== "ready") {
+    return bootstrapFailure(access, tenantArtifactsRead);
+  }
+
+  const { credential } = credentialRead;
+  const { tenantArtifacts } = tenantArtifactsRead;
+  if (!hasActiveRegistryCredential(credential)) {
+    return bootstrapReady(access, {
+      status: credential.validationPending
+        ? REGISTRY_BOOTSTRAP_STATE.VALIDATION_PENDING
+        : REGISTRY_BOOTSTRAP_STATE.ONBOARDING,
+      credential,
+      tenantArtifacts,
+    });
+  }
+
+  const providers = await readRegistryProviders(access.accessToken, credential);
+  if (providers.status !== "ready") return bootstrapFailure(access, providers);
+  const catalog = await readCompleteRegistryCatalog(
+    access.accessToken,
+    credential,
+  );
+  if (catalog.status === REGISTRY_FAILURE.ACCESS_DENIED) {
+    return { status: REGISTRY_FAILURE.ACCESS_DENIED };
+  }
+  if (catalog.status === REGISTRY_CATALOG.INCOMPLETE) {
+    return bootstrapReady(access, {
+      status: REGISTRY_BOOTSTRAP_STATE.INCOMPLETE,
+      catalog,
+    });
+  }
+  if (catalog.status !== REGISTRY_CATALOG.COMPLETE) {
+    return bootstrapFailure(access, catalog);
+  }
+
+  return bootstrapReady(access, {
+    status: REGISTRY_BOOTSTRAP_STATE.READY,
+    credential,
+    catalog,
+    tenantArtifacts,
+  });
+}
+
+export async function refreshRegistryCredential(): Promise<RegistryCredentialReadResult> {
+  const access = await getRegistryAccess();
+  if (!access) return { status: REGISTRY_FAILURE.ACCESS_DENIED };
+  return readRegistryCredential(access.accessToken);
+}
+
+export async function refreshRegistryCollections(): Promise<RegistryCollectionsResult> {
+  const access = await getRegistryAccess();
+  if (!access) return { status: REGISTRY_FAILURE.ACCESS_DENIED };
+
+  const providers = await readRegistryProviders(access.accessToken, null);
+  if (providers.status !== "ready") return providers;
+  const catalog = await readCompleteRegistryCatalog(access.accessToken, null);
+  if (catalog.status !== REGISTRY_CATALOG.COMPLETE) return catalog;
+  const tenantArtifactsRead = await readRegistryTenantArtifacts(
+    access.accessToken,
+  );
+  return tenantArtifactsRead.status === "ready"
+    ? {
+        status: REGISTRY_CATALOG.COMPLETE,
+        catalog,
+        tenantArtifacts: tenantArtifactsRead.tenantArtifacts,
+      }
+    : tenantArtifactsRead;
+}
+
+export async function submitRegistryCredential(
+  key: string,
+): Promise<RegistryCredentialActionResult> {
+  const access = await getRegistryAccess();
+  if (!access) return { status: REGISTRY_FAILURE.ACCESS_DENIED };
+
+  const priorCredential = await readRegistryCredential(access.accessToken);
+  if (priorCredential.status !== REGISTRY_CREDENTIAL_READ.STATUS) {
+    return priorCredential;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${apiBaseUrl}/registry/credential`, {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        Accept: "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        Authorization: `Bearer ${access.accessToken}`,
+      },
+      body: JSON.stringify({
+        data: { type: "registry-credentials", attributes: { api_key: key } },
+      }),
+    });
+  } catch {
+    return { status: REGISTRY_FAILURE.ERROR };
+  }
+  if (response.status === 401 || response.status === 403) {
+    return { status: REGISTRY_FAILURE.ACCESS_DENIED };
+  }
+
+  const submission = await parseRegistryCredentialSubmission(response);
+  const taskCompleted =
+    submission.status === "pending" &&
+    (await credentialTaskCompleted(submission.taskId));
+  const credential = await readRegistryCredential(access.accessToken);
+  if (credential.status !== REGISTRY_CREDENTIAL_READ.STATUS) return credential;
+
+  return credentialActionResult(
+    priorCredential.credential,
+    credential.credential,
+    submission.status === "pending",
+    taskCompleted,
+  );
+}
+
+export async function disconnectRegistryCredential(): Promise<RegistryCredentialActionResult> {
+  const access = await getRegistryAccess();
+  if (!access) return { status: REGISTRY_FAILURE.ACCESS_DENIED };
+
+  let response: Response;
+  try {
+    response = await fetch(`${apiBaseUrl}/registry/credential`, {
+      method: "DELETE",
+      cache: "no-store",
+      headers: {
+        Accept: "application/vnd.api+json",
+        Authorization: `Bearer ${access.accessToken}`,
+      },
+    });
+  } catch {
+    return { status: REGISTRY_FAILURE.ERROR };
+  }
+  if (response.status === 401 || response.status === 403) {
+    return { status: REGISTRY_FAILURE.ACCESS_DENIED };
+  }
+
+  const credential = await readRegistryCredential(access.accessToken);
+  const tenantArtifacts = await readRegistryTenantArtifacts(access.accessToken);
+  if (credential.status !== REGISTRY_CREDENTIAL_READ.STATUS) return credential;
+  if (tenantArtifacts.status !== "ready") return tenantArtifacts;
+  if (!response.ok) return { status: REGISTRY_FAILURE.ERROR };
+
+  return {
+    status: REGISTRY_CREDENTIAL_ACTION.DISCONNECTED,
+    credential: credential.credential,
+    tenantArtifacts: tenantArtifacts.tenantArtifacts,
+  };
+}

--- a/ui/app/(prowler)/registry/page.tsx
+++ b/ui/app/(prowler)/registry/page.tsx
@@ -1,17 +1,17 @@
 import { redirect } from "next/navigation";
 
-import { auth } from "@/auth.config";
+import { getRegistryBootstrap } from "@/actions/registry/registry";
 import { RegistryAccessBoundary } from "@/components/registry/registry-access-boundary";
-import { REGISTRY_ACCESS } from "@/lib/registry/access";
-import { evaluateRegistryAccess } from "@/lib/registry/access.server";
+import { REGISTRY_FAILURE } from "@/types/registry";
 
 export const dynamic = "force-dynamic";
 
 export default async function RegistryPage() {
-  const access = await evaluateRegistryAccess((await auth())?.accessToken);
-  if (access.status !== REGISTRY_ACCESS.ELIGIBLE) redirect("/profile");
+  const bootstrap = await getRegistryBootstrap();
+  if (bootstrap.status === REGISTRY_FAILURE.ACCESS_DENIED) redirect("/profile");
+
   return (
-    <RegistryAccessBoundary initialLeaseDurationMs={access.leaseDurationMs}>
+    <RegistryAccessBoundary initialLeaseDurationMs={bootstrap.leaseDurationMs}>
       {null}
     </RegistryAccessBoundary>
   );

--- a/ui/types/registry.ts
+++ b/ui/types/registry.ts
@@ -98,3 +98,102 @@ export type RegistryCatalogResult =
       reason: RegistryCatalogIncompleteReason;
       collectedCount: number;
     };
+
+export const REGISTRY_CREDENTIAL_READ = {
+  STATUS: "status",
+} as const;
+
+export type RegistryCredentialReadResult =
+  | {
+      status: typeof REGISTRY_CREDENTIAL_READ.STATUS;
+      credential: RegistryCredentialStatus;
+    }
+  | RegistryFailureResult;
+
+export const REGISTRY_CREDENTIAL_ACTION = {
+  CONNECTED: "connected",
+  DISCONNECTED: "disconnected",
+  INVALID: "invalid",
+  PENDING: "pending",
+  REPLACEMENT_FAILED: "replacement_failed",
+} as const;
+
+export type RegistryCredentialActionResult =
+  | {
+      status: typeof REGISTRY_CREDENTIAL_ACTION.CONNECTED;
+      credential: RegistryCredentialStatus;
+    }
+  | {
+      status: typeof REGISTRY_CREDENTIAL_ACTION.DISCONNECTED;
+      credential: RegistryCredentialStatus;
+      tenantArtifacts: RegistryTenantArtifact[];
+    }
+  | {
+      status:
+        | typeof REGISTRY_CREDENTIAL_ACTION.INVALID
+        | typeof REGISTRY_CREDENTIAL_ACTION.PENDING
+        | typeof REGISTRY_CREDENTIAL_ACTION.REPLACEMENT_FAILED;
+      credential: RegistryCredentialStatus;
+    }
+  | RegistryFailureResult;
+
+type RegistryCompleteCatalog = Extract<
+  RegistryCatalogResult,
+  { status: typeof REGISTRY_CATALOG.COMPLETE }
+>;
+type RegistryIncompleteCatalog = Exclude<
+  RegistryCatalogResult,
+  RegistryCompleteCatalog
+>;
+
+export type RegistryCollectionsResult =
+  | {
+      status: typeof REGISTRY_CATALOG.COMPLETE;
+      catalog: RegistryCompleteCatalog;
+      tenantArtifacts: RegistryTenantArtifact[];
+    }
+  | RegistryIncompleteCatalog
+  | RegistryFailureResult;
+
+export const REGISTRY_BOOTSTRAP_STATE = {
+  ONBOARDING: "onboarding",
+  VALIDATION_PENDING: "validation_pending",
+  READY: "ready",
+  RECONNECT: "reconnect",
+  UNAVAILABLE: "unavailable",
+  INCOMPLETE: "incomplete",
+  ERROR: "error",
+} as const;
+
+export type RegistryBootstrapState =
+  | {
+      status:
+        | typeof REGISTRY_BOOTSTRAP_STATE.ONBOARDING
+        | typeof REGISTRY_BOOTSTRAP_STATE.VALIDATION_PENDING;
+      credential: RegistryCredentialStatus;
+      tenantArtifacts: RegistryTenantArtifact[];
+    }
+  | {
+      status: typeof REGISTRY_BOOTSTRAP_STATE.READY;
+      credential: RegistryCredentialStatus;
+      catalog: RegistryCompleteCatalog;
+      tenantArtifacts: RegistryTenantArtifact[];
+    }
+  | {
+      status:
+        | typeof REGISTRY_BOOTSTRAP_STATE.RECONNECT
+        | typeof REGISTRY_BOOTSTRAP_STATE.UNAVAILABLE
+        | typeof REGISTRY_BOOTSTRAP_STATE.ERROR;
+    }
+  | {
+      status: typeof REGISTRY_BOOTSTRAP_STATE.INCOMPLETE;
+      catalog: RegistryIncompleteCatalog;
+    };
+
+export type RegistryBootstrapResult =
+  | {
+      status: typeof REGISTRY_BOOTSTRAP_STATE.READY;
+      leaseDurationMs: number;
+      state: RegistryBootstrapState;
+    }
+  | { status: typeof REGISTRY_FAILURE.ACCESS_DENIED };


### PR DESCRIPTION
## 🔗 Part of Chained PRs

| Field | Value |
|---|---|
| Feature Branch | `feat/prowler-2414-registry-ui` |
| Main PR | #12494 |
| Position | 6 of 8 |
| Base | `feat/prowler-2414-registry-ui-05-catalog-model` |
| Depends on | #12504 |
| Follow-up | PR 7, interactive Registry explorer and authoritative transactions |
| Non-test budget | 542 / 600 changed lines |
| Excluded test lines | 676 changed lines |
| All-path diff | 1,218 changed lines |
| Starts at | Safe adapters and complete catalog model without Registry server actions |
| Ends with | Fresh-guarded reads, bootstrap, credential lifecycle, and authoritative recovery |

### Chain Overview

```text
feat/prowler-2414-registry-ui (#12494 tracker)
└── #12495 PR 1: permissions and flag typing
    └── #12497 PR 2: fresh access authority
        └── #12499 PR 3: lease, navigation, and route guards
            └── #12503 PR 4: DTO and error adapters
                └── #12504 PR 5: complete catalog model
                    └── 📍 #12505 PR 6: Registry server integration
                        └── PR 7: interactive explorer and transactions (planned)
                            └── PR 8: acceptance hardening
                                └── #12494 tracker -> master
```

### Scope

- Includes: independently guarded Registry reads, authoritative bootstrap ordering, credential submit/replace/disconnect lifecycle, bounded task polling, and safe recovery outcomes.
- Excludes: React explorer presentation, dialogs, Add/Remove artifact transactions, shared primitive changes, Playwright, backend changes, migrations, deployment, and documentation.

### Autonomy

- [x] Focused and full unit-test results are recorded.
- [x] Runtime UI verification is not applicable because this slice adds server actions and no complete explorer interaction.
- [x] Rollback is the single child commit and excludes unrelated work.
- [x] Non-test paths remain within 600 changed lines; excluded test paths are reported separately and remain part of the work unit.

### Context

Registry UI state must come from fresh server authority and complete authoritative collections. A browser lease, stale JWT permission, accepted task response, or optimistic mutation cannot establish access, connection, or artifact ownership.

This slice creates the complete server-action boundary before the interactive explorer consumes it.

### Description

- Freshly evaluate Registry access for every exported read and credential action.
- Make zero Registry calls when current authority is ineligible, unknown, revoked, or unavailable.
- Use fixed endpoints and `cache: "no-store"` for Registry reads.
- Bootstrap in credential, My artifacts, Providers, then complete available-catalog order.
- Block catalog reads while credential validation is pending.
- Preserve authorization-first classification and complete-only catalog semantics.
- Return fixed onboarding, reconnect, retry, and generic outcomes only for documented evidence.
- Submit write-only credentials through strict matching HTTP 202 task binding; 202 never means connected.
- Poll tasks at most 20 times with a three-second delay and discard task payload/results.
- Re-read authoritative credential state after settled success, failure, cancellation, or timeout.
- Preserve an active credential and confirmed catalog when a replacement fails.
- Disconnect through a fresh guard, then re-read credential and My artifacts so tenant artifacts remain preserved.
- Keep submitted keys, request bodies, task metadata/results, backend details, storage, URLs, logs, and toast inputs out of returned DTOs.

No npm dependency, backend endpoint, migration, runtime-flag enablement, or user-visible explorer is introduced.

### Steps to review

1. Confirm every exported action calls the fresh Registry access evaluator and denied access performs no Registry I/O.
2. Review bootstrap endpoint order, no-store requests, pending blocking, authorization precedence, and complete-only catalog results.
3. Review credential submission for strict task binding, 20×3-second polling, discarded task data, and authoritative post-settlement re-reads.
4. Confirm failed replacement preserves prior active state and disconnect preserves authoritative My artifacts.
5. Confirm no key or arbitrary backend detail can cross the action boundary.
6. Run `cd ui && pnpm exec vitest run --project unit actions/registry/registry.test.ts actions/registry/registry.adapter.test.ts actions/task/tasks.test.ts actions/task/task.adapter.test.ts lib/registry/access.test.ts lib/registry/access.server.test.ts`; the recorded result is 6 files / 57 tests.
7. Run `cd ui && pnpm run test:unit`; the recorded result is 3,108 passing tests.
8. Run `PREK_NO_CONCURRENCY=1 uv run --directory . prek run`; Prettier, ESLint, TypeScript, related tests, and root hooks are recorded as passing.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md): not required for this server-action slice.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable: SDK/CLI is not changed.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI: the interactive explorer is delivered by PR 7.
- [x] This PR adds or updates no npm dependencies.
- [x] Mobile screenshots/video are not applicable because this slice exposes no complete UI workflow.
- [x] Tablet screenshots/video are not applicable because this slice exposes no complete UI workflow.
- [x] Desktop screenshots/video are not applicable because this slice exposes no complete UI workflow.
- [x] No UI changelog fragment is added for this internal server-integration slice; the PR uses `no-changelog`, and PR 7 will add the user-visible fragment.

#### API
- [x] The API is not changed by this PR.
- [x] Endpoint output, query analysis, performance evidence, API specs, versions, and API changelog are not applicable.

#### MCP Server
- [x] The MCP Server is not changed by this PR.
- [x] The MCP changelog is not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
