### PR TITLE
fix(api): omit empty AWS session token when creating S3 client

### DIFF
--- a/api/changelog.d/s3-output-empty-session-token.fixed.md
+++ b/api/changelog.d/s3-output-empty-session-token.fixed.md
@@ -1,0 +1,1 @@
+Fix presigned report downloads failing with AccessDenied on S3-compatible object storage by omitting the empty AWS session token in `get_s3_client`

--- a/api/src/backend/tasks/jobs/export.py
+++ b/api/src/backend/tasks/jobs/export.py
@@ -221,7 +221,7 @@ def get_s3_client():
             "s3",
             aws_access_key_id=settings.DJANGO_OUTPUT_S3_AWS_ACCESS_KEY_ID,
             aws_secret_access_key=settings.DJANGO_OUTPUT_S3_AWS_SECRET_ACCESS_KEY,
-            aws_session_token=settings.DJANGO_OUTPUT_S3_AWS_SESSION_TOKEN,
+            aws_session_token=settings.DJANGO_OUTPUT_S3_AWS_SESSION_TOKEN or None,
             region_name=settings.DJANGO_OUTPUT_S3_AWS_DEFAULT_REGION,
         )
         s3_client.list_buckets()

--- a/api/src/backend/tasks/tests/test_export.py
+++ b/api/src/backend/tasks/tests/test_export.py
@@ -45,6 +45,39 @@ class TestOutputs:
 
         client = get_s3_client()
         assert client is not None
+        mock_boto_client.assert_called_once_with(
+            "s3",
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+            aws_session_token="token",
+            region_name="eu-west-1",
+        )
+        client_mock.list_buckets.assert_called()
+
+    @patch("tasks.jobs.export.boto3.client")
+    @patch("tasks.jobs.export.settings")
+    def test_get_s3_client_empty_session_token_passed_as_none(
+        self, mock_settings, mock_boto_client
+    ):
+        mock_settings.DJANGO_OUTPUT_S3_AWS_ACCESS_KEY_ID = "test"
+        mock_settings.DJANGO_OUTPUT_S3_AWS_SECRET_ACCESS_KEY = "test"
+        mock_settings.DJANGO_OUTPUT_S3_AWS_SESSION_TOKEN = ""
+        mock_settings.DJANGO_OUTPUT_S3_AWS_DEFAULT_REGION = "eu-west-1"
+
+        client_mock = MagicMock()
+        mock_boto_client.return_value = client_mock
+
+        client = get_s3_client()
+        assert client is not None
+        # botocore emits an empty X-Amz-Security-Token in presigned URLs for
+        # any token that is not None, which S3-compatible stores reject.
+        mock_boto_client.assert_called_once_with(
+            "s3",
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+            aws_session_token=None,
+            region_name="eu-west-1",
+        )
         client_mock.list_buckets.assert_called()
 
     @patch("tasks.jobs.export.boto3.client")


### PR DESCRIPTION
### Context

Self-hosted Prowler App deployments offloading scan output to S3-compatible, non-AWS object storage (Hetzner Object Storage / Ceph RGW, MinIO, R2) get 403 AccessDenied when downloading reports: GET /api/v1/scans/{id}/report returns a 302 to a presigned URL containing an empty X-Amz-Security-Token= parameter, which these stores reject.
DJANGO_OUTPUT_S3_AWS_SESSION_TOKEN defaults to "" in config/django/base.py, and get_s3_client() forwarded it verbatim. botocore's SigV4 query auth emits the token parameter for any value that is not None, so long-lived access keys were signed as if they were temporary credentials. Uploads mask the bug because they sign headers, not the query string.

Fixes #12508

### Description

One-line fix in tasks/jobs/export.py:get_s3_client():
aws_session_token=settings.DJANGO_OUTPUT_S3_AWS_SESSION_TOKEN or None,
Coercing at the boto3 boundary is preferred over changing the settings default, because deployments commonly set the env var explicitly-but-empty (including this repo's own .env template), which bypasses any default change.
Also adds unit coverage in tasks/tests/test_export.py:
- test_get_s3_client_empty_session_token_passed_as_none — asserts boto3.client receives aws_session_token=None when the setting is ""
- strengthened test_get_s3_client_success with an exact-kwargs assertion proving real tokens still pass through unchanged
Adds changelog fragment api/changelog.d/s3-output-empty-session-token.fixed.md. No dependencies added or changed.

### Steps to review

1. Confirm the root cause: botocore emits X-Amz-Security-Token= for any non-None token (SigV4QueryAuth), so "" breaks non-AWS endpoints while remaining harmless on AWS.
2. Review the coercion in get_s3_client() — both _upload_to_s3() and the report view (api/v1/views.py) share this client, so upload and download are fixed together.
3. Run uv run pytest src/backend/tasks/tests/test_export.py -v from api/ — 10/10 pass (new test fails without the fix).
4. uv run ruff check . --exclude contrib && uv run ruff format --check . --exclude contrib && uv run pylint --disable=W,C,R,E -j 0 -rn -sn src/ — all clean on the changed files.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- Review if the code is being covered by tests. — new regression test included
- Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- Review if backport is needed. — no release-branch changes made; maintainers may wish to backport since self-hosted stable images are impacted
- Review if is needed to change the README.md (https://github.com/prowler-cloud/prowler/blob/master/README.md) — not needed
- Ensure a changelog fragment is added under prowler/changelog.d/ (https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. — SDK not affected; fragment added under api/changelog.d/
SDK/CLI
- Are there new checks included in this PR? No
- If so, do we need to update permissions for the provider? Not applicable.
#### UI
- All issue/task requirements work as expected on the UI — Not applicable; UI unchanged.
- If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient. — No npm dependencies added or updated.
- Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px) — Not applicable; backend-only change.
- Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px) — Not applicable; backend-only change.
- Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px) — Not applicable; backend-only change.
- Ensure a changelog fragment is added under ui/changelog.d/ (https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable. — Not applicable.
#### API
- All issue/task requirements work as expected on the API — test_export.py: 10/10 passed, including the new regression test.
- Endpoint response output (if applicable) — Not applicable; no endpoint contract changed (presigned URLs now omit the token parameter entirely).
- EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable) — Not applicable; no queries touched.
- Performance test results (if applicable) — Not applicable.
- Any other relevant evidence of the implementation (if applicable) — TDD: new test failed before the fix (aws_session_token="" vs expected None) and passes after; ruff check, ruff format --check, and CI-equivalent pylint all clean on changed files.
- Verify if API specs need to be regenerated. — No; no schema or endpoint change.
- Check if version updates are required (e.g., specs, uv, etc.). — No.
- Ensure a changelog fragment is added under api/changelog.d/ (https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable. — Added api/changelog.d/s3-output-empty-session-token.fixed.md.
#### MCP Server
- All issue/task requirements work as expected on the MCP Server — Not applicable; MCP Server code is unchanged.
- Ensure a changelog fragment is added under mcp_server/changelog.d/ (https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable. — Not applicable.
License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed presigned report downloads on S3-compatible storage when no AWS session token is configured.
  * Presigned downloads now work correctly with empty session-token settings.

* **Tests**
  * Added coverage to verify S3 client creation and bucket validation with empty session tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->