### PR TITLE
fix(api): upgrade sqlparse to 0.6.0

### DIFF
--- a/api/changelog.d/sqlparse-0.6.security.md
+++ b/api/changelog.d/sqlparse-0.6.security.md
@@ -1,0 +1,1 @@
+`sqlparse` upgraded to 0.6.0, patching CVE-2026-54284, CVE-2026-59893, and CVE-2026-71491

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
   "cartography (==0.138.1)",
   "gevent (==25.9.1)",
   "werkzeug (==3.1.7)",
-  "sqlparse (==0.5.5)",
+  "sqlparse (==0.6.0)",
   "fonttools (==4.62.1)",
   "uvicorn-worker (==0.4.0)"
 ]
@@ -423,7 +423,7 @@ constraint-dependencies = [
   "six==1.17.0",
   "slack-sdk==3.39.0",
   "sniffio==1.3.1",
-  "sqlparse==0.5.5",
+  "sqlparse==0.6.0",
   "statsd==4.0.1",
   "std-uritemplate==2.0.8",
   "stevedore==5.6.0",

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -339,7 +339,7 @@ constraints = [
     { name = "six", specifier = "==1.17.0" },
     { name = "slack-sdk", specifier = "==3.39.0" },
     { name = "sniffio", specifier = "==1.3.1" },
-    { name = "sqlparse", specifier = "==0.5.5" },
+    { name = "sqlparse", specifier = "==0.6.0" },
     { name = "statsd", specifier = "==4.0.1" },
     { name = "std-uritemplate", specifier = "==2.0.8" },
     { name = "stevedore", specifier = "==5.6.0" },
@@ -5040,7 +5040,7 @@ requires-dist = [
     { name = "pytest-celery", extras = ["redis"], specifier = "==1.3.0" },
     { name = "reportlab", specifier = "==4.4.10" },
     { name = "sentry-sdk", extras = ["django"], specifier = "==2.56.0" },
-    { name = "sqlparse", specifier = "==0.5.5" },
+    { name = "sqlparse", specifier = "==0.6.0" },
     { name = "uuid6", specifier = "==2024.7.10" },
     { name = "uvicorn-worker", specifier = "==0.4.0" },
     { name = "uvloop", specifier = "==0.22.1" },
@@ -6049,11 +6049,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Context

The API container scan now detects three HIGH vulnerabilities in `sqlparse` 0.5.5: CVE-2026-54284, CVE-2026-59893, and CVE-2026-71491. The fixed 0.6.0 release supports the API Python range and has passed the seven-day PyPI cooldown.

### Description

- Upgrade both API `sqlparse` pins to 0.6.0
- Regenerate the API uv lockfile
- Add the API security changelog fragment

### Steps to review

1. Confirm `api/pyproject.toml` pins `sqlparse==0.6.0` in dependencies and constraints.
2. Run `cd api && uv lock --check`.
3. Build the API image and run the standard Trivy scan.

Local verification:

- `uv lock --check`
- `uv sync --locked`
- Django 5.1.15 with sqlparse 0.6.0 import check
- `manage.py check`
- Ruff lint and format checks
- API Docker image build
- Trivy 0.74.0 with a fresh database: zero fixed HIGH/CRITICAL findings

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] I have reviewed open pull requests and confirmed there is no existing PR with the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if backport is needed.
- [x] Review if is needed to change the README.md.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- Not applicable

#### API
- [x] All issue/task requirements work as expected on the API
- [x] API specs do not need regeneration
- [x] Lockfile and dependency versions were updated
- [x] Security changelog fragment added under `api/changelog.d/`

#### MCP Server
- Not applicable

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated the SQL parsing component to version 0.6.0.
  - Includes fixes for three known security vulnerabilities.
- **Documentation**
  - Added a changelog entry describing the security update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->