### PR TITLE
fix(github,aws): prevent incomplete security scans from passing

### DIFF
--- a/prowler/changelog.d/github-actions-scan-and-repository-discovery.fixed.md
+++ b/prowler/changelog.d/github-actions-scan-and-repository-discovery.fixed.md
@@ -1,0 +1,1 @@
+GitHub repository discovery now paginates GraphQL results, GitHub Actions scans report incomplete scanner runs as MANUAL, and CodePipeline repository privacy checks report failed anonymous probes as MANUAL

--- a/prowler/providers/aws/services/codepipeline/codepipeline_project_repo_private/codepipeline_project_repo_private.py
+++ b/prowler/providers/aws/services/codepipeline/codepipeline_project_repo_private/codepipeline_project_repo_private.py
@@ -1,7 +1,9 @@
 import ssl
 import urllib.error
 import urllib.request
+from typing import Optional
 
+from prowler.lib.logger import logger
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.codepipeline.codepipeline_client import (
     codepipeline_client,
@@ -59,6 +61,13 @@ class codepipeline_project_repo_private(Check):
                 elif is_public_gitlab:
                     report.status = "FAIL"
                     report.status_extended = f"CodePipeline {pipeline.name} source repository is public: {gitlab_url}"
+                elif is_public_github is None and is_public_gitlab is None:
+                    report.status = "MANUAL"
+                    report.status_extended = (
+                        f"CodePipeline {pipeline.name} source repository "
+                        f"{pipeline.source.repository_id} could not be verified because "
+                        "the anonymous repository probes failed."
+                    )
                 else:
                     report.status = "PASS"
                     report.status_extended = f"CodePipeline {pipeline.name} source repository {pipeline.source.repository_id} is private."
@@ -67,7 +76,7 @@ class codepipeline_project_repo_private(Check):
 
         return findings
 
-    def _is_public_repo(self, repo_url: str) -> bool:
+    def _is_public_repo(self, repo_url: str) -> Optional[bool]:
         """Checks if a repository is publicly accessible.
 
         Attempts to access the repository URL anonymously to determine if it's
@@ -77,13 +86,14 @@ class codepipeline_project_repo_private(Check):
             repo_url: String containing the repository URL to check.
 
         Returns:
-            bool: True if the repository is public, False if private or inaccessible.
+            Optional[bool]: True if the repository is public, False if it is
+                inaccessible with a 404 response, or None if it could not be
+                verified due to a probe error.
 
         Note:
             The method considers a repository private if:
             - The URL redirects to a sign-in page
-            - The request fails with HTTP errors
-            - The URL is not accessible
+            - The URL returns a 404 response
         """
         if repo_url.endswith(".git"):
             repo_url = repo_url[:-4]
@@ -92,5 +102,16 @@ class codepipeline_project_repo_private(Check):
             req = urllib.request.Request(repo_url, method="HEAD")
             response = urllib.request.urlopen(req, timeout=HTTP_TIMEOUT)
             return not response.geturl().endswith("sign_in")
-        except (urllib.error.URLError, TimeoutError, ssl.SSLError):
-            return False
+        except urllib.error.HTTPError as error:
+            if error.code == 404:
+                return False
+            logger.warning(
+                f"Failed to verify repository {repo_url}: HTTP {error.code}."
+            )
+            return None
+        except (urllib.error.URLError, TimeoutError, ssl.SSLError) as error:
+            logger.warning(
+                f"Failed to verify repository {repo_url}: "
+                f"{error.__class__.__name__}: {error}"
+            )
+            return None

--- a/prowler/providers/github/services/githubactions/githubactions_service.py
+++ b/prowler/providers/github/services/githubactions/githubactions_service.py
@@ -20,6 +20,7 @@ class GithubActions(GithubService):
         super().__init__(__class__.__name__, provider)
 
         self.findings: dict[int, list[GithubActionsWorkflowFinding]] = {}
+        self.scan_errors: dict[int, str] = {}
         self.scan_enabled = False
 
         if not getattr(provider, "github_actions_enabled", True):
@@ -54,9 +55,13 @@ class GithubActions(GithubService):
                     provider.session.token,
                 )
                 if not temp_dir:
+                    self.scan_errors[repo_id] = "Repository could not be cloned."
                     continue
 
                 raw_findings = self._run_zizmor(temp_dir)
+                if raw_findings is None:
+                    self.scan_errors[repo_id] = "zizmor scan did not complete successfully."
+                    continue
 
                 repo_findings = []
                 for finding in raw_findings:
@@ -82,6 +87,7 @@ class GithubActions(GithubService):
                 self.findings[repo_id] = repo_findings
 
             except Exception as error:
+                self.scan_errors[repo_id] = "zizmor scan did not complete successfully."
                 logger.error(
                     f"Error scanning repository {repo.full_name}: "
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -93,6 +99,7 @@ class GithubActions(GithubService):
     def _clone_repository(
         self, repository_url: str, token: str = None
     ) -> Optional[str]:
+        temp_dir = None
         try:
             auth_url = repository_url
             if token:
@@ -106,6 +113,8 @@ class GithubActions(GithubService):
             porcelain.clone(auth_url, temp_dir, depth=1, errstream=io.BytesIO())
             return temp_dir
         except Exception as error:
+            if temp_dir:
+                shutil.rmtree(temp_dir, ignore_errors=True)
             error_msg = str(error)
             if token:
                 error_msg = error_msg.replace(token, "***")
@@ -115,7 +124,7 @@ class GithubActions(GithubService):
             )
             return None
 
-    def _run_zizmor(self, directory: str) -> list[dict]:
+    def _run_zizmor(self, directory: str) -> Optional[list[dict]]:
         try:
             process = subprocess.run(
                 ["zizmor", directory, "--format", "json"],
@@ -129,24 +138,33 @@ class GithubActions(GithubService):
                     if line.strip():
                         logger.debug(f"zizmor: {line}")
 
+            if process.returncode != 0:
+                logger.error(f"zizmor exited with code {process.returncode}.")
+                return None
+
             if not process.stdout:
-                return []
+                logger.warning("zizmor returned no JSON output.")
+                return None
 
             output = json.loads(process.stdout)
-            if not output or (isinstance(output, list) and len(output) == 0):
+            if not isinstance(output, list):
+                logger.warning("zizmor returned JSON in an unexpected format.")
+                return None
+
+            if not output:
                 return []
 
             return output
 
         except json.JSONDecodeError as error:
             logger.warning(f"Failed to parse zizmor output as JSON: {error}")
-            return []
+            return None
         except Exception as error:
             logger.error(
                 f"Error running zizmor: "
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
-            return []
+            return None
 
     @staticmethod
     def _should_exclude_workflow(

--- a/prowler/providers/github/services/githubactions/githubactions_workflow_security_scan/githubactions_workflow_security_scan.py
+++ b/prowler/providers/github/services/githubactions/githubactions_workflow_security_scan/githubactions_workflow_security_scan.py
@@ -17,10 +17,25 @@ class githubactions_workflow_security_scan(Check):
         if not githubactions_client.scan_enabled:
             return findings
 
+        scan_errors = getattr(githubactions_client, "scan_errors", {})
+        if not isinstance(scan_errors, dict):
+            scan_errors = {}
+
         for repo_id, repo in repository_client.repositories.items():
             repo_findings = githubactions_client.findings.get(repo_id, [])
 
-            if not repo_findings:
+            if repo_id in scan_errors:
+                report = CheckReportGithub(
+                    metadata=self.metadata(),
+                    resource=repo,
+                )
+                report.status = "MANUAL"
+                report.status_extended = (
+                    f"GitHub Actions workflow security scan for repository {repo.name} "
+                    f"could not be completed: {scan_errors[repo_id]}"
+                )
+                findings.append(report)
+            elif not repo_findings:
                 report = CheckReportGithub(
                     metadata=self.metadata(),
                     resource=repo,

--- a/prowler/providers/github/services/repository/repository_service.py
+++ b/prowler/providers/github/services/repository/repository_service.py
@@ -65,11 +65,19 @@ class Repository(GithubService):
             "Content-Type": "application/json",
         }
         query = """
-        {
+        query($after: String) {
           viewer {
-            repositories(first: 100, affiliations: [OWNER, ORGANIZATION_MEMBER]) {
+            repositories(
+              first: 100,
+              after: $after,
+              affiliations: [OWNER, ORGANIZATION_MEMBER]
+            ) {
               nodes {
                 nameWithOwner
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
               }
             }
           }
@@ -77,23 +85,40 @@ class Repository(GithubService):
         """
 
         try:
-            response = requests.post(
-                graphql_url, json={"query": query}, headers=headers
-            )
-            response.raise_for_status()
-            data = response.json()
+            repositories = []
+            cursor = None
 
-            if "errors" in data:
-                logger.error(f"Error in GraphQL query: {data['errors']}")
-                return []
+            while True:
+                response = requests.post(
+                    graphql_url,
+                    json={"query": query, "variables": {"after": cursor}},
+                    headers=headers,
+                )
+                response.raise_for_status()
+                data = response.json()
 
-            repo_nodes = (
-                data.get("data", {})
-                .get("viewer", {})
-                .get("repositories", {})
-                .get("nodes", [])
-            )
-            return [repo["nameWithOwner"] for repo in repo_nodes]
+                if "errors" in data:
+                    logger.error(f"Error in GraphQL query: {data['errors']}")
+                    return []
+
+                repository_data = (
+                    data.get("data", {}).get("viewer", {}).get("repositories", {})
+                )
+                repositories.extend(
+                    repo["nameWithOwner"]
+                    for repo in repository_data.get("nodes", [])
+                )
+
+                page_info = repository_data.get("pageInfo", {})
+                if not page_info.get("hasNextPage"):
+                    return repositories
+
+                cursor = page_info.get("endCursor")
+                if not cursor:
+                    logger.error(
+                        "GraphQL repository discovery returned a next page without a cursor."
+                    )
+                    return repositories
 
         except requests.exceptions.RequestException as error:
             logger.error(

--- a/tests/providers/aws/services/codepipeline/codepipeline_project_repo_private/codepipeline_project_repo_private_test.py
+++ b/tests/providers/aws/services/codepipeline/codepipeline_project_repo_private/codepipeline_project_repo_private_test.py
@@ -173,12 +173,8 @@ class Test_codepipeline_project_repo_private:
                 assert result[0].resource_tags == []
                 assert result[0].region == AWS_REGION
 
-    def test_pipeline_repo_ssl_verification_failure(self):
-        """Test that a TLS certificate verification failure is treated as private.
-        When the probe cannot verify the server certificate (e.g. a MITM
-        presenting a forged certificate), the repository must not be reported
-        as public.
-        """
+    def test_pipeline_repo_ssl_verification_failure_is_manual(self):
+        """A TLS verification failure cannot establish that a repository is private."""
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=set_mocked_aws_provider([AWS_REGION]),
@@ -236,11 +232,8 @@ class Test_codepipeline_project_repo_private:
                 result = check.execute()
 
                 assert len(result) == 1
-                assert result[0].status == "PASS"
-                assert (
-                    result[0].status_extended
-                    == f"CodePipeline {pipeline_name} source repository {repo_id} is private."
-                )
+                assert result[0].status == "MANUAL"
+                assert "could not be verified" in result[0].status_extended
 
     def test_pipeline_repo_probe_verifies_certificate_and_sets_timeout(self):
         """Test the probe never disables certificate verification and sets a timeout.

--- a/tests/providers/github/services/githubactions/githubactions_service_test.py
+++ b/tests/providers/github/services/githubactions/githubactions_service_test.py
@@ -151,16 +151,18 @@ class TestGithubActionsService:
 
     def test_run_zizmor_no_output(self):
         mock_process = MagicMock()
+        mock_process.returncode = 0
         mock_process.stdout = ""
         mock_process.stderr = ""
 
         with patch("subprocess.run", return_value=mock_process):
             service = GithubActions.__new__(GithubActions)
             result = service._run_zizmor("/tmp/test")
-            assert result == []
+            assert result is None
 
     def test_run_zizmor_empty_array(self):
         mock_process = MagicMock()
+        mock_process.returncode = 0
         mock_process.stdout = "[]"
         mock_process.stderr = ""
 
@@ -191,6 +193,7 @@ class TestGithubActionsService:
             }
         ]
         mock_process = MagicMock()
+        mock_process.returncode = 0
         mock_process.stdout = json.dumps(mock_output)
         mock_process.stderr = ""
 
@@ -202,13 +205,26 @@ class TestGithubActionsService:
 
     def test_run_zizmor_invalid_json(self):
         mock_process = MagicMock()
+        mock_process.returncode = 0
         mock_process.stdout = "not valid json"
         mock_process.stderr = ""
 
         with patch("subprocess.run", return_value=mock_process):
             service = GithubActions.__new__(GithubActions)
             result = service._run_zizmor("/tmp/test")
-            assert result == []
+            assert result is None
+
+    def test_run_zizmor_nonzero_exit_does_not_look_clean(self):
+        mock_process = MagicMock()
+        mock_process.returncode = 1
+        mock_process.stdout = "[]"
+        mock_process.stderr = "zizmor failed"
+
+        with patch("subprocess.run", return_value=mock_process):
+            service = GithubActions.__new__(GithubActions)
+            result = service._run_zizmor("/tmp/test")
+
+        assert result is None
 
     def test_clone_repository_with_token(self):
         with (
@@ -252,10 +268,12 @@ class TestGithubActionsService:
         with (
             patch("tempfile.mkdtemp", return_value="/tmp/test"),
             patch("dulwich.porcelain.clone", side_effect=Exception("clone failed")),
+            patch("shutil.rmtree") as mock_rmtree,
         ):
             service = GithubActions.__new__(GithubActions)
             result = service._clone_repository("https://github.com/owner/repo")
             assert result is None
+            mock_rmtree.assert_called_once_with("/tmp/test", ignore_errors=True)
 
     def test_init_zizmor_missing(self):
         mock_provider = MagicMock()
@@ -351,6 +369,42 @@ class TestGithubActionsService:
             finding.workflow_url
             == "https://github.com/owner/repo/blob/main/.github/workflows/release.yml"
         )
+
+    def test_scan_repositories_records_scan_failure(self):
+        mock_repo = MagicMock()
+        mock_repo.id = 1
+        mock_repo.name = "repo"
+        mock_repo.full_name = "owner/repo"
+
+        mock_repo_client = MagicMock()
+        mock_repo_client.repositories = {1: mock_repo}
+
+        mock_provider = MagicMock()
+        mock_provider.session.token = "test-token"
+        mock_provider.exclude_workflows = []
+
+        service = GithubActions.__new__(GithubActions)
+        service.findings = {}
+        service.scan_errors = {}
+
+        mock_repo_module = MagicMock()
+        mock_repo_module.repository_client = mock_repo_client
+
+        with (
+            patch.object(service, "_clone_repository", return_value="/tmp/test"),
+            patch.object(service, "_run_zizmor", return_value=None),
+            patch.dict(
+                sys.modules,
+                {
+                    "prowler.providers.github.services.repository.repository_client": mock_repo_module,
+                },
+            ),
+            patch("shutil.rmtree"),
+        ):
+            service._scan_repositories(mock_provider)
+
+        assert service.findings == {}
+        assert 1 in service.scan_errors
 
     def test_init_github_actions_disabled(self):
         mock_provider = MagicMock()

--- a/tests/providers/github/services/githubactions/githubactions_workflow_security_scan/githubactions_workflow_security_scan_test.py
+++ b/tests/providers/github/services/githubactions/githubactions_workflow_security_scan/githubactions_workflow_security_scan_test.py
@@ -164,6 +164,40 @@ class Test_githubactions_workflow_security_scan:
                 in result[0].status_extended
             )
 
+    def test_repository_scan_failure_is_manual(self):
+        repo = _make_repo()
+        repository_client = mock.MagicMock()
+        repository_client.repositories = {1: repo}
+
+        githubactions_client = mock.MagicMock()
+        githubactions_client.findings = {}
+        githubactions_client.scan_errors = {1: "zizmor exited unsuccessfully"}
+        githubactions_client.scan_enabled = True
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_github_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.github.services.githubactions.githubactions_workflow_security_scan.githubactions_workflow_security_scan.repository_client",
+                new=repository_client,
+            ),
+            mock.patch(
+                "prowler.providers.github.services.githubactions.githubactions_workflow_security_scan.githubactions_workflow_security_scan.githubactions_client",
+                new=githubactions_client,
+            ),
+        ):
+            from prowler.providers.github.services.githubactions.githubactions_workflow_security_scan.githubactions_workflow_security_scan import (
+                githubactions_workflow_security_scan,
+            )
+
+            result = githubactions_workflow_security_scan().execute()
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+        assert "could not be completed" in result[0].status_extended
+
     def test_repository_with_findings_fail(self):
         repo = _make_repo()
         finding = _make_finding()

--- a/tests/providers/github/services/repository/repository_service_test.py
+++ b/tests/providers/github/services/repository/repository_service_test.py
@@ -159,6 +159,44 @@ class Test_Repository_GraphQL:
                 mock_graphql_call.assert_called_once()
                 mock_client.get_repo.assert_called_once_with("owner1/repo1")
 
+    def test_graphql_discovery_paginates_all_accessible_repositories(self):
+        provider = set_mocked_github_provider()
+        repository_service = Repository.__new__(Repository)
+        repository_service.provider = provider
+
+        first_response = MagicMock()
+        first_response.json.return_value = {
+            "data": {
+                "viewer": {
+                    "repositories": {
+                        "nodes": [{"nameWithOwner": "owner/repo-1"}],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                    }
+                }
+            }
+        }
+        second_response = MagicMock()
+        second_response.json.return_value = {
+            "data": {
+                "viewer": {
+                    "repositories": {
+                        "nodes": [{"nameWithOwner": "owner/repo-2"}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        }
+
+        with patch("requests.post", side_effect=[first_response, second_response]) as post:
+            repositories = repository_service._get_accessible_repos_graphql()
+
+        assert repositories == ["owner/repo-1", "owner/repo-2"]
+        assert post.call_count == 2
+        assert post.call_args_list[0].kwargs["json"]["variables"] == {"after": None}
+        assert post.call_args_list[1].kwargs["json"]["variables"] == {
+            "after": "cursor-1"
+        }
+
     def test_graphql_call_api_error(self):
         """Test that an error during the GraphQL call is handled gracefully"""
         provider = set_mocked_github_provider()


### PR DESCRIPTION
### Context

This PR fixes four cases where Prowler could omit repositories or report a security check as PASS without completing the underlying verification.

### Description

1. **Paginate GitHub repository discovery**
   - The GraphQL discovery query only returned the first 100 repositories accessible to an unscoped fine-grained token.
   - It now follows `pageInfo.endCursor` until every available page has been collected, preventing silent partial audits.

2. **Do not turn failed zizmor scans into PASS**
   - A non-zero exit code, invalid JSON, or empty output was converted into an empty findings list. The check then emitted PASS despite not having completed a scan.
   - These conditions now emit MANUAL with the scan failure reason. A successful empty JSON array still emits PASS.

3. **Clean up failed clone directories**
   - A temporary directory created before a clone failure was leaked.
   - The clone error path now removes that directory, avoiding accumulation during larger audits.

4. **Do not treat CodePipeline probe failures as private repositories**
   - TLS, timeout, and network failures during anonymous GitHub/GitLab probes were reported as PASS/private.
   - A 404 remains non-public, while failure of all probes now emits MANUAL because visibility could not be verified.

No new checks, permissions, dependencies, API, UI, or MCP changes are included.

### Steps to review

1. Review the GraphQL pagination loop and the cursor regression test.
2. Review the explicit `None` failure path from `zizmor` through the GitHub Actions check to a MANUAL report.
3. Review the clone cleanup test.
4. Review the CodePipeline TLS regression test and the distinction between 404 and an unsuccessful probe.

### Validation

- Ran focused tests:
  `76 passed`
- Files covered: GitHub repository discovery, GitHub Actions service and workflow-security check, and AWS CodePipeline repository privacy check.
- Added `prowler/changelog.d/github-actions-scan-and-repository-discovery.fixed.md`.

### Checklist

- [x] Reviewed open PRs; no matching implementation was found.
- [x] Code is covered by regression tests.
- [x] Code paths and behavior changes are documented above.
- [x] A Prowler changelog fragment was added.
- [ ] Backport needed.
- [ ] README change needed.

#### SDK/CLI

- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub repository discovery now supports pagination, ensuring more repositories are found.
* **Bug Fixes**
  * Incomplete GitHub Actions scans are reported as **MANUAL** instead of incorrectly passing.
  * Failed security scans now include an explanatory status message.
  * Repository privacy checks distinguish private repositories from unverifiable results, reporting **MANUAL** when verification fails.
  * Temporary files are cleaned up after failed repository clones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->