### PR TITLE
docs: explain AWS Organization account membership updates

### DIFF
--- a/docs/user-guide/tutorials/prowler-cloud-aws-organizations.mdx
+++ b/docs/user-guide/tutorials/prowler-cloud-aws-organizations.mdx
@@ -266,7 +266,7 @@ Click **Save**, **Save and launch scan**, or **Launch scan**, depending on the s
 After launching:
 - Scans appear in the **Scans** page as they start and complete.
 - Results populate the **Overview** and **Findings** pages.
-- Prowler runs an **automatic sync every 6 hours** to detect accounts added to or removed from your Organization. New accounts under the targeted OU or root are onboarded automatically.
+- To detect accounts added to or removed from the AWS Organization, repeat the discovery flow described in [Add or Remove Organization Accounts](#add-or-remove-organization-accounts).
 
 ## Manage Your Organization After Onboarding
 
@@ -287,6 +287,24 @@ Open the row actions menu on the organization row on the **Providers** page.
 | **Delete Organization** | Deletes the organization and cascades to its providers. |
 
 Organizational unit rows carry the same **Test Connections** and **Delete Organizational Unit** actions, scoped to the accounts beneath them.
+
+### Add or Remove Organization Accounts
+
+To refresh the account membership of an existing AWS Organization, repeat the same discovery flow used during onboarding:
+
+1. Navigate to **Providers**, click **Add Provider**, and select **Amazon Web Services**.
+2. Choose **Add Multiple Accounts With AWS Organizations**.
+3. Enter the existing **Organization ID**, proceed to **Authentication Details**, and use the existing deployment account **Role ARN**.
+4. Confirm that the stack is deployed and click **Authenticate**. Prowler reuses the existing organization and starts a new discovery instead of creating a duplicate.
+
+The refreshed tree shows the accounts currently returned by AWS Organizations:
+
+- **New accounts** appear in the tree. Select them, test their connections, and save the configuration to connect them as providers. Existing providers and their historical data are preserved.
+- **Accounts that left the Organization** no longer appear in the tree. Discovery does not automatically delete their existing providers. To remove one, return to the **Providers** page, open the account provider actions, and select **Delete Provider**.
+
+<Danger>
+Deleting a provider permanently removes its scans, findings, resources, and other stored data. Confirm that the account has left the AWS Organization and that its historical data is no longer required before deleting it.
+</Danger>
 
 ### Update Organization Credentials
 
@@ -467,7 +485,7 @@ Deploy the ProwlerScan role to every member account with a [CloudFormation Stack
 5. Choose your deployment targets (entire organization or specific OUs) and regions, then click **Create StackSet**.
 6. Open the **Stack instances** tab and confirm every instance shows **Status: CURRENT** and **Stack status: CREATE_COMPLETE**. Deployment typically takes **2–5 minutes**; large organizations (500+ accounts) may take longer.
 
-The StackSet role uses read-only access only (`SecurityAudit`, `ViewOnlyAccess`, plus a small set of additional read-only permissions). Prowler makes no changes to your accounts. See the [CloudFormation template](https://prowler-cloud-public.s3.eu-west-1.amazonaws.com/permissions/templates/aws/cloudformation/prowler-scan-role.yml) for the full list. When you add new accounts under the targeted OU or root, the StackSet deploys the role automatically, and Prowler's 6-hour sync onboards them end-to-end.
+The StackSet role uses read-only access only (`SecurityAudit`, `ViewOnlyAccess`, plus a small set of additional read-only permissions). Prowler makes no changes to your accounts. See the [CloudFormation template](https://prowler-cloud-public.s3.eu-west-1.amazonaws.com/permissions/templates/aws/cloudformation/prowler-scan-role.yml) for the full list. When you add new accounts under the targeted OU or root, the StackSet deploys the role automatically. Repeat the [organization discovery flow](#add-or-remove-organization-accounts) to connect those accounts in Prowler Cloud.
 
 ## Key Concepts
 

--- a/docs/user-guide/tutorials/prowler-cloud-aws-organizations.mdx
+++ b/docs/user-guide/tutorials/prowler-cloud-aws-organizations.mdx
@@ -476,16 +476,17 @@ Deploy the ProwlerScan role to every member account with a [CloudFormation Stack
 </Note>
 
 1. In your management account, navigate to **CloudFormation > StackSets > Create StackSet** ([open directly](https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacksets/create)).
-2. Choose **Service-managed permissions** so AWS Organizations deploys the role automatically across current and future member accounts.
-3. Select **Amazon S3 URL** as the template source and paste:
+2. Choose **Service-managed permissions**.
+3. Enable **Automatic deployment** so CloudFormation deploys the role to accounts added to the targeted root or OUs. Configure the account removal behavior based on whether the stack and its resources should be retained when an account leaves the target.
+4. Select **Amazon S3 URL** as the template source and paste:
    ```
    https://prowler-cloud-public.s3.eu-west-1.amazonaws.com/permissions/templates/aws/cloudformation/prowler-scan-role.yml
    ```
-4. Set the **ExternalId** parameter to the External ID shown in the Prowler wizard.
-5. Choose your deployment targets (entire organization or specific OUs) and regions, then click **Create StackSet**.
-6. Open the **Stack instances** tab and confirm every instance shows **Status: CURRENT** and **Stack status: CREATE_COMPLETE**. Deployment typically takes **2–5 minutes**; large organizations (500+ accounts) may take longer.
+5. Set the **ExternalId** parameter to the External ID shown in the Prowler wizard.
+6. Choose your deployment targets (entire organization or specific OUs) and regions, then click **Create StackSet**.
+7. Open the **Stack instances** tab and confirm every instance shows **Status: CURRENT** and **Stack status: CREATE_COMPLETE**. Deployment typically takes **2–5 minutes**; large organizations (500+ accounts) may take longer.
 
-The StackSet role uses read-only access only (`SecurityAudit`, `ViewOnlyAccess`, plus a small set of additional read-only permissions). Prowler makes no changes to your accounts. See the [CloudFormation template](https://prowler-cloud-public.s3.eu-west-1.amazonaws.com/permissions/templates/aws/cloudformation/prowler-scan-role.yml) for the full list. When you add new accounts under the targeted OU or root, the StackSet deploys the role automatically. Repeat the [organization discovery flow](#add-or-remove-organization-accounts) to connect those accounts in Prowler Cloud.
+The StackSet role uses read-only access only (`SecurityAudit`, `ViewOnlyAccess`, plus a small set of additional read-only permissions). Prowler makes no changes to your accounts. See the [CloudFormation template](https://prowler-cloud-public.s3.eu-west-1.amazonaws.com/permissions/templates/aws/cloudformation/prowler-scan-role.yml) for the full list. When **Automatic deployment** is enabled, the StackSet deploys the role to new accounts under the targeted OU or root. Repeat the [organization discovery flow](#add-or-remove-organization-accounts) to connect those accounts in Prowler Cloud.
 
 ## Key Concepts
 


### PR DESCRIPTION
### Context

The AWS Organizations guide stated that account membership synchronized automatically every six hours, but maintaining an existing Organization requires running discovery again. The missing procedure made it unclear how to detect and manage accounts that joined or left.

### Description

- Replace the automatic synchronization claim with the supported rediscovery workflow.
- Document how to connect newly discovered accounts without duplicating existing providers or losing historical data.
- Document how to identify accounts that left and safely remove their providers.

### Steps to review

1. Open `docs/user-guide/tutorials/prowler-cloud-aws-organizations.mdx`.
2. Review **Manage Your Organization After Onboarding > Add or Remove Organization Accounts**.
3. Confirm the onboarding and manual role deployment sections link to the new procedure.
4. Run `cd docs && npx mint broken-links`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the open issues or roadmap.
- [ ] It is assigned to me.
- [x] I reviewed the open pull requests and found no existing PR implementing the same outcome.

</details>

- [x] No code changes require test coverage.
- [x] Documentation follows the repository style guide.
- [x] No backport is required.
- [x] No README changes are required.
- [x] No component changelog fragment is applicable to this documentation-only change.

#### SDK/CLI

- New checks included: No.

#### UI

- Not applicable.

#### API

- Not applicable.

#### MCP Server

- Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the AWS Organizations tutorial to reflect manual, on-demand account discovery.
  * Added instructions for refreshing organizations and connecting newly discovered accounts.
  * Clarified how newly added and removed accounts appear in the account tree.
  * Documented that removed providers must be deleted manually, permanently deleting stored data.
  * Updated StackSet guidance to enable automatic deployment and repeat organization discovery to connect new accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->