### PR TITLE
fix(api): document Azure certificate credentials

### DIFF
--- a/api/changelog.d/azure-certificate-openapi-schema.fixed.md
+++ b/api/changelog.d/azure-certificate-openapi-schema.fixed.md
@@ -1,0 +1,1 @@
+`POST /api/v1/providers` OpenAPI schema documents Azure certificate authentication credentials

--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -6091,16 +6091,6 @@ paths:
         schema:
           type: string
           format: date
-      - in: query
-        name: filter[updated_at__gte]
-        schema:
-          type: string
-          format: date-time
-      - in: query
-        name: filter[updated_at__lte]
-        schema:
-          type: string
-          format: date-time
       - name: sort
         required: false
         in: query
@@ -16312,7 +16302,7 @@ paths:
           content:
             application/vnd.api+json:
               schema:
-                $ref: '#/components/schemas/UserResponse'
+                $ref: '#/components/schemas/UserMeResponse'
           description: ''
 components:
   schemas:
@@ -16444,6 +16434,17 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/AttackPathsQueryParameter'
+            outcome:
+              type: object
+              nullable: true
+              properties:
+                kind:
+                  type: string
+                label:
+                  type: string
+                partial:
+                  type: boolean
+              readOnly: true
           required:
           - id
           - name
@@ -17680,7 +17681,11 @@ components:
                       can be generated from your Atlassian account settings.
                   domain:
                     type: string
-                    description: The JIRA domain/instance URL (e.g., 'your-domain.atlassian.net').
+                    description: The Jira site name without the '.atlassian.net' suffix
+                      (e.g., 'your-domain').
+                    minLength: 1
+                    maxLength: 63
+                    pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
                 required:
                 - user_mail
                 - api_token
@@ -17865,7 +17870,11 @@ components:
                           can be generated from your Atlassian account settings.
                       domain:
                         type: string
-                        description: The JIRA domain/instance URL (e.g., 'your-domain.atlassian.net').
+                        description: The Jira site name without the '.atlassian.net'
+                          suffix (e.g., 'your-domain').
+                        minLength: 1
+                        maxLength: 63
+                        pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
                     required:
                     - user_mail
                     - api_token
@@ -18127,7 +18136,11 @@ components:
                       can be generated from your Atlassian account settings.
                   domain:
                     type: string
-                    description: The JIRA domain/instance URL (e.g., 'your-domain.atlassian.net').
+                    description: The Jira site name without the '.atlassian.net' suffix
+                      (e.g., 'your-domain').
+                    minLength: 1
+                    maxLength: 63
+                    pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
                 required:
                 - user_mail
                 - api_token
@@ -20554,7 +20567,11 @@ components:
                           can be generated from your Atlassian account settings.
                       domain:
                         type: string
-                        description: The JIRA domain/instance URL (e.g., 'your-domain.atlassian.net').
+                        description: The Jira site name without the '.atlassian.net'
+                          suffix (e.g., 'your-domain').
+                        minLength: 1
+                        maxLength: 63
+                        pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
                     required:
                     - user_mail
                     - api_token
@@ -21272,7 +21289,7 @@ components:
                     - role_arn
                     - external_id
                   - type: object
-                    title: Azure Static Credentials
+                    title: Azure Client Secret Credentials
                     properties:
                       client_id:
                         type: string
@@ -21290,6 +21307,27 @@ components:
                     - client_id
                     - client_secret
                     - tenant_id
+                    additionalProperties: false
+                  - type: object
+                    title: Azure Certificate Credentials
+                    properties:
+                      client_id:
+                        type: string
+                        description: The Azure application (client) ID for authentication
+                          in Azure AD.
+                      certificate_content:
+                        type: string
+                        description: Base64-encoded PEM certificate and private key
+                          content for certificate-based authentication.
+                      tenant_id:
+                        type: string
+                        description: The Azure tenant ID, representing the directory
+                          where the application is registered.
+                    required:
+                    - client_id
+                    - certificate_content
+                    - tenant_id
+                    additionalProperties: false
                   - type: object
                     title: M365 Static Credentials
                     properties:
@@ -21387,7 +21425,8 @@ components:
                       kubeconfig_content:
                         type: string
                         description: The content of the Kubernetes kubeconfig file,
-                          encoded as a string.
+                          encoded as a string. Kubeconfig command-based authentication
+                          is not supported in Prowler Cloud for security reasons.
                     required:
                     - kubeconfig_content
                   - type: object
@@ -21450,18 +21489,23 @@ components:
                       tenancy:
                         type: string
                         description: The OCID of the tenancy.
-                      region:
-                        type: string
-                        description: The OCI region identifier (e.g., us-ashburn-1,
-                          us-phoenix-1).
                       pass_phrase:
                         type: string
                         description: The passphrase for the private key, if encrypted.
+                      region:
+                        type: string
+                        deprecated: true
+                        description: Legacy OCI region field accepted for backwards
+                          compatibility but ignored; OCI scans all regions.
                     required:
                     - user
                     - fingerprint
                     - tenancy
-                    - region
+                    anyOf:
+                    - required:
+                      - key_file
+                    - required:
+                      - key_content
                   - type: object
                     title: MongoDB Atlas API Key
                     properties:
@@ -23396,7 +23440,7 @@ components:
                 - role_arn
                 - external_id
               - type: object
-                title: Azure Static Credentials
+                title: Azure Client Secret Credentials
                 properties:
                   client_id:
                     type: string
@@ -23414,6 +23458,27 @@ components:
                 - client_id
                 - client_secret
                 - tenant_id
+                additionalProperties: false
+              - type: object
+                title: Azure Certificate Credentials
+                properties:
+                  client_id:
+                    type: string
+                    description: The Azure application (client) ID for authentication
+                      in Azure AD.
+                  certificate_content:
+                    type: string
+                    description: Base64-encoded PEM certificate and private key content
+                      for certificate-based authentication.
+                  tenant_id:
+                    type: string
+                    description: The Azure tenant ID, representing the directory where
+                      the application is registered.
+                required:
+                - client_id
+                - certificate_content
+                - tenant_id
+                additionalProperties: false
               - type: object
                 title: M365 Static Credentials
                 properties:
@@ -23510,7 +23575,8 @@ components:
                   kubeconfig_content:
                     type: string
                     description: The content of the Kubernetes kubeconfig file, encoded
-                      as a string.
+                      as a string. Kubeconfig command-based authentication is not
+                      supported in Prowler Cloud for security reasons.
                 required:
                 - kubeconfig_content
               - type: object
@@ -23572,17 +23638,23 @@ components:
                   tenancy:
                     type: string
                     description: The OCID of the tenancy.
-                  region:
-                    type: string
-                    description: The OCI region identifier (e.g., us-ashburn-1, us-phoenix-1).
                   pass_phrase:
                     type: string
                     description: The passphrase for the private key, if encrypted.
+                  region:
+                    type: string
+                    deprecated: true
+                    description: Legacy OCI region field accepted for backwards compatibility
+                      but ignored; OCI scans all regions.
                 required:
                 - user
                 - fingerprint
                 - tenancy
-                - region
+                anyOf:
+                - required:
+                  - key_file
+                - required:
+                  - key_content
               - type: object
                 title: MongoDB Atlas API Key
                 properties:
@@ -23835,7 +23907,7 @@ components:
                     - role_arn
                     - external_id
                   - type: object
-                    title: Azure Static Credentials
+                    title: Azure Client Secret Credentials
                     properties:
                       client_id:
                         type: string
@@ -23853,6 +23925,27 @@ components:
                     - client_id
                     - client_secret
                     - tenant_id
+                    additionalProperties: false
+                  - type: object
+                    title: Azure Certificate Credentials
+                    properties:
+                      client_id:
+                        type: string
+                        description: The Azure application (client) ID for authentication
+                          in Azure AD.
+                      certificate_content:
+                        type: string
+                        description: Base64-encoded PEM certificate and private key
+                          content for certificate-based authentication.
+                      tenant_id:
+                        type: string
+                        description: The Azure tenant ID, representing the directory
+                          where the application is registered.
+                    required:
+                    - client_id
+                    - certificate_content
+                    - tenant_id
+                    additionalProperties: false
                   - type: object
                     title: M365 Static Credentials
                     properties:
@@ -23950,7 +24043,8 @@ components:
                       kubeconfig_content:
                         type: string
                         description: The content of the Kubernetes kubeconfig file,
-                          encoded as a string.
+                          encoded as a string. Kubeconfig command-based authentication
+                          is not supported in Prowler Cloud for security reasons.
                     required:
                     - kubeconfig_content
                   - type: object
@@ -24013,18 +24107,23 @@ components:
                       tenancy:
                         type: string
                         description: The OCID of the tenancy.
-                      region:
-                        type: string
-                        description: The OCI region identifier (e.g., us-ashburn-1,
-                          us-phoenix-1).
                       pass_phrase:
                         type: string
                         description: The passphrase for the private key, if encrypted.
+                      region:
+                        type: string
+                        deprecated: true
+                        description: Legacy OCI region field accepted for backwards
+                          compatibility but ignored; OCI scans all regions.
                     required:
                     - user
                     - fingerprint
                     - tenancy
-                    - region
+                    anyOf:
+                    - required:
+                      - key_file
+                    - required:
+                      - key_content
                   - type: object
                     title: MongoDB Atlas API Key
                     properties:
@@ -24297,7 +24396,7 @@ components:
                 - role_arn
                 - external_id
               - type: object
-                title: Azure Static Credentials
+                title: Azure Client Secret Credentials
                 properties:
                   client_id:
                     type: string
@@ -24315,6 +24414,27 @@ components:
                 - client_id
                 - client_secret
                 - tenant_id
+                additionalProperties: false
+              - type: object
+                title: Azure Certificate Credentials
+                properties:
+                  client_id:
+                    type: string
+                    description: The Azure application (client) ID for authentication
+                      in Azure AD.
+                  certificate_content:
+                    type: string
+                    description: Base64-encoded PEM certificate and private key content
+                      for certificate-based authentication.
+                  tenant_id:
+                    type: string
+                    description: The Azure tenant ID, representing the directory where
+                      the application is registered.
+                required:
+                - client_id
+                - certificate_content
+                - tenant_id
+                additionalProperties: false
               - type: object
                 title: M365 Static Credentials
                 properties:
@@ -24411,7 +24531,8 @@ components:
                   kubeconfig_content:
                     type: string
                     description: The content of the Kubernetes kubeconfig file, encoded
-                      as a string.
+                      as a string. Kubeconfig command-based authentication is not
+                      supported in Prowler Cloud for security reasons.
                 required:
                 - kubeconfig_content
               - type: object
@@ -24473,17 +24594,23 @@ components:
                   tenancy:
                     type: string
                     description: The OCID of the tenancy.
-                  region:
-                    type: string
-                    description: The OCI region identifier (e.g., us-ashburn-1, us-phoenix-1).
                   pass_phrase:
                     type: string
                     description: The passphrase for the private key, if encrypted.
+                  region:
+                    type: string
+                    deprecated: true
+                    description: Legacy OCI region field accepted for backwards compatibility
+                      but ignored; OCI scans all regions.
                 required:
                 - user
                 - fingerprint
                 - tenancy
-                - region
+                anyOf:
+                - required:
+                  - key_file
+                - required:
+                  - key_content
               - type: object
                 title: MongoDB Atlas API Key
                 properties:
@@ -26807,6 +26934,103 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/UserCreate'
+      required:
+      - data
+    UserMe:
+      type: object
+      required:
+      - type
+      - id
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+            member is used to describe resource objects that share common attributes
+            and relationships.
+          enum:
+          - users
+        id:
+          type: string
+          format: uuid
+        attributes:
+          type: object
+          properties:
+            name:
+              type: string
+              maxLength: 150
+              minLength: 3
+            email:
+              type: string
+              format: email
+              description: Case insensitive
+              maxLength: 254
+            company_name:
+              type: string
+              maxLength: 150
+            date_joined:
+              type: string
+              format: date-time
+              readOnly: true
+          required:
+          - name
+          - email
+        relationships:
+          type: object
+          properties:
+            memberships:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    type:
+                      type: string
+                      enum:
+                      - memberships
+                      title: Resource Type Name
+                      description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                        member is used to describe resource objects that share common
+                        attributes and relationships.
+                  required:
+                  - id
+                  - type
+              required:
+              - data
+              description: The identifier of the related object.
+              title: Resource Identifier
+              readOnly: true
+            roles:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    type:
+                      type: string
+                      enum:
+                      - roles
+                      title: Resource Type Name
+                      description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                        member is used to describe resource objects that share common
+                        attributes and relationships.
+                  required:
+                  - id
+                  - type
+              required:
+              - data
+              description: The identifier of the related object.
+              title: Resource Identifier
+              readOnly: true
+    UserMeResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/UserMe'
       required:
       - data
     UserResponse:

--- a/api/src/backend/api/tests/test_serializers.py
+++ b/api/src/backend/api/tests/test_serializers.py
@@ -244,6 +244,47 @@ class TestOracleCloudProviderSecret:
 
 
 class TestProviderSecretFieldSchema:
+    def test_azure_schema_exposes_exclusive_supported_credential_shapes(self):
+        schema = ProviderSecretField._spectacular_annotation["field"]
+        azure_schemas = {
+            credential_schema["title"]: credential_schema
+            for credential_schema in schema["oneOf"]
+            if credential_schema["title"].startswith("Azure ")
+        }
+
+        assert set(azure_schemas) == {
+            "Azure Client Secret Credentials",
+            "Azure Certificate Credentials",
+        }
+        assert azure_schemas["Azure Client Secret Credentials"]["required"] == [
+            "client_id",
+            "client_secret",
+            "tenant_id",
+        ]
+        assert set(azure_schemas["Azure Client Secret Credentials"]["properties"]) == {
+            "client_id",
+            "client_secret",
+            "tenant_id",
+        }
+        assert (
+            azure_schemas["Azure Client Secret Credentials"]["additionalProperties"]
+            is False
+        )
+        assert azure_schemas["Azure Certificate Credentials"]["required"] == [
+            "client_id",
+            "certificate_content",
+            "tenant_id",
+        ]
+        assert set(azure_schemas["Azure Certificate Credentials"]["properties"]) == {
+            "client_id",
+            "certificate_content",
+            "tenant_id",
+        }
+        assert (
+            azure_schemas["Azure Certificate Credentials"]["additionalProperties"]
+            is False
+        )
+
     def test_oraclecloud_schema_includes_legacy_region_field(self):
         schema = ProviderSecretField._spectacular_annotation["field"]
         oraclecloud_schema = next(

--- a/api/src/backend/api/v1/serializer_utils/providers.py
+++ b/api/src/backend/api/v1/serializer_utils/providers.py
@@ -78,7 +78,7 @@ from rest_framework_json_api import serializers
             },
             {
                 "type": "object",
-                "title": "Azure Static Credentials",
+                "title": "Azure Client Secret Credentials",
                 "properties": {
                     "client_id": {
                         "type": "string",
@@ -96,6 +96,28 @@ from rest_framework_json_api import serializers
                     },
                 },
                 "required": ["client_id", "client_secret", "tenant_id"],
+                "additionalProperties": False,
+            },
+            {
+                "type": "object",
+                "title": "Azure Certificate Credentials",
+                "properties": {
+                    "client_id": {
+                        "type": "string",
+                        "description": "The Azure application (client) ID for authentication in Azure AD.",
+                    },
+                    "certificate_content": {
+                        "type": "string",
+                        "description": "Base64-encoded PEM certificate and private key content for certificate-based authentication.",
+                    },
+                    "tenant_id": {
+                        "type": "string",
+                        "description": "The Azure tenant ID, representing the directory where the application is "
+                        "registered.",
+                    },
+                },
+                "required": ["client_id", "certificate_content", "tenant_id"],
+                "additionalProperties": False,
             },
             {
                 "type": "object",


### PR DESCRIPTION
### Context

Depends on #12421

Do not merge until #12421 has merged and the Azure documentation/template asset has been deployed.

This PR intentionally targets `master` rather than the feature branch so the public contract change is visible but not stacked. Draft status is the merge guard.

### Description

Depends on #12421

Do not merge until #12421 has merged and the Azure documentation/template asset has been deployed.

This PR updates the public OpenAPI contract to document the two exclusive Azure credential shapes: client secret credentials or certificate content credentials. It also adds regression coverage that verifies both schemas expose only their required fields and reject additional properties.

The approved API changelog fragment is included. The committed `v1.yaml` is the byte-for-byte output of the canonical `GET /api/v1/schema` endpoint on current `master`; this also reconciles schema drift already emitted by current master code but not yet reflected in the committed artifact.

This PR intentionally targets `master` rather than the feature branch so it remains visible without being stacked; draft status prevents merge while the dependency is outstanding.

### Steps to review

1. Confirm the branch diff against `master` contains only the four intended API schema, serializer, test, and changelog paths.
2. Review the Azure `oneOf` schemas for mutually exclusive `client_secret` and `certificate_content` credential shapes.
3. Review the focused regression test and changelog fragment.
4. Re-run the focused verification commands below.

```bash
cd api
uv run pytest src/backend/api/tests/test_serializers.py::TestProviderSecretFieldSchema::test_azure_schema_exposes_exclusive_supported_credential_shapes -q
```

Outcome: `1 passed, 2 warnings`.

```bash
cd api
PYTHONPATH=src/backend DJANGO_SETTINGS_MODULE=config.django.testing uv run python -c 'import django; django.setup(); from pathlib import Path; from rest_framework.test import APIClient; response = APIClient().get("/api/v1/schema", HTTP_HOST="localhost"); assert response.status_code == 200, response.status_code; generated = response.content; committed = Path("src/backend/api/specs/v1.yaml").read_bytes(); assert generated == committed, "endpoint schema differs from committed v1.yaml"; print(f"canonical-byte-match: yes ({len(generated)} bytes)")'
```

Outcome: `canonical-byte-match: yes (840213 bytes)`. The generator also emitted the existing repository schema warnings; no strict schema-validation pass is claimed.

```bash
uv run prek run --files api/src/backend/api/v1/serializer_utils/providers.py api/src/backend/api/tests/test_serializers.py api/src/backend/api/specs/v1.yaml api/changelog.d/azure-certificate-openapi-schema.fixed.md
git diff --cached --check
```

Outcome: every applicable path-scoped hook passed, including API Ruff format/check, YAML, Markdown, TruffleHog, Bandit, and Vulture; `git diff --cached --check` passed with no output.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
