### PR TITLE
Add SQS check for secure transport enabled

### DIFF
--- a/prowler/providers/aws/services/sqs/sqs_queues_secure_transport_enabled/sqs_queues_secure_transport_enabled.metadata.json
+++ b/prowler/providers/aws/services/sqs/sqs_queues_secure_transport_enabled/sqs_queues_secure_transport_enabled.metadata.json
@@ -1,0 +1,42 @@
+{
+  "Provider": "aws",
+  "CheckID": "sqs_queues_secure_transport_enabled",
+  "CheckTitle": "SQS queue policy denies requests over insecure transport",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices",
+    "Effects/Data Exposure"
+  ],
+  "ServiceName": "sqs",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "AwsSqsQueue",
+  "ResourceGroup": "messaging",
+  "Description": "**Amazon SQS queues** are evaluated to ensure their **policies deny requests over insecure transport** (HTTP).\n\nQueues without such policies are identified.",
+  "Risk": "Without a policy denying insecure transport, message bodies can be transmitted over HTTP, increasing the risk of **data exposure** and **man-in-the-middle attacks**.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-security-best-practices.html#enforce-encryption-data-in-transit",
+    "https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-securetransport",
+    "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-create-queue.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws sqs set-queue-attributes --queue-url <example_queue_url> --attributes Policy='{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"sqs:*\",\"Resource\":\"<example_queue_arn>\",\"Condition\":{\"Bool\":{\"aws:SecureTransport\":\"false\"}}}]}'",
+      "NativeIaC": "```yaml\n# CloudFormation: Deny requests that do not use SSL/TLS\nResources:\n  QueuePolicy:\n    Type: AWS::SQS::QueuePolicy\n    Properties:\n      Queues:\n        - !Ref <example_resource_name>\n      PolicyDocument:\n        Version: \"2012-10-17\"\n        Statement:\n          - Effect: Deny\n            Principal: \"*\"\n            Action: \"sqs:*\"\n            Resource: !GetAtt <example_resource_name>.Arn\n            Condition:\n              Bool:\n                aws:SecureTransport: \"false\"  # Critical: deny requests not using SSL/TLS\n```",
+      "Other": "1. In the AWS Console, go to Amazon SQS > Queues and select <example_resource_name>\n2. Select Edit, then expand Access policy\n3. Add this statement to the queue policy, replacing the queue ARN:\n   ```\n   {\n     \"Effect\": \"Deny\",\n     \"Principal\": \"*\",\n     \"Action\": \"sqs:*\",\n     \"Resource\": \"<example_queue_arn>\",\n     \"Condition\": { \"Bool\": { \"aws:SecureTransport\": \"false\" } }\n   }\n   ```\n4. Save the changes\n",
+      "Terraform": "```hcl\n# Deny requests that do not use SSL/TLS\nresource \"aws_sqs_queue_policy\" \"<example_resource_name>\" {\n  queue_url = aws_sqs_queue.<example_resource_name>.url\n  policy = jsonencode({\n    Version = \"2012-10-17\"\n    Statement = [{\n      Effect    = \"Deny\"\n      Principal = \"*\"\n      Action    = \"sqs:*\"\n      Resource  = aws_sqs_queue.<example_resource_name>.arn\n      Condition = {\n        Bool = {\n          \"aws:SecureTransport\" = \"false\" # Critical: deny requests not using SSL/TLS\n        }\n      }\n    }]\n  })\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Enforce **HTTPS-only** access with a queue policy that denies requests when `aws:SecureTransport=false`. Keep the explicit `Deny` alongside least-privilege `Allow` statements because explicit denies override otherwise-permitted insecure requests. Monitor CloudTrail for denied SQS API calls to identify clients that need to use TLS.",
+      "Url": "https://hub.prowler.com/check/sqs_queues_secure_transport_enabled"
+    }
+  },
+  "Categories": [
+    "encryption"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/sqs/sqs_queues_secure_transport_enabled/sqs_queues_secure_transport_enabled.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_secure_transport_enabled/sqs_queues_secure_transport_enabled.py
@@ -1,0 +1,40 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.sqs.sqs_client import sqs_client
+
+
+class sqs_queues_secure_transport_enabled(Check):
+    def execute(self):
+        findings = []
+        for queue in sqs_client.queues:
+            report = Check_Report_AWS(metadata=self.metadata(), resource=queue)
+            # Check if SQS policy enforces SSL
+            if not queue.policy:
+                report.status = "FAIL"
+                report.status_extended = f"SQS queue {queue.id} does not have a policy, thus it allows HTTP requests."
+            else:
+                report.status = "FAIL"
+                report.status_extended = f"SQS queue {queue.id} allows requests over insecure transport in the policy."
+                for statement in queue.policy["Statement"]:
+                    if (
+                        statement["Effect"] == "Deny"
+                        and "Condition" in statement
+                        and "Action" in statement
+                        and (
+                            "sqs:SendMessage" in statement["Action"]
+                            or "*" in statement["Action"]
+                            or "sqs:*" in statement["Action"]
+                        )
+                    ):
+                        if "Bool" in statement["Condition"]:
+                            if "aws:SecureTransport" in statement["Condition"]["Bool"]:
+                                if (
+                                    statement["Condition"]["Bool"][
+                                        "aws:SecureTransport"
+                                    ]
+                                    == "false"
+                                ):
+                                    report.status = "PASS"
+                                    report.status_extended = f"SQS queue {queue.id} has a policy to deny requests over insecure transport."
+
+            findings.append(report)
+        return findings

--- a/prowler/providers/aws/services/sqs/sqs_queues_secure_transport_enabled/sqs_queues_secure_transport_enabled.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_secure_transport_enabled/sqs_queues_secure_transport_enabled.py
@@ -1,9 +1,42 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.sqs.sqs_client import sqs_client
 
+SQS_ACTIONS = {
+    "sqs:addpermission",
+    "sqs:cancelmessagemovetask",
+    "sqs:changemessagevisibility",
+    "sqs:changemessagevisibilitybatch",
+    "sqs:createqueue",
+    "sqs:deletemessage",
+    "sqs:deletemessagebatch",
+    "sqs:deletequeue",
+    "sqs:getqueueattributes",
+    "sqs:getqueueurl",
+    "sqs:listdeadlettersourcequeues",
+    "sqs:listmessagemovetasks",
+    "sqs:listqueues",
+    "sqs:listqueuetags",
+    "sqs:purgequeue",
+    "sqs:receivemessage",
+    "sqs:removepermission",
+    "sqs:sendmessage",
+    "sqs:sendmessagebatch",
+    "sqs:setqueueattributes",
+    "sqs:startmessagemovetask",
+    "sqs:tagqueue",
+    "sqs:untagqueue",
+}
+
 
 class sqs_queues_secure_transport_enabled(Check):
-    def execute(self):
+    """Check that SQS queue policies deny insecure transport."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Evaluate secure transport enforcement for each SQS queue.
+
+        Returns:
+            One report for each SQS queue.
+        """
         findings = []
         for queue in sqs_client.queues:
             report = Check_Report_AWS(metadata=self.metadata(), resource=queue)
@@ -14,23 +47,45 @@ class sqs_queues_secure_transport_enabled(Check):
             else:
                 report.status = "FAIL"
                 report.status_extended = f"SQS queue {queue.id} allows requests over insecure transport in the policy."
-                for statement in queue.policy["Statement"]:
+                statements = queue.policy.get("Statement", [])
+                if isinstance(statements, dict):
+                    statements = [statements]
+                for statement in statements:
+                    if "Action" not in statement:
+                        continue
+                    actions = statement["Action"]
+                    if isinstance(actions, str):
+                        actions = [actions]
+                    if not isinstance(actions, list) or not all(
+                        isinstance(action, str) for action in actions
+                    ):
+                        continue
+                    actions = {action.casefold() for action in actions}
                     if (
                         statement["Effect"] == "Deny"
-                        and "Condition" in statement
-                        and "Action" in statement
+                        and "Principal" in statement
                         and (
-                            "sqs:SendMessage" in statement["Action"]
-                            or "*" in statement["Action"]
-                            or "sqs:*" in statement["Action"]
+                            statement["Principal"] == "*"
+                            or statement["Principal"] == {"AWS": "*"}
+                        )
+                        and "Condition" in statement
+                        and (
+                            "*" in actions
+                            or "sqs:*" in actions
+                            or SQS_ACTIONS <= actions
                         )
                     ):
                         if "Bool" in statement["Condition"]:
-                            if "aws:SecureTransport" in statement["Condition"]["Bool"]:
+                            bool_conditions = statement["Condition"]["Bool"]
+                            if isinstance(bool_conditions, dict):
+                                normalized_bool_conditions = {
+                                    str(key).casefold(): value
+                                    for key, value in bool_conditions.items()
+                                }
                                 if (
-                                    statement["Condition"]["Bool"][
-                                        "aws:SecureTransport"
-                                    ]
+                                    normalized_bool_conditions.get(
+                                        "aws:securetransport"
+                                    )
                                     == "false"
                                 ):
                                     report.status = "PASS"

--- a/tests/providers/aws/services/sqs/sqs_queues_secure_transport_enabled/sqs_queues_secure_transport_enabled_test.py
+++ b/tests/providers/aws/services/sqs/sqs_queues_secure_transport_enabled/sqs_queues_secure_transport_enabled_test.py
@@ -1,0 +1,361 @@
+from unittest import mock
+from uuid import uuid4
+
+from prowler.providers.aws.services.sqs.sqs_service import Queue
+from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_EU_WEST_1
+
+test_queue_name = str(uuid4())
+test_queue_url = f"https://sqs.{AWS_REGION_EU_WEST_1}.amazonaws.com/{AWS_ACCOUNT_NUMBER}/{test_queue_name}"
+test_queue_arn = (
+    f"arn:aws:sqs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:{test_queue_name}"
+)
+
+
+class Test_sqs_queues_secure_transport_enabled:
+    def test_no_queues(self):
+        sqs_client = mock.MagicMock
+        sqs_client.queues = []
+        with (
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_service.SQS",
+                new=sqs_client,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+                new=sqs_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sqs.sqs_queues_secure_transport_enabled.sqs_queues_secure_transport_enabled import (
+                sqs_queues_secure_transport_enabled,
+            )
+
+            check = sqs_queues_secure_transport_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_queues_no_policy(self):
+        sqs_client = mock.MagicMock
+        sqs_client.queues = []
+        sqs_client.queues.append(
+            Queue(
+                id=test_queue_url,
+                name=test_queue_name,
+                region=AWS_REGION_EU_WEST_1,
+                arn=test_queue_arn,
+            )
+        )
+        with (
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_service.SQS",
+                new=sqs_client,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+                new=sqs_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sqs.sqs_queues_secure_transport_enabled.sqs_queues_secure_transport_enabled import (
+                sqs_queues_secure_transport_enabled,
+            )
+
+            check = sqs_queues_secure_transport_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQS queue {test_queue_url} does not have a policy, thus it allows HTTP requests."
+            )
+            assert result[0].resource_id == test_queue_url
+            assert result[0].resource_arn == test_queue_arn
+
+    def test_queues_policy_statement_list_pass(self):
+        sqs_client = mock.MagicMock
+        sqs_client.queues = []
+        sqs_client.queues.append(
+            Queue(
+                id=test_queue_url,
+                name=test_queue_name,
+                region=AWS_REGION_EU_WEST_1,
+                arn=test_queue_arn,
+                policy={
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Deny",
+                            "Action": "sqs:*",
+                            "Principal": "*",
+                            "Resource": test_queue_arn,
+                            "Condition": {"Bool": {"aws:SecureTransport": "false"}},
+                        }
+                    ],
+                },
+            )
+        )
+        with (
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_service.SQS",
+                new=sqs_client,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+                new=sqs_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sqs.sqs_queues_secure_transport_enabled.sqs_queues_secure_transport_enabled import (
+                sqs_queues_secure_transport_enabled,
+            )
+
+            check = sqs_queues_secure_transport_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SQS queue {test_queue_url} has a policy to deny requests over insecure transport."
+            )
+            assert result[0].resource_id == test_queue_url
+            assert result[0].resource_arn == test_queue_arn
+
+    def test_queues_policy_statement_single_action_fail(self):
+        sqs_client = mock.MagicMock
+        sqs_client.queues = []
+        sqs_client.queues.append(
+            Queue(
+                id=test_queue_url,
+                name=test_queue_name,
+                region=AWS_REGION_EU_WEST_1,
+                arn=test_queue_arn,
+                policy={
+                    "Version": "2012-10-17",
+                    "Statement": {
+                        "Effect": "Deny",
+                        "Action": "sqs:SendMessage",
+                        "Principal": {"AWS": "*"},
+                        "Resource": test_queue_arn,
+                        "Condition": {"Bool": {"aws:SecureTransport": "false"}},
+                    },
+                },
+            )
+        )
+        with (
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_service.SQS",
+                new=sqs_client,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+                new=sqs_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sqs.sqs_queues_secure_transport_enabled.sqs_queues_secure_transport_enabled import (
+                sqs_queues_secure_transport_enabled,
+            )
+
+            check = sqs_queues_secure_transport_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQS queue {test_queue_url} allows requests over insecure transport in the policy."
+            )
+            assert result[0].resource_id == test_queue_url
+            assert result[0].resource_arn == test_queue_arn
+
+    def test_queues_policy_statement_uppercase_secure_transport_key_pass(self):
+        sqs_client = mock.MagicMock
+        sqs_client.queues = []
+        sqs_client.queues.append(
+            Queue(
+                id=test_queue_url,
+                name=test_queue_name,
+                region=AWS_REGION_EU_WEST_1,
+                arn=test_queue_arn,
+                policy={
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Deny",
+                            "Action": "sqs:*",
+                            "Principal": "*",
+                            "Resource": test_queue_arn,
+                            "Condition": {"Bool": {"AWS:SecureTransport": "false"}},
+                        }
+                    ],
+                },
+            )
+        )
+        with (
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_service.SQS",
+                new=sqs_client,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+                new=sqs_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sqs.sqs_queues_secure_transport_enabled.sqs_queues_secure_transport_enabled import (
+                sqs_queues_secure_transport_enabled,
+            )
+
+            check = sqs_queues_secure_transport_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SQS queue {test_queue_url} has a policy to deny requests over insecure transport."
+            )
+
+    def test_queues_policy_statement_complete_action_set_pass(self):
+        sqs_client = mock.MagicMock
+        sqs_client.queues = [
+            Queue(
+                id=test_queue_url,
+                name=test_queue_name,
+                region=AWS_REGION_EU_WEST_1,
+                arn=test_queue_arn,
+                policy={
+                    "Version": "2012-10-17",
+                    "Statement": {
+                        "Effect": "Deny",
+                        "Action": [
+                            "SQS:AddPermission",
+                            "SQS:CancelMessageMoveTask",
+                            "SQS:ChangeMessageVisibility",
+                            "SQS:ChangeMessageVisibilityBatch",
+                            "SQS:CreateQueue",
+                            "SQS:DeleteMessage",
+                            "SQS:DeleteMessageBatch",
+                            "SQS:DeleteQueue",
+                            "SQS:GetQueueAttributes",
+                            "SQS:GetQueueUrl",
+                            "SQS:ListDeadLetterSourceQueues",
+                            "SQS:ListMessageMoveTasks",
+                            "SQS:ListQueues",
+                            "SQS:ListQueueTags",
+                            "SQS:PurgeQueue",
+                            "SQS:ReceiveMessage",
+                            "SQS:RemovePermission",
+                            "SQS:SendMessage",
+                            "SQS:SendMessageBatch",
+                            "SQS:SetQueueAttributes",
+                            "SQS:StartMessageMoveTask",
+                            "SQS:TagQueue",
+                            "SQS:UntagQueue",
+                        ],
+                        "Principal": {"AWS": "*"},
+                        "Resource": test_queue_arn,
+                        "Condition": {"Bool": {"aws:SecureTransport": "false"}},
+                    },
+                },
+            )
+        ]
+        with (
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_service.SQS",
+                new=sqs_client,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+                new=sqs_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sqs.sqs_queues_secure_transport_enabled.sqs_queues_secure_transport_enabled import (
+                sqs_queues_secure_transport_enabled,
+            )
+
+            check = sqs_queues_secure_transport_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SQS queue {test_queue_url} has a policy to deny requests over insecure transport."
+            )
+
+    def test_queues_policy_statement_scoped_principal_fail(self):
+        sqs_client = mock.MagicMock
+        sqs_client.queues = []
+        sqs_client.queues.append(
+            Queue(
+                id=test_queue_url,
+                name=test_queue_name,
+                region=AWS_REGION_EU_WEST_1,
+                arn=test_queue_arn,
+                policy={
+                    "Version": "2012-10-17",
+                    "Statement": {
+                        "Effect": "Deny",
+                        "Action": "sqs:*",
+                        "Principal": {"AWS": "arn:aws:iam::123456789012:role/example"},
+                        "Resource": test_queue_arn,
+                        "Condition": {"Bool": {"aws:SecureTransport": "false"}},
+                    },
+                },
+            )
+        )
+        with (
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_service.SQS",
+                new=sqs_client,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+                new=sqs_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sqs.sqs_queues_secure_transport_enabled.sqs_queues_secure_transport_enabled import (
+                sqs_queues_secure_transport_enabled,
+            )
+
+            check = sqs_queues_secure_transport_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+
+    def test_queues_policy_statement_single_object_fail(self):
+        sqs_client = mock.MagicMock
+        sqs_client.queues = []
+        sqs_client.queues.append(
+            Queue(
+                id=test_queue_url,
+                name=test_queue_name,
+                region=AWS_REGION_EU_WEST_1,
+                arn=test_queue_arn,
+                policy={
+                    "Version": "2012-10-17",
+                    "Statement": {
+                        "Effect": "Allow",
+                        "Action": "sqs:*",
+                        "Resource": test_queue_arn,
+                    },
+                },
+            )
+        )
+        with (
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_service.SQS",
+                new=sqs_client,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+                new=sqs_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sqs.sqs_queues_secure_transport_enabled.sqs_queues_secure_transport_enabled import (
+                sqs_queues_secure_transport_enabled,
+            )
+
+            check = sqs_queues_secure_transport_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQS queue {test_queue_url} allows requests over insecure transport in the policy."
+            )
+            assert result[0].resource_id == test_queue_url
+            assert result[0].resource_arn == test_queue_arn


### PR DESCRIPTION
### Context

There are currently 2 existing checks for SQS, the security best practices page also lists enforce encryption of data in transit so this PR adds that check

Fix #12516

### Description

This PR adds a check to ensure `aws:SecureTransport` is enforced and a deny policy is in place to deny when connections are made using HTTP

### Steps to review

Create some SQS queues in the AWS console, that either have no policy or a policy that has `aws:SecureTransport = true` (Or `aws:SecureTransport` is not existent in the SQS policy)

Run `uv run python prowler-cli.py aws --log-level ERROR --verbose --check sqs_queues_secure_transport_enabled`

Expect the SQS queues that have no policy to FAIL with:
`FAIL eu-west-1: SQS queue https://sqs.eu-west-1.amazonaws.com/<account-id>/<queue-name> does not have a policy, thus it allows HTTP requests.`

Expect the SQS queues that have a policy that either does not include `aws:SecureTransport` or that includes `aws:SecureTransport = true` to FAIL with:
`FAIL eu-west-1: SQS queue https://sqs.eu-west-1.amazonaws.com/<account-id>/<queue-name> allows requests over insecure transport in the policy.`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AWS SQS security check that evaluates queue policies for secure transport enforcement.
  * Queues without policies or permitting insecure transport are flagged, while qualifying HTTPS-only deny policies pass.
  * Added remediation guidance, severity classification, risk details, and documentation references for securing SQS queues.
* **Tests**
  * Added coverage for policy conditions, actions, principals, case variations, and queues without policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->