### PR TITLE
[CHAIN] feat(ui): add Registry artifact explorer

### DIFF
--- a/ui/actions/registry/registry.adapter.ts
+++ b/ui/actions/registry/registry.adapter.ts
@@ -5,6 +5,7 @@ import {
   REGISTRY_CATALOG_INCOMPLETE_REASON,
   REGISTRY_ENDPOINT,
   REGISTRY_FAILURE,
+  REGISTRY_MUTATION,
   REGISTRY_SUBMISSION,
   type RegistryCatalogArtifact,
   type RegistryCatalogResult,
@@ -12,6 +13,7 @@ import {
   type RegistryCredentialSubmissionResult,
   type RegistryEndpoint,
   type RegistryFailureResult,
+  type RegistryMutationResult,
   type RegistryTenantArtifact,
 } from "@/types/registry";
 
@@ -19,6 +21,14 @@ const REGISTRY_TASK_PATH_PREFIX = "/api/v1/tasks/";
 const REGISTRY_ERROR_CODE = {
   KEY_REJECTED: "registry_key_rejected",
   UNAVAILABLE: "registry_unavailable",
+} as const;
+const REGISTRY_MUTATION_REFUSAL_COPY = {
+  no_installable_version: "No available version can be added.",
+  registry_artifact_not_found: "This artifact is no longer available.",
+  version_not_found: "This version is not available.",
+  version_not_processed: "This version is not ready to add yet.",
+  version_not_verified: "This version is not verified and cannot be added.",
+  version_yanked: "This version is no longer available.",
 } as const;
 const registryDiscoveryEndpoints = new Set<RegistryEndpoint>([
   REGISTRY_ENDPOINT.PROVIDERS,
@@ -125,6 +135,18 @@ export async function parseRegistryCredentialSubmission(
   return { status: REGISTRY_SUBMISSION.PENDING, taskId };
 }
 
+export async function classifyRegistryMutationRefusal(
+  response: Response,
+): Promise<Extract<RegistryMutationResult, { status: "refused" }> | null> {
+  const code = await getRegistryErrorCode(response);
+  const message = code
+    ? REGISTRY_MUTATION_REFUSAL_COPY[
+        code as keyof typeof REGISTRY_MUTATION_REFUSAL_COPY
+      ]
+    : undefined;
+  return message ? { status: REGISTRY_MUTATION.REFUSED, message } : null;
+}
+
 export async function classifyRegistryFailure(
   response: Response,
   endpoint: RegistryEndpoint,
@@ -184,19 +206,37 @@ async function getRegistryErrorCode(response: Response) {
 const REGISTRY_CATALOG_PAGE_SIZE = 100;
 const REGISTRY_CATALOG_MAX_PAGES = 1000;
 const safeInteger = z.number().int().nonnegative().safe();
-// prettier-ignore
 const catalogPageSchema = z.object({
   data: z.array(z.unknown()),
-  meta: z.object({ pagination: z.object({ page: safeInteger, pages: safeInteger, count: safeInteger }) }),
+  meta: z.object({
+    pagination: z.object({
+      page: safeInteger,
+      pages: safeInteger,
+      count: safeInteger,
+    }),
+  }),
 });
-// prettier-ignore
 const catalogAttributesSchema = z.object({
-  name: z.string().optional(), description: z.string().optional(), latest_version: z.string().optional(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  latest_version: z.string().optional(),
   providers: z.array(z.string().trim().min(1)).optional(),
-  owners: z.array(z.object({ name: z.string().trim().min(1), type: z.string().trim().min(1) })).optional(),
-  is_verified: z.boolean().optional(), is_official: z.boolean().optional(), is_meta: z.boolean().optional(),
-  has_provider: z.boolean().optional(), has_checks: z.boolean().optional(), has_compliance: z.boolean().optional(),
-  version_count: safeInteger.optional(), total_downloads: safeInteger.optional(),
+  owners: z
+    .array(
+      z.object({
+        name: z.string().trim().min(1),
+        type: z.string().trim().min(1),
+      }),
+    )
+    .optional(),
+  is_verified: z.boolean().optional(),
+  is_official: z.boolean().optional(),
+  is_meta: z.boolean().optional(),
+  has_provider: z.boolean().optional(),
+  has_checks: z.boolean().optional(),
+  has_compliance: z.boolean().optional(),
+  version_count: safeInteger.optional(),
+  total_downloads: safeInteger.optional(),
 });
 const catalogResourceSchema = z.object({
   type: z.string().trim().min(1),
@@ -276,30 +316,58 @@ function mergeCatalogResources(resources: unknown[]): RegistryCatalogResult {
   };
 }
 
-// prettier-ignore
-function adaptCatalogArtifact(resource: unknown): RegistryCatalogArtifact | null {
+function adaptCatalogArtifact(
+  resource: unknown,
+): RegistryCatalogArtifact | null {
   const parsed = catalogResourceSchema.safeParse(resource);
   if (!parsed.success) return null;
   const { attributes: a, id } = parsed.data;
   return {
-    normalizedName: id, name: text(a.name), description: text(a.description), latestVersion: text(a.latest_version),
-    providers: unique(a.providers?.map((provider) => provider.toLowerCase()) ?? []), owners: uniqueOwners(a.owners ?? []),
-    isVerified: a.is_verified ?? false, isOfficial: a.is_official ?? false, isMeta: a.is_meta ?? false,
-    hasProvider: a.has_provider ?? false, hasChecks: a.has_checks ?? false, hasCompliance: a.has_compliance ?? false,
-    versionCount: a.version_count ?? 0, totalDownloads: a.total_downloads ?? 0,
+    normalizedName: id,
+    name: text(a.name),
+    description: text(a.description),
+    latestVersion: text(a.latest_version),
+    providers: unique(
+      a.providers?.map((provider) => provider.toLowerCase()) ?? [],
+    ),
+    owners: uniqueOwners(a.owners ?? []),
+    isVerified: a.is_verified ?? false,
+    isOfficial: a.is_official ?? false,
+    isMeta: a.is_meta ?? false,
+    hasProvider: a.has_provider ?? false,
+    hasChecks: a.has_checks ?? false,
+    hasCompliance: a.has_compliance ?? false,
+    versionCount: a.version_count ?? 0,
+    totalDownloads: a.total_downloads ?? 0,
   };
 }
 
-// prettier-ignore
-function mergeArtifacts(left: RegistryCatalogArtifact, right: RegistryCatalogArtifact): RegistryCatalogArtifact | null {
-  const [name, description, latestVersion] = [mergeText(left.name, right.name), mergeText(left.description, right.description), mergeText(left.latestVersion, right.latestVersion)];
-  if ([name, description, latestVersion].some((value) => value === null)) return null;
+function mergeArtifacts(
+  left: RegistryCatalogArtifact,
+  right: RegistryCatalogArtifact,
+): RegistryCatalogArtifact | null {
+  const [name, description, latestVersion] = [
+    mergeText(left.name, right.name),
+    mergeText(left.description, right.description),
+    mergeText(left.latestVersion, right.latestVersion),
+  ];
+  if ([name, description, latestVersion].some((value) => value === null))
+    return null;
   return {
-    ...left, name: name ?? undefined, description: description ?? undefined, latestVersion: latestVersion ?? undefined,
-    providers: unique([...left.providers, ...right.providers]), owners: uniqueOwners([...left.owners, ...right.owners]),
-    isVerified: left.isVerified || right.isVerified, isOfficial: left.isOfficial || right.isOfficial, isMeta: left.isMeta || right.isMeta,
-    hasProvider: left.hasProvider || right.hasProvider, hasChecks: left.hasChecks || right.hasChecks, hasCompliance: left.hasCompliance || right.hasCompliance,
-    versionCount: Math.max(left.versionCount, right.versionCount), totalDownloads: Math.max(left.totalDownloads, right.totalDownloads),
+    ...left,
+    name: name ?? undefined,
+    description: description ?? undefined,
+    latestVersion: latestVersion ?? undefined,
+    providers: unique([...left.providers, ...right.providers]),
+    owners: uniqueOwners([...left.owners, ...right.owners]),
+    isVerified: left.isVerified || right.isVerified,
+    isOfficial: left.isOfficial || right.isOfficial,
+    isMeta: left.isMeta || right.isMeta,
+    hasProvider: left.hasProvider || right.hasProvider,
+    hasChecks: left.hasChecks || right.hasChecks,
+    hasCompliance: left.hasCompliance || right.hasCompliance,
+    versionCount: Math.max(left.versionCount, right.versionCount),
+    totalDownloads: Math.max(left.totalDownloads, right.totalDownloads),
   };
 }
 

--- a/ui/actions/registry/registry.test.ts
+++ b/ui/actions/registry/registry.test.ts
@@ -25,9 +25,11 @@ vi.mock("@/lib/registry/access.server", () => ({
 }));
 
 import {
+  addRegistryArtifact,
   disconnectRegistryCredential,
   getRegistryBootstrap,
   refreshRegistryCollections,
+  removeRegistryArtifact,
   refreshRegistryCredential,
   refreshRegistryEligibility,
   submitRegistryCredential,
@@ -673,4 +675,169 @@ describe("Registry guarded reads", () => {
     expect(disconnected).toEqual({ status: "access_denied" });
     expect(fetchMock).toHaveBeenCalledTimes(6);
   });
+
+  it("confirms an exact Add only after My artifacts reports the artifact", async () => {
+    // Given
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 201 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [
+            {
+              type: "registry-tenant-artifacts",
+              id: "later-guard",
+              attributes: { version_spec: "2.0.0" },
+            },
+          ],
+        }),
+      );
+
+    // When
+    const result = await addRegistryArtifact({
+      normalizedName: "later-guard",
+      versionSpec: " 2.0.0 ",
+    });
+
+    // Then
+    expect(result).toEqual({
+      status: "confirmed",
+      tenantArtifacts: [
+        { normalizedName: "later-guard", versionSpec: "2.0.0" },
+      ],
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.test/api/v1/registry/my-artifacts",
+      expect.objectContaining({
+        body: JSON.stringify({
+          data: {
+            type: "registry-tenant-artifacts",
+            id: "later-guard",
+            attributes: { version_spec: "2.0.0" },
+          },
+        }),
+        cache: "no-store",
+        method: "POST",
+      }),
+    );
+  });
+
+  it("defaults Add to latest", async () => {
+    // Given
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 201 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [
+            {
+              type: "registry-tenant-artifacts",
+              id: "later-guard",
+              attributes: { version_spec: "latest" },
+            },
+          ],
+        }),
+      );
+
+    // When
+    await addRegistryArtifact({ normalizedName: "later-guard" });
+
+    // Then
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.test/api/v1/registry/my-artifacts",
+      expect.objectContaining({
+        body: JSON.stringify({
+          data: {
+            type: "registry-tenant-artifacts",
+            id: "later-guard",
+            attributes: { version_spec: "latest" },
+          },
+        }),
+      }),
+    );
+  });
+
+  it.each([
+    ["registry_artifact_not_found", "This artifact is no longer available."],
+    ["version_yanked", "This version is no longer available."],
+    [
+      "version_not_verified",
+      "This version is not verified and cannot be added.",
+    ],
+    ["version_not_processed", "This version is not ready to add yet."],
+    ["version_not_found", "This version is not available."],
+    ["no_installable_version", "No available version can be added."],
+  ])("keeps membership unchanged for %s", async (code, message) => {
+    // Given
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        { errors: [{ code }] },
+        code === "registry_artifact_not_found" ? 404 : 400,
+      ),
+    );
+
+    // When
+    const result = await addRegistryArtifact({
+      normalizedName: "later-guard",
+      versionSpec: "2.0.0",
+    });
+
+    // Then
+    expect(result).toEqual({ status: "refused", message });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("encodes the deletion identity and confirms Remove after an absent refresh", async () => {
+    // Given
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+    // When
+    const result = await removeRegistryArtifact("guard/with space");
+
+    // Then
+    expect(result).toEqual({ status: "confirmed", tenantArtifacts: [] });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.test/api/v1/registry/my-artifacts/guard%2Fwith%20space",
+      expect.objectContaining({ cache: "no-store", method: "DELETE" }),
+    );
+  });
+
+  it.each([
+    [
+      "Add",
+      () => addRegistryArtifact({ normalizedName: "later-guard" }),
+      { data: [] },
+    ],
+    [
+      "Remove",
+      () => removeRegistryArtifact("later-guard"),
+      {
+        data: [
+          {
+            type: "registry-tenant-artifacts",
+            id: "later-guard",
+            attributes: { version_spec: "latest" },
+          },
+        ],
+      },
+    ],
+  ])(
+    "keeps membership unchanged when %s refresh contradicts acceptance",
+    async (_name, mutate, refreshedArtifacts) => {
+      // Given
+      fetchMock
+        .mockResolvedValueOnce(new Response(null, { status: 204 }))
+        .mockResolvedValueOnce(jsonResponse(refreshedArtifacts));
+
+      // When
+      const result = await mutate();
+
+      // Then
+      expect(result).toEqual({ status: "refresh_failed" });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
 });

--- a/ui/actions/registry/registry.ts
+++ b/ui/actions/registry/registry.ts
@@ -19,12 +19,14 @@ import {
   type RegistryCredentialReadResult,
   type RegistryCredentialStatus,
   type RegistryFailureResult,
+  type RegistryMutationResult,
 } from "@/types/registry";
 
 import {
   adaptRegistryCredentialStatus,
   adaptRegistryTenantArtifacts,
   classifyRegistryFailure,
+  classifyRegistryMutationRefusal,
   collectCompleteRegistryCatalog,
   isRegistryCollection,
   parseRegistryCredentialSubmission,
@@ -32,6 +34,11 @@ import {
 } from "./registry.adapter";
 
 type GuardedRegistryAccess = { accessToken: string; leaseDurationMs: number };
+
+interface RegistryAddArtifactInput {
+  normalizedName: string;
+  versionSpec?: string;
+}
 
 async function getRegistryAccess(): Promise<GuardedRegistryAccess | null> {
   const accessToken = (await auth())?.accessToken;
@@ -198,6 +205,28 @@ function credentialActionResult(
     : { status: REGISTRY_FAILURE.ERROR };
 }
 
+async function confirmRegistryMutation(
+  accessToken: string,
+  normalizedName: string,
+  shouldBePresent: boolean,
+): Promise<RegistryMutationResult> {
+  const tenantArtifacts = await readRegistryTenantArtifacts(accessToken);
+  if (tenantArtifacts.status === REGISTRY_FAILURE.ACCESS_DENIED)
+    return tenantArtifacts;
+  if (
+    tenantArtifacts.status !== "ready" ||
+    tenantArtifacts.tenantArtifacts.some(
+      (artifact) => artifact.normalizedName === normalizedName,
+    ) !== shouldBePresent
+  ) {
+    return { status: "refresh_failed" };
+  }
+  return {
+    status: "confirmed",
+    tenantArtifacts: tenantArtifacts.tenantArtifacts,
+  };
+}
+
 function bootstrapReady(
   access: GuardedRegistryAccess,
   state: RegistryBootstrapState,
@@ -304,6 +333,79 @@ export async function refreshRegistryCollections(): Promise<RegistryCollectionsR
         tenantArtifacts: tenantArtifactsRead.tenantArtifacts,
       }
     : tenantArtifactsRead;
+}
+
+export async function addRegistryArtifact({
+  normalizedName,
+  versionSpec,
+}: RegistryAddArtifactInput): Promise<RegistryMutationResult> {
+  const access = await getRegistryAccess();
+  if (!access) return { status: REGISTRY_FAILURE.ACCESS_DENIED } as const;
+  const selectedVersion = versionSpec?.trim() || "latest";
+
+  let response: Response;
+  try {
+    response = await fetch(`${apiBaseUrl}/registry/my-artifacts`, {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        Accept: "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+        Authorization: `Bearer ${access.accessToken}`,
+      },
+      body: JSON.stringify({
+        data: {
+          type: "registry-tenant-artifacts",
+          id: normalizedName,
+          attributes: { version_spec: selectedVersion },
+        },
+      }),
+    });
+  } catch {
+    return { status: REGISTRY_FAILURE.ERROR } as const;
+  }
+  if (response.status === 401 || response.status === 403) {
+    return { status: REGISTRY_FAILURE.ACCESS_DENIED } as const;
+  }
+  if (!response.ok) {
+    return (
+      (await classifyRegistryMutationRefusal(response)) ?? {
+        status: REGISTRY_FAILURE.ERROR,
+      }
+    );
+  }
+
+  return confirmRegistryMutation(access.accessToken, normalizedName, true);
+}
+
+export async function removeRegistryArtifact(
+  normalizedName: string,
+): Promise<RegistryMutationResult> {
+  const access = await getRegistryAccess();
+  if (!access) return { status: REGISTRY_FAILURE.ACCESS_DENIED };
+
+  let response: Response;
+  try {
+    response = await fetch(
+      `${apiBaseUrl}/registry/my-artifacts/${encodeURIComponent(normalizedName)}`,
+      {
+        method: "DELETE",
+        cache: "no-store",
+        headers: {
+          Accept: "application/vnd.api+json",
+          Authorization: `Bearer ${access.accessToken}`,
+        },
+      },
+    );
+  } catch {
+    return { status: REGISTRY_FAILURE.ERROR };
+  }
+  if (response.status === 401 || response.status === 403) {
+    return { status: REGISTRY_FAILURE.ACCESS_DENIED };
+  }
+  if (!response.ok) return { status: REGISTRY_FAILURE.ERROR };
+
+  return confirmRegistryMutation(access.accessToken, normalizedName, false);
 }
 
 export async function submitRegistryCredential(

--- a/ui/app/(prowler)/registry/page.tsx
+++ b/ui/app/(prowler)/registry/page.tsx
@@ -2,6 +2,8 @@ import { redirect } from "next/navigation";
 
 import { getRegistryBootstrap } from "@/actions/registry/registry";
 import { RegistryAccessBoundary } from "@/components/registry/registry-access-boundary";
+import { RegistryExplorer } from "@/components/registry/registry-explorer";
+import { ContentLayout } from "@/components/shadcn/content-layout/content-layout";
 import { REGISTRY_FAILURE } from "@/types/registry";
 
 export const dynamic = "force-dynamic";
@@ -11,8 +13,12 @@ export default async function RegistryPage() {
   if (bootstrap.status === REGISTRY_FAILURE.ACCESS_DENIED) redirect("/profile");
 
   return (
-    <RegistryAccessBoundary initialLeaseDurationMs={bootstrap.leaseDurationMs}>
-      {null}
-    </RegistryAccessBoundary>
+    <ContentLayout title="Registry">
+      <RegistryAccessBoundary
+        initialLeaseDurationMs={bootstrap.leaseDurationMs}
+      >
+        <RegistryExplorer initialState={bootstrap.state} />
+      </RegistryAccessBoundary>
+    </ContentLayout>
   );
 }

--- a/ui/changelog.d/registry-artifact-transactions.added.md
+++ b/ui/changelog.d/registry-artifact-transactions.added.md
@@ -1,0 +1,1 @@
+Authoritative Registry artifact Add and Remove workflows

--- a/ui/components/registry/registry-access-dialog.tsx
+++ b/ui/components/registry/registry-access-dialog.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useRef } from "react";
+
+import { Button } from "@/components/shadcn/button/button";
+import { Input } from "@/components/shadcn/input/input";
+import { Modal } from "@/components/shadcn/modal/modal";
+
+interface RegistryAccessDialogCommonProps {
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (key: string) => Promise<void>;
+  open: boolean;
+  pending: boolean;
+}
+
+type ConnectRegistryAccessDialogProps = RegistryAccessDialogCommonProps & {
+  mode: "connect";
+  onDisconnect?: never;
+};
+
+type ManageRegistryAccessDialogProps = RegistryAccessDialogCommonProps & {
+  mode: "manage";
+  onDisconnect: () => Promise<void>;
+};
+
+type RegistryAccessDialogProps =
+  | ConnectRegistryAccessDialogProps
+  | ManageRegistryAccessDialogProps;
+
+export function RegistryAccessDialog({
+  mode,
+  onDisconnect,
+  onOpenChange,
+  onSubmit,
+  open,
+  pending,
+}: RegistryAccessDialogProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const keyInputRef = useRef<HTMLInputElement>(null);
+  const actionLabel = mode === "connect" ? "Connect" : "Replace Registry key";
+
+  async function handleSubmit(formData: FormData) {
+    const key = formData.get("registry-key");
+    if (typeof key !== "string" || key.trim().length === 0) return;
+
+    formRef.current?.reset();
+    await onSubmit(key);
+  }
+
+  return (
+    <Modal
+      description="Your Registry key is validated asynchronously and is never stored by this browser."
+      onOpenAutoFocus={(event) => {
+        event.preventDefault();
+        keyInputRef.current?.focus();
+      }}
+      onOpenChange={onOpenChange}
+      open={open}
+      size="sm"
+      title={mode === "connect" ? "Connect Registry" : "Manage Registry access"}
+    >
+      <form action={handleSubmit} ref={formRef} className="space-y-4">
+        <label className="space-y-2 text-sm" htmlFor="registry-key">
+          <span>Registry key</span>
+          <Input
+            autoComplete="new-password"
+            disabled={pending}
+            id="registry-key"
+            name="registry-key"
+            ref={keyInputRef}
+            spellCheck={false}
+            type="password"
+          />
+        </label>
+        <div className="flex flex-wrap justify-end gap-2">
+          {mode === "manage" && (
+            <Button
+              disabled={pending}
+              onClick={onDisconnect}
+              type="button"
+              variant="destructive"
+            >
+              Disconnect Registry
+            </Button>
+          )}
+          <Button disabled={pending} type="submit">
+            {pending ? "Validating Registry key" : actionLabel}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/ui/components/registry/registry-artifact-detail.tsx
+++ b/ui/components/registry/registry-artifact-detail.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+
+import { Badge } from "@/components/shadcn/badge/badge";
+import { Button } from "@/components/shadcn/button/button";
+import { Checkbox } from "@/components/shadcn/checkbox";
+import { Input } from "@/components/shadcn/input/input";
+import { getProviderDisplayName } from "@/types/providers";
+import type {
+  RegistryCatalogArtifact,
+  RegistryTenantArtifact,
+} from "@/types/registry";
+
+interface RegistryArtifactDetailProps {
+  catalogArtifact?: RegistryCatalogArtifact;
+  tenantArtifact?: RegistryTenantArtifact;
+  isMutationPending?: boolean;
+  onAdd?: (versionSpec?: string) => void;
+  onRemove?: () => void;
+}
+
+export function RegistryArtifactDetail({
+  catalogArtifact: artifact,
+  tenantArtifact,
+  isMutationPending = false,
+  onAdd,
+  onRemove,
+}: RegistryArtifactDetailProps) {
+  const [isAddFormOpen, setIsAddFormOpen] = useState(false);
+  const [usesExactVersion, setUsesExactVersion] = useState(false);
+  const [exactVersion, setExactVersion] = useState("");
+  const name = artifact?.name ?? tenantArtifact?.normalizedName;
+  if (!name) return null;
+
+  const badges: [boolean, string][] = artifact
+    ? [
+        [artifact.isOfficial, "Official"],
+        [artifact.isVerified, "Verified"],
+        [artifact.isMeta, "Meta"],
+        [artifact.hasProvider, "Provider"],
+        [artifact.hasChecks, "Checks"],
+        [artifact.hasCompliance, "Compliance"],
+      ]
+    : [];
+  const metadata = artifact
+    ? [
+        `Providers: ${artifact.providers.map(getProviderDisplayName).join(", ")}`,
+        `Latest version: ${artifact.latestVersion ?? "Not supplied"}`,
+        `Versions: ${artifact.versionCount}`,
+        `Downloads: ${artifact.totalDownloads}`,
+        `Owners: ${artifact.owners.length ? artifact.owners.map(({ name: ownerName, type }) => `${ownerName} (${type})`).join(", ") : "Not supplied"}`,
+      ]
+    : [];
+
+  return (
+    <section aria-labelledby="registry-artifact-title">
+      <h1 id="registry-artifact-title" className="text-xl font-semibold">
+        {name}
+      </h1>
+      {artifact?.description && (
+        <p className="text-text-neutral-secondary mt-2 text-sm">
+          {artifact.description}
+        </p>
+      )}
+      <div className="mt-4 flex flex-wrap gap-2">
+        {badges.map(([visible, label]) =>
+          visible ? (
+            <Badge key={label} variant="outline">
+              {label}
+            </Badge>
+          ) : null,
+        )}
+      </div>
+      <div className="mt-6 space-y-3 text-sm">
+        {metadata.map((value) => (
+          <p key={value}>{value}</p>
+        ))}
+        {tenantArtifact && (
+          <p>My version specification: {tenantArtifact.versionSpec}</p>
+        )}
+      </div>
+      {tenantArtifact ? (
+        <Button
+          className="mt-6"
+          onClick={onRemove}
+          type="button"
+          variant="destructive"
+        >
+          Remove
+        </Button>
+      ) : artifact ? (
+        isAddFormOpen ? (
+          <div className="mt-6 space-y-4">
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox
+                checked={usesExactVersion}
+                id="registry-exact-version"
+                onCheckedChange={(checked) =>
+                  setUsesExactVersion(checked === true)
+                }
+              />
+              Use an exact version
+            </label>
+            {usesExactVersion && (
+              <Input
+                aria-label="Exact version pin"
+                onChange={(event) => setExactVersion(event.target.value)}
+                placeholder="1.2.3"
+                value={exactVersion}
+              />
+            )}
+            <div className="flex flex-wrap gap-2">
+              <Button
+                disabled={
+                  isMutationPending ||
+                  (usesExactVersion && exactVersion.trim().length === 0)
+                }
+                onClick={() =>
+                  onAdd?.(usesExactVersion ? exactVersion.trim() : undefined)
+                }
+                type="button"
+              >
+                {isMutationPending ? "Adding artifact" : "Add artifact"}
+              </Button>
+              <Button
+                disabled={isMutationPending}
+                onClick={() => setIsAddFormOpen(false)}
+                type="button"
+                variant="outline"
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button onClick={() => setIsAddFormOpen(true)} type="button">
+            Add
+          </Button>
+        )
+      ) : null}
+    </section>
+  );
+}

--- a/ui/components/registry/registry-explorer.integration.test.tsx
+++ b/ui/components/registry/registry-explorer.integration.test.tsx
@@ -1,0 +1,640 @@
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  addRegistryArtifactMock,
+  disconnectRegistryCredentialMock,
+  refreshRegistryCollectionsMock,
+  removeRegistryArtifactMock,
+  submitRegistryCredentialMock,
+} = vi.hoisted(() => ({
+  addRegistryArtifactMock: vi.fn(),
+  disconnectRegistryCredentialMock: vi.fn(),
+  refreshRegistryCollectionsMock: vi.fn(),
+  removeRegistryArtifactMock: vi.fn(),
+  submitRegistryCredentialMock: vi.fn(),
+}));
+
+vi.mock("@/actions/registry/registry", () => ({
+  addRegistryArtifact: addRegistryArtifactMock,
+  disconnectRegistryCredential: disconnectRegistryCredentialMock,
+  refreshRegistryCollections: refreshRegistryCollectionsMock,
+  removeRegistryArtifact: removeRegistryArtifactMock,
+  submitRegistryCredential: submitRegistryCredentialMock,
+}));
+
+import { render } from "@/__tests__/render-browser";
+import type { RegistryBootstrapState } from "@/types/registry";
+
+import { RegistryExplorer } from "./registry-explorer";
+
+const onboardingState: RegistryBootstrapState = {
+  status: "onboarding",
+  credential: {
+    configured: false,
+    isValid: false,
+    scopes: [],
+    validationPending: false,
+  },
+  tenantArtifacts: [],
+};
+
+const readyState: RegistryBootstrapState = {
+  status: "ready",
+  credential: {
+    configured: true,
+    isValid: true,
+    scopes: ["catalog:read"],
+    validationPending: false,
+  },
+  catalog: {
+    status: "complete",
+    artifacts: [
+      {
+        normalizedName: "aws-guard",
+        name: "AWS guard",
+        description: "Already added artifact",
+        latestVersion: "1.2.3",
+        providers: ["aws"],
+        isVerified: true,
+        isOfficial: true,
+        isMeta: false,
+        hasProvider: true,
+        hasChecks: true,
+        hasCompliance: false,
+        versionCount: 2,
+        totalDownloads: 12,
+        owners: [{ name: "Prowler", type: "organization" }],
+      },
+      {
+        normalizedName: "later-guard",
+        name: "Later guard",
+        description: "Artifact collected from a later page",
+        latestVersion: "2.0.0",
+        providers: ["azure"],
+        isVerified: false,
+        isOfficial: false,
+        isMeta: false,
+        hasProvider: false,
+        hasChecks: true,
+        hasCompliance: true,
+        versionCount: 1,
+        totalDownloads: 3,
+        owners: [],
+      },
+      {
+        normalizedName: "cloud-guard",
+        name: "Cloud guard",
+        description: "Multi-provider artifact",
+        latestVersion: "3.0.0",
+        providers: ["aws", "gcp"],
+        isVerified: true,
+        isOfficial: true,
+        isMeta: true,
+        hasProvider: true,
+        hasChecks: true,
+        hasCompliance: true,
+        versionCount: 4,
+        totalDownloads: 42,
+        owners: [{ name: "Registry team", type: "organization" }],
+      },
+    ],
+  },
+  tenantArtifacts: [
+    { normalizedName: "aws-guard", versionSpec: "latest" },
+    { normalizedName: "saved-artifact", versionSpec: "1.0.0" },
+  ],
+};
+
+function AccessInvalidationHarness() {
+  const [isAllowed, setIsAllowed] = useState(true);
+
+  return (
+    <>
+      <button onClick={() => setIsAllowed(false)} type="button">
+        Invalidate access
+      </button>
+      {isAllowed && <RegistryExplorer initialState={readyState} />}
+    </>
+  );
+}
+
+const incompleteState: RegistryBootstrapState = {
+  status: "incomplete",
+  catalog: { status: "incomplete", reason: "page_failed", collectedCount: 100 },
+};
+
+describe("RegistryExplorer", () => {
+  beforeEach(() => {
+    addRegistryArtifactMock.mockReset();
+    disconnectRegistryCredentialMock.mockReset();
+    refreshRegistryCollectionsMock.mockReset();
+    removeRegistryArtifactMock.mockReset();
+    submitRegistryCredentialMock.mockReset();
+  });
+
+  describe("when Registry access is not connected", () => {
+    it("shows onboarding instead of a catalog", async () => {
+      // Given / When
+      await render(<RegistryExplorer initialState={onboardingState} />);
+
+      // Then
+      expect(document.body.textContent).toContain("Connect Registry");
+      expect(document.body.textContent).not.toContain("Available artifacts");
+    });
+
+    it("keeps catalog controls unavailable while validation is pending", async () => {
+      // Given / When
+      await render(
+        <RegistryExplorer
+          initialState={{ ...onboardingState, status: "validation_pending" }}
+        />,
+      );
+
+      // Then
+      expect(document.body.textContent).toContain(
+        "Registry validation in progress",
+      );
+      expect(document.body.textContent).not.toContain(
+        "Search Registry artifacts",
+      );
+    });
+  });
+
+  it("resets a write-only key before loading authoritative collections", async () => {
+    // Given
+    const key = "registry-test-key";
+    let resolveSubmission: ((result: unknown) => void) | undefined;
+    submitRegistryCredentialMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSubmission = resolve;
+        }),
+    );
+    refreshRegistryCollectionsMock.mockResolvedValue({
+      status: "complete",
+      catalog: readyState.catalog,
+      tenantArtifacts: readyState.tenantArtifacts,
+    });
+    const screen = await render(
+      <RegistryExplorer initialState={onboardingState} />,
+    );
+
+    // When
+    await screen.getByRole("button", { name: "Connect Registry" }).click();
+    await screen.getByLabelText("Registry key").fill(key);
+    await screen.getByRole("button", { name: "Connect", exact: true }).click();
+
+    // Then
+    await expect
+      .poll(() => submitRegistryCredentialMock.mock.calls)
+      .toEqual([[key]]);
+    await expect.element(screen.getByLabelText("Registry key")).toHaveValue("");
+    expect(document.body.innerHTML).not.toContain(key);
+    expect(window.location.href).not.toContain(key);
+    expect(localStorage.getItem("registry-key")).toBeNull();
+    expect(sessionStorage.getItem("registry-key")).toBeNull();
+
+    // When
+    resolveSubmission?.({
+      status: "connected",
+      credential: readyState.credential,
+    });
+
+    // Then
+    await expect
+      .poll(() => document.body.textContent)
+      .toContain("Available artifacts");
+  });
+
+  it("ignores a late mutation result after Registry access invalidates", async () => {
+    // Given
+    let resolveMutation: ((result: unknown) => void) | undefined;
+    addRegistryArtifactMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+    const screen = await render(<AccessInvalidationHarness />);
+    await screen.getByText("Multi-provider").click();
+    await screen
+      .getByLabelText("Registry explorer")
+      .getByText("Cloud guard")
+      .click();
+    await screen.getByRole("button", { name: "Add" }).click();
+    await screen.getByRole("button", { name: "Add artifact" }).click();
+
+    // When
+    await screen.getByRole("button", { name: "Invalidate access" }).click();
+    resolveMutation?.({
+      status: "confirmed",
+      tenantArtifacts: [
+        ...readyState.tenantArtifacts,
+        { normalizedName: "cloud-guard", versionSpec: "latest" },
+      ],
+    });
+
+    // Then
+    await expect
+      .poll(() => document.body.textContent)
+      .not.toContain("Artifact added");
+  });
+
+  it("keeps the rendered catalog after a failed credential replacement", async () => {
+    // Given
+    const key = "replacement-key";
+    submitRegistryCredentialMock.mockResolvedValue({
+      status: "replacement_failed",
+      credential: readyState.credential,
+    });
+    const screen = await render(<RegistryExplorer initialState={readyState} />);
+
+    // When
+    await screen.getByRole("button", { name: "Manage access" }).click();
+    await screen.getByLabelText("Registry key").fill(key);
+    await screen.getByRole("button", { name: "Replace Registry key" }).click();
+
+    // Then
+    await expect
+      .poll(() => document.body.textContent)
+      .toContain("Existing access is unchanged");
+    expect(document.body.textContent).toContain("Available artifacts");
+    await expect.element(screen.getByLabelText("Registry key")).toHaveValue("");
+    expect(document.body.innerHTML).not.toContain(key);
+  });
+
+  describe("when the complete catalog is ready", () => {
+    it("keeps Available and authoritative My artifacts distinct", async () => {
+      // Given / When
+      await render(<RegistryExplorer initialState={readyState} />);
+
+      // Then
+      expect(document.body.textContent).toContain("Available artifacts");
+      expect(document.body.textContent).toContain("My artifacts");
+      expect(document.body.textContent).toContain("Multi-provider");
+      expect(document.body.textContent).toContain("Later guard");
+      expect(document.body.textContent).toContain("saved-artifact");
+      expect(document.body.textContent).toContain("Official artifacts");
+    });
+
+    it("derives search from all normalized catalog artifacts", async () => {
+      // Given
+      const screen = await render(
+        <RegistryExplorer initialState={readyState} />,
+      );
+
+      // When
+      await screen.getByLabelText("Search Registry artifacts").fill("later");
+
+      // Then
+      await expect
+        .poll(() => document.body.textContent)
+        .toContain("Later guard");
+      await expect
+        .poll(() => document.body.textContent)
+        .not.toContain("Cloud guard");
+    });
+
+    it("shows a complete empty catalog without degrading controls", async () => {
+      // Given / When
+      const screen = await render(
+        <RegistryExplorer
+          initialState={{
+            ...readyState,
+            catalog: { status: "complete", artifacts: [] },
+            tenantArtifacts: [],
+          }}
+        />,
+      );
+
+      // Then
+      expect(document.body.textContent).toContain(
+        "No artifacts match this complete catalog view.",
+      );
+      await expect
+        .element(screen.getByLabelText("Search Registry artifacts"))
+        .toBeVisible();
+    });
+
+    it("filters complete results by capability", async () => {
+      // Given
+      const screen = await render(
+        <RegistryExplorer initialState={readyState} />,
+      );
+
+      // When
+      await screen.getByText("Provider", { exact: true }).click();
+
+      // Then
+      await expect
+        .poll(() => document.body.textContent)
+        .toContain("Cloud guard");
+      await expect
+        .poll(() => document.body.textContent)
+        .not.toContain("Later guard");
+    });
+
+    it("resolves a Multi-provider leaf to one metadata detail", async () => {
+      // Given
+      const screen = await render(
+        <RegistryExplorer initialState={readyState} />,
+      );
+
+      // When
+      await screen.getByText("Multi-provider").click();
+      await expect
+        .poll(() => document.body.textContent)
+        .toContain("multi-provider artifacts");
+      await screen
+        .getByLabelText("Registry explorer")
+        .getByText("Cloud guard")
+        .click();
+
+      // Then
+      await expect
+        .poll(() => document.body.textContent)
+        .toContain("Latest version");
+      expect(document.body.textContent).toContain(
+        "Registry team (organization)",
+      );
+      expect(document.body.textContent).not.toContain("Browse versions");
+    });
+  });
+
+  it("offers Add for an available artifact detail", async () => {
+    // Given
+    const screen = await render(<RegistryExplorer initialState={readyState} />);
+
+    // When
+    await screen.getByText("Multi-provider").click();
+    await expect
+      .poll(() => document.body.textContent)
+      .toContain("multi-provider artifacts");
+    await screen
+      .getByLabelText("Registry explorer")
+      .getByText("Cloud guard")
+      .click();
+
+    // Then
+    await expect
+      .element(screen.getByRole("button", { name: "Add" }))
+      .toBeVisible();
+  });
+
+  it("keeps membership unchanged until an Add is authoritatively confirmed", async () => {
+    // Given
+    addRegistryArtifactMock.mockResolvedValue({
+      status: "confirmed",
+      tenantArtifacts: [
+        { normalizedName: "aws-guard", versionSpec: "latest" },
+        { normalizedName: "saved-artifact", versionSpec: "1.0.0" },
+        { normalizedName: "cloud-guard", versionSpec: "latest" },
+      ],
+    });
+    const screen = await render(<RegistryExplorer initialState={readyState} />);
+    await screen.getByText("Multi-provider").click();
+    await screen
+      .getByLabelText("Registry explorer")
+      .getByText("Cloud guard")
+      .click();
+
+    // When
+    await screen.getByRole("button", { name: "Add" }).click();
+
+    // Then
+    await expect
+      .element(screen.getByRole("button", { name: "Add artifact" }))
+      .toBeVisible();
+    expect(document.body.textContent).not.toContain("Artifact added");
+
+    // When
+    await screen.getByRole("button", { name: "Add artifact" }).click();
+
+    // Then
+    await expect
+      .poll(() => addRegistryArtifactMock.mock.calls)
+      .toEqual([[{ normalizedName: "cloud-guard" }]]);
+    await expect
+      .poll(() => document.body.textContent)
+      .toContain("Artifact added");
+  });
+
+  it("keeps roots unchanged when an accepted Add cannot be confirmed", async () => {
+    // Given
+    addRegistryArtifactMock.mockResolvedValue({ status: "refresh_failed" });
+    const screen = await render(<RegistryExplorer initialState={readyState} />);
+    await screen.getByText("Multi-provider").click();
+    await screen
+      .getByLabelText("Registry explorer")
+      .getByText("Cloud guard")
+      .click();
+    await screen.getByRole("button", { name: "Add" }).click();
+
+    // When
+    await screen.getByRole("button", { name: "Add artifact" }).click();
+
+    // Then
+    await expect
+      .poll(() => document.body.textContent)
+      .toContain("Registry membership could not be confirmed");
+    await expect
+      .element(screen.getByRole("button", { name: "Add artifact" }))
+      .toBeVisible();
+  });
+
+  it("shows documented Add refusals without moving membership", async () => {
+    // Given
+    addRegistryArtifactMock.mockResolvedValue({
+      status: "refused",
+      message: "This version is not verified and cannot be added.",
+    });
+    const screen = await render(<RegistryExplorer initialState={readyState} />);
+    await screen.getByText("Multi-provider").click();
+    await screen
+      .getByLabelText("Registry explorer")
+      .getByText("Cloud guard")
+      .click();
+    await screen.getByRole("button", { name: "Add" }).click();
+
+    // When
+    await screen.getByRole("button", { name: "Add artifact" }).click();
+
+    // Then
+    await expect
+      .poll(() => document.body.textContent)
+      .toContain("This version is not verified and cannot be added.");
+    await expect
+      .element(screen.getByRole("button", { name: "Add artifact" }))
+      .toBeVisible();
+  });
+
+  it("disables duplicate Add submission while confirmation is pending", async () => {
+    // Given
+    addRegistryArtifactMock.mockReturnValue(new Promise(() => {}));
+    const screen = await render(<RegistryExplorer initialState={readyState} />);
+    await screen.getByText("Multi-provider").click();
+    await screen
+      .getByLabelText("Registry explorer")
+      .getByText("Cloud guard")
+      .click();
+    await screen.getByRole("button", { name: "Add" }).click();
+
+    // When
+    await screen.getByRole("button", { name: "Add artifact" }).click();
+
+    // Then
+    await expect
+      .element(screen.getByRole("button", { name: "Adding artifact" }))
+      .toBeDisabled();
+    expect(addRegistryArtifactMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("submits a manually entered exact version without version browsing", async () => {
+    // Given
+    addRegistryArtifactMock.mockResolvedValue({
+      status: "confirmed",
+      tenantArtifacts: [
+        { normalizedName: "aws-guard", versionSpec: "latest" },
+        { normalizedName: "saved-artifact", versionSpec: "1.0.0" },
+        { normalizedName: "cloud-guard", versionSpec: "2.0.0" },
+      ],
+    });
+    const screen = await render(<RegistryExplorer initialState={readyState} />);
+    await screen.getByText("Multi-provider").click();
+    await screen
+      .getByLabelText("Registry explorer")
+      .getByText("Cloud guard")
+      .click();
+    await screen.getByRole("button", { name: "Add" }).click();
+
+    // When
+    await screen.getByLabelText("Use an exact version").click();
+    await screen.getByLabelText("Exact version pin").fill(" 2.0.0 ");
+    await screen.getByRole("button", { name: "Add artifact" }).click();
+
+    // Then
+    await expect
+      .poll(() => addRegistryArtifactMock.mock.calls)
+      .toEqual([[{ normalizedName: "cloud-guard", versionSpec: "2.0.0" }]]);
+    expect(document.body.textContent).not.toContain("Browse versions");
+  });
+
+  it("requires confirmation before Remove and commits only after confirmation", async () => {
+    // Given
+    removeRegistryArtifactMock.mockResolvedValue({
+      status: "confirmed",
+      tenantArtifacts: [
+        { normalizedName: "saved-artifact", versionSpec: "1.0.0" },
+      ],
+    });
+    const screen = await render(<RegistryExplorer initialState={readyState} />);
+    await screen
+      .getByLabelText("Registry explorer")
+      .getByText("aws-guard")
+      .click();
+
+    // When
+    await screen.getByRole("button", { name: "Remove" }).click();
+
+    // Then
+    await expect
+      .element(screen.getByRole("button", { name: "Confirm Remove" }))
+      .toBeVisible();
+    expect(removeRegistryArtifactMock).not.toHaveBeenCalled();
+
+    // When
+    await screen.getByRole("button", { name: "Cancel" }).click();
+
+    // Then
+    expect(removeRegistryArtifactMock).not.toHaveBeenCalled();
+
+    // When
+    await screen.getByRole("button", { name: "Remove" }).click();
+    await screen.getByRole("button", { name: "Confirm Remove" }).click();
+
+    // Then
+    await expect
+      .poll(() => removeRegistryArtifactMock.mock.calls)
+      .toEqual([["aws-guard"]]);
+    await expect
+      .poll(() => document.body.textContent)
+      .toContain("Artifact removed");
+  });
+
+  it("disables duplicate Remove submission while confirmation is pending", async () => {
+    // Given
+    removeRegistryArtifactMock.mockReturnValue(new Promise(() => {}));
+    const screen = await render(<RegistryExplorer initialState={readyState} />);
+    await screen
+      .getByLabelText("Registry explorer")
+      .getByText("aws-guard")
+      .click();
+    await screen.getByRole("button", { name: "Remove" }).click();
+
+    // When
+    await screen.getByRole("button", { name: "Confirm Remove" }).click();
+
+    // Then
+    await expect
+      .element(screen.getByRole("button", { name: "Removing artifact" }))
+      .toBeDisabled();
+    expect(removeRegistryArtifactMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps My artifacts visible when a Remove refresh cannot confirm absence", async () => {
+    // Given
+    removeRegistryArtifactMock.mockResolvedValue({ status: "refresh_failed" });
+    const screen = await render(<RegistryExplorer initialState={readyState} />);
+    await screen
+      .getByLabelText("Registry explorer")
+      .getByText("aws-guard")
+      .click();
+    await screen.getByRole("button", { name: "Remove" }).click();
+
+    // When
+    await screen.getByRole("button", { name: "Confirm Remove" }).click();
+
+    // Then
+    await expect
+      .poll(() => document.body.textContent)
+      .toContain("Registry membership could not be confirmed");
+    await expect
+      .element(screen.getByRole("button", { name: "Confirm Remove" }))
+      .toBeVisible();
+  });
+
+  describe("when complete catalog data is unavailable", () => {
+    it("keeps incomplete catalog controls and metrics hidden while exposing Retry", async () => {
+      // Given / When
+      await render(<RegistryExplorer initialState={incompleteState} />);
+
+      // Then
+      expect(document.body.textContent).toContain(
+        "Registry catalog is incomplete",
+      );
+      expect(document.body.textContent).toContain("Retry");
+      expect(document.body.textContent).not.toContain(
+        "Search Registry artifacts",
+      );
+      expect(document.body.textContent).not.toContain("Official artifacts");
+    });
+
+    it("labels documented unavailability as stale and leaves generic errors generic", async () => {
+      // Given / When
+      await render(
+        <RegistryExplorer initialState={{ status: "unavailable" }} />,
+      );
+
+      // Then
+      expect(document.body.textContent).toContain("stale or unavailable");
+
+      // Given / When
+      await render(<RegistryExplorer initialState={{ status: "error" }} />);
+
+      // Then
+      expect(document.body.textContent).toContain("unexpected Registry error");
+      expect(document.body.textContent).not.toContain("Reconnect Registry");
+    });
+  });
+});

--- a/ui/components/registry/registry-explorer.tsx
+++ b/ui/components/registry/registry-explorer.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import {
+  addRegistryArtifact,
+  disconnectRegistryCredential,
+  refreshRegistryCollections,
+  removeRegistryArtifact,
+  submitRegistryCredential,
+} from "@/actions/registry/registry";
+import { Button } from "@/components/shadcn/button/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/shadcn/sheet";
+import { toast } from "@/components/shadcn/toast/use-toast";
+import {
+  REGISTRY_BOOTSTRAP_STATE,
+  REGISTRY_MUTATION,
+  type RegistryBootstrapState,
+  type RegistryMutationResult,
+} from "@/types/registry";
+
+import { RegistryAccessDialog } from "./registry-access-dialog";
+import { RegistryArtifactDetail } from "./registry-artifact-detail";
+import {
+  buildRegistryExplorerModel,
+  getRegistryArtifactDetail,
+  type RegistryExplorerFilters,
+} from "./registry-explorer.model";
+import { RegistryNavigation } from "./registry-navigation";
+import { RegistryOnboarding } from "./registry-onboarding";
+import { RegistryOverview } from "./registry-overview";
+import { RegistryRemoveDialog } from "./registry-remove-dialog";
+
+function RetryState({ title, children }: { title: string; children: string }) {
+  return (
+    <section aria-live="polite" className="mx-auto max-w-2xl py-12 text-center">
+      <h1 className="text-xl font-semibold">{title}</h1>
+      <p className="text-text-neutral-secondary mt-3 text-sm">{children}</p>
+      <Button className="mt-6" onClick={() => window.location.reload()}>
+        Retry
+      </Button>
+    </section>
+  );
+}
+
+function artifactName(id: string) {
+  return id.startsWith("leaf:")
+    ? decodeURIComponent(id.slice(id.lastIndexOf(":") + 1))
+    : undefined;
+}
+
+function mutationFailureMessage(result: RegistryMutationResult) {
+  if (result.status === REGISTRY_MUTATION.REFUSED) return result.message;
+  if (result.status === REGISTRY_MUTATION.REFRESH_FAILED) {
+    return "Registry membership could not be confirmed. Try again.";
+  }
+  if (result.status === "access_denied") {
+    return "Registry access is no longer available.";
+  }
+  return "The Registry operation could not be completed. Try again.";
+}
+
+export function RegistryExplorer({
+  initialState,
+}: {
+  initialState: RegistryBootstrapState;
+}) {
+  // Access invalidation unmounts this component, clearing every local snapshot.
+  const [state, setState] = useState(initialState);
+  const [filters, setFilters] = useState<RegistryExplorerFilters>({});
+  const [selectedId, setSelectedId] = useState("root:available");
+  const [expandedIds, setExpandedIds] = useState([
+    "root:available",
+    "root:my-artifacts",
+  ]);
+  const [pendingOperation, setPendingOperation] = useState<
+    "add" | "credential" | "remove" | null
+  >(null);
+  const [accessDialogMode, setAccessDialogMode] = useState<
+    "connect" | "manage"
+  >();
+  const [removeTarget, setRemoveTarget] = useState<string>();
+  const [operationMessage, setOperationMessage] = useState<string>();
+  const operationGeneration = useRef(0);
+
+  useEffect(
+    () => () => {
+      operationGeneration.current += 1;
+    },
+    [],
+  );
+
+  async function handleAdd(normalizedName: string, versionSpec?: string) {
+    const generation = operationGeneration.current;
+    setOperationMessage(undefined);
+    setPendingOperation("add");
+    const result = await addRegistryArtifact(
+      versionSpec ? { normalizedName, versionSpec } : { normalizedName },
+    );
+    if (generation !== operationGeneration.current) return;
+
+    setPendingOperation(null);
+    if (result.status !== REGISTRY_MUTATION.CONFIRMED) {
+      setOperationMessage(mutationFailureMessage(result));
+      return;
+    }
+
+    setState((current) =>
+      current.status === REGISTRY_BOOTSTRAP_STATE.READY
+        ? { ...current, tenantArtifacts: result.tenantArtifacts }
+        : current,
+    );
+    toast({ title: "Artifact added" });
+  }
+
+  async function handleCredentialSubmit(key: string) {
+    const generation = operationGeneration.current;
+    setOperationMessage(undefined);
+    setPendingOperation("credential");
+    const result = await submitRegistryCredential(key);
+    if (generation !== operationGeneration.current) return;
+
+    if (result.status === "connected") {
+      const collections = await refreshRegistryCollections();
+      if (generation !== operationGeneration.current) return;
+      setPendingOperation(null);
+      if (collections.status === "complete") {
+        setAccessDialogMode(undefined);
+        setState({
+          status: REGISTRY_BOOTSTRAP_STATE.READY,
+          credential: result.credential,
+          catalog: collections.catalog,
+          tenantArtifacts: collections.tenantArtifacts,
+        });
+        return;
+      }
+      setOperationMessage(
+        "Registry collections could not be loaded. Try again.",
+      );
+      return;
+    }
+
+    setPendingOperation(null);
+    if (result.status === "pending" || result.status === "invalid") {
+      setAccessDialogMode(undefined);
+      setState((current) =>
+        current.status === REGISTRY_BOOTSTRAP_STATE.ONBOARDING ||
+        current.status === REGISTRY_BOOTSTRAP_STATE.VALIDATION_PENDING
+          ? {
+              status:
+                result.status === "pending"
+                  ? REGISTRY_BOOTSTRAP_STATE.VALIDATION_PENDING
+                  : REGISTRY_BOOTSTRAP_STATE.ONBOARDING,
+              credential: result.credential,
+              tenantArtifacts: current.tenantArtifacts,
+            }
+          : current,
+      );
+      return;
+    }
+
+    setOperationMessage(
+      result.status === "replacement_failed"
+        ? "Registry key validation failed. Existing access is unchanged."
+        : "Registry key validation could not be completed. Try again.",
+    );
+  }
+
+  async function handleDisconnect() {
+    const generation = operationGeneration.current;
+    setOperationMessage(undefined);
+    setPendingOperation("credential");
+    const result = await disconnectRegistryCredential();
+    if (generation !== operationGeneration.current) return;
+
+    setPendingOperation(null);
+    if (result.status !== "disconnected") {
+      setOperationMessage(
+        "Registry access could not be disconnected. Try again.",
+      );
+      return;
+    }
+
+    setAccessDialogMode(undefined);
+    setState({
+      status: REGISTRY_BOOTSTRAP_STATE.ONBOARDING,
+      credential: result.credential,
+      tenantArtifacts: result.tenantArtifacts,
+    });
+  }
+
+  async function handleRemove(normalizedName: string) {
+    const generation = operationGeneration.current;
+    setOperationMessage(undefined);
+    setPendingOperation("remove");
+    const result = await removeRegistryArtifact(normalizedName);
+    if (generation !== operationGeneration.current) return;
+
+    setPendingOperation(null);
+    if (result.status !== REGISTRY_MUTATION.CONFIRMED) {
+      setOperationMessage(mutationFailureMessage(result));
+      return;
+    }
+
+    setRemoveTarget(undefined);
+    setState((current) =>
+      current.status === REGISTRY_BOOTSTRAP_STATE.READY
+        ? { ...current, tenantArtifacts: result.tenantArtifacts }
+        : current,
+    );
+    toast({ title: "Artifact removed" });
+  }
+
+  const accessDialogProps = {
+    onOpenChange: (open: boolean) => {
+      if (!open && pendingOperation !== "credential") {
+        setAccessDialogMode(undefined);
+      }
+    },
+    onSubmit: handleCredentialSubmit,
+    open: true,
+    pending: pendingOperation === "credential",
+  };
+  const accessDialog =
+    accessDialogMode === "connect" ? (
+      <RegistryAccessDialog mode="connect" {...accessDialogProps} />
+    ) : accessDialogMode === "manage" ? (
+      <RegistryAccessDialog
+        mode="manage"
+        onDisconnect={handleDisconnect}
+        {...accessDialogProps}
+      />
+    ) : null;
+
+  if (
+    state.status === REGISTRY_BOOTSTRAP_STATE.ONBOARDING ||
+    state.status === REGISTRY_BOOTSTRAP_STATE.VALIDATION_PENDING
+  ) {
+    return (
+      <>
+        <RegistryOnboarding
+          onConnect={() => setAccessDialogMode("connect")}
+          tenantArtifacts={state.tenantArtifacts}
+          validationPending={
+            state.status === REGISTRY_BOOTSTRAP_STATE.VALIDATION_PENDING
+          }
+        />
+        {accessDialog}
+      </>
+    );
+  }
+  if (state.status !== REGISTRY_BOOTSTRAP_STATE.READY) {
+    const messages = {
+      incomplete: [
+        "Registry catalog is incomplete",
+        "Complete catalog controls and metrics are unavailable until every catalog page loads. Retry to load the catalog again.",
+      ],
+      unavailable: [
+        "Registry is unavailable",
+        "Registry data may be stale or unavailable. Retry when the service is available.",
+      ],
+      reconnect: [
+        "Reconnect Registry",
+        "Reconnect Registry before exploring artifacts.",
+      ],
+      error: [
+        "Registry could not be loaded",
+        "An unexpected Registry error occurred. Retry to load the explorer again.",
+      ],
+    } as const;
+    const [title, message] = messages[state.status];
+    return <RetryState title={title}>{message}</RetryState>;
+  }
+
+  const model = buildRegistryExplorerModel(
+    state.catalog,
+    state.tenantArtifacts,
+    filters,
+  );
+  if (!model.isComplete) {
+    return (
+      <RetryState title="Registry catalog is incomplete">
+        Complete catalog controls and metrics are unavailable.
+      </RetryState>
+    );
+  }
+  const selectedDetail = artifactName(selectedId)
+    ? getRegistryArtifactDetail(
+        artifactName(selectedId)!,
+        state.catalog.artifacts,
+        state.tenantArtifacts,
+      )
+    : null;
+  const providers = model.hierarchy.providers.map(({ provider }) => provider);
+  const navigation = (
+    <RegistryNavigation
+      artifacts={model.available}
+      expandedIds={expandedIds}
+      filters={filters}
+      onExpandedChange={setExpandedIds}
+      onFiltersChange={setFilters}
+      onSelectedIdChange={setSelectedId}
+      providers={providers}
+      selectedId={selectedId}
+      tenantArtifacts={state.tenantArtifacts}
+    />
+  );
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[18rem_minmax(0,1fr)]">
+      <aside className="hidden lg:block">{navigation}</aside>
+      <div className="lg:hidden">
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="outline">Browse artifacts</Button>
+          </SheetTrigger>
+          <SheetContent side="left">
+            <SheetTitle>Browse artifacts</SheetTitle>
+            {navigation}
+          </SheetContent>
+        </Sheet>
+      </div>
+      <main>
+        <Button
+          onClick={() => setAccessDialogMode("manage")}
+          type="button"
+          variant="outline"
+        >
+          Manage access
+        </Button>
+        {operationMessage && <p role="alert">{operationMessage}</p>}
+        {selectedDetail ? (
+          <RegistryArtifactDetail
+            {...selectedDetail}
+            isMutationPending={pendingOperation === "add"}
+            onAdd={
+              selectedDetail.catalogArtifact && !selectedDetail.tenantArtifact
+                ? (versionSpec) =>
+                    handleAdd(
+                      selectedDetail.catalogArtifact!.normalizedName,
+                      versionSpec,
+                    )
+                : undefined
+            }
+            onRemove={
+              selectedDetail.tenantArtifact
+                ? () =>
+                    setRemoveTarget(
+                      selectedDetail.tenantArtifact!.normalizedName,
+                    )
+                : undefined
+            }
+          />
+        ) : (
+          <RegistryOverview
+            availableArtifacts={model.available}
+            metrics={model.metrics}
+            selectedId={selectedId}
+            tenantArtifacts={state.tenantArtifacts}
+          />
+        )}
+      </main>
+      {accessDialog}
+      <RegistryRemoveDialog
+        artifactName={removeTarget}
+        isPending={pendingOperation === "remove"}
+        onConfirm={() => removeTarget && handleRemove(removeTarget)}
+        onOpenChange={(open) => {
+          if (!open && pendingOperation !== "remove")
+            setRemoveTarget(undefined);
+        }}
+        open={removeTarget !== undefined}
+      />
+    </div>
+  );
+}

--- a/ui/components/registry/registry-navigation.tsx
+++ b/ui/components/registry/registry-navigation.tsx
@@ -1,0 +1,168 @@
+import { Checkbox } from "@/components/shadcn/checkbox";
+import { Input } from "@/components/shadcn/input/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/shadcn/select/select";
+import { TreeView } from "@/components/shadcn/tree-view";
+import { getProviderDisplayName } from "@/types/providers";
+import type {
+  RegistryCatalogArtifact,
+  RegistryTenantArtifact,
+} from "@/types/registry";
+import type { TreeDataItem } from "@/types/tree";
+
+import {
+  REGISTRY_CATALOG_CAPABILITY,
+  type RegistryCatalogCapability,
+  type RegistryExplorerFilters,
+} from "./registry-explorer.model";
+
+interface RegistryNavigationProps {
+  artifacts: RegistryCatalogArtifact[];
+  expandedIds: string[];
+  filters: RegistryExplorerFilters;
+  onExpandedChange: (ids: string[]) => void;
+  onFiltersChange: (filters: RegistryExplorerFilters) => void;
+  onSelectedIdChange: (id: string) => void;
+  providers: string[];
+  selectedId: string;
+  tenantArtifacts: RegistryTenantArtifact[];
+}
+
+const capabilities = Object.values(REGISTRY_CATALOG_CAPABILITY);
+const capabilityLabels = {
+  provider: "Provider",
+  checks: "Checks",
+  compliance: "Compliance",
+} as const satisfies Record<RegistryCatalogCapability, string>;
+
+function leaf(
+  collection: string,
+  artifact: RegistryCatalogArtifact | RegistryTenantArtifact,
+): TreeDataItem {
+  return {
+    id: `leaf:${collection}:${encodeURIComponent(artifact.normalizedName)}`,
+    name:
+      ("name" in artifact ? artifact.name : undefined) ??
+      artifact.normalizedName,
+  };
+}
+
+export function RegistryNavigation({
+  artifacts,
+  expandedIds,
+  filters,
+  onExpandedChange,
+  onFiltersChange,
+  onSelectedIdChange,
+  providers,
+  selectedId,
+  tenantArtifacts,
+}: RegistryNavigationProps) {
+  const selectedCapabilities = filters.capabilities ?? [];
+  const data: TreeDataItem[] = [
+    {
+      id: "root:available",
+      name: "Available artifacts",
+      children: [
+        ...providers.map((provider) => ({
+          id: `group:${provider}`,
+          name: getProviderDisplayName(provider),
+          children: artifacts
+            .filter((artifact) => artifact.providers.includes(provider))
+            .map((artifact) => leaf(provider, artifact)),
+        })),
+        {
+          id: "group:multi-provider",
+          name: "Multi-provider",
+          children: artifacts
+            .filter((artifact) => artifact.providers.length > 1)
+            .map((artifact) => leaf("multi-provider", artifact)),
+        },
+      ],
+    },
+    {
+      id: "root:my-artifacts",
+      name: "My artifacts",
+      children: tenantArtifacts.map((artifact) =>
+        leaf("my-artifacts", artifact),
+      ),
+    },
+  ];
+  const updateExpanded = (ids: string[]) => {
+    const selected =
+      ids.find((id) => !expandedIds.includes(id)) ??
+      expandedIds.find((id) => !ids.includes(id));
+    onExpandedChange(ids);
+    if (selected) onSelectedIdChange(selected);
+  };
+  const updateCapability = (
+    capability: RegistryCatalogCapability,
+    checked: boolean,
+  ) =>
+    onFiltersChange({
+      ...filters,
+      capabilities: checked
+        ? [...selectedCapabilities, capability]
+        : selectedCapabilities.filter((value) => value !== capability),
+    });
+
+  return (
+    <nav aria-label="Registry explorer" className="space-y-4">
+      <Input
+        aria-label="Search Registry artifacts"
+        placeholder="Search artifacts"
+        value={filters.search ?? ""}
+        onChange={(event) =>
+          onFiltersChange({ ...filters, search: event.target.value })
+        }
+      />
+      <Select
+        value={filters.provider ?? "all"}
+        onValueChange={(provider) =>
+          onFiltersChange({
+            ...filters,
+            provider: provider === "all" ? undefined : provider,
+          })
+        }
+      >
+        <SelectTrigger aria-label="Filter by provider" size="sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All providers</SelectItem>
+          {providers.map((provider) => (
+            <SelectItem key={provider} value={provider}>
+              {getProviderDisplayName(provider)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {capabilities.map((capability) => (
+        <label key={capability} className="flex items-center gap-2 text-sm">
+          <Checkbox
+            checked={selectedCapabilities.includes(capability)}
+            onCheckedChange={(checked) =>
+              updateCapability(capability, checked === true)
+            }
+          />
+          {capabilityLabels[capability]}
+        </label>
+      ))}
+      <TreeView
+        data={data}
+        enableSelectChildren={false}
+        expandedIds={expandedIds}
+        onExpandedChange={updateExpanded}
+        onSelectionChange={(ids) =>
+          onSelectedIdChange(ids.at(-1) ?? "root:available")
+        }
+        selectedIds={[selectedId]}
+      />
+    </nav>
+  );
+}

--- a/ui/components/registry/registry-onboarding.tsx
+++ b/ui/components/registry/registry-onboarding.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@/components/shadcn/button/button";
+import type { RegistryTenantArtifact } from "@/types/registry";
+
+export function RegistryOnboarding({
+  tenantArtifacts,
+  validationPending,
+  onConnect,
+}: {
+  tenantArtifacts: RegistryTenantArtifact[];
+  validationPending: boolean;
+  onConnect: () => void;
+}) {
+  const title = validationPending
+    ? "Registry validation in progress"
+    : "Connect Registry";
+  const copy = validationPending
+    ? "Your Registry key is being validated. Catalog exploration will be available after validation succeeds."
+    : "Connect a Registry key to browse available artifacts.";
+
+  return (
+    <section aria-live="polite" className="mx-auto max-w-2xl py-12 text-center">
+      <h1 className="text-xl font-semibold">{title}</h1>
+      <p className="text-text-neutral-secondary mt-3 text-sm">{copy}</p>
+      <p className="text-text-neutral-secondary mt-3 text-sm">
+        {tenantArtifacts.length} preserved tenant artifact
+        {tenantArtifacts.length === 1 ? "" : "s"} remain in My artifacts.
+      </p>
+      {!validationPending && (
+        <Button className="mt-6" onClick={onConnect} type="button">
+          Connect Registry
+        </Button>
+      )}
+      <Button asChild className="mt-6" variant="outline">
+        <a
+          href="https://registry.prowler.com"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Open Registry (opens in a new tab)
+        </a>
+      </Button>
+    </section>
+  );
+}

--- a/ui/components/registry/registry-overview.tsx
+++ b/ui/components/registry/registry-overview.tsx
@@ -1,0 +1,70 @@
+import type { RegistryTenantArtifact } from "@/types/registry";
+
+interface RegistryOverviewProps {
+  availableArtifacts: {
+    name?: string;
+    normalizedName: string;
+    providers: string[];
+  }[];
+  metrics: Record<
+    "providers" | "availableArtifacts" | "myArtifacts" | "officialArtifacts",
+    number
+  >;
+  selectedId: string;
+  tenantArtifacts: RegistryTenantArtifact[];
+}
+
+export function RegistryOverview({
+  availableArtifacts,
+  metrics,
+  selectedId,
+  tenantArtifacts,
+}: RegistryOverviewProps) {
+  const group = selectedId.startsWith("group:")
+    ? selectedId.slice("group:".length)
+    : undefined;
+  const rows =
+    selectedId === "root:my-artifacts"
+      ? tenantArtifacts
+      : group === "multi-provider"
+        ? availableArtifacts.filter((artifact) => artifact.providers.length > 1)
+        : group
+          ? availableArtifacts.filter((artifact) =>
+              artifact.providers.includes(group),
+            )
+          : availableArtifacts;
+  return (
+    <section aria-labelledby="registry-overview-title">
+      <h1 id="registry-overview-title" className="text-xl font-semibold">
+        {selectedId === "root:my-artifacts"
+          ? "My artifacts"
+          : group
+            ? `${group} artifacts`
+            : "Registry overview"}
+      </h1>
+      <div className="mt-6 grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-4">
+        <p>Providers: {metrics.providers}</p>
+        <p>Available artifacts: {metrics.availableArtifacts}</p>
+        <p>My artifacts: {metrics.myArtifacts}</p>
+        <p>Official artifacts: {metrics.officialArtifacts}</p>
+      </div>
+      <p className="text-text-neutral-secondary mt-6 text-sm">
+        {rows.length} artifact{rows.length === 1 ? "" : "s"} in this view.
+      </p>
+      {rows.length ? (
+        <ul className="mt-3 space-y-2 text-sm">
+          {rows.map((artifact) => (
+            <li key={artifact.normalizedName}>
+              {("name" in artifact ? artifact.name : undefined) ??
+                artifact.normalizedName}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-text-neutral-secondary mt-3 text-sm">
+          No artifacts match this complete catalog view.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/ui/components/registry/registry-remove-dialog.tsx
+++ b/ui/components/registry/registry-remove-dialog.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/components/shadcn/button/button";
+import { Modal } from "@/components/shadcn/modal/modal";
+
+interface RegistryRemoveDialogProps {
+  artifactName?: string;
+  isPending: boolean;
+  onConfirm: () => void;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}
+
+export function RegistryRemoveDialog({
+  artifactName,
+  isPending,
+  onConfirm,
+  onOpenChange,
+  open,
+}: RegistryRemoveDialogProps) {
+  return (
+    <Modal
+      description={`Remove ${artifactName ?? "this artifact"} from My artifacts.`}
+      onOpenChange={onOpenChange}
+      open={open}
+      size="sm"
+      title="Remove artifact"
+    >
+      <div className="flex flex-wrap justify-end gap-2">
+        <Button
+          disabled={isPending}
+          onClick={() => onOpenChange(false)}
+          type="button"
+          variant="outline"
+        >
+          Cancel
+        </Button>
+        <Button
+          disabled={isPending}
+          onClick={onConfirm}
+          type="button"
+          variant="destructive"
+        >
+          {isPending ? "Removing artifact" : "Confirm Remove"}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/ui/types/registry.ts
+++ b/ui/types/registry.ts
@@ -155,6 +155,26 @@ export type RegistryCollectionsResult =
   | RegistryIncompleteCatalog
   | RegistryFailureResult;
 
+export const REGISTRY_MUTATION = {
+  CONFIRMED: "confirmed",
+  REFRESH_FAILED: "refresh_failed",
+  REFUSED: "refused",
+} as const;
+
+export type RegistryMutationResult =
+  | {
+      status: typeof REGISTRY_MUTATION.CONFIRMED;
+      tenantArtifacts: RegistryTenantArtifact[];
+    }
+  | {
+      status: typeof REGISTRY_MUTATION.REFRESH_FAILED;
+    }
+  | {
+      status: typeof REGISTRY_MUTATION.REFUSED;
+      message: string;
+    }
+  | RegistryFailureResult;
+
 export const REGISTRY_BOOTSTRAP_STATE = {
   ONBOARDING: "onboarding",
   VALIDATION_PENDING: "validation_pending",


### PR DESCRIPTION
## 🔗 Part of Chained PRs

| Field | Value |
|---|---|
| Feature Branch | `feat/prowler-2414-registry-ui` |
| Main PR | #12494 |
| Position | 7 of 8 |
| Base | `feat/prowler-2414-registry-ui-06-guarded-reads` |
| Depends on | #12505 |
| Follow-up | PR 8, acceptance hardening |
| Non-test budget | 1,198 / 1,200 changed lines, explicit maintainer-approved size exception |
| Excluded test lines | 807 changed lines |
| All-path diff | 2,005 changed lines |
| Starts at | Guarded Registry server integration |
| Ends with | Complete interactive explorer plus refresh-confirmed Add/Remove and access management |

### Chain Overview

```text
feat/prowler-2414-registry-ui (#12494 tracker)
└── #12495 PR 1: permissions and flag typing
    └── #12497 PR 2: fresh access authority
        └── #12499 PR 3: lease, navigation, and route guards
            └── #12503 PR 4: DTO and error adapters
                └── #12504 PR 5: complete catalog model
                    └── #12505 PR 6: guarded Registry server integration
                        └── 📍 #12515 PR 7: interactive explorer and authoritative Add/Remove
                            └── PR 8: acceptance hardening (planned)
                                └── #12494 tracker -> master
```

### Scope

- Includes the complete interactive Registry explorer, authoritative Available and My artifact views, search, filters, provider navigation, onboarding, access management, and refresh-confirmed Add/Remove transactions.
- Rollback is limited to this child PR. Reverting it removes the explorer and its transactions without changing backend credentials or tenant artifacts.
- Excludes shared primitive changes; Playwright, configuration, and documentation work; backend changes; migrations; deployment; and runtime-flag enablement. Those boundaries remain with PR 8 or outside this chain.
- No new npm dependencies are introduced.

### Context

The Registry experience must show only complete, authoritative server state. A successful mutation does not move an artifact between views or produce a success toast until a fresh My-artifacts read confirms the expected presence or absence.

This child builds on the guarded Registry server integration in #12505 and completes the interactive explorer and access-management work. PR 8 remains responsible for shared accessibility and reduced-motion primitives, Playwright/configuration/documentation work, browser acceptance, and final feature-level evidence.

### Description

- Render onboarding, validation-pending, ready, incomplete, empty, stale, and recoverable error states from authoritative bootstrap DTOs.
- Provide complete-catalog search, filtering, metrics, provider grouping, Multi-provider navigation, and artifact details without partial-catalog controls or version browsing.
- Add guarded Add and Remove actions with literal `latest` or an exact pin, encoded removal, confirmation, fixed refusal outcomes, and no optimistic membership moves.
- Refresh My artifacts after each mutation and update membership and toasts only after the expected authoritative result is confirmed.
- Provide reconnect and manage-access dialogs that preserve confirmed catalog state on failed credential replacement and immediately clear submitted write-only keys.
- Preserve access invalidation, late-result suppression, accessible dialog labels and confirmations, and no animation-dependent success behavior.
- Include the approved UI changelog fragment at `ui/changelog.d/registry-artifact-transactions.added.md`.

### Steps to review

1. Confirm the explorer exposes only complete-catalog search, filters, metrics, navigation, and details, with clear onboarding, pending, incomplete, stale, and error boundaries.
2. Verify that Add and Remove use authoritative My-artifact refreshes before changing visible membership or emitting success feedback. Check both literal `latest` and exact-pin input behavior, encoded removal, confirmation, and refusal outcomes.
3. Verify access-management failure preserves confirmed catalog state and submitted keys are immediately reset and never surfaced in returned data, URLs, storage, logs, or toast inputs.
4. Run `cd ui && pnpm exec vitest run --project unit actions/registry/registry.test.ts`; recorded result: PASS, 33 tests.
5. Run `cd ui && pnpm exec vitest run --project integration components/registry/registry-explorer.integration.test.tsx`; recorded result: PASS, 21 tests.
6. Run `cd ui && pnpm exec vitest run --project unit actions/registry/registry.adapter.test.ts components/registry/registry-explorer.model.test.ts lib/registry/access.test.ts lib/registry/access.server.test.ts`; recorded result: PASS, 4 files / 26 tests.
7. Run `cd ui && pnpm exec vitest run --project unit proxy.test.ts lib/registry/access.server.test.ts components/layout/main-layout/main-layout.test.tsx components/layout/app-sidebar/navigation-config.test.ts components/layout/app-sidebar/app-sidebar-content.test.tsx`; recorded result: PASS, 5 files / 29 tests.
8. Run `cd ui && pnpm run test:unit`; recorded result: PASS, 436 files / 3,119 tests. Run `cd ui && pnpm run test:integration`; recorded result: PASS, 8 files / 132 tests.
9. Recorded checks also pass: `cd ui && pnpm run typecheck`, `cd ui && pnpm run lint:check`, `cd ui && pnpm run format:check`, tracked and untracked candidate `git diff --check`, and `PREK_NO_CONCURRENCY=1 uv run --directory . prek run --files <all 14 PR 7 candidate paths>`.
10. `typescript-language-server` was unavailable; local `tsserver` reported PASS with 0 syntax or semantic diagnostics across the 13 TS/TSX candidate files.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md): not required for this child.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable: SDK/CLI is not changed.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI: PR 8 acceptance hardening remains pending.
- [x] This PR adds or updates no npm dependencies.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px): pending PR 8 acceptance.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px): pending PR 8 acceptance.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px): pending PR 8 acceptance.
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable: `registry-artifact-transactions.added.md` is included.

#### API
- [x] The API is not changed by this PR.
- [x] Endpoint response output, query analysis, performance evidence, API specs, versions, and API changelog are not applicable.

#### MCP Server
- [x] The MCP Server is not changed by this PR.
- [x] The MCP changelog is not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
