### PR TITLE
feat(azure): add certificate authentication to Azure SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ docker-compose.override.yml
 docker-compose-dev.override.yml
 # Local Pi runtime state
 .atl/
+.gga

--- a/prowler/changelog.d/azure-certificate-authentication.added.md
+++ b/prowler/changelog.d/azure-certificate-authentication.added.md
@@ -1,0 +1,1 @@
+Certificate-based Service Principal authentication for Azure using a base64-encoded or file-based certificate/private-key bundle

--- a/prowler/changelog.d/azure-certificate-authentication.added.md
+++ b/prowler/changelog.d/azure-certificate-authentication.added.md
@@ -1,1 +1,1 @@
-Certificate-based Service Principal authentication for Azure using a base64-encoded or file-based certificate/private-key bundle
+Add certificate authentication for the Azure provider

--- a/prowler/changelog.d/azure-certificate-authentication.added.md
+++ b/prowler/changelog.d/azure-certificate-authentication.added.md
@@ -1,1 +1,1 @@
-Certificate authentication for the Azure provider
+Certificate-based service principal authentication for the Azure provider, alongside the existing client-secret flow

--- a/prowler/changelog.d/azure-certificate-authentication.added.md
+++ b/prowler/changelog.d/azure-certificate-authentication.added.md
@@ -1,1 +1,1 @@
-Add certificate authentication for the Azure provider
+Certificate authentication for the Azure provider

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -111,6 +111,20 @@ def _find_transport_cause(error: BaseException) -> Optional[BaseException]:
     return None
 
 
+def _decode_certificate_content(certificate_content: str) -> bytes:
+    """Base64-decode certificate content, tolerating shell-added whitespace.
+
+    ``AZURE_CERTIFICATE_CONTENT`` values almost always arrive with a
+    trailing newline (shell command substitution) or embedded line
+    breaks (``openssl base64`` wraps output at 64 columns by default).
+    ``base64.b64decode(..., validate=True)`` rejects both as
+    ``binascii.Error``. Strip whitespace before decoding so the strict
+    validation still rejects non-base64 characters without penalising the
+    common copy-paste and env-var flows.
+    """
+    return base64.b64decode("".join(certificate_content.split()), validate=True)
+
+
 def _build_certificate_credential(
     tenant_id: str,
     client_id: str,
@@ -417,9 +431,9 @@ class AzureProvider(Provider):
             sp_env_auth,
             browser_auth,
             managed_identity_auth,
-            certificate_auth,
             subscription_ids,
             client_id,
+            certificate_auth=certificate_auth,
         )
 
         # TODO: should we keep this here or within the identity?
@@ -813,8 +827,8 @@ class AzureProvider(Provider):
                             with open(certificate_path, "rb") as cert_file:
                                 certificate_data = cert_file.read()
                         else:
-                            certificate_data = base64.b64decode(
-                                getenv("AZURE_CERTIFICATE_CONTENT"), validate=True
+                            certificate_data = _decode_certificate_content(
+                                getenv("AZURE_CERTIFICATE_CONTENT")
                             )
                         # Same fail-fast validation the static path runs. The
                         # returned bundle is normalized so the leaf appears
@@ -1134,13 +1148,20 @@ class AzureProvider(Provider):
             if raise_on_exception:
                 raise credential_unavailable_error
             return Connection(error=credential_unavailable_error)
-        except AzureDefaultAzureCredentialError as default_credentials_error:
+        except AzureNotValidCertificateContentError as certificate_content_error:
             logger.error(
-                f"{default_credentials_error.__class__.__name__}[{default_credentials_error.__traceback__.tb_lineno}]: {default_credentials_error}"
+                f"{certificate_content_error.__class__.__name__}[{certificate_content_error.__traceback__.tb_lineno}]: {certificate_content_error}"
             )
             if raise_on_exception:
-                raise default_credentials_error
-            return Connection(error=default_credentials_error)
+                raise certificate_content_error
+            return Connection(error=certificate_content_error)
+        except AzureNotValidCertificatePathError as certificate_path_error:
+            logger.error(
+                f"{certificate_path_error.__class__.__name__}[{certificate_path_error.__traceback__.tb_lineno}]: {certificate_path_error}"
+            )
+            if raise_on_exception:
+                raise certificate_path_error
+            return Connection(error=certificate_path_error)
         except (
             AzureClientIdAndClientSecretNotBelongingToTenantIdError
         ) as tenant_id_error:
@@ -1261,9 +1282,13 @@ class AzureProvider(Provider):
         sp_env_auth,
         browser_auth,
         managed_identity_auth,
-        certificate_auth,
         subscription_ids,
         client_id,
+        # Keyword-only so external callers using the pre-cert-auth positional
+        # layout (`..., managed_identity_auth, subscription_ids, client_id`)
+        # keep binding those slots correctly.
+        *,
+        certificate_auth: bool = False,
     ):
         """
         Sets up the identity for the Azure provider.
@@ -1643,7 +1668,7 @@ class AzureProvider(Provider):
                 # exception several call frames deeper if this fails, which
                 # makes for a bad UX in the API/UI.
                 normalized_bundle = validate_certificate_bundle(
-                    base64.b64decode(certificate_content, validate=True)
+                    _decode_certificate_content(certificate_content)
                 )
                 # Persist the normalized (leaf-first) bundle so downstream
                 # `CertificateCredential` calls don't pick an intermediate CA.
@@ -1821,7 +1846,7 @@ class AzureProvider(Provider):
         transport = None
         try:
             if certificate_content:
-                certificate_data = base64.b64decode(certificate_content, validate=True)
+                certificate_data = _decode_certificate_content(certificate_content)
             elif certificate_path:
                 with open(certificate_path, "rb") as cert_file:
                     certificate_data = cert_file.read()
@@ -1855,15 +1880,17 @@ class AzureProvider(Provider):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
             )
             # `azure.identity` wraps `_request_token` with `wrap_exceptions`,
-            # so a `RequestsTransport` connect/read timeout reaches this
+            # so a `RequestsTransport` connect/read failure reaches this
             # handler as `ClientAuthenticationError`. Distinguish transport
             # failures (credentials unavailable) from a genuinely rejected
-            # certificate by walking the cause chain.
+            # certificate by walking the cause chain. The transport error
+            # covers DNS, TLS, connection reset and timeout indistinctly, so
+            # the message must not claim the request timed out.
             if _find_transport_cause(error) is not None:
                 raise AzureCredentialsUnavailableError(
                     file=os.path.basename(__file__),
                     message=(
-                        "Timed out waiting for Entra ID to issue a token "
+                        "Entra ID was not reachable while acquiring a token "
                         "for the provided certificate."
                     ),
                     original_exception=error,
@@ -1908,18 +1935,21 @@ class AzureProvider(Provider):
             # Always release the transient credential and its transport:
             # cleanup failures are logged and swallowed so they cannot
             # replace the primary typed exception on its way up. The
-            # transport is closed independently to cover the case where
-            # `CertificateCredential.__init__` raised before `credential`
-            # took ownership of it.
+            # transport is closed as a fallback when the credential was
+            # never assigned (`CertificateCredential.__init__` raised
+            # before ownership transferred) or when `credential.close()`
+            # itself failed and could not release the underlying pipeline.
+            credential_closed = False
             if credential is not None:
                 try:
                     credential.close()
+                    credential_closed = True
                 except Exception as cleanup_error:
                     logger.warning(
                         f"{cleanup_error.__class__.__name__}: failed to close "
                         f"CertificateCredential during verify_client cleanup"
                     )
-            elif transport is not None:
+            if transport is not None and not credential_closed:
                 try:
                     transport.close()
                 except Exception as cleanup_error:

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -1511,6 +1511,9 @@ class AzureProvider(Provider):
                 certificate_data = base64.b64decode(certificate_content, validate=True)
                 validate_certificate_bundle(certificate_data)
             except Exception as e:
+                logger.error(
+                    f"{e.__class__.__name__}[{e.__traceback__.tb_lineno}]: {e}"
+                )
                 raise AzureNotValidCertificateContentError(
                     file=os.path.basename(__file__),
                     message=f"The provided certificate content is not a valid base64-encoded certificate/private-key bundle: {str(e)}",
@@ -1521,6 +1524,9 @@ class AzureProvider(Provider):
                 with open(certificate_path, "rb") as cert_file:
                     validate_certificate_bundle(cert_file.read())
             except Exception as e:
+                logger.error(
+                    f"{e.__class__.__name__}[{e.__traceback__.tb_lineno}]: {e}"
+                )
                 raise AzureNotValidCertificatePathError(
                     file=os.path.basename(__file__),
                     message=f"The provided certificate path does not contain a valid certificate/private-key bundle: {str(e)}",

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -1833,10 +1833,13 @@ class AzureProvider(Provider):
             PermissionError,
             IsADirectoryError,
             OSError,
+            TypeError,
             ValueError,
         ) as error:
-            # Malformed base64, unreadable path, or bytes CertificateCredential
-            # cannot parse. Route to the typed certificate errors.
+            # Malformed base64, unreadable path, encrypted PEM key
+            # (`load_pem_private_key(password=None)` raises `TypeError`), or
+            # bytes CertificateCredential cannot parse. Route to the typed
+            # certificate errors.
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
             )

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -15,6 +15,7 @@ from azure.core.exceptions import (
     ClientAuthenticationError,
     HttpResponseError,
     ServiceRequestError,
+    ServiceResponseError,
 )
 from azure.core.pipeline.transport import RequestsTransport
 from azure.identity import (
@@ -85,7 +86,29 @@ _CERTIFICATE_THUMBPRINT_FALLBACK: dict[int, str] = {}
 
 # Matches the 30s HTTP timeout on the client-secret path so a hung Entra ID
 # endpoint cannot stall a request thread or Celery worker on either flow.
+# Applied per-request as the RequestsTransport connect and read deadlines,
+# not as a token TTL or an overall pipeline timeout.
 _TOKEN_ACQUISITION_TIMEOUT_SECONDS = 30
+
+
+def _find_transport_cause(error: BaseException) -> Optional[BaseException]:
+    """Return the first transport-level cause in the exception chain, if any.
+
+    ``azure.identity`` decorates ``_request_token`` with ``wrap_exceptions``,
+    so a ``RequestsTransport`` connect or read failure arrives at the caller
+    as ``ClientAuthenticationError`` with the underlying
+    ``ServiceRequestError``/``ServiceResponseError`` preserved via
+    ``__cause__``/``__context__``. Callers use this to distinguish a real
+    transport failure from a rejected certificate.
+    """
+    seen: set[int] = set()
+    current = error.__cause__ or error.__context__
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, (ServiceRequestError, ServiceResponseError)):
+            return current
+        current = current.__cause__ or current.__context__
+    return None
 
 
 def _build_certificate_credential(
@@ -224,10 +247,14 @@ class AzureProvider(Provider):
         mutelist_content: dict = None,
         client_id: str = None,
         client_secret: str = None,
+        resource_groups: list = [],
+        # Keep `resource_groups` in its original positional slot for callers
+        # that pass it positionally; only the new certificate kwargs are
+        # keyword-only.
+        *,
         certificate_auth: bool = False,
         certificate_content: str = None,
         certificate_path: str = None,
-        resource_groups: list = [],
     ):
         """
         Initializes the Azure provider.
@@ -1536,9 +1563,13 @@ class AzureProvider(Provider):
         tenant_id: str = None,
         client_id: str = None,
         client_secret: str = None,
+        region_config: AzureRegionConfig = None,
+        # Keep `region_config` in its original positional slot for callers
+        # that pass it positionally; only the new certificate kwargs are
+        # keyword-only.
+        *,
         certificate_content: str = None,
         certificate_path: str = None,
-        region_config: AzureRegionConfig = None,
     ) -> dict:
         """
         Validates the static credentials for the Azure provider.
@@ -1779,6 +1810,7 @@ class AzureProvider(Provider):
         # Graph permissions, `get_token` still returns a token — the point
         # here is to prove the private key matches an active `keyCredentials`
         # entry on the app registration.
+        credential = None
         try:
             if certificate_content:
                 certificate_data = base64.b64decode(certificate_content, validate=True)
@@ -1788,10 +1820,12 @@ class AzureProvider(Provider):
             else:
                 return
 
-            # Enforce the deadline on the HTTP transport itself instead of
-            # racing an off-thread `get_token` — background workers cannot
-            # be cancelled once running, and any non-timeout exception used
-            # to bypass executor shutdown, leaking a thread per validation.
+            # Enforce the deadline on the HTTP transport — the previous
+            # off-thread `future.result(timeout=...)` could not cancel a
+            # running `get_token`, so timeouts and non-timeout failures
+            # leaked a worker per validation under Entra ID degradation.
+            # `retry_total=0` stops Azure Core from replaying each request
+            # and multiplying the effective deadline.
             credential = CertificateCredential(
                 client_id=client_id,
                 tenant_id=tenant_id,
@@ -1801,10 +1835,19 @@ class AzureProvider(Provider):
                     connection_timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS,
                     read_timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS,
                 ),
+                retry_total=0,
             )
-            try:
-                credential.get_token(region_config.graph_scope)
-            except ServiceRequestError as error:
+            credential.get_token(region_config.graph_scope)
+        except ClientAuthenticationError as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+            )
+            # `azure.identity` wraps `_request_token` with `wrap_exceptions`,
+            # so a `RequestsTransport` connect/read timeout reaches this
+            # handler as `ClientAuthenticationError`. Distinguish transport
+            # failures (credentials unavailable) from a genuinely rejected
+            # certificate by walking the cause chain.
+            if _find_transport_cause(error) is not None:
                 raise AzureCredentialsUnavailableError(
                     file=os.path.basename(__file__),
                     message=(
@@ -1813,10 +1856,6 @@ class AzureProvider(Provider):
                     ),
                     original_exception=error,
                 )
-        except ClientAuthenticationError as error:
-            logger.error(
-                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
-            )
             if certificate_content:
                 raise AzureNotValidCertificateContentError(
                     file=os.path.basename(__file__),
@@ -1853,3 +1892,15 @@ class AzureProvider(Provider):
                 file=os.path.basename(__file__),
                 original_exception=error,
             )
+        finally:
+            # Always release the transient credential (and its transport):
+            # a `close()` failure must be logged and swallowed so it cannot
+            # replace the primary typed exception on its way up.
+            if credential is not None:
+                try:
+                    credential.close()
+                except Exception as cleanup_error:
+                    logger.warning(
+                        f"{cleanup_error.__class__.__name__}: failed to close "
+                        f"CertificateCredential during verify_client cleanup"
+                    )

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -1,16 +1,18 @@
 import asyncio
+import base64
 import logging
 import os
 import re
 from argparse import ArgumentTypeError
 from itertools import chain
 from os import getenv
-from typing import Union
+from typing import Optional, Union
 from uuid import UUID
 
 import requests
 from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
 from azure.identity import (
+    CertificateCredential,
     ClientSecretCredential,
     CredentialUnavailableError,
     DefaultAzureCredential,
@@ -19,6 +21,10 @@ from azure.identity import (
 from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.subscription import SubscriptionClient
 from colorama import Fore, Style
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.serialization import pkcs12
 from msgraph import GraphServiceClient
 
 from prowler.config.config import (
@@ -44,6 +50,8 @@ from prowler.providers.azure.exceptions.exceptions import (
     AzureNoAuthenticationMethodError,
     AzureNoSubscriptionsError,
     AzureNotTenantIdButClientIdAndClienSecretError,
+    AzureNotValidCertificateContentError,
+    AzureNotValidCertificatePathError,
     AzureNotValidClientIdError,
     AzureNotValidClientSecretError,
     AzureNotValidTenantIdError,
@@ -55,11 +63,72 @@ from prowler.providers.azure.exceptions.exceptions import (
     AzureTenantIDNoBrowserAuthError,
 )
 from prowler.providers.azure.lib.arguments.arguments import validate_azure_region
+from prowler.providers.azure.lib.certificate import validate_certificate_bundle
 from prowler.providers.azure.lib.mutelist.mutelist import AzureMutelist
 from prowler.providers.azure.lib.regions.regions import get_regions_config
 from prowler.providers.azure.models import AzureIdentityInfo, AzureRegionConfig
 from prowler.providers.common.models import Audit_Metadata, Connection
 from prowler.providers.common.provider import Provider
+
+# Attribute we stash on `CertificateCredential` instances so `setup_identity`
+# can surface the certificate SHA-1 thumbprint without reaching into
+# azure-identity's private `_client_credential` dict (which can — and does —
+# change shape across azure-identity versions).
+_PROWLER_CERT_THUMBPRINT_ATTR = "_prowler_certificate_thumbprint"
+
+
+def _build_certificate_credential(
+    tenant_id: str,
+    client_id: str,
+    certificate_data: bytes,
+    authority: Optional[str],
+) -> "CertificateCredential":
+    """Build a `CertificateCredential` and stash the SHA-1 thumbprint on it.
+
+    Centralises the three-step ritual (construct credential, compute
+    thumbprint, `setattr` it under `_PROWLER_CERT_THUMBPRINT_ATTR`) that
+    `setup_session` and friends would otherwise repeat identically for every
+    cert entry point (static content, static path, env-var cert-auth). Missing
+    the `setattr` in any one call site silently degrades the identity report
+    to "Unknown certificate thumbprint", so keeping it in one place is a real
+    correctness win.
+    """
+    credentials = CertificateCredential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        certificate_data=certificate_data,
+        authority=authority,
+    )
+    setattr(
+        credentials,
+        _PROWLER_CERT_THUMBPRINT_ATTR,
+        _compute_certificate_thumbprint(certificate_data),
+    )
+    return credentials
+
+
+def _compute_certificate_thumbprint(cert_data: bytes) -> Optional[str]:
+    """Compute the SHA-1 thumbprint of an X.509 certificate.
+
+    Accepts the same certificate_data formats `azure.identity.CertificateCredential`
+    accepts (PEM, DER, or PKCS#12/PFX with the private key) and returns the
+    thumbprint as an uppercase hex string, matching how Entra ID displays it
+    in the App Registration blade. Returns None if none of the parsers can
+    read the bytes so the caller can fall back to a placeholder.
+    """
+    for loader in (
+        lambda data: pkcs12.load_key_and_certificates(data, None, default_backend())[1],
+        lambda data: x509.load_pem_x509_certificate(data, default_backend()),
+        lambda data: x509.load_der_x509_certificate(data, default_backend()),
+    ):
+        try:
+            cert = loader(cert_data)
+        except Exception:
+            continue
+        if cert is None:
+            continue
+        return cert.fingerprint(hashes.SHA1()).hex().upper()
+    return None
 
 
 class AzureProvider(Provider):
@@ -125,6 +194,9 @@ class AzureProvider(Provider):
         mutelist_content: dict = None,
         client_id: str = None,
         client_secret: str = None,
+        certificate_auth: bool = False,
+        certificate_content: str = None,
+        certificate_path: str = None,
         resource_groups: list = [],
     ):
         """
@@ -145,6 +217,9 @@ class AzureProvider(Provider):
             mutelist_content (dict): The mutelist content.
             client_id (str): The Azure client ID.
             client_secret (str): The Azure client secret.
+            certificate_auth (bool): Flag indicating whether to use certificate authentication with environment variables (AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CERTIFICATE_CONTENT).
+            certificate_content (str): Base64-encoded certificate and private key bundle matching the App Registration certificate.
+            certificate_path (str): Path to a certificate and private key bundle matching the App Registration certificate.
             resource_groups (list): List of resource group names.
 
         Returns:
@@ -239,9 +314,12 @@ class AzureProvider(Provider):
             sp_env_auth,
             browser_auth,
             managed_identity_auth,
+            certificate_auth,
             tenant_id,
             client_id,
             client_secret,
+            certificate_content,
+            certificate_path,
         )
 
         logger.info("Checking if region is different than default one")
@@ -249,11 +327,17 @@ class AzureProvider(Provider):
 
         # Get the dict from the static credentials
         azure_credentials = None
-        if tenant_id and client_id and client_secret:
+        if (
+            tenant_id
+            and client_id
+            and (client_secret or certificate_content or certificate_path)
+        ):
             azure_credentials = self.validate_static_credentials(
                 tenant_id=tenant_id,
                 client_id=client_id,
                 client_secret=client_secret,
+                certificate_content=certificate_content,
+                certificate_path=certificate_path,
                 region_config=self._region_config,
             )
 
@@ -263,6 +347,8 @@ class AzureProvider(Provider):
             sp_env_auth,
             browser_auth,
             managed_identity_auth,
+            certificate_auth,
+            certificate_path,
             tenant_id,
             azure_credentials,
             self._region_config,
@@ -274,6 +360,7 @@ class AzureProvider(Provider):
             sp_env_auth,
             browser_auth,
             managed_identity_auth,
+            certificate_auth,
             subscription_ids,
             client_id,
         )
@@ -361,9 +448,12 @@ class AzureProvider(Provider):
         sp_env_auth: bool,
         browser_auth: bool,
         managed_identity_auth: bool,
+        certificate_auth: bool,
         tenant_id: str,
         client_id: str,
         client_secret: str,
+        certificate_content: str,
+        certificate_path: str,
     ):
         """
         Validates the authentication arguments for the Azure provider.
@@ -373,15 +463,23 @@ class AzureProvider(Provider):
             sp_env_auth (bool): Flag indicating whether Service Principal environment authentication is enabled.
             browser_auth (bool): Flag indicating whether browser authentication is enabled.
             managed_identity_auth (bool): Flag indicating whether managed identity authentication is enabled.
+            certificate_auth (bool): Flag indicating whether certificate authentication is enabled.
             tenant_id (str): The Azure Tenant ID.
             client_id (str): The Azure Client ID.
             client_secret (str): The Azure Client Secret.
+            certificate_content (str): The base64-encoded Azure certificate content.
+            certificate_path (str): The path to the Azure certificate file.
 
         Raises:
             AzureBrowserAuthNoTenantIDError: If browser authentication is enabled but the tenant ID is not found.
         """
 
-        if not client_id and not client_secret:
+        if (
+            not client_id
+            and not client_secret
+            and not certificate_content
+            and not certificate_path
+        ):
             if not browser_auth and tenant_id:
                 raise AzureTenantIDNoBrowserAuthError(
                     file=os.path.basename(__file__),
@@ -392,10 +490,11 @@ class AzureProvider(Provider):
                 and not sp_env_auth
                 and not browser_auth
                 and not managed_identity_auth
+                and not certificate_auth
             ):
                 raise AzureNoAuthenticationMethodError(
                     file=os.path.basename(__file__),
-                    message="Azure provider requires at least one authentication method set: [--az-cli-auth | --sp-env-auth | --browser-auth | --managed-identity-auth]",
+                    message="Azure provider requires at least one authentication method set: [--az-cli-auth | --sp-env-auth | --browser-auth | --managed-identity-auth | --certificate-auth]",
                 )
             elif browser_auth and not tenant_id:
                 raise AzureBrowserAuthNoTenantIDError(
@@ -408,6 +507,25 @@ class AzureProvider(Provider):
                     file=os.path.basename(__file__),
                     message="Tenant Id is required for Azure static credentials. Make sure you are using the correct credentials.",
                 )
+            if not client_secret and not certificate_content and not certificate_path:
+                raise AzureConfigCredentialsError(
+                    file=os.path.basename(__file__),
+                    message="You must provide a client secret, certificate content or certificate path for Azure static credentials.",
+                )
+            # Client secret and certificate are mutually exclusive: `setup_session`
+            # short-circuits on the certificate branch and silently drops the
+            # secret, which is confusing. Fail fast at argument-validation time.
+            if client_secret and (certificate_content or certificate_path):
+                raise AzureConfigCredentialsError(
+                    file=os.path.basename(__file__),
+                    message="Provide either a client secret or a certificate (content/path) for Azure static credentials, not both.",
+                )
+        # Certificate content and path are also mutually exclusive.
+        if certificate_content and certificate_path:
+            raise AzureConfigCredentialsError(
+                file=os.path.basename(__file__),
+                message="Provide either certificate content or a certificate path, not both.",
+            )
 
     @staticmethod
     def setup_region_config(region):
@@ -474,6 +592,10 @@ class AzureProvider(Provider):
             f"Azure Resource Groups: {Fore.YELLOW}{sorted({rg for rgs in self._resource_groups.values() for rg in rgs}) if any(self._resource_groups.values()) else ('NONE (no matching resource groups found)' if self._resource_groups else 'ALL')}{Style.RESET_ALL}",
             f"Azure Identity Type: {Fore.YELLOW}{self._identity.identity_type}{Style.RESET_ALL} Azure Identity ID: {Fore.YELLOW}{self._identity.identity_id}{Style.RESET_ALL}",
         ]
+        if self._identity.certificate_thumbprint:
+            report_lines.append(
+                f"Azure Certificate Thumbprint: {Fore.YELLOW}{self._identity.certificate_thumbprint}{Style.RESET_ALL}"
+            )
         report_title = (
             f"{Style.BRIGHT}Using the Azure credentials below:{Style.RESET_ALL}"
         )
@@ -487,6 +609,8 @@ class AzureProvider(Provider):
         sp_env_auth: bool,
         browser_auth: bool,
         managed_identity_auth: bool,
+        certificate_auth: bool,
+        certificate_path: str,
         tenant_id: str,
         azure_credentials: dict,
         region_config: AzureRegionConfig,
@@ -500,11 +624,15 @@ class AzureProvider(Provider):
             sp_env_auth (bool): Flag indicating whether to use Service Principal authentication with environment variables.
             browser_auth (bool): Flag indicating whether to use interactive browser authentication.
             managed_identity_auth (bool): Flag indicating whether to use managed identity authentication.
+            certificate_auth (bool): Flag indicating whether to use certificate authentication with environment variables.
+            certificate_path (str): Path to a certificate file used when certificate_auth is enabled and certificate content is not supplied via env var.
             tenant_id (str): The Azure Active Directory tenant ID.
             azure_credentials (dict): The Azure configuration object. It contains the following keys:
                 - tenant_id: The Azure Active Directory tenant ID.
                 - client_id: The Azure client ID.
-                - client_secret: The Azure client secret
+                - client_secret: The Azure client secret.
+                - certificate_content: The base64-encoded Azure certificate content.
+                - certificate_path: The path to the Azure certificate file.
             region_config (AzureRegionConfig): The region configuration object.
 
         Returns:
@@ -524,15 +652,46 @@ class AzureProvider(Provider):
                         f"{environment_credentials_error.__class__.__name__}[{environment_credentials_error.__traceback__.tb_lineno}] -- {environment_credentials_error}"
                     )
                     raise environment_credentials_error
+            elif certificate_auth:
+                try:
+                    AzureProvider.check_certificate_creds_env_vars(
+                        check_certificate_content=not certificate_path
+                    )
+                except AzureEnvironmentVariableError as environment_variable_error:
+                    logger.critical(
+                        f"{environment_variable_error.__class__.__name__}[{environment_variable_error.__traceback__.tb_lineno}] -- {environment_variable_error}"
+                    )
+                    raise environment_variable_error
             try:
                 if azure_credentials:
                     try:
-                        credentials = ClientSecretCredential(
-                            tenant_id=azure_credentials["tenant_id"],
-                            client_id=azure_credentials["client_id"],
-                            client_secret=azure_credentials["client_secret"],
-                            authority=region_config.authority,
-                        )
+                        if azure_credentials.get("certificate_content"):
+                            credentials = _build_certificate_credential(
+                                tenant_id=azure_credentials["tenant_id"],
+                                client_id=azure_credentials["client_id"],
+                                certificate_data=base64.b64decode(
+                                    azure_credentials["certificate_content"]
+                                ),
+                                authority=region_config.authority,
+                            )
+                        elif azure_credentials.get("certificate_path"):
+                            with open(
+                                azure_credentials["certificate_path"], "rb"
+                            ) as cert_file:
+                                certificate_data = cert_file.read()
+                            credentials = _build_certificate_credential(
+                                tenant_id=azure_credentials["tenant_id"],
+                                client_id=azure_credentials["client_id"],
+                                certificate_data=certificate_data,
+                                authority=region_config.authority,
+                            )
+                        else:
+                            credentials = ClientSecretCredential(
+                                tenant_id=azure_credentials["tenant_id"],
+                                client_id=azure_credentials["client_id"],
+                                client_secret=azure_credentials["client_secret"],
+                                authority=region_config.authority,
+                            )
                         return credentials
                     except ClientAuthenticationError as error:
                         logger.error(
@@ -553,6 +712,29 @@ class AzureProvider(Provider):
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         raise AzureConfigCredentialsError(
+                            file=os.path.basename(__file__), original_exception=error
+                        )
+                elif certificate_auth:
+                    try:
+                        if certificate_path:
+                            with open(certificate_path, "rb") as cert_file:
+                                certificate_data = cert_file.read()
+                        else:
+                            certificate_data = base64.b64decode(
+                                getenv("AZURE_CERTIFICATE_CONTENT")
+                            )
+                        credentials = _build_certificate_credential(
+                            tenant_id=getenv("AZURE_TENANT_ID"),
+                            client_id=getenv("AZURE_CLIENT_ID"),
+                            certificate_data=certificate_data,
+                            authority=region_config.authority,
+                        )
+                        return credentials
+                    except ClientAuthenticationError as error:
+                        logger.error(
+                            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+                        )
+                        raise AzureClientAuthenticationError(
                             file=os.path.basename(__file__), original_exception=error
                         )
                 else:
@@ -632,6 +814,13 @@ class AzureProvider(Provider):
         raise_on_exception=True,
         client_id=None,
         client_secret=None,
+        # Certificate-based auth is keyword-only so callers cannot
+        # accidentally bind `provider_id` (which used to sit right after
+        # `client_secret`) to any of these when calling positionally.
+        *,
+        certificate_auth: bool = False,
+        certificate_content: str = None,
+        certificate_path: str = None,
         provider_id=None,
     ) -> Connection:
         """Test connection to Azure subscription.
@@ -677,19 +866,28 @@ class AzureProvider(Provider):
                 sp_env_auth,
                 browser_auth,
                 managed_identity_auth,
+                certificate_auth,
                 tenant_id,
                 client_id,
                 client_secret,
+                certificate_content,
+                certificate_path,
             )
             region_config = AzureProvider.setup_region_config(region)
 
             # Get the dict from the static credentials
             azure_credentials = None
-            if tenant_id and client_id and client_secret:
+            if (
+                tenant_id
+                and client_id
+                and (client_secret or certificate_content or certificate_path)
+            ):
                 azure_credentials = AzureProvider.validate_static_credentials(
                     tenant_id=tenant_id,
                     client_id=client_id,
                     client_secret=client_secret,
+                    certificate_content=certificate_content,
+                    certificate_path=certificate_path,
                     region_config=region_config,
                 )
 
@@ -699,6 +897,8 @@ class AzureProvider(Provider):
                 sp_env_auth,
                 browser_auth,
                 managed_identity_auth,
+                certificate_auth,
+                certificate_path,
                 tenant_id,
                 azure_credentials,
                 region_config,
@@ -890,12 +1090,43 @@ class AzureProvider(Provider):
                     message=f"Missing environment variable {env_var} required to authenticate.",
                 )
 
+    @staticmethod
+    def check_certificate_creds_env_vars(check_certificate_content: bool):
+        """
+        Checks the presence of required environment variables for certificate-based
+        service principal authentication against Azure.
+
+        This method checks for the presence of the following environment variables:
+        - AZURE_CLIENT_ID: Azure client ID
+        - AZURE_TENANT_ID: Azure tenant ID
+        - AZURE_CERTIFICATE_CONTENT: base64-encoded certificate content (only
+          required when a certificate file path is not provided)
+
+        Raises:
+            AzureEnvironmentVariableError: If any required environment variable
+                is missing.
+        """
+        logger.info("Azure provider: checking certificate environment variables ...")
+        env_vars = ["AZURE_CLIENT_ID", "AZURE_TENANT_ID"]
+        if check_certificate_content:
+            env_vars.append("AZURE_CERTIFICATE_CONTENT")
+        for env_var in env_vars:
+            if not getenv(env_var):
+                logger.critical(
+                    f"Azure provider: Missing environment variable {env_var} needed to authenticate against Azure"
+                )
+                raise AzureEnvironmentVariableError(
+                    file=os.path.basename(__file__),
+                    message=f"Missing environment variable {env_var} required to authenticate.",
+                )
+
     def setup_identity(
         self,
         az_cli_auth,
         sp_env_auth,
         browser_auth,
         managed_identity_auth,
+        certificate_auth,
         subscription_ids,
         client_id,
     ):
@@ -920,7 +1151,7 @@ class AzureProvider(Provider):
         # the identity can access AAD and retrieve the tenant domain name.
         # With cli also should be possible but right now it does not work, azure python package issue is coming
         # At the time of writting this with az cli creds is not working, despite that is included
-        if sp_env_auth or browser_auth or az_cli_auth or client_id:
+        if sp_env_auth or browser_auth or az_cli_auth or certificate_auth or client_id:
 
             async def get_azure_identity():
                 # Trying to recover tenant domain info
@@ -957,7 +1188,29 @@ class AzureProvider(Provider):
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                     )
                 # since that exception is not considered as critical, we keep filling another identity fields
-                if sp_env_auth or client_id:
+                if isinstance(credentials, CertificateCredential):
+                    # Prefer the explicit constructor param over the ambient
+                    # env var: with static credentials the caller has
+                    # unambiguously said "this is the client id" and using
+                    # the env var could silently substitute another
+                    # principal's id if the shell happens to have
+                    # `AZURE_CLIENT_ID` set. Fall back to the env var only
+                    # for the env-only cert-auth path where `client_id` is
+                    # `None`.
+                    identity.identity_id = client_id or getenv("AZURE_CLIENT_ID")
+                    identity.identity_type = "Service Principal with Certificate"
+                    # The SHA-1 thumbprint is computed from the certificate
+                    # bytes by `_compute_certificate_thumbprint` at
+                    # `setup_session` time and stashed on the credential via
+                    # `_PROWLER_CERT_THUMBPRINT_ATTR`. This avoids the older
+                    # pattern of reaching into `credentials._client_credential`,
+                    # which is azure-identity private state and drifts across
+                    # library versions.
+                    identity.certificate_thumbprint = (
+                        getattr(credentials, _PROWLER_CERT_THUMBPRINT_ATTR, None)
+                        or "Unknown certificate thumbprint"
+                    )
+                elif sp_env_auth or client_id:
                     # The id of the sp can be retrieved from environment variables
                     identity.identity_id = getenv("AZURE_CLIENT_ID", default=client_id)
                     identity.identity_type = "Service Principal"
@@ -1186,6 +1439,8 @@ class AzureProvider(Provider):
         tenant_id: str = None,
         client_id: str = None,
         client_secret: str = None,
+        certificate_content: str = None,
+        certificate_path: str = None,
         region_config: AzureRegionConfig = None,
     ) -> dict:
         """
@@ -1195,6 +1450,8 @@ class AzureProvider(Provider):
             tenant_id (str): The Azure Active Directory tenant ID.
             client_id (str): The Azure client ID.
             client_secret (str): The Azure client secret.
+            certificate_content (str): The base64-encoded Azure certificate content.
+            certificate_path (str): The path to the Azure certificate file.
             region_config (AzureRegionConfig): The region configuration used to
                 build the per-cloud login endpoint and Graph scope. Defaults to
                 the public-cloud configuration when not provided.
@@ -1203,6 +1460,8 @@ class AzureProvider(Provider):
             AzureNotValidTenantIdError: If the provided Azure Tenant ID is not valid.
             AzureNotValidClientIdError: If the provided Azure Client ID is not valid.
             AzureNotValidClientSecretError: If the provided Azure Client Secret is not valid.
+            AzureNotValidCertificateContentError: If the provided base64 certificate content is not valid.
+            AzureNotValidCertificatePathError: If the provided certificate path cannot be read or does not contain a valid certificate/private-key bundle.
             AzureClientIdAndClientSecretNotBelongingToTenantIdError: If the provided Azure Client ID and Client Secret do not belong to the specified Tenant ID.
             AzureTenantIdAndClientSecretNotBelongingToClientIdError: If the provided Azure Tenant ID and Client Secret do not belong to the specified Client ID.
             AzureTenantIdAndClientIdNotBelongingToClientSecretError: If the provided Azure Tenant ID and Client ID do not belong to the specified Client Secret.
@@ -1227,24 +1486,64 @@ class AzureProvider(Provider):
                 file=os.path.basename(__file__),
                 message="The provided Azure Client ID is not valid.",
             )
-        # Validate the Client Secret
-        if not re.match("^[a-zA-Z0-9._~-]+$", client_secret):
+
+        if not client_secret and not certificate_content and not certificate_path:
+            raise AzureNotValidClientSecretError(
+                file=os.path.basename(__file__),
+                message="You must provide a client secret, certificate content or certificate path. Please check your credentials and try again.",
+            )
+
+        # Validate the Client Secret only when using the client-secret path.
+        # For certificate auth this check must be skipped so the None value
+        # does not trip the regex.
+        if client_secret and not re.match("^[a-zA-Z0-9._~-]+$", client_secret):
             raise AzureNotValidClientSecretError(
                 file=os.path.basename(__file__),
                 message="The provided Azure Client Secret is not valid.",
             )
+
+        if certificate_content:
+            try:
+                # Confirm the payload is valid base64 before handing it off to
+                # azure-identity: `CertificateCredential` raises an opaque
+                # exception several call frames deeper if this fails, which
+                # makes for a bad UX in the API/UI.
+                certificate_data = base64.b64decode(certificate_content, validate=True)
+                validate_certificate_bundle(certificate_data)
+            except Exception as e:
+                raise AzureNotValidCertificateContentError(
+                    file=os.path.basename(__file__),
+                    message=f"The provided certificate content is not a valid base64-encoded certificate/private-key bundle: {str(e)}",
+                )
+
+        if certificate_path:
+            try:
+                with open(certificate_path, "rb") as cert_file:
+                    validate_certificate_bundle(cert_file.read())
+            except Exception as e:
+                raise AzureNotValidCertificatePathError(
+                    file=os.path.basename(__file__),
+                    message=f"The provided certificate path does not contain a valid certificate/private-key bundle: {str(e)}",
+                )
 
         if region_config is None:
             region_config = AzureProvider.setup_region_config("AzureCloud")
 
         try:
             AzureProvider.verify_client(
-                tenant_id, client_id, client_secret, region_config
+                tenant_id,
+                client_id,
+                client_secret,
+                region_config,
+                certificate_content=certificate_content,
+                certificate_path=certificate_path,
             )
             return {
                 "tenant_id": tenant_id,
                 "client_id": client_id,
                 "client_secret": client_secret,
+                "certificate_content": certificate_content,
+                "certificate_path": certificate_path,
             }
         except AzureNotValidTenantIdError as tenant_id_error:
             logger.error(
@@ -1273,10 +1572,16 @@ class AzureProvider(Provider):
 
     @staticmethod
     def verify_client(
-        tenant_id, client_id, client_secret, region_config: AzureRegionConfig = None
+        tenant_id,
+        client_id,
+        client_secret,
+        region_config: AzureRegionConfig = None,
+        certificate_content: str = None,
+        certificate_path: str = None,
     ) -> None:
         """
-        Verifies the Azure client credentials using the specified tenant ID, client ID, and client secret.
+        Verifies the Azure client credentials using the specified tenant ID, client ID, and either
+        a client secret or a certificate.
 
         Args:
             tenant_id (str): The Azure Active Directory tenant ID.
@@ -1285,49 +1590,104 @@ class AzureProvider(Provider):
             region_config (AzureRegionConfig): The region configuration used to
                 build the per-cloud login endpoint and Graph scope. Defaults to
                 the public-cloud configuration when not provided.
+            certificate_content (str): The base64-encoded Azure certificate content.
+            certificate_path (str): The path to the Azure certificate file.
 
         Raises:
             AzureNotValidTenantIdError: If the provided Azure Tenant ID is not valid.
             AzureNotValidClientIdError: If the provided Azure Client ID is not valid.
             AzureNotValidClientSecretError: If the provided Azure Client Secret is not valid.
+            AzureNotValidCertificateContentError: If the provided certificate content cannot obtain a token.
+            AzureNotValidCertificatePathError: If the provided certificate file cannot obtain a token.
 
         Returns:
             None
         """
         if region_config is None:
             region_config = AzureProvider.setup_region_config("AzureCloud")
-        # `authority` is None for the public cloud and a bare host (e.g.
-        # `login.chinacloudapi.cn`) for sovereign clouds, mirroring the
-        # `AzureAuthorityHosts` constants used by azure-identity.
-        login_endpoint = region_config.authority or "login.microsoftonline.com"
-        url = f"https://{login_endpoint}/{tenant_id}/oauth2/v2.0/token"
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Accept": "application/json",
-        }
-        data = {
-            "grant_type": "client_credentials",
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "scope": region_config.graph_scope,
-        }
-        response = requests.post(url, headers=headers, data=data).json()
-        if "access_token" not in response.keys() and "error_codes" in response.keys():
-            if f"Tenant '{tenant_id}'" in response["error_description"]:
-                raise AzureNotValidTenantIdError(
-                    file=os.path.basename(__file__),
-                    message="The provided Azure Tenant ID is not valid for the specified Client ID and Client Secret.",
-                )
+
+        if client_secret:
+            # `authority` is None for the public cloud and a bare host (e.g.
+            # `login.chinacloudapi.cn`) for sovereign clouds, mirroring the
+            # `AzureAuthorityHosts` constants used by azure-identity.
+            login_endpoint = region_config.authority or "login.microsoftonline.com"
+            url = f"https://{login_endpoint}/{tenant_id}/oauth2/v2.0/token"
+            headers = {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+            }
+            data = {
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "scope": region_config.graph_scope,
+            }
+            # Hard timeout so a hung Entra ID endpoint cannot stall the
+            # calling worker (this runs on request threads and Celery tasks
+            # in the API path). 30s covers the p99 of the token endpoint
+            # comfortably.
+            response = requests.post(url, headers=headers, data=data, timeout=30).json()
             if (
-                f"Application with identifier '{client_id}'"
-                in response["error_description"]
+                "access_token" not in response.keys()
+                and "error_codes" in response.keys()
             ):
-                raise AzureNotValidClientIdError(
+                if f"Tenant '{tenant_id}'" in response["error_description"]:
+                    raise AzureNotValidTenantIdError(
+                        file=os.path.basename(__file__),
+                        message="The provided Azure Tenant ID is not valid for the specified Client ID and Client Secret.",
+                    )
+                if (
+                    f"Application with identifier '{client_id}'"
+                    in response["error_description"]
+                ):
+                    raise AzureNotValidClientIdError(
+                        file=os.path.basename(__file__),
+                        message="The provided Azure Client ID is not valid for the specified Tenant ID and Client Secret.",
+                    )
+                if "Invalid client secret provided" in response["error_description"]:
+                    raise AzureNotValidClientSecretError(
+                        file=os.path.basename(__file__),
+                        message="The provided Azure Client Secret is not valid for the specified Tenant ID and Client ID.",
+                    )
+            return
+
+        # Certificate-based flows: instantiate a `CertificateCredential` and
+        # attempt a Graph call. If the credential itself is invalid, msal
+        # raises inside the constructor. If it is valid but the app has no
+        # Graph permissions, `get_token` still returns a token — the point
+        # here is to prove the private key matches an active `keyCredentials`
+        # entry on the app registration.
+        try:
+            if certificate_content:
+                certificate_data = base64.b64decode(certificate_content)
+            elif certificate_path:
+                with open(certificate_path, "rb") as cert_file:
+                    certificate_data = cert_file.read()
+            else:
+                return
+
+            credential = CertificateCredential(
+                client_id=client_id,
+                tenant_id=tenant_id,
+                certificate_data=certificate_data,
+                authority=region_config.authority,
+            )
+            # Acquire a token to force msal to validate the certificate
+            # against Entra ID. A failure raises `ClientAuthenticationError`,
+            # which we translate into the specific certificate error below.
+            credential.get_token(region_config.graph_scope)
+        except ClientAuthenticationError as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+            )
+            if certificate_content:
+                raise AzureNotValidCertificateContentError(
                     file=os.path.basename(__file__),
-                    message="The provided Azure Client ID is not valid for the specified Tenant ID and Client Secret.",
+                    original_exception=error,
+                    message="The provided certificate content is not valid for the specified Tenant ID and Client ID.",
                 )
-            if "Invalid client secret provided" in response["error_description"]:
-                raise AzureNotValidClientSecretError(
-                    file=os.path.basename(__file__),
-                    message="The provided Azure Client Secret is not valid for the specified Tenant ID and Client ID.",
-                )
+            raise AzureNotValidCertificatePathError(
+                file=os.path.basename(__file__),
+                original_exception=error,
+                message="The provided certificate is not valid for the specified Tenant ID and Client ID.",
+            )

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -499,18 +499,23 @@ class AzureProvider(Provider):
 
         Raises:
             AzureBrowserAuthNoTenantIDError: If browser authentication is enabled but the tenant ID is not found.
+            AzureTenantIDNoBrowserAuthError: If a tenant ID is passed without an authentication mode that supports it.
+            AzureNoAuthenticationMethodError: If no authentication mode is selected and no static credentials are supplied.
+            AzureNotTenantIdButClientIdAndClienSecretError: If static credentials are supplied without a tenant ID.
+            AzureConfigCredentialsError: If a certificate is supplied without --certificate-auth (or a static-credentials trio), if a client secret and a certificate are both supplied, or if both certificate content and path are supplied.
         """
 
-        # `--certificate-content`/`--certificate-path` are meaningful only with
-        # `--certificate-auth` or a full static-credentials trio; without one
+        # A certificate value (from --certificate-path, or from the API/UI
+        # `certificate_content` field) is meaningful only with
+        # --certificate-auth or a full static-credentials trio; without one
         # of those, setup_session would silently drop the certificate.
         if (certificate_content or certificate_path) and not certificate_auth:
             if not (tenant_id and client_id):
                 raise AzureConfigCredentialsError(
                     file=os.path.basename(__file__),
                     message=(
-                        "--certificate-content and --certificate-path require --certificate-auth, "
-                        "or --tenant-id together with --client-id for the static-credentials flow."
+                        "A certificate credential requires --certificate-auth, "
+                        "or a tenant id and client id for the static-credentials flow."
                     ),
                 )
 
@@ -792,11 +797,12 @@ class AzureProvider(Provider):
                         PermissionError,
                         IsADirectoryError,
                         OSError,
+                        TypeError,
                         ValueError,
                     ) as error:
                         # Base64 with stray whitespace, unreadable file, or bytes
-                        # CertificateCredential cannot parse. Surface a
-                        # certificate-specific error instead of a generic one.
+                        # (or a password-protected PEM) CertificateCredential
+                        # cannot parse. Surface a certificate-specific error.
                         logger.error(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
@@ -848,6 +854,13 @@ class AzureProvider(Provider):
                         raise AzureDefaultAzureCredentialError(
                             file=os.path.basename(__file__), original_exception=error
                         )
+            except (
+                AzureNotValidCertificateContentError,
+                AzureNotValidCertificatePathError,
+            ):
+                # Preserve certificate-specific errors so API/UI consumers can
+                # distinguish "bad certificate" from a generic session failure.
+                raise
             except Exception as error:
                 logger.critical("Failed to retrieve azure credentials")
                 logger.critical(
@@ -1210,7 +1223,9 @@ class AzureProvider(Provider):
             sp_env_auth (bool): Flag indicating if Service Principal environment authentication is used.
             browser_auth (bool): Flag indicating if browser authentication is used.
             managed_identity_auth (bool): Flag indicating if managed entity authentication is used.
+            certificate_auth (bool): Flag indicating if certificate-based Service Principal authentication is used.
             subscription_ids (list): List of subscription IDs.
+            client_id (str): The Azure client ID; used to populate the identity id under static-credential and certificate flows.
 
         Returns:
             AzureIdentityInfo: An instance of AzureIdentityInfo containing the identity information.
@@ -1670,6 +1685,7 @@ class AzureProvider(Provider):
             AzureNotValidClientSecretError: If the provided Azure Client Secret is not valid.
             AzureNotValidCertificateContentError: If the provided certificate content cannot obtain a token.
             AzureNotValidCertificatePathError: If the provided certificate file cannot obtain a token.
+            AzureCredentialsUnavailableError: If the token acquisition exceeds the configured timeout.
 
         Returns:
             None
@@ -1695,9 +1711,13 @@ class AzureProvider(Provider):
             }
             # Hard timeout so a hung Entra ID endpoint cannot stall the
             # calling worker (this runs on request threads and Celery tasks
-            # in the API path). 30s covers the p99 of the token endpoint
-            # comfortably.
-            response = requests.post(url, headers=headers, data=data, timeout=30).json()
+            # in the API path).
+            response = requests.post(
+                url,
+                headers=headers,
+                data=data,
+                timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS,
+            ).json()
             if (
                 "access_token" not in response.keys()
                 and "error_codes" in response.keys()
@@ -1745,21 +1765,25 @@ class AzureProvider(Provider):
             )
             # get_token has no native timeout parameter, so run it off-thread
             # with a hard deadline (matches the 30s on the client-secret path).
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(
-                    credential.get_token, region_config.graph_scope
+            # Manage the executor explicitly: the context-manager form calls
+            # shutdown(wait=True) on exit and would block until get_token
+            # returns anyway, defeating the timeout.
+            executor = ThreadPoolExecutor(max_workers=1)
+            future = executor.submit(credential.get_token, region_config.graph_scope)
+            try:
+                future.result(timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS)
+            except FuturesTimeoutError as error:
+                executor.shutdown(wait=False)
+                raise AzureCredentialsUnavailableError(
+                    file=os.path.basename(__file__),
+                    message=(
+                        "Timed out waiting for Entra ID to issue a token "
+                        "for the provided certificate."
+                    ),
+                    original_exception=error,
                 )
-                try:
-                    future.result(timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS)
-                except FuturesTimeoutError as error:
-                    raise AzureCredentialsUnavailableError(
-                        file=os.path.basename(__file__),
-                        message=(
-                            "Timed out waiting for Entra ID to issue a token "
-                            "for the provided certificate."
-                        ),
-                        original_exception=error,
-                    )
+            else:
+                executor.shutdown(wait=True)
         except ClientAuthenticationError as error:
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -5,15 +5,18 @@ import logging
 import os
 import re
 from argparse import ArgumentTypeError
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import TimeoutError as FuturesTimeoutError
 from itertools import chain
 from os import getenv
 from typing import Optional, Union
 from uuid import UUID
 
 import requests
-from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
+from azure.core.exceptions import (
+    ClientAuthenticationError,
+    HttpResponseError,
+    ServiceRequestError,
+)
+from azure.core.pipeline.transport import RequestsTransport
 from azure.identity import (
     CertificateCredential,
     ClientSecretCredential,
@@ -1785,23 +1788,23 @@ class AzureProvider(Provider):
             else:
                 return
 
+            # Enforce the deadline on the HTTP transport itself instead of
+            # racing an off-thread `get_token` — background workers cannot
+            # be cancelled once running, and any non-timeout exception used
+            # to bypass executor shutdown, leaking a thread per validation.
             credential = CertificateCredential(
                 client_id=client_id,
                 tenant_id=tenant_id,
                 certificate_data=validate_certificate_bundle(certificate_data),
                 authority=region_config.authority,
+                transport=RequestsTransport(
+                    connection_timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS,
+                    read_timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS,
+                ),
             )
-            # get_token has no native timeout parameter, so run it off-thread
-            # with a hard deadline (matches the 30s on the client-secret path).
-            # Manage the executor explicitly: the context-manager form calls
-            # shutdown(wait=True) on exit and would block until get_token
-            # returns anyway, defeating the timeout.
-            executor = ThreadPoolExecutor(max_workers=1)
-            future = executor.submit(credential.get_token, region_config.graph_scope)
             try:
-                future.result(timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS)
-            except FuturesTimeoutError as error:
-                executor.shutdown(wait=False)
+                credential.get_token(region_config.graph_scope)
+            except ServiceRequestError as error:
                 raise AzureCredentialsUnavailableError(
                     file=os.path.basename(__file__),
                     message=(
@@ -1810,8 +1813,6 @@ class AzureProvider(Provider):
                     ),
                     original_exception=error,
                 )
-            else:
-                executor.shutdown(wait=True)
         except ClientAuthenticationError as error:
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -213,10 +213,10 @@ class AzureProvider(Provider):
         fixer_config(self): Returns the fixer configuration.
         output_options(self, options: tuple): Sets the output options for the Azure provider.
         mutelist(self) -> AzureMutelist: Returns the mutelist object associated with the Azure provider.
-        validate_arguments(cls, az_cli_auth, sp_env_auth, browser_auth, managed_identity_auth, tenant_id): Validates the authentication arguments for the Azure provider.
+        validate_arguments(az_cli_auth, sp_env_auth, browser_auth, managed_identity_auth, tenant_id, client_id, client_secret, *, certificate_auth, certificate_content, certificate_path): Validates the authentication arguments for the Azure provider.
         setup_region_config(cls, region): Sets up the region configuration for the Azure provider.
         print_credentials(self): Prints the Azure credentials information.
-        setup_session(cls, az_cli_auth, sp_env_auth, browser_auth, managed_identity_auth, tenant_id, region_config): Set up the Azure session with the specified authentication method.
+        setup_session(az_cli_auth, sp_env_auth, browser_auth, managed_identity_auth, tenant_id, azure_credentials, region_config, *, certificate_auth, certificate_path): Set up the Azure session with the specified authentication method.
     """
 
     _type: str = "azure"
@@ -371,12 +371,12 @@ class AzureProvider(Provider):
             sp_env_auth,
             browser_auth,
             managed_identity_auth,
-            certificate_auth,
             tenant_id,
             client_id,
             client_secret,
-            certificate_content,
-            certificate_path,
+            certificate_auth=certificate_auth,
+            certificate_content=certificate_content,
+            certificate_path=certificate_path,
         )
 
         logger.info("Checking if region is different than default one")
@@ -404,11 +404,11 @@ class AzureProvider(Provider):
             sp_env_auth,
             browser_auth,
             managed_identity_auth,
-            certificate_auth,
-            certificate_path,
             tenant_id,
             azure_credentials,
             self._region_config,
+            certificate_auth=certificate_auth,
+            certificate_path=certificate_path,
         )
 
         # Set up the identity
@@ -505,12 +505,16 @@ class AzureProvider(Provider):
         sp_env_auth: bool,
         browser_auth: bool,
         managed_identity_auth: bool,
-        certificate_auth: bool,
         tenant_id: str,
         client_id: str,
         client_secret: str,
-        certificate_content: str,
-        certificate_path: str,
+        # Certificate kwargs are keyword-only so they cannot displace
+        # `tenant_id`/`client_id`/`client_secret` for callers passing
+        # positionally the way the pre-cert-auth signature accepted.
+        *,
+        certificate_auth: bool = False,
+        certificate_content: str = None,
+        certificate_path: str = None,
     ):
         """
         Validates the authentication arguments for the Azure provider.
@@ -687,11 +691,15 @@ class AzureProvider(Provider):
         sp_env_auth: bool,
         browser_auth: bool,
         managed_identity_auth: bool,
-        certificate_auth: bool,
-        certificate_path: str,
         tenant_id: str,
         azure_credentials: dict,
         region_config: AzureRegionConfig,
+        # Certificate kwargs are keyword-only so callers that pass
+        # `tenant_id`/`azure_credentials`/`region_config` positionally the
+        # way the pre-cert-auth signature accepted keep binding those slots.
+        *,
+        certificate_auth: bool = False,
+        certificate_path: str = None,
     ):
         """Returns the Azure credentials object.
 
@@ -989,12 +997,12 @@ class AzureProvider(Provider):
                 sp_env_auth,
                 browser_auth,
                 managed_identity_auth,
-                certificate_auth,
                 tenant_id,
                 client_id,
                 client_secret,
-                certificate_content,
-                certificate_path,
+                certificate_auth=certificate_auth,
+                certificate_content=certificate_content,
+                certificate_path=certificate_path,
             )
             region_config = AzureProvider.setup_region_config(region)
 
@@ -1020,11 +1028,11 @@ class AzureProvider(Provider):
                 sp_env_auth,
                 browser_auth,
                 managed_identity_auth,
-                certificate_auth,
-                certificate_path,
                 tenant_id,
                 azure_credentials,
                 region_config,
+                certificate_auth=certificate_auth,
+                certificate_path=certificate_path,
             )
             # Create a SubscriptionClient
             subscription_client = SubscriptionClient(
@@ -1217,26 +1225,24 @@ class AzureProvider(Provider):
     def check_certificate_creds_env_vars(
         check_certificate_content: bool,
         tenant_id: Optional[str] = None,
-        client_id: Optional[str] = None,
     ):
         """
         Checks the presence of required environment variables for certificate-based
         service principal authentication against Azure.
 
         Environment variables are only required when the caller has not already
-        supplied the value explicitly: an explicit ``tenant_id`` or ``client_id``
-        substitutes for AZURE_TENANT_ID / AZURE_CLIENT_ID respectively.
+        supplied the value explicitly: an explicit ``tenant_id`` substitutes
+        for AZURE_TENANT_ID. There is no CLI/API path that overrides
+        AZURE_CLIENT_ID on the env-var flow, so it must always be set.
 
         Raises:
             AzureEnvironmentVariableError: If any required environment variable
                 is missing and no explicit value was supplied.
         """
         logger.info("Azure provider: checking certificate environment variables ...")
-        env_vars: list[str] = []
+        env_vars: list[str] = ["AZURE_CLIENT_ID"]
         if not tenant_id:
             env_vars.append("AZURE_TENANT_ID")
-        if not client_id:
-            env_vars.append("AZURE_CLIENT_ID")
         if check_certificate_content:
             env_vars.append("AZURE_CERTIFICATE_CONTENT")
         for env_var in env_vars:
@@ -1714,6 +1720,7 @@ class AzureProvider(Provider):
         client_id,
         client_secret,
         region_config: AzureRegionConfig = None,
+        *,
         certificate_content: str = None,
         certificate_path: str = None,
     ) -> None:
@@ -1811,6 +1818,7 @@ class AzureProvider(Provider):
         # here is to prove the private key matches an active `keyCredentials`
         # entry on the app registration.
         credential = None
+        transport = None
         try:
             if certificate_content:
                 certificate_data = base64.b64decode(certificate_content, validate=True)
@@ -1825,16 +1833,20 @@ class AzureProvider(Provider):
             # running `get_token`, so timeouts and non-timeout failures
             # leaked a worker per validation under Entra ID degradation.
             # `retry_total=0` stops Azure Core from replaying each request
-            # and multiplying the effective deadline.
+            # and multiplying the effective deadline. The transport is
+            # bound to a local so `finally` can close it even when
+            # `CertificateCredential.__init__` raises before the
+            # credential is assigned.
+            transport = RequestsTransport(
+                connection_timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS,
+                read_timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS,
+            )
             credential = CertificateCredential(
                 client_id=client_id,
                 tenant_id=tenant_id,
                 certificate_data=validate_certificate_bundle(certificate_data),
                 authority=region_config.authority,
-                transport=RequestsTransport(
-                    connection_timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS,
-                    read_timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS,
-                ),
+                transport=transport,
                 retry_total=0,
             )
             credential.get_token(region_config.graph_scope)
@@ -1893,9 +1905,12 @@ class AzureProvider(Provider):
                 original_exception=error,
             )
         finally:
-            # Always release the transient credential (and its transport):
-            # a `close()` failure must be logged and swallowed so it cannot
-            # replace the primary typed exception on its way up.
+            # Always release the transient credential and its transport:
+            # cleanup failures are logged and swallowed so they cannot
+            # replace the primary typed exception on its way up. The
+            # transport is closed independently to cover the case where
+            # `CertificateCredential.__init__` raised before `credential`
+            # took ownership of it.
             if credential is not None:
                 try:
                     credential.close()
@@ -1903,4 +1918,12 @@ class AzureProvider(Provider):
                     logger.warning(
                         f"{cleanup_error.__class__.__name__}: failed to close "
                         f"CertificateCredential during verify_client cleanup"
+                    )
+            elif transport is not None:
+                try:
+                    transport.close()
+                except Exception as cleanup_error:
+                    logger.warning(
+                        f"{cleanup_error.__class__.__name__}: failed to close "
+                        f"RequestsTransport during verify_client cleanup"
                     )

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -1,9 +1,12 @@
 import asyncio
 import base64
+import binascii
 import logging
 import os
 import re
 from argparse import ArgumentTypeError
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from itertools import chain
 from os import getenv
 from typing import Optional, Union
@@ -70,11 +73,16 @@ from prowler.providers.azure.models import AzureIdentityInfo, AzureRegionConfig
 from prowler.providers.common.models import Audit_Metadata, Connection
 from prowler.providers.common.provider import Provider
 
-# Attribute we stash on `CertificateCredential` instances so `setup_identity`
-# can surface the certificate SHA-1 thumbprint without reaching into
-# azure-identity's private `_client_credential` dict (which can — and does —
-# change shape across azure-identity versions).
 _PROWLER_CERT_THUMBPRINT_ATTR = "_prowler_certificate_thumbprint"
+
+# Fallback storage used only when `setattr` is rejected (a future azure-identity
+# release that locks the credential with `__slots__`); accessed via id() so no
+# extra references keep the credential alive.
+_CERTIFICATE_THUMBPRINT_FALLBACK: dict[int, str] = {}
+
+# Matches the 30s HTTP timeout on the client-secret path so a hung Entra ID
+# endpoint cannot stall a request thread or Celery worker on either flow.
+_TOKEN_ACQUISITION_TIMEOUT_SECONDS = 30
 
 
 def _build_certificate_credential(
@@ -83,51 +91,70 @@ def _build_certificate_credential(
     certificate_data: bytes,
     authority: Optional[str],
 ) -> "CertificateCredential":
-    """Build a `CertificateCredential` and stash the SHA-1 thumbprint on it.
-
-    Centralises the three-step ritual (construct credential, compute
-    thumbprint, `setattr` it under `_PROWLER_CERT_THUMBPRINT_ATTR`) that
-    `setup_session` and friends would otherwise repeat identically for every
-    cert entry point (static content, static path, env-var cert-auth). Missing
-    the `setattr` in any one call site silently degrades the identity report
-    to "Unknown certificate thumbprint", so keeping it in one place is a real
-    correctness win.
-    """
+    """Build a `CertificateCredential` and remember its SHA-1 thumbprint."""
     credentials = CertificateCredential(
         tenant_id=tenant_id,
         client_id=client_id,
         certificate_data=certificate_data,
         authority=authority,
     )
-    setattr(
-        credentials,
-        _PROWLER_CERT_THUMBPRINT_ATTR,
-        _compute_certificate_thumbprint(certificate_data),
+    _remember_certificate_thumbprint(
+        credentials, _compute_certificate_thumbprint(certificate_data)
     )
     return credentials
 
 
-def _compute_certificate_thumbprint(cert_data: bytes) -> Optional[str]:
-    """Compute the SHA-1 thumbprint of an X.509 certificate.
+def _remember_certificate_thumbprint(
+    credential: "CertificateCredential", thumbprint: Optional[str]
+) -> None:
+    """Stash the thumbprint on the credential, tolerating slotted types."""
+    if thumbprint is None:
+        return
+    try:
+        setattr(credential, _PROWLER_CERT_THUMBPRINT_ATTR, thumbprint)
+    except AttributeError:
+        _CERTIFICATE_THUMBPRINT_FALLBACK[id(credential)] = thumbprint
 
-    Accepts the same certificate_data formats `azure.identity.CertificateCredential`
-    accepts (PEM, DER, or PKCS#12/PFX with the private key) and returns the
-    thumbprint as an uppercase hex string, matching how Entra ID displays it
-    in the App Registration blade. Returns None if none of the parsers can
-    read the bytes so the caller can fall back to a placeholder.
+
+def _get_certificate_thumbprint(credential: object) -> Optional[str]:
+    """Return the thumbprint previously stashed for `credential`, if any."""
+    thumbprint = getattr(credential, _PROWLER_CERT_THUMBPRINT_ATTR, None)
+    if thumbprint is not None:
+        return thumbprint
+    return _CERTIFICATE_THUMBPRINT_FALLBACK.get(id(credential))
+
+
+def _compute_certificate_thumbprint(cert_data: bytes) -> Optional[str]:
+    """Compute the SHA-1 thumbprint of an X.509 certificate as uppercase hex.
+
+    Accepts PEM, DER, or PKCS#12/PFX (with the private key). Returns None if
+    no parser can read the bytes; logs each parser failure so the "Unknown
+    certificate thumbprint" placeholder in `setup_identity` is diagnosable.
     """
-    for loader in (
-        lambda data: pkcs12.load_key_and_certificates(data, None, default_backend())[1],
-        lambda data: x509.load_pem_x509_certificate(data, default_backend()),
-        lambda data: x509.load_der_x509_certificate(data, default_backend()),
+    parser_errors: list[str] = []
+    for loader_name, loader in (
+        (
+            "pkcs12",
+            lambda data: pkcs12.load_key_and_certificates(
+                data, None, default_backend()
+            )[1],
+        ),
+        ("pem", lambda data: x509.load_pem_x509_certificate(data, default_backend())),
+        ("der", lambda data: x509.load_der_x509_certificate(data, default_backend())),
     ):
         try:
             cert = loader(cert_data)
-        except Exception:
+        except Exception as error:
+            parser_errors.append(f"{loader_name}: {error.__class__.__name__}: {error}")
             continue
         if cert is None:
             continue
         return cert.fingerprint(hashes.SHA1()).hex().upper()
+    if parser_errors:
+        logger.warning(
+            "Could not compute certificate thumbprint. Parsers tried: "
+            + "; ".join(parser_errors)
+        )
     return None
 
 
@@ -474,13 +501,26 @@ class AzureProvider(Provider):
             AzureBrowserAuthNoTenantIDError: If browser authentication is enabled but the tenant ID is not found.
         """
 
+        # `--certificate-content`/`--certificate-path` are meaningful only with
+        # `--certificate-auth` or a full static-credentials trio; without one
+        # of those, setup_session would silently drop the certificate.
+        if (certificate_content or certificate_path) and not certificate_auth:
+            if not (tenant_id and client_id):
+                raise AzureConfigCredentialsError(
+                    file=os.path.basename(__file__),
+                    message=(
+                        "--certificate-content and --certificate-path require --certificate-auth, "
+                        "or --tenant-id together with --client-id for the static-credentials flow."
+                    ),
+                )
+
         if (
             not client_id
             and not client_secret
             and not certificate_content
             and not certificate_path
         ):
-            if not browser_auth and tenant_id:
+            if not browser_auth and not certificate_auth and tenant_id:
                 raise AzureTenantIDNoBrowserAuthError(
                     file=os.path.basename(__file__),
                     message="Azure Tenant ID (--tenant-id) is required for browser authentication mode",
@@ -502,7 +542,10 @@ class AzureProvider(Provider):
                     message="Azure Tenant ID (--tenant-id) is required for browser authentication mode",
                 )
         else:
-            if not tenant_id:
+            # `--certificate-auth` reads tenant_id from AZURE_TENANT_ID at
+            # setup_session time, so a missing --tenant-id is not a fatal
+            # error for this specific mode.
+            if not tenant_id and not certificate_auth:
                 raise AzureNotTenantIdButClientIdAndClienSecretError(
                     file=os.path.basename(__file__),
                     message="Tenant Id is required for Azure static credentials. Make sure you are using the correct credentials.",
@@ -652,7 +695,9 @@ class AzureProvider(Provider):
                         f"{environment_credentials_error.__class__.__name__}[{environment_credentials_error.__traceback__.tb_lineno}] -- {environment_credentials_error}"
                     )
                     raise environment_credentials_error
-            elif certificate_auth:
+            elif certificate_auth and not azure_credentials:
+                # Env vars are only required for the pure env-var flow; skip
+                # this check when azure_credentials already carries the material.
                 try:
                     AzureProvider.check_certificate_creds_env_vars(
                         check_certificate_content=not certificate_path
@@ -721,10 +766,14 @@ class AzureProvider(Provider):
                                 certificate_data = cert_file.read()
                         else:
                             certificate_data = base64.b64decode(
-                                getenv("AZURE_CERTIFICATE_CONTENT")
+                                getenv("AZURE_CERTIFICATE_CONTENT"), validate=True
                             )
+                        # Same fail-fast validation the static path runs.
+                        validate_certificate_bundle(certificate_data)
+                        # Prefer the explicit --tenant-id so a stale env var
+                        # cannot silently authenticate against the wrong tenant.
                         credentials = _build_certificate_credential(
-                            tenant_id=getenv("AZURE_TENANT_ID"),
+                            tenant_id=tenant_id or getenv("AZURE_TENANT_ID"),
                             client_id=getenv("AZURE_CLIENT_ID"),
                             certificate_data=certificate_data,
                             authority=region_config.authority,
@@ -736,6 +785,29 @@ class AzureProvider(Provider):
                         )
                         raise AzureClientAuthenticationError(
                             file=os.path.basename(__file__), original_exception=error
+                        )
+                    except (
+                        binascii.Error,
+                        FileNotFoundError,
+                        PermissionError,
+                        IsADirectoryError,
+                        OSError,
+                        ValueError,
+                    ) as error:
+                        # Base64 with stray whitespace, unreadable file, or bytes
+                        # CertificateCredential cannot parse. Surface a
+                        # certificate-specific error instead of a generic one.
+                        logger.error(
+                            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+                        )
+                        if certificate_path:
+                            raise AzureNotValidCertificatePathError(
+                                file=os.path.basename(__file__),
+                                original_exception=error,
+                            )
+                        raise AzureNotValidCertificateContentError(
+                            file=os.path.basename(__file__),
+                            original_exception=error,
                         )
                 else:
                     # Since the authentication method to be used will come as True, we have to negate it since
@@ -1199,15 +1271,8 @@ class AzureProvider(Provider):
                     # `None`.
                     identity.identity_id = client_id or getenv("AZURE_CLIENT_ID")
                     identity.identity_type = "Service Principal with Certificate"
-                    # The SHA-1 thumbprint is computed from the certificate
-                    # bytes by `_compute_certificate_thumbprint` at
-                    # `setup_session` time and stashed on the credential via
-                    # `_PROWLER_CERT_THUMBPRINT_ATTR`. This avoids the older
-                    # pattern of reaching into `credentials._client_credential`,
-                    # which is azure-identity private state and drifts across
-                    # library versions.
                     identity.certificate_thumbprint = (
-                        getattr(credentials, _PROWLER_CERT_THUMBPRINT_ATTR, None)
+                        _get_certificate_thumbprint(credentials)
                         or "Unknown certificate thumbprint"
                     )
                 elif sp_env_auth or client_id:
@@ -1665,7 +1730,7 @@ class AzureProvider(Provider):
         # entry on the app registration.
         try:
             if certificate_content:
-                certificate_data = base64.b64decode(certificate_content)
+                certificate_data = base64.b64decode(certificate_content, validate=True)
             elif certificate_path:
                 with open(certificate_path, "rb") as cert_file:
                     certificate_data = cert_file.read()
@@ -1678,10 +1743,23 @@ class AzureProvider(Provider):
                 certificate_data=certificate_data,
                 authority=region_config.authority,
             )
-            # Acquire a token to force msal to validate the certificate
-            # against Entra ID. A failure raises `ClientAuthenticationError`,
-            # which we translate into the specific certificate error below.
-            credential.get_token(region_config.graph_scope)
+            # get_token has no native timeout parameter, so run it off-thread
+            # with a hard deadline (matches the 30s on the client-secret path).
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(
+                    credential.get_token, region_config.graph_scope
+                )
+                try:
+                    future.result(timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS)
+                except FuturesTimeoutError as error:
+                    raise AzureCredentialsUnavailableError(
+                        file=os.path.basename(__file__),
+                        message=(
+                            "Timed out waiting for Entra ID to issue a token "
+                            "for the provided certificate."
+                        ),
+                        original_exception=error,
+                    )
         except ClientAuthenticationError as error:
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
@@ -1696,4 +1774,26 @@ class AzureProvider(Provider):
                 file=os.path.basename(__file__),
                 original_exception=error,
                 message="The provided certificate is not valid for the specified Tenant ID and Client ID.",
+            )
+        except (
+            binascii.Error,
+            FileNotFoundError,
+            PermissionError,
+            IsADirectoryError,
+            OSError,
+            ValueError,
+        ) as error:
+            # Malformed base64, unreadable path, or bytes CertificateCredential
+            # cannot parse. Route to the typed certificate errors.
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+            )
+            if certificate_content:
+                raise AzureNotValidCertificateContentError(
+                    file=os.path.basename(__file__),
+                    original_exception=error,
+                )
+            raise AzureNotValidCertificatePathError(
+                file=os.path.basename(__file__),
+                original_exception=error,
             )

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -705,7 +705,8 @@ class AzureProvider(Provider):
                 # this check when azure_credentials already carries the material.
                 try:
                     AzureProvider.check_certificate_creds_env_vars(
-                        check_certificate_content=not certificate_path
+                        check_certificate_content=not certificate_path,
+                        tenant_id=tenant_id,
                     )
                 except AzureEnvironmentVariableError as environment_variable_error:
                     logger.critical(
@@ -719,8 +720,10 @@ class AzureProvider(Provider):
                             credentials = _build_certificate_credential(
                                 tenant_id=azure_credentials["tenant_id"],
                                 client_id=azure_credentials["client_id"],
-                                certificate_data=base64.b64decode(
-                                    azure_credentials["certificate_content"]
+                                certificate_data=validate_certificate_bundle(
+                                    base64.b64decode(
+                                        azure_credentials["certificate_content"]
+                                    )
                                 ),
                                 authority=region_config.authority,
                             )
@@ -732,7 +735,9 @@ class AzureProvider(Provider):
                             credentials = _build_certificate_credential(
                                 tenant_id=azure_credentials["tenant_id"],
                                 client_id=azure_credentials["client_id"],
-                                certificate_data=certificate_data,
+                                certificate_data=validate_certificate_bundle(
+                                    certificate_data
+                                ),
                                 authority=region_config.authority,
                             )
                         else:
@@ -773,8 +778,11 @@ class AzureProvider(Provider):
                             certificate_data = base64.b64decode(
                                 getenv("AZURE_CERTIFICATE_CONTENT"), validate=True
                             )
-                        # Same fail-fast validation the static path runs.
-                        validate_certificate_bundle(certificate_data)
+                        # Same fail-fast validation the static path runs. The
+                        # returned bundle is normalized so the leaf appears
+                        # before the private key — azure-identity picks the
+                        # first PEM certificate when computing the thumbprint.
+                        certificate_data = validate_certificate_bundle(certificate_data)
                         # Prefer the explicit --tenant-id so a stale env var
                         # cannot silently authenticate against the wrong tenant.
                         credentials = _build_certificate_credential(
@@ -1176,23 +1184,29 @@ class AzureProvider(Provider):
                 )
 
     @staticmethod
-    def check_certificate_creds_env_vars(check_certificate_content: bool):
+    def check_certificate_creds_env_vars(
+        check_certificate_content: bool,
+        tenant_id: Optional[str] = None,
+        client_id: Optional[str] = None,
+    ):
         """
         Checks the presence of required environment variables for certificate-based
         service principal authentication against Azure.
 
-        This method checks for the presence of the following environment variables:
-        - AZURE_CLIENT_ID: Azure client ID
-        - AZURE_TENANT_ID: Azure tenant ID
-        - AZURE_CERTIFICATE_CONTENT: base64-encoded certificate content (only
-          required when a certificate file path is not provided)
+        Environment variables are only required when the caller has not already
+        supplied the value explicitly: an explicit ``tenant_id`` or ``client_id``
+        substitutes for AZURE_TENANT_ID / AZURE_CLIENT_ID respectively.
 
         Raises:
             AzureEnvironmentVariableError: If any required environment variable
-                is missing.
+                is missing and no explicit value was supplied.
         """
         logger.info("Azure provider: checking certificate environment variables ...")
-        env_vars = ["AZURE_CLIENT_ID", "AZURE_TENANT_ID"]
+        env_vars: list[str] = []
+        if not tenant_id:
+            env_vars.append("AZURE_TENANT_ID")
+        if not client_id:
+            env_vars.append("AZURE_CLIENT_ID")
         if check_certificate_content:
             env_vars.append("AZURE_CERTIFICATE_CONTENT")
         for env_var in env_vars:
@@ -1588,8 +1602,12 @@ class AzureProvider(Provider):
                 # azure-identity: `CertificateCredential` raises an opaque
                 # exception several call frames deeper if this fails, which
                 # makes for a bad UX in the API/UI.
-                certificate_data = base64.b64decode(certificate_content, validate=True)
-                validate_certificate_bundle(certificate_data)
+                normalized_bundle = validate_certificate_bundle(
+                    base64.b64decode(certificate_content, validate=True)
+                )
+                # Persist the normalized (leaf-first) bundle so downstream
+                # `CertificateCredential` calls don't pick an intermediate CA.
+                certificate_content = base64.b64encode(normalized_bundle).decode()
             except Exception as e:
                 logger.error(
                     f"{e.__class__.__name__}[{e.__traceback__.tb_lineno}]: {e}"
@@ -1712,12 +1730,22 @@ class AzureProvider(Provider):
             # Hard timeout so a hung Entra ID endpoint cannot stall the
             # calling worker (this runs on request threads and Celery tasks
             # in the API path).
-            response = requests.post(
-                url,
-                headers=headers,
-                data=data,
-                timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS,
-            ).json()
+            try:
+                response = requests.post(
+                    url,
+                    headers=headers,
+                    data=data,
+                    timeout=_TOKEN_ACQUISITION_TIMEOUT_SECONDS,
+                ).json()
+            except requests.exceptions.Timeout as error:
+                raise AzureCredentialsUnavailableError(
+                    file=os.path.basename(__file__),
+                    message=(
+                        "Timed out waiting for Entra ID to issue a token "
+                        "for the provided client secret."
+                    ),
+                    original_exception=error,
+                )
             if (
                 "access_token" not in response.keys()
                 and "error_codes" in response.keys()
@@ -1760,7 +1788,7 @@ class AzureProvider(Provider):
             credential = CertificateCredential(
                 client_id=client_id,
                 tenant_id=tenant_id,
-                certificate_data=certificate_data,
+                certificate_data=validate_certificate_bundle(certificate_data),
                 authority=region_config.authority,
             )
             # get_token has no native timeout parameter, so run it off-thread

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -907,14 +907,14 @@ class AzureProvider(Provider):
         raise_on_exception=True,
         client_id=None,
         client_secret=None,
-        # Certificate-based auth is keyword-only so callers cannot
-        # accidentally bind `provider_id` (which used to sit right after
-        # `client_secret`) to any of these when calling positionally.
+        provider_id=None,
+        # Keep `provider_id` in its original positional slot for callers
+        # that pass it positionally; only the new certificate kwargs are
+        # keyword-only.
         *,
         certificate_auth: bool = False,
         certificate_content: str = None,
         certificate_path: str = None,
-        provider_id=None,
     ) -> Connection:
         """Test connection to Azure subscription.
 

--- a/prowler/providers/azure/exceptions/exceptions.py
+++ b/prowler/providers/azure/exceptions/exceptions.py
@@ -102,6 +102,14 @@ class AzureBaseException(ProwlerException):
             "message": "The provided provider_id does not match with the available subscriptions",
             "remediation": "Check the provider_id and ensure it is a valid subscription for the given credentials.",
         },
+        (2024, "AzureNotValidCertificateContentError"): {
+            "message": "The provided certificate content is not valid",
+            "remediation": "Check that the certificate content is a valid base64-encoded PEM or PFX bound to the app registration's keyCredentials.",
+        },
+        (2025, "AzureNotValidCertificatePathError"): {
+            "message": "The provided certificate path is not valid",
+            "remediation": "Check that the certificate file exists, is readable, and matches an entry in the app registration's keyCredentials.",
+        },
     }
 
     def __init__(self, code, file=None, original_exception=None, message=None):
@@ -290,4 +298,18 @@ class AzureInvalidProviderIdError(AzureBaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             2023, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureNotValidCertificateContentError(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            2024, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureNotValidCertificatePathError(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            2025, file=file, original_exception=original_exception, message=message
         )

--- a/prowler/providers/azure/lib/arguments/arguments.py
+++ b/prowler/providers/azure/lib/arguments/arguments.py
@@ -29,6 +29,17 @@ def init_parser(self):
         action="store_true",
         help="Use managed identity authentication to log in against Azure ",
     )
+    azure_auth_modes_group.add_argument(
+        "--certificate-auth",
+        action="store_true",
+        help="Use certificate authentication to log in against Azure",
+    )
+    azure_parser.add_argument(
+        "--certificate-path",
+        nargs="?",
+        default=None,
+        help="Path to the certificate file to be used with --certificate-auth option",
+    )
     # Subscriptions
     azure_subscriptions_subparser = azure_parser.add_argument_group("Subscriptions")
     azure_subscriptions_subparser.add_argument(

--- a/prowler/providers/azure/lib/arguments/arguments.py
+++ b/prowler/providers/azure/lib/arguments/arguments.py
@@ -34,6 +34,10 @@ def init_parser(self):
         action="store_true",
         help="Use certificate authentication to log in against Azure",
     )
+    # Modifier of --certificate-auth, not a separate mode. The pairing is
+    # enforced in `validate_arguments` so a stray combination like
+    # `--browser-auth --certificate-path X` fails fast instead of dropping
+    # the certificate silently.
     azure_parser.add_argument(
         "--certificate-path",
         nargs="?",

--- a/prowler/providers/azure/lib/certificate.py
+++ b/prowler/providers/azure/lib/certificate.py
@@ -7,6 +7,11 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.serialization import pkcs12
 
+# Reject bundles larger than this before parsing: legitimate PEM and PFX
+# bundles are under ~10 KiB, and a multi-MB payload would waste memory on
+# the doubling that base64 decoding plus PKCS#12/PEM parsing perform.
+_MAX_CERTIFICATE_BUNDLE_BYTES = 50 * 1024
+
 _CERTIFICATE_BLOCK_RE = re.compile(
     rb"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
     re.DOTALL,
@@ -27,9 +32,10 @@ def validate_certificate_bundle(certificate_data: bytes) -> bytes:
 
     Accepts either a PKCS#12/PFX blob (encrypted or unencrypted with a null
     password) or a concatenated PEM bundle. Raises ``ValueError`` when the
-    payload is missing a certificate, missing a private key, or contains a
-    pair whose public keys do not match. Raises ``TypeError`` for
-    password-protected PEM private keys, which cryptography surfaces from
+    payload exceeds the maximum bundle size, is missing a certificate,
+    missing a private key, or contains a pair whose public keys do not
+    match. Raises ``TypeError`` for password-protected PEM private keys,
+    which cryptography surfaces from
     ``load_pem_private_key(..., password=None)``.
 
     The normalized bytes always place the leaf certificate before the private
@@ -38,6 +44,11 @@ def validate_certificate_bundle(certificate_data: bytes) -> bytes:
     picks an intermediate CA over the matching leaf. PKCS#12 blobs are
     returned as-is.
     """
+    if len(certificate_data) > _MAX_CERTIFICATE_BUNDLE_BYTES:
+        raise ValueError(
+            f"the payload exceeds the maximum bundle size of "
+            f"{_MAX_CERTIFICATE_BUNDLE_BYTES} bytes"
+        )
     try:
         private_key, certificate, additional_certs = pkcs12.load_key_and_certificates(
             certificate_data, None, default_backend()

--- a/prowler/providers/azure/lib/certificate.py
+++ b/prowler/providers/azure/lib/certificate.py
@@ -1,4 +1,5 @@
 import re
+from typing import Optional
 
 from cryptography import x509
 from cryptography.exceptions import UnsupportedAlgorithm
@@ -63,30 +64,42 @@ def validate_certificate_bundle(certificate_data: bytes) -> bytes:
 def _normalize_pem_bundle(certificate_data: bytes) -> bytes:
     """Validate a PEM bundle and return it with the matching leaf first."""
     certificate_blocks = _CERTIFICATE_BLOCK_RE.findall(certificate_data)
-    private_key_match = _PRIVATE_KEY_BLOCK_RE.search(certificate_data)
+    private_key_matches = list(_PRIVATE_KEY_BLOCK_RE.finditer(certificate_data))
 
-    if not certificate_blocks or not private_key_match:
+    if not certificate_blocks or not private_key_matches:
         raise ValueError("the payload must contain a certificate and its private key")
 
-    private_key = serialization.load_pem_private_key(
-        private_key_match.group(), password=None, backend=default_backend()
-    )
-    key_public_bytes = private_key.public_key().public_bytes(
-        serialization.Encoding.DER,
-        serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-
-    for pem_block in certificate_blocks:
-        candidate = x509.load_pem_x509_certificate(pem_block, default_backend())
-        candidate_public_bytes = candidate.public_key().public_bytes(
+    # A bundle may carry more than one private key block (e.g. legacy tools
+    # export both an RSA and a PKCS#8 copy). Try each in order; preserve the
+    # first parse error so that a single encrypted key still surfaces the
+    # TypeError callers rely on to route to the typed certificate errors.
+    first_key_error: Optional[Exception] = None
+    for key_match in private_key_matches:
+        try:
+            private_key = serialization.load_pem_private_key(
+                key_match.group(), password=None, backend=default_backend()
+            )
+        except (ValueError, TypeError) as error:
+            if first_key_error is None:
+                first_key_error = error
+            continue
+        key_public_bytes = private_key.public_key().public_bytes(
             serialization.Encoding.DER,
             serialization.PublicFormat.SubjectPublicKeyInfo,
         )
-        if candidate_public_bytes == key_public_bytes:
-            # azure-identity's CertificateCredential uses the first BEGIN
-            # CERTIFICATE block to compute the credential thumbprint. Put the
-            # matching leaf first so authentication uses the correct
-            # certificate regardless of the bundle's original ordering.
-            return pem_block + b"\n" + private_key_match.group() + b"\n"
+        for pem_block in certificate_blocks:
+            candidate = x509.load_pem_x509_certificate(pem_block, default_backend())
+            candidate_public_bytes = candidate.public_key().public_bytes(
+                serialization.Encoding.DER,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            if candidate_public_bytes == key_public_bytes:
+                # azure-identity's CertificateCredential uses the first BEGIN
+                # CERTIFICATE block to compute the credential thumbprint. Put
+                # the matching leaf first so authentication uses the correct
+                # certificate regardless of the bundle's original ordering.
+                return pem_block + b"\n" + key_match.group() + b"\n"
 
+    if first_key_error is not None:
+        raise first_key_error
     raise ValueError("the certificate does not match the private key")

--- a/prowler/providers/azure/lib/certificate.py
+++ b/prowler/providers/azure/lib/certificate.py
@@ -27,7 +27,9 @@ def validate_certificate_bundle(certificate_data: bytes) -> bytes:
     Accepts either a PKCS#12/PFX blob (encrypted or unencrypted with a null
     password) or a concatenated PEM bundle. Raises ``ValueError`` when the
     payload is missing a certificate, missing a private key, or contains a
-    pair whose public keys do not match.
+    pair whose public keys do not match. Raises ``TypeError`` for
+    password-protected PEM private keys, which cryptography surfaces from
+    ``load_pem_private_key(..., password=None)``.
 
     The normalized bytes always place the leaf certificate before the private
     key so ``azure.identity.CertificateCredential`` — which uses the first

--- a/prowler/providers/azure/lib/certificate.py
+++ b/prowler/providers/azure/lib/certificate.py
@@ -21,13 +21,19 @@ _PRIVATE_KEY_BLOCK_RE = re.compile(
 )
 
 
-def validate_certificate_bundle(certificate_data: bytes) -> None:
-    """Validate that certificate data contains a matching certificate and key.
+def validate_certificate_bundle(certificate_data: bytes) -> bytes:
+    """Validate the bundle and return a normalized copy safe for azure-identity.
 
     Accepts either a PKCS#12/PFX blob (encrypted or unencrypted with a null
-    password) or a concatenated PEM bundle. Raises `ValueError` with a
-    diagnostic message when the payload is missing a certificate, missing a
-    private key, or contains a pair whose public keys do not match.
+    password) or a concatenated PEM bundle. Raises ``ValueError`` when the
+    payload is missing a certificate, missing a private key, or contains a
+    pair whose public keys do not match.
+
+    The normalized bytes always place the leaf certificate before the private
+    key so ``azure.identity.CertificateCredential`` — which uses the first
+    ``BEGIN CERTIFICATE`` block to compute the credential thumbprint — never
+    picks an intermediate CA over the matching leaf. PKCS#12 blobs are
+    returned as-is.
     """
     try:
         private_key, certificate, _ = pkcs12.load_key_and_certificates(
@@ -36,7 +42,7 @@ def validate_certificate_bundle(certificate_data: bytes) -> None:
     except (ValueError, UnsupportedAlgorithm):
         # Not PKCS#12, or PKCS#12 uses a cipher this build cannot decrypt.
         # Fall through to the PEM path.
-        certificate, private_key = _load_pem_bundle(certificate_data)
+        return _normalize_pem_bundle(certificate_data)
 
     if certificate is None or private_key is None:
         raise ValueError("the payload must contain a certificate and its private key")
@@ -48,13 +54,12 @@ def validate_certificate_bundle(certificate_data: bytes) -> None:
     ) != private_key.public_key().public_bytes(encoding, public_format):
         raise ValueError("the certificate does not match the private key")
 
+    # PKCS#12 blobs are consumed directly by azure-identity; no reordering.
+    return certificate_data
 
-def _load_pem_bundle(certificate_data: bytes):
-    """Return the (certificate, private_key) pair from a PEM bundle.
 
-    Walks every certificate block so bundles that place the intermediate CA
-    before the leaf (openssl/Key Vault exports) still pair correctly.
-    """
+def _normalize_pem_bundle(certificate_data: bytes) -> bytes:
+    """Validate a PEM bundle and return it with the matching leaf first."""
     certificate_blocks = _CERTIFICATE_BLOCK_RE.findall(certificate_data)
     private_key_match = _PRIVATE_KEY_BLOCK_RE.search(certificate_data)
 
@@ -76,11 +81,10 @@ def _load_pem_bundle(certificate_data: bytes):
             serialization.PublicFormat.SubjectPublicKeyInfo,
         )
         if candidate_public_bytes == key_public_bytes:
-            return candidate, private_key
+            # azure-identity's CertificateCredential uses the first BEGIN
+            # CERTIFICATE block to compute the credential thumbprint. Put the
+            # matching leaf first so authentication uses the correct
+            # certificate regardless of the bundle's original ordering.
+            return pem_block + b"\n" + private_key_match.group() + b"\n"
 
-    # No match. Return the first cert so the caller's public-key comparison
-    # raises the canonical "certificate does not match" error.
-    return (
-        x509.load_pem_x509_certificate(certificate_blocks[0], default_backend()),
-        private_key,
-    )
+    raise ValueError("the certificate does not match the private key")

--- a/prowler/providers/azure/lib/certificate.py
+++ b/prowler/providers/azure/lib/certificate.py
@@ -39,26 +39,57 @@ def validate_certificate_bundle(certificate_data: bytes) -> bytes:
     returned as-is.
     """
     try:
-        private_key, certificate, _ = pkcs12.load_key_and_certificates(
+        private_key, certificate, additional_certs = pkcs12.load_key_and_certificates(
             certificate_data, None, default_backend()
         )
-    except (ValueError, UnsupportedAlgorithm):
-        # Not PKCS#12, or PKCS#12 uses a cipher this build cannot decrypt.
-        # Fall through to the PEM path.
+    except (ValueError, UnsupportedAlgorithm) as error:
+        # `load_key_and_certificates` also raises `ValueError` when the
+        # PKCS#12 archive is password-protected (message text: "Invalid
+        # password or PKCS12 data"). Fall through to the PEM parser only
+        # when the payload smells like PEM; otherwise raise a specific
+        # error so the caller does not see the misleading "missing
+        # certificate or key" message from `_normalize_pem_bundle`.
+        if b"-----BEGIN" not in certificate_data:
+            raise ValueError(
+                "the payload is not a valid PEM bundle nor an unencrypted "
+                "PKCS#12 archive; password-protected PKCS#12 archives are "
+                "not supported"
+            ) from error
         return _normalize_pem_bundle(certificate_data)
 
-    if certificate is None or private_key is None:
-        raise ValueError("the payload must contain a certificate and its private key")
+    if private_key is None:
+        raise ValueError("the PKCS#12 archive does not contain a private key")
+    if certificate is None and not additional_certs:
+        raise ValueError("the PKCS#12 archive does not contain a certificate")
 
     encoding = serialization.Encoding.DER
     public_format = serialization.PublicFormat.SubjectPublicKeyInfo
-    if certificate.public_key().public_bytes(
-        encoding, public_format
-    ) != private_key.public_key().public_bytes(encoding, public_format):
-        raise ValueError("the certificate does not match the private key")
+    key_public_bytes = private_key.public_key().public_bytes(encoding, public_format)
+    if (
+        certificate is not None
+        and certificate.public_key().public_bytes(encoding, public_format)
+        == key_public_bytes
+    ):
+        # PKCS#12 blobs are consumed directly by azure-identity; no reordering.
+        return certificate_data
 
-    # PKCS#12 blobs are consumed directly by azure-identity; no reordering.
-    return certificate_data
+    # Some `openssl pkcs12 -export -certfile` workflows write the leaf
+    # certificate into the additional-certs bag instead of the primary
+    # slot. azure-identity reads the primary certificate for the
+    # thumbprint, so accepting the archive as-is would authenticate
+    # against the wrong thumbprint. Detect that case and raise an
+    # actionable error rather than the opaque "does not match" message.
+    for candidate in additional_certs or ():
+        if (
+            candidate.public_key().public_bytes(encoding, public_format)
+            == key_public_bytes
+        ):
+            raise ValueError(
+                "the PKCS#12 archive has the certificate matching the "
+                "private key in the additional-certs bag; re-export the "
+                "archive with the leaf certificate as the primary entry"
+            )
+    raise ValueError("the certificate does not match the private key")
 
 
 def _normalize_pem_bundle(certificate_data: bytes) -> bytes:

--- a/prowler/providers/azure/lib/certificate.py
+++ b/prowler/providers/azure/lib/certificate.py
@@ -1,38 +1,42 @@
 import re
 
 from cryptography import x509
+from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.serialization import pkcs12
 
+_CERTIFICATE_BLOCK_RE = re.compile(
+    rb"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
+    re.DOTALL,
+)
+
+# Covers PKCS#8 (encrypted or not), legacy RSA/EC/DSA and OpenSSH PEM labels.
+# The actual decoding is delegated to `load_pem_private_key` below.
+_PRIVATE_KEY_BLOCK_RE = re.compile(
+    rb"-----BEGIN (?:ENCRYPTED |OPENSSH |RSA |EC |DSA )?PRIVATE KEY-----"
+    rb".*?"
+    rb"-----END (?:ENCRYPTED |OPENSSH |RSA |EC |DSA )?PRIVATE KEY-----",
+    re.DOTALL,
+)
+
 
 def validate_certificate_bundle(certificate_data: bytes) -> None:
-    """Validate that certificate data contains a matching certificate and key."""
+    """Validate that certificate data contains a matching certificate and key.
+
+    Accepts either a PKCS#12/PFX blob (encrypted or unencrypted with a null
+    password) or a concatenated PEM bundle. Raises `ValueError` with a
+    diagnostic message when the payload is missing a certificate, missing a
+    private key, or contains a pair whose public keys do not match.
+    """
     try:
         private_key, certificate, _ = pkcs12.load_key_and_certificates(
             certificate_data, None, default_backend()
         )
-    except ValueError:
-        certificate_match = re.search(
-            rb"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
-            certificate_data,
-            re.DOTALL,
-        )
-        private_key_match = re.search(
-            rb"-----BEGIN (?:RSA |EC )?PRIVATE KEY-----.*?-----END (?:RSA |EC )?PRIVATE KEY-----",
-            certificate_data,
-            re.DOTALL,
-        )
-        if not certificate_match or not private_key_match:
-            raise ValueError(
-                "the payload must contain a certificate and its private key"
-            )
-        certificate = x509.load_pem_x509_certificate(
-            certificate_match.group(), default_backend()
-        )
-        private_key = serialization.load_pem_private_key(
-            private_key_match.group(), password=None, backend=default_backend()
-        )
+    except (ValueError, UnsupportedAlgorithm):
+        # Not PKCS#12, or PKCS#12 uses a cipher this build cannot decrypt.
+        # Fall through to the PEM path.
+        certificate, private_key = _load_pem_bundle(certificate_data)
 
     if certificate is None or private_key is None:
         raise ValueError("the payload must contain a certificate and its private key")
@@ -43,3 +47,40 @@ def validate_certificate_bundle(certificate_data: bytes) -> None:
         encoding, public_format
     ) != private_key.public_key().public_bytes(encoding, public_format):
         raise ValueError("the certificate does not match the private key")
+
+
+def _load_pem_bundle(certificate_data: bytes):
+    """Return the (certificate, private_key) pair from a PEM bundle.
+
+    Walks every certificate block so bundles that place the intermediate CA
+    before the leaf (openssl/Key Vault exports) still pair correctly.
+    """
+    certificate_blocks = _CERTIFICATE_BLOCK_RE.findall(certificate_data)
+    private_key_match = _PRIVATE_KEY_BLOCK_RE.search(certificate_data)
+
+    if not certificate_blocks or not private_key_match:
+        raise ValueError("the payload must contain a certificate and its private key")
+
+    private_key = serialization.load_pem_private_key(
+        private_key_match.group(), password=None, backend=default_backend()
+    )
+    key_public_bytes = private_key.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    for pem_block in certificate_blocks:
+        candidate = x509.load_pem_x509_certificate(pem_block, default_backend())
+        candidate_public_bytes = candidate.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        if candidate_public_bytes == key_public_bytes:
+            return candidate, private_key
+
+    # No match. Return the first cert so the caller's public-key comparison
+    # raises the canonical "certificate does not match" error.
+    return (
+        x509.load_pem_x509_certificate(certificate_blocks[0], default_backend()),
+        private_key,
+    )

--- a/prowler/providers/azure/lib/certificate.py
+++ b/prowler/providers/azure/lib/certificate.py
@@ -1,0 +1,45 @@
+import re
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.serialization import pkcs12
+
+
+def validate_certificate_bundle(certificate_data: bytes) -> None:
+    """Validate that certificate data contains a matching certificate and key."""
+    try:
+        private_key, certificate, _ = pkcs12.load_key_and_certificates(
+            certificate_data, None, default_backend()
+        )
+    except ValueError:
+        certificate_match = re.search(
+            rb"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
+            certificate_data,
+            re.DOTALL,
+        )
+        private_key_match = re.search(
+            rb"-----BEGIN (?:RSA |EC )?PRIVATE KEY-----.*?-----END (?:RSA |EC )?PRIVATE KEY-----",
+            certificate_data,
+            re.DOTALL,
+        )
+        if not certificate_match or not private_key_match:
+            raise ValueError(
+                "the payload must contain a certificate and its private key"
+            )
+        certificate = x509.load_pem_x509_certificate(
+            certificate_match.group(), default_backend()
+        )
+        private_key = serialization.load_pem_private_key(
+            private_key_match.group(), password=None, backend=default_backend()
+        )
+
+    if certificate is None or private_key is None:
+        raise ValueError("the payload must contain a certificate and its private key")
+
+    encoding = serialization.Encoding.DER
+    public_format = serialization.PublicFormat.SubjectPublicKeyInfo
+    if certificate.public_key().public_bytes(
+        encoding, public_format
+    ) != private_key.public_key().public_bytes(encoding, public_format):
+        raise ValueError("the certificate does not match the private key")

--- a/prowler/providers/azure/models.py
+++ b/prowler/providers/azure/models.py
@@ -11,6 +11,7 @@ class AzureIdentityInfo(BaseModel):
     identity_type: str = ""
     tenant_ids: list[str] = []
     tenant_domain: str = "Unknown tenant domain (missing AAD permissions)"
+    certificate_thumbprint: str = ""
     subscriptions: dict = {}
     locations: dict = {}
 

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -404,6 +404,8 @@ class Provider(ABC):
                         sp_env_auth=arguments.sp_env_auth,
                         browser_auth=arguments.browser_auth,
                         managed_identity_auth=arguments.managed_identity_auth,
+                        certificate_auth=arguments.certificate_auth,
+                        certificate_path=arguments.certificate_path,
                         tenant_id=arguments.tenant_id,
                         region=arguments.azure_region,
                         subscription_ids=arguments.subscription_id,

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -12,6 +12,7 @@ from prowler.providers.aws.lib.arguments.arguments import (
     validate_role_session_name,
 )
 from prowler.providers.azure.lib.arguments.arguments import validate_azure_region
+from prowler.providers.common.provider import Provider
 
 prowler_command = "prowler"
 
@@ -153,6 +154,53 @@ class Test_Parser:
         assert not parsed.browser_auth
         assert not parsed.managed_identity_auth
         assert not parsed.shodan
+
+    def test_azure_certificate_auth_arguments(self):
+        certificate_path = "/secure/path/prowler-cert.pem"
+
+        parsed = self.parser.parse(
+            [
+                prowler_command,
+                "azure",
+                "--certificate-auth",
+                "--certificate-path",
+                certificate_path,
+            ]
+        )
+
+        assert parsed.certificate_auth
+        assert parsed.certificate_path == certificate_path
+
+    def test_azure_certificate_auth_arguments_are_forwarded(self):
+        certificate_path = "/secure/path/prowler-cert.pem"
+        parsed = self.parser.parse(
+            [
+                prowler_command,
+                "azure",
+                "--certificate-auth",
+                "--certificate-path",
+                certificate_path,
+            ]
+        )
+        captured = {}
+
+        class AzureProviderStub:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        with (
+            patch.object(Provider, "_global", None),
+            patch.object(Provider, "get_class", return_value=AzureProviderStub),
+            patch.object(Provider, "is_builtin", return_value=True),
+            patch(
+                "prowler.providers.common.provider.load_and_validate_config_file",
+                return_value={},
+            ),
+        ):
+            Provider.init_global_provider(parsed)
+
+        assert captured["certificate_auth"] is True
+        assert captured["certificate_path"] == certificate_path
 
     def test_default_parser_no_arguments_gcp(self):
         provider = "gcp"

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -1592,7 +1592,16 @@ class TestAzureProviderCertificateAuth:
                 region_config=self._region_config(),
             )
 
-        assert credentials["certificate_path"] == str(certificate_path)
+        # Assert the full contract, not just certificate_path — a stray
+        # truthy certificate_content or client_secret would route
+        # setup_session to the wrong branch and stay undetected.
+        assert credentials == {
+            "tenant_id": self._TENANT_ID,
+            "client_id": self._CLIENT_ID,
+            "client_secret": None,
+            "certificate_content": None,
+            "certificate_path": str(certificate_path),
+        }
 
     def test_validate_static_credentials_accepts_valid_pkcs12_cert_file(self, tmp_path):
         from cryptography.hazmat.primitives import serialization
@@ -1620,7 +1629,14 @@ class TestAzureProviderCertificateAuth:
                 region_config=self._region_config(),
             )
 
-        assert credentials["certificate_path"] == str(certificate_path)
+        # Same rationale as the PEM test above: assert the full dict.
+        assert credentials == {
+            "tenant_id": self._TENANT_ID,
+            "client_id": self._CLIENT_ID,
+            "client_secret": None,
+            "certificate_content": None,
+            "certificate_path": str(certificate_path),
+        }
 
     def test_setup_session_static_credentials_cert_content_uses_certificate_credential(
         self,

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 import pytest
 from azure.core.credentials import AccessToken
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
 from azure.identity import DefaultAzureCredential
 from mock import MagicMock
 
@@ -16,9 +16,17 @@ from prowler.config.config import (
 from prowler.providers.azure.azure_provider import AzureProvider
 from prowler.providers.azure.exceptions.exceptions import (
     AzureBrowserAuthNoTenantIDError,
+    AzureConfigCredentialsError,
+    AzureEnvironmentVariableError,
     AzureHTTPResponseError,
     AzureInvalidProviderIdError,
     AzureNoAuthenticationMethodError,
+    AzureNotValidCertificateContentError,
+    AzureNotValidCertificatePathError,
+    AzureNotValidClientIdError,
+    AzureNotValidClientSecretError,
+    AzureNotValidTenantIdError,
+    AzureSetUpSessionError,
     AzureTenantIDNoBrowserAuthError,
 )
 from prowler.providers.azure.models import AzureIdentityInfo, AzureRegionConfig
@@ -158,7 +166,7 @@ class TestAzureProvider:
                 )
             assert exception.type == AzureNoAuthenticationMethodError
             assert (
-                "Azure provider requires at least one authentication method set: [--az-cli-auth | --sp-env-auth | --browser-auth | --managed-identity-auth]"
+                "Azure provider requires at least one authentication method set: [--az-cli-auth | --sp-env-auth | --browser-auth | --managed-identity-auth | --certificate-auth]"
                 in exception.value.args[0]
             )
 
@@ -475,7 +483,7 @@ class TestAzureProvider:
 
         assert exception.type == AzureNoAuthenticationMethodError
         assert (
-            "[2003] Azure provider requires at least one authentication method set: [--az-cli-auth | --sp-env-auth | --browser-auth | --managed-identity-auth]"
+            "[2003] Azure provider requires at least one authentication method set: [--az-cli-auth | --sp-env-auth | --browser-auth | --managed-identity-auth | --certificate-auth]"
             in exception.value.args[0]
         )
 
@@ -746,6 +754,7 @@ class TestAzureProviderSetupIdentitySubscriptions:
                 sp_env_auth=False,
                 browser_auth=False,
                 managed_identity_auth=False,
+                certificate_auth=False,
                 subscription_ids=[],
                 client_id=None,
             )
@@ -778,6 +787,7 @@ class TestAzureProviderSetupIdentitySubscriptions:
                 sp_env_auth=False,
                 browser_auth=False,
                 managed_identity_auth=False,
+                certificate_auth=False,
                 subscription_ids=[],
                 client_id=None,
             )
@@ -807,6 +817,7 @@ class TestAzureProviderSetupIdentitySubscriptions:
                 sp_env_auth=False,
                 browser_auth=False,
                 managed_identity_auth=False,
+                certificate_auth=False,
                 subscription_ids=[first_id, second_id],
                 client_id=None,
             )
@@ -837,6 +848,7 @@ class TestAzureProviderSetupIdentitySubscriptions:
                 sp_env_auth=False,
                 browser_auth=False,
                 managed_identity_auth=False,
+                certificate_auth=False,
                 subscription_ids=[first_id, second_id],
                 client_id=None,
             )
@@ -941,6 +953,8 @@ class TestAzureProviderSovereignCloudSupport:
                 sp_env_auth=False,
                 browser_auth=False,
                 managed_identity_auth=False,
+                certificate_auth=False,
+                certificate_path=None,
                 tenant_id=azure_credentials["tenant_id"],
                 azure_credentials=azure_credentials,
                 region_config=region_config,
@@ -978,6 +992,8 @@ class TestAzureProviderSovereignCloudSupport:
                 sp_env_auth=False,
                 browser_auth=True,
                 managed_identity_auth=False,
+                certificate_auth=False,
+                certificate_path=None,
                 tenant_id=tenant_id,
                 azure_credentials=None,
                 region_config=region_config,
@@ -1012,6 +1028,8 @@ class TestAzureProviderSovereignCloudSupport:
                 sp_env_auth=False,
                 browser_auth=False,
                 managed_identity_auth=False,
+                certificate_auth=False,
+                certificate_path=None,
                 tenant_id=None,
                 azure_credentials=None,
                 region_config=region_config,
@@ -1214,6 +1232,7 @@ class TestAzureProviderSetupIdentityEventLoop:
                     sp_env_auth=True,
                     browser_auth=False,
                     managed_identity_auth=False,
+                    certificate_auth=False,
                     subscription_ids=[],
                     client_id="00000000-0000-0000-0000-000000000000",
                 )
@@ -1224,3 +1243,978 @@ class TestAzureProviderSetupIdentityEventLoop:
         assert isinstance(identity, AzureIdentityInfo)
         assert identity.subscriptions == {sub_id: "Sub"}
         graph_client.domains.get.assert_awaited_once()
+
+
+class TestAzureProviderCertificateAuth:
+    """Coverage for the certificate-based service-principal auth path added
+    by the Deploy-to-Azure quick-start (PROWLER-2378)."""
+
+    _TENANT_ID = "12345678-1234-1234-1234-123456789012"
+    _CLIENT_ID = "87654321-4321-4321-4321-210987654321"
+    # Base64 of a valid tiny DER payload — the tests only check that base64
+    # decoding succeeds inside `validate_static_credentials`; the actual
+    # certificate parsing is mocked at the `CertificateCredential` boundary.
+    _CERT_CONTENT_B64 = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA"
+
+    def _region_config(self):
+        return AzureProvider.setup_region_config("AzureCloud")
+
+    @staticmethod
+    def _certificate_and_key():
+        from datetime import datetime, timedelta, timezone
+
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Prowler")])
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .sign(private_key, hashes.SHA256())
+        )
+        return certificate, private_key
+
+    def test_validate_arguments_rejects_client_secret_and_cert_together(self):
+        with pytest.raises(AzureConfigCredentialsError) as exception:
+            AzureProvider.validate_arguments(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=False,
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret="some-secret",
+                certificate_content=self._CERT_CONTENT_B64,
+                certificate_path=None,
+            )
+        assert "not both" in exception.value.args[0]
+
+    def test_validate_arguments_rejects_cert_content_and_path_together(self):
+        with pytest.raises(AzureConfigCredentialsError) as exception:
+            AzureProvider.validate_arguments(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=False,
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=self._CERT_CONTENT_B64,
+                certificate_path="/tmp/anything",
+            )
+        assert "not both" in exception.value.args[0]
+
+    def test_validate_arguments_accepts_certificate_content_only(self):
+        # Should not raise: cert content alone is a valid credential shape.
+        AzureProvider.validate_arguments(
+            az_cli_auth=False,
+            sp_env_auth=False,
+            browser_auth=False,
+            managed_identity_auth=False,
+            certificate_auth=False,
+            tenant_id=self._TENANT_ID,
+            client_id=self._CLIENT_ID,
+            client_secret=None,
+            certificate_content=self._CERT_CONTENT_B64,
+            certificate_path=None,
+        )
+
+    def test_validate_arguments_rejects_client_id_without_credential_material(self):
+        with pytest.raises(AzureConfigCredentialsError, match="must provide"):
+            AzureProvider.validate_arguments(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=False,
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=None,
+                certificate_path=None,
+            )
+
+    def test_check_certificate_creds_env_vars_missing_content(self, monkeypatch):
+        monkeypatch.setenv("AZURE_CLIENT_ID", self._CLIENT_ID)
+        monkeypatch.setenv("AZURE_TENANT_ID", self._TENANT_ID)
+        monkeypatch.delenv("AZURE_CERTIFICATE_CONTENT", raising=False)
+        with pytest.raises(AzureEnvironmentVariableError) as exception:
+            AzureProvider.check_certificate_creds_env_vars(
+                check_certificate_content=True
+            )
+        assert "AZURE_CERTIFICATE_CONTENT" in exception.value.args[0]
+
+    def test_check_certificate_creds_env_vars_skips_content_check_with_path(
+        self, monkeypatch
+    ):
+        # When a certificate path is provided at construction time, we must
+        # NOT require AZURE_CERTIFICATE_CONTENT in the environment.
+        monkeypatch.setenv("AZURE_CLIENT_ID", self._CLIENT_ID)
+        monkeypatch.setenv("AZURE_TENANT_ID", self._TENANT_ID)
+        monkeypatch.delenv("AZURE_CERTIFICATE_CONTENT", raising=False)
+        # Should not raise
+        AzureProvider.check_certificate_creds_env_vars(check_certificate_content=False)
+
+    def test_validate_static_credentials_rejects_non_base64_cert_content(self):
+        with pytest.raises(AzureNotValidCertificateContentError):
+            AzureProvider.validate_static_credentials(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content="not_valid_base64_@@@",
+                certificate_path=None,
+                region_config=self._region_config(),
+            )
+
+    def test_validate_static_credentials_rejects_key_only_pem(self):
+        import base64
+
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        key_only_pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+        with (
+            patch.object(AzureProvider, "verify_client"),
+            pytest.raises(AzureNotValidCertificateContentError),
+        ):
+            AzureProvider.validate_static_credentials(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=base64.b64encode(key_only_pem).decode("ascii"),
+                certificate_path=None,
+                region_config=self._region_config(),
+            )
+
+    def test_validate_static_credentials_rejects_key_only_pkcs12(self):
+        import base64
+
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.serialization import pkcs12
+
+        _, private_key = self._certificate_and_key()
+        key_only_pkcs12 = pkcs12.serialize_key_and_certificates(
+            name=b"prowler",
+            key=private_key,
+            cert=None,
+            cas=None,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+        with pytest.raises(AzureNotValidCertificateContentError):
+            AzureProvider.validate_static_credentials(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=base64.b64encode(key_only_pkcs12).decode("ascii"),
+                certificate_path=None,
+                region_config=self._region_config(),
+            )
+
+    def test_validate_static_credentials_rejects_missing_credential_material(self):
+        with pytest.raises(AzureNotValidClientSecretError, match="must provide"):
+            AzureProvider.validate_static_credentials(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=None,
+                certificate_path=None,
+                region_config=self._region_config(),
+            )
+
+    def test_validate_static_credentials_rejects_mismatched_certificate_and_key(self):
+        import base64
+        from datetime import datetime, timedelta, timezone
+
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+
+        certificate_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        different_private_key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048
+        )
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Prowler")])
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(certificate_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .sign(certificate_key, hashes.SHA256())
+        )
+        mismatched_bundle = certificate.public_bytes(
+            serialization.Encoding.PEM
+        ) + different_private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+        with (
+            patch.object(AzureProvider, "verify_client"),
+            pytest.raises(AzureNotValidCertificateContentError),
+        ):
+            AzureProvider.validate_static_credentials(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=base64.b64encode(mismatched_bundle).decode("ascii"),
+                certificate_path=None,
+                region_config=self._region_config(),
+            )
+
+    def test_validate_static_credentials_rejects_missing_cert_file(self):
+        with pytest.raises(AzureNotValidCertificatePathError):
+            AzureProvider.validate_static_credentials(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=None,
+                certificate_path="/tmp/does-not-exist-prowler-cert.pem",
+                region_config=self._region_config(),
+            )
+
+    def test_validate_static_credentials_rejects_invalid_cert_file(self, tmp_path):
+        certificate_path = tmp_path / "invalid-certificate.pem"
+        certificate_path.write_bytes(b"not a certificate bundle")
+
+        with (
+            patch.object(AzureProvider, "verify_client"),
+            pytest.raises(AzureNotValidCertificatePathError),
+        ):
+            AzureProvider.validate_static_credentials(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=None,
+                certificate_path=str(certificate_path),
+                region_config=self._region_config(),
+            )
+
+    def test_validate_static_credentials_rejects_key_only_cert_file(self, tmp_path):
+        from cryptography.hazmat.primitives import serialization
+
+        _, private_key = self._certificate_and_key()
+        certificate_path = tmp_path / "key-only.pem"
+        certificate_path.write_bytes(
+            private_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+
+        with (
+            patch.object(AzureProvider, "verify_client"),
+            pytest.raises(AzureNotValidCertificatePathError),
+        ):
+            AzureProvider.validate_static_credentials(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=None,
+                certificate_path=str(certificate_path),
+                region_config=self._region_config(),
+            )
+
+    def test_validate_static_credentials_rejects_mismatched_cert_file(self, tmp_path):
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        certificate, _ = self._certificate_and_key()
+        different_private_key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048
+        )
+        certificate_path = tmp_path / "mismatched-certificate.pem"
+        certificate_path.write_bytes(
+            certificate.public_bytes(serialization.Encoding.PEM)
+            + different_private_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+
+        with (
+            patch.object(AzureProvider, "verify_client"),
+            pytest.raises(AzureNotValidCertificatePathError),
+        ):
+            AzureProvider.validate_static_credentials(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=None,
+                certificate_path=str(certificate_path),
+                region_config=self._region_config(),
+            )
+
+    def test_validate_static_credentials_accepts_valid_pem_cert_file(self, tmp_path):
+        from cryptography.hazmat.primitives import serialization
+
+        certificate, private_key = self._certificate_and_key()
+        certificate_path = tmp_path / "certificate-bundle.pem"
+        certificate_path.write_bytes(
+            certificate.public_bytes(serialization.Encoding.PEM)
+            + private_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+
+        with patch.object(AzureProvider, "verify_client"):
+            credentials = AzureProvider.validate_static_credentials(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=None,
+                certificate_path=str(certificate_path),
+                region_config=self._region_config(),
+            )
+
+        assert credentials["certificate_path"] == str(certificate_path)
+
+    def test_validate_static_credentials_accepts_valid_pkcs12_cert_file(self, tmp_path):
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.serialization import pkcs12
+
+        certificate, private_key = self._certificate_and_key()
+        certificate_path = tmp_path / "certificate-bundle.pfx"
+        certificate_path.write_bytes(
+            pkcs12.serialize_key_and_certificates(
+                name=b"prowler",
+                key=private_key,
+                cert=certificate,
+                cas=None,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+
+        with patch.object(AzureProvider, "verify_client"):
+            credentials = AzureProvider.validate_static_credentials(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=None,
+                certificate_path=str(certificate_path),
+                region_config=self._region_config(),
+            )
+
+        assert credentials["certificate_path"] == str(certificate_path)
+
+    def test_setup_session_static_credentials_cert_content_uses_certificate_credential(
+        self,
+    ):
+        # When the credentials dict carries a certificate_content, setup_session
+        # must instantiate CertificateCredential (not ClientSecretCredential)
+        # with the decoded bytes.
+        with patch(
+            "prowler.providers.azure.azure_provider.CertificateCredential"
+        ) as mock_cert_cred:
+            AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=False,
+                certificate_path=None,
+                tenant_id=self._TENANT_ID,
+                azure_credentials={
+                    "tenant_id": self._TENANT_ID,
+                    "client_id": self._CLIENT_ID,
+                    "client_secret": None,
+                    "certificate_content": self._CERT_CONTENT_B64,
+                    "certificate_path": None,
+                },
+                region_config=self._region_config(),
+            )
+            mock_cert_cred.assert_called_once()
+            _, kwargs = mock_cert_cred.call_args
+            assert kwargs["tenant_id"] == self._TENANT_ID
+            assert kwargs["client_id"] == self._CLIENT_ID
+            # The dict content is passed through base64.b64decode into bytes.
+            assert isinstance(kwargs["certificate_data"], (bytes, bytearray))
+
+    def test_setup_session_static_credentials_certificate_path_reads_bundle(
+        self, tmp_path
+    ):
+        certificate_path = tmp_path / "prowler-cert.pem"
+        certificate_path.write_bytes(b"certificate bundle")
+        expected_credentials = MagicMock()
+
+        with patch(
+            "prowler.providers.azure.azure_provider._build_certificate_credential",
+            return_value=expected_credentials,
+        ) as build_certificate_credential:
+            credentials = AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=False,
+                certificate_path=None,
+                tenant_id=self._TENANT_ID,
+                azure_credentials={
+                    "tenant_id": self._TENANT_ID,
+                    "client_id": self._CLIENT_ID,
+                    "client_secret": None,
+                    "certificate_content": None,
+                    "certificate_path": str(certificate_path),
+                },
+                region_config=self._region_config(),
+            )
+
+        assert credentials is expected_credentials
+        build_certificate_credential.assert_called_once_with(
+            tenant_id=self._TENANT_ID,
+            client_id=self._CLIENT_ID,
+            certificate_data=b"certificate bundle",
+            authority=None,
+        )
+
+    def test_setup_session_env_cert_auth_uses_certificate_credential(self, monkeypatch):
+        monkeypatch.setenv("AZURE_CLIENT_ID", self._CLIENT_ID)
+        monkeypatch.setenv("AZURE_TENANT_ID", self._TENANT_ID)
+        monkeypatch.setenv("AZURE_CERTIFICATE_CONTENT", self._CERT_CONTENT_B64)
+        with patch(
+            "prowler.providers.azure.azure_provider.CertificateCredential"
+        ) as mock_cert_cred:
+            AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=True,
+                certificate_path=None,
+                tenant_id=None,
+                azure_credentials=None,
+                region_config=self._region_config(),
+            )
+            mock_cert_cred.assert_called_once()
+            _, kwargs = mock_cert_cred.call_args
+            assert kwargs["tenant_id"] == self._TENANT_ID
+            assert kwargs["client_id"] == self._CLIENT_ID
+
+    def test_setup_session_env_cert_auth_reads_certificate_path(
+        self, monkeypatch, tmp_path
+    ):
+        certificate_path = tmp_path / "prowler-cert.pem"
+        certificate_path.write_bytes(b"environment certificate bundle")
+        monkeypatch.setenv("AZURE_CLIENT_ID", self._CLIENT_ID)
+        monkeypatch.setenv("AZURE_TENANT_ID", self._TENANT_ID)
+        expected_credentials = MagicMock()
+
+        with patch(
+            "prowler.providers.azure.azure_provider._build_certificate_credential",
+            return_value=expected_credentials,
+        ) as build_certificate_credential:
+            credentials = AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=True,
+                certificate_path=str(certificate_path),
+                tenant_id=None,
+                azure_credentials=None,
+                region_config=self._region_config(),
+            )
+
+        assert credentials is expected_credentials
+        build_certificate_credential.assert_called_once_with(
+            tenant_id=self._TENANT_ID,
+            client_id=self._CLIENT_ID,
+            certificate_data=b"environment certificate bundle",
+            authority=None,
+        )
+
+    def test_setup_session_env_cert_auth_preserves_missing_variable_error(self):
+        expected_error = AzureEnvironmentVariableError(
+            file="azure_provider.py",
+            message="Missing certificate credentials.",
+        )
+
+        with (
+            patch.object(
+                AzureProvider,
+                "check_certificate_creds_env_vars",
+                side_effect=expected_error,
+            ),
+            pytest.raises(AzureEnvironmentVariableError) as exception,
+        ):
+            AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=True,
+                certificate_path=None,
+                tenant_id=None,
+                azure_credentials=None,
+                region_config=self._region_config(),
+            )
+
+        assert exception.value is expected_error
+
+    def test_setup_session_env_cert_auth_translates_authentication_error(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("AZURE_CLIENT_ID", self._CLIENT_ID)
+        monkeypatch.setenv("AZURE_TENANT_ID", self._TENANT_ID)
+        monkeypatch.setenv("AZURE_CERTIFICATE_CONTENT", self._CERT_CONTENT_B64)
+
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider._build_certificate_credential",
+                side_effect=ClientAuthenticationError("invalid certificate"),
+            ),
+            pytest.raises(AzureSetUpSessionError, match="client authentication"),
+        ):
+            AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=True,
+                certificate_path=None,
+                tenant_id=None,
+                azure_credentials=None,
+                region_config=self._region_config(),
+            )
+
+    @pytest.mark.parametrize(
+        ("tenant_id", "client_id", "error_description", "expected_error"),
+        [
+            (
+                "invalid-tenant",
+                _CLIENT_ID,
+                "Tenant 'invalid-tenant' was not found",
+                AzureNotValidTenantIdError,
+            ),
+            (
+                _TENANT_ID,
+                "invalid-client",
+                "Application with identifier 'invalid-client' was not found",
+                AzureNotValidClientIdError,
+            ),
+            (
+                _TENANT_ID,
+                _CLIENT_ID,
+                "Invalid client secret provided",
+                AzureNotValidClientSecretError,
+            ),
+        ],
+    )
+    def test_verify_client_translates_token_endpoint_errors(
+        self, tenant_id, client_id, error_description, expected_error
+    ):
+        with (
+            patch("prowler.providers.azure.azure_provider.requests.post") as post,
+            pytest.raises(expected_error),
+        ):
+            post.return_value.json.return_value = {
+                "error_codes": [700016],
+                "error_description": error_description,
+            }
+            AzureProvider.verify_client(
+                tenant_id,
+                client_id,
+                "invalid-secret",
+                self._region_config(),
+            )
+
+    def test_verify_client_certificate_content_acquires_graph_token(self):
+        import base64
+
+        with patch(
+            "prowler.providers.azure.azure_provider.CertificateCredential"
+        ) as certificate_credential:
+            AzureProvider.verify_client(
+                self._TENANT_ID,
+                self._CLIENT_ID,
+                client_secret=None,
+                region_config=self._region_config(),
+                certificate_content=self._CERT_CONTENT_B64,
+            )
+
+        certificate_credential.assert_called_once_with(
+            client_id=self._CLIENT_ID,
+            tenant_id=self._TENANT_ID,
+            certificate_data=base64.b64decode(self._CERT_CONTENT_B64),
+            authority=None,
+        )
+        certificate_credential.return_value.get_token.assert_called_once_with(
+            "https://graph.microsoft.com/.default"
+        )
+
+    def test_verify_client_certificate_path_reads_bundle(self, tmp_path):
+        certificate_path = tmp_path / "prowler-cert.pem"
+        certificate_path.write_bytes(b"certificate bundle")
+
+        with patch(
+            "prowler.providers.azure.azure_provider.CertificateCredential"
+        ) as certificate_credential:
+            AzureProvider.verify_client(
+                self._TENANT_ID,
+                self._CLIENT_ID,
+                client_secret=None,
+                region_config=self._region_config(),
+                certificate_path=str(certificate_path),
+            )
+
+        assert (
+            certificate_credential.call_args.kwargs["certificate_data"]
+            == b"certificate bundle"
+        )
+        certificate_credential.return_value.get_token.assert_called_once_with(
+            "https://graph.microsoft.com/.default"
+        )
+
+    @pytest.mark.parametrize("credential_source", ["content", "path"])
+    def test_verify_client_translates_certificate_authentication_error(
+        self, credential_source, tmp_path
+    ):
+        certificate_content = None
+        certificate_path = None
+        expected_error = AzureNotValidCertificateContentError
+        if credential_source == "content":
+            certificate_content = self._CERT_CONTENT_B64
+        else:
+            path = tmp_path / "prowler-cert.pem"
+            path.write_bytes(b"certificate bundle")
+            certificate_path = str(path)
+            expected_error = AzureNotValidCertificatePathError
+
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider.CertificateCredential",
+                side_effect=ClientAuthenticationError("invalid certificate"),
+            ),
+            pytest.raises(expected_error),
+        ):
+            AzureProvider.verify_client(
+                self._TENANT_ID,
+                self._CLIENT_ID,
+                client_secret=None,
+                region_config=self._region_config(),
+                certificate_content=certificate_content,
+                certificate_path=certificate_path,
+            )
+
+    def test_verify_client_without_credential_material_returns(self):
+        assert (
+            AzureProvider.verify_client(
+                self._TENANT_ID,
+                self._CLIENT_ID,
+                client_secret=None,
+                region_config=self._region_config(),
+            )
+            is None
+        )
+
+    def test_certificate_identity_and_printed_credentials_include_thumbprint(self):
+        from cryptography.hazmat.primitives import hashes, serialization
+
+        from prowler.providers.azure.azure_provider import (
+            _build_certificate_credential,
+        )
+
+        certificate, private_key = self._certificate_and_key()
+        bundle = certificate.public_bytes(
+            serialization.Encoding.PEM
+        ) + private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        expected_thumbprint = certificate.fingerprint(hashes.SHA1()).hex().upper()
+        credentials = _build_certificate_credential(
+            tenant_id=self._TENANT_ID,
+            client_id=self._CLIENT_ID,
+            certificate_data=bundle,
+            authority=None,
+        )
+
+        with patch.object(AzureProvider, "__init__", return_value=None):
+            provider = AzureProvider()
+        provider._session = credentials
+        provider._region_config = self._region_config()
+
+        graph_client = MagicMock()
+        graph_client.domains.get = AsyncMock(return_value=MagicMock(value=[]))
+        subscription_client = MagicMock()
+        subscription_client.subscriptions.list.return_value = [
+            MagicMock(display_name="Subscription", subscription_id="subscription-id")
+        ]
+        subscription_client.tenants.list.return_value = [
+            MagicMock(tenant_id=self._TENANT_ID)
+        ]
+
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider.GraphServiceClient",
+                return_value=graph_client,
+            ),
+            patch(
+                "prowler.providers.azure.azure_provider.SubscriptionClient",
+                return_value=subscription_client,
+            ),
+        ):
+            identity = provider.setup_identity(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=False,
+                subscription_ids=[],
+                client_id=self._CLIENT_ID,
+            )
+
+        assert identity.identity_id == self._CLIENT_ID
+        assert identity.identity_type == "Service Principal with Certificate"
+        assert identity.certificate_thumbprint == expected_thumbprint
+
+        provider._identity = identity
+        provider._resource_groups = {}
+        with patch("prowler.providers.azure.azure_provider.print_boxes") as print_boxes:
+            provider.print_credentials()
+
+        report_lines = print_boxes.call_args.args[0]
+        assert any(expected_thumbprint in line for line in report_lines)
+
+    def test_setup_session_attaches_computed_thumbprint(self):
+        # Regression guard for the thumbprint handoff added in PROWLER-2378.
+        # The earlier `test_setup_session_static_credentials_cert_content_...`
+        # test patches `CertificateCredential` with a `MagicMock` which
+        # silently accepts any `setattr`, so even a missing hand-off would
+        # look green. This test uses a REAL certificate so
+        # `_compute_certificate_thumbprint` returns a real value and asserts
+        # the credential object actually carries it under
+        # `_PROWLER_CERT_THUMBPRINT_ATTR` — the sole reason that attribute
+        # exists is `setup_identity`'s cert-branch reading it.
+        import base64
+        from datetime import datetime, timedelta, timezone
+
+        from cryptography import x509
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.hazmat.primitives.serialization import pkcs12
+        from cryptography.x509.oid import NameOID
+
+        from prowler.providers.azure.azure_provider import (
+            _PROWLER_CERT_THUMBPRINT_ATTR,
+        )
+
+        key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048, backend=default_backend()
+        )
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, "prowler-test")]
+        )
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .sign(key, hashes.SHA256(), default_backend())
+        )
+        expected_thumbprint = cert.fingerprint(hashes.SHA1()).hex().upper()
+        # azure-identity accepts PKCS#12; encode it so the dict looks like
+        # what the API layer stores after the serializer runs.
+        pfx = pkcs12.serialize_key_and_certificates(
+            name=b"prowler",
+            key=key,
+            cert=cert,
+            cas=None,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        cert_content_b64 = base64.b64encode(pfx).decode("ascii")
+
+        credentials = AzureProvider.setup_session(
+            az_cli_auth=False,
+            sp_env_auth=False,
+            browser_auth=False,
+            managed_identity_auth=False,
+            certificate_auth=False,
+            certificate_path=None,
+            tenant_id=self._TENANT_ID,
+            azure_credentials={
+                "tenant_id": self._TENANT_ID,
+                "client_id": self._CLIENT_ID,
+                "client_secret": None,
+                "certificate_content": cert_content_b64,
+                "certificate_path": None,
+            },
+            region_config=self._region_config(),
+        )
+        assert (
+            getattr(credentials, _PROWLER_CERT_THUMBPRINT_ATTR, None)
+            == expected_thumbprint
+        )
+
+    def test_setup_session_static_credentials_client_secret_still_works(self):
+        # Regression guard: adding cert branches to setup_session must not
+        # break the pre-existing client-secret static credentials flow.
+        with patch(
+            "prowler.providers.azure.azure_provider.ClientSecretCredential"
+        ) as mock_secret_cred:
+            AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=False,
+                certificate_path=None,
+                tenant_id=self._TENANT_ID,
+                azure_credentials={
+                    "tenant_id": self._TENANT_ID,
+                    "client_id": self._CLIENT_ID,
+                    "client_secret": "fake-secret",
+                    "certificate_content": None,
+                    "certificate_path": None,
+                },
+                region_config=self._region_config(),
+            )
+            mock_secret_cred.assert_called_once_with(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret="fake-secret",
+                authority=self._region_config().authority,
+            )
+
+
+class TestAzureProviderCertificateThumbprint:
+    """Coverage for `_compute_certificate_thumbprint` — the SHA-1 fingerprint
+    helper that replaces azure-identity's private `_client_credential` API
+    for the identity report."""
+
+    def _self_signed_pem_and_thumbprint(self):
+        # Generate a real self-signed cert in-memory so the test verifies the
+        # actual thumbprint computation instead of relying on hardcoded values.
+        # This mirrors what an openssl-generated cert looks like on disk.
+        from datetime import datetime, timedelta, timezone
+
+        from cryptography import x509
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+
+        key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048, backend=default_backend()
+        )
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, "prowler-test")]
+        )
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .sign(key, hashes.SHA256(), default_backend())
+        )
+        pem = cert.public_bytes(serialization.Encoding.PEM)
+        der = cert.public_bytes(serialization.Encoding.DER)
+        thumbprint = cert.fingerprint(hashes.SHA1()).hex().upper()
+        return pem, der, key, thumbprint
+
+    def test_computes_thumbprint_from_pem(self):
+        from prowler.providers.azure.azure_provider import (
+            _compute_certificate_thumbprint,
+        )
+
+        pem, _, _, expected = self._self_signed_pem_and_thumbprint()
+        assert _compute_certificate_thumbprint(pem) == expected
+
+    def test_computes_thumbprint_from_der(self):
+        from prowler.providers.azure.azure_provider import (
+            _compute_certificate_thumbprint,
+        )
+
+        _, der, _, expected = self._self_signed_pem_and_thumbprint()
+        assert _compute_certificate_thumbprint(der) == expected
+
+    def test_computes_thumbprint_from_pfx(self):
+        # PowerShell's `Export('Pfx', '')` produces exactly this: PKCS#12 with
+        # no password. `azure-identity.CertificateCredential` accepts it, so
+        # our helper must recognise it too.
+        from cryptography.hazmat.primitives.serialization import pkcs12
+
+        from prowler.providers.azure.azure_provider import (
+            _compute_certificate_thumbprint,
+        )
+
+        pem, _, key, expected = self._self_signed_pem_and_thumbprint()
+        from cryptography import x509
+        from cryptography.hazmat.backends import default_backend
+
+        cert = x509.load_pem_x509_certificate(pem, default_backend())
+        pfx = pkcs12.serialize_key_and_certificates(
+            name=b"prowler",
+            key=key,
+            cert=cert,
+            cas=None,
+            encryption_algorithm=serialization_no_encryption(),
+        )
+        assert _compute_certificate_thumbprint(pfx) == expected
+
+    def test_returns_none_for_garbage_bytes(self):
+        from prowler.providers.azure.azure_provider import (
+            _compute_certificate_thumbprint,
+        )
+
+        assert _compute_certificate_thumbprint(b"definitely not a cert") is None
+
+    def test_returns_none_for_key_only_pkcs12(self):
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.serialization import pkcs12
+
+        from prowler.providers.azure.azure_provider import (
+            _compute_certificate_thumbprint,
+        )
+
+        _, _, key, _ = self._self_signed_pem_and_thumbprint()
+        key_only_pkcs12 = pkcs12.serialize_key_and_certificates(
+            name=b"prowler",
+            key=key,
+            cert=None,
+            cas=None,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+        assert _compute_certificate_thumbprint(key_only_pkcs12) is None
+
+
+def serialization_no_encryption():
+    # Kept out of the test method so the PKCS#12 test reads cleanly. Wraps
+    # the deliberate "no password" export path.
+    from cryptography.hazmat.primitives import serialization
+
+    return serialization.NoEncryption()

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -3242,6 +3242,23 @@ class TestValidateCertificateBundleMultiKey:
             validate_certificate_bundle(cert_pem + encrypted_key_pem)
 
 
+class TestValidateCertificateBundleSizeCap:
+    """Legitimate PEM/PFX bundles are well under 10 KiB. A multi-MB payload
+    would waste memory on base64 decoding + PKCS#12/PEM parsing before the
+    validator rejects it, so the size check runs before any parsing."""
+
+    def test_rejects_bundle_larger_than_the_cap(self):
+        from prowler.providers.azure.lib.certificate import (
+            _MAX_CERTIFICATE_BUNDLE_BYTES,
+            validate_certificate_bundle,
+        )
+
+        oversized = b"\x00" * (_MAX_CERTIFICATE_BUNDLE_BYTES + 1)
+
+        with pytest.raises(ValueError, match="maximum bundle size"):
+            validate_certificate_bundle(oversized)
+
+
 def serialization_no_encryption():
     # Kept out of the test method so the PKCS#12 test reads cleanly. Wraps
     # the deliberate "no password" export path.

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -1926,12 +1926,14 @@ class TestAzureProviderCertificateAuth:
                 certificate_content=self._CERT_CONTENT_B64,
             )
 
-        certificate_credential.assert_called_once_with(
-            client_id=self._CLIENT_ID,
-            tenant_id=self._TENANT_ID,
-            certificate_data=base64.b64decode(self._CERT_CONTENT_B64),
-            authority=None,
+        assert certificate_credential.call_count == 1
+        credential_kwargs = certificate_credential.call_args.kwargs
+        assert credential_kwargs["client_id"] == self._CLIENT_ID
+        assert credential_kwargs["tenant_id"] == self._TENANT_ID
+        assert credential_kwargs["certificate_data"] == base64.b64decode(
+            self._CERT_CONTENT_B64
         )
+        assert credential_kwargs["authority"] is None
         certificate_credential.return_value.get_token.assert_called_once_with(
             "https://graph.microsoft.com/.default"
         )
@@ -2076,22 +2078,21 @@ class TestAzureProviderCertificateAuth:
     def test_verify_client_certificate_content_timeout_translates_to_credentials_unavailable(
         self,
     ):
-        # The certificate path runs token acquisition on a
-        # `ThreadPoolExecutor` because `get_token` has no native timeout.
-        # A hung Entra ID endpoint surfaces as `FuturesTimeoutError` and
-        # must be translated to the typed Azure error.
+        # The certificate path enforces the deadline on the HTTP transport,
+        # so a hung Entra ID endpoint surfaces as `ServiceRequestError`.
+        # `verify_client` must translate it to the typed Azure error.
         import base64
-        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        from azure.core.exceptions import ServiceRequestError
 
         with (
-            patch("prowler.providers.azure.azure_provider.CertificateCredential"),
             patch(
-                "prowler.providers.azure.azure_provider.ThreadPoolExecutor"
-            ) as executor_cls,
+                "prowler.providers.azure.azure_provider.CertificateCredential"
+            ) as cert_credential_cls,
             pytest.raises(AzureCredentialsUnavailableError),
         ):
-            executor_cls.return_value.submit.return_value.result.side_effect = (
-                FuturesTimeoutError()
+            cert_credential_cls.return_value.get_token.side_effect = (
+                ServiceRequestError("hung transport")
             )
             AzureProvider.verify_client(
                 self._TENANT_ID,
@@ -2106,20 +2107,19 @@ class TestAzureProviderCertificateAuth:
     def test_verify_client_certificate_path_timeout_translates_to_credentials_unavailable(
         self, tmp_path
     ):
-        from concurrent.futures import TimeoutError as FuturesTimeoutError
+        from azure.core.exceptions import ServiceRequestError
 
         certificate_path = tmp_path / "prowler-cert.pem"
         certificate_path.write_bytes(self._leaf_first_bundle())
 
         with (
-            patch("prowler.providers.azure.azure_provider.CertificateCredential"),
             patch(
-                "prowler.providers.azure.azure_provider.ThreadPoolExecutor"
-            ) as executor_cls,
+                "prowler.providers.azure.azure_provider.CertificateCredential"
+            ) as cert_credential_cls,
             pytest.raises(AzureCredentialsUnavailableError),
         ):
-            executor_cls.return_value.submit.return_value.result.side_effect = (
-                FuturesTimeoutError()
+            cert_credential_cls.return_value.get_token.side_effect = (
+                ServiceRequestError("hung transport")
             )
             AzureProvider.verify_client(
                 self._TENANT_ID,
@@ -2136,16 +2136,14 @@ class TestAzureProviderCertificateAuth:
         # path too: consumers must receive
         # `Connection(error=AzureCredentialsUnavailableError)`.
         import base64
-        from concurrent.futures import TimeoutError as FuturesTimeoutError
 
-        with (
-            patch("prowler.providers.azure.azure_provider.CertificateCredential"),
-            patch(
-                "prowler.providers.azure.azure_provider.ThreadPoolExecutor"
-            ) as executor_cls,
-        ):
-            executor_cls.return_value.submit.return_value.result.side_effect = (
-                FuturesTimeoutError()
+        from azure.core.exceptions import ServiceRequestError
+
+        with patch(
+            "prowler.providers.azure.azure_provider.CertificateCredential"
+        ) as cert_credential_cls:
+            cert_credential_cls.return_value.get_token.side_effect = (
+                ServiceRequestError("hung transport")
             )
             connection = AzureProvider.test_connection(
                 tenant_id=self._TENANT_ID,
@@ -2164,19 +2162,16 @@ class TestAzureProviderCertificateAuth:
     def test_test_connection_certificate_path_timeout_returns_credentials_unavailable_error(
         self, tmp_path
     ):
-        from concurrent.futures import TimeoutError as FuturesTimeoutError
+        from azure.core.exceptions import ServiceRequestError
 
         certificate_path = tmp_path / "prowler-cert.pem"
         certificate_path.write_bytes(self._leaf_first_bundle())
 
-        with (
-            patch("prowler.providers.azure.azure_provider.CertificateCredential"),
-            patch(
-                "prowler.providers.azure.azure_provider.ThreadPoolExecutor"
-            ) as executor_cls,
-        ):
-            executor_cls.return_value.submit.return_value.result.side_effect = (
-                FuturesTimeoutError()
+        with patch(
+            "prowler.providers.azure.azure_provider.CertificateCredential"
+        ) as cert_credential_cls:
+            cert_credential_cls.return_value.get_token.side_effect = (
+                ServiceRequestError("hung transport")
             )
             connection = AzureProvider.test_connection(
                 tenant_id=self._TENANT_ID,
@@ -2810,17 +2805,9 @@ class TestValidateCertificateBundleOrdering:
 
         region_config = AzureProvider.setup_region_config("AzureCloud")
 
-        with (
-            patch(
-                "prowler.providers.azure.azure_provider.CertificateCredential"
-            ) as cert_credential,
-            patch(
-                "prowler.providers.azure.azure_provider.ThreadPoolExecutor"
-            ) as executor_cls,
-        ):
-            executor_cls.return_value.submit.return_value.result.return_value = (
-                MagicMock()
-            )
+        with patch(
+            "prowler.providers.azure.azure_provider.CertificateCredential"
+        ) as cert_credential:
             AzureProvider.verify_client(
                 "12345678-1234-1234-1234-123456789012",
                 "87654321-4321-4321-4321-210987654321",
@@ -2843,17 +2830,9 @@ class TestValidateCertificateBundleOrdering:
 
         region_config = AzureProvider.setup_region_config("AzureCloud")
 
-        with (
-            patch(
-                "prowler.providers.azure.azure_provider.CertificateCredential"
-            ) as cert_credential,
-            patch(
-                "prowler.providers.azure.azure_provider.ThreadPoolExecutor"
-            ) as executor_cls,
-        ):
-            executor_cls.return_value.submit.return_value.result.return_value = (
-                MagicMock()
-            )
+        with patch(
+            "prowler.providers.azure.azure_provider.CertificateCredential"
+        ) as cert_credential:
             AzureProvider.verify_client(
                 "12345678-1234-1234-1234-123456789012",
                 "87654321-4321-4321-4321-210987654321",

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -1712,9 +1712,12 @@ class TestAzureProviderCertificateAuth:
         monkeypatch.setenv("AZURE_CLIENT_ID", self._CLIENT_ID)
         monkeypatch.setenv("AZURE_TENANT_ID", self._TENANT_ID)
         monkeypatch.setenv("AZURE_CERTIFICATE_CONTENT", self._CERT_CONTENT_B64)
-        with patch(
-            "prowler.providers.azure.azure_provider.CertificateCredential"
-        ) as mock_cert_cred:
+        with (
+            patch("prowler.providers.azure.azure_provider.validate_certificate_bundle"),
+            patch(
+                "prowler.providers.azure.azure_provider.CertificateCredential"
+            ) as mock_cert_cred,
+        ):
             AzureProvider.setup_session(
                 az_cli_auth=False,
                 sp_env_auth=False,
@@ -1740,10 +1743,13 @@ class TestAzureProviderCertificateAuth:
         monkeypatch.setenv("AZURE_TENANT_ID", self._TENANT_ID)
         expected_credentials = MagicMock()
 
-        with patch(
-            "prowler.providers.azure.azure_provider._build_certificate_credential",
-            return_value=expected_credentials,
-        ) as build_certificate_credential:
+        with (
+            patch("prowler.providers.azure.azure_provider.validate_certificate_bundle"),
+            patch(
+                "prowler.providers.azure.azure_provider._build_certificate_credential",
+                return_value=expected_credentials,
+            ) as build_certificate_credential,
+        ):
             credentials = AzureProvider.setup_session(
                 az_cli_auth=False,
                 sp_env_auth=False,
@@ -1800,6 +1806,11 @@ class TestAzureProviderCertificateAuth:
         monkeypatch.setenv("AZURE_CERTIFICATE_CONTENT", self._CERT_CONTENT_B64)
 
         with (
+            # `validate_certificate_bundle` runs first on the env-var branch to
+            # fail fast on unparseable bytes; this test isolates the
+            # authentication-error translation path, so keep the placeholder
+            # base64 payload from tripping the bundle check.
+            patch("prowler.providers.azure.azure_provider.validate_certificate_bundle"),
             patch(
                 "prowler.providers.azure.azure_provider._build_certificate_credential",
                 side_effect=ClientAuthenticationError("invalid certificate"),
@@ -2226,6 +2237,181 @@ class TestAzureProviderCertificateThumbprint:
         )
 
         assert _compute_certificate_thumbprint(key_only_pkcs12) is None
+
+
+class TestAzureProviderValidateArguments:
+    """Coverage for the CLI argument-validation edge cases the code review
+    of PROWLER-2378 surfaced (see the SDK PR description for the finding list)."""
+
+    _TENANT_ID = "12345678-1234-1234-1234-123456789012"
+    _CLIENT_ID = "87654321-4321-4321-4321-210987654321"
+
+    def test_certificate_path_without_certificate_auth_or_static_trio_fails(self):
+        # `--browser-auth --certificate-path X` used to parse cleanly and
+        # silently drop the certificate in setup_session; now it fails fast.
+        with pytest.raises(AzureConfigCredentialsError, match="--certificate-auth"):
+            AzureProvider.validate_arguments(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=True,
+                managed_identity_auth=False,
+                certificate_auth=False,
+                tenant_id=self._TENANT_ID,
+                client_id=None,
+                client_secret=None,
+                certificate_content=None,
+                certificate_path="/tmp/prowler-cert.pem",
+            )
+
+    def test_certificate_auth_with_only_tenant_id_does_not_raise(self):
+        # Env-var flow: only --certificate-auth (and optionally --tenant-id)
+        # on the CLI; tenant_id/client_id/cert come from env at setup_session.
+        AzureProvider.validate_arguments(
+            az_cli_auth=False,
+            sp_env_auth=False,
+            browser_auth=False,
+            managed_identity_auth=False,
+            certificate_auth=True,
+            tenant_id=self._TENANT_ID,
+            client_id=None,
+            client_secret=None,
+            certificate_content=None,
+            certificate_path=None,
+        )
+
+    def test_certificate_auth_with_certificate_path_only_does_not_raise(self):
+        # The documented env-var + --certificate-path combination: setup_session
+        # reads AZURE_TENANT_ID / AZURE_CLIENT_ID and loads the file from disk.
+        AzureProvider.validate_arguments(
+            az_cli_auth=False,
+            sp_env_auth=False,
+            browser_auth=False,
+            managed_identity_auth=False,
+            certificate_auth=True,
+            tenant_id=None,
+            client_id=None,
+            client_secret=None,
+            certificate_content=None,
+            certificate_path="/tmp/prowler-cert.pem",
+        )
+
+
+class TestAzureProviderSetupSessionCertificateOverrides:
+    """Ensure the env-var certificate path prefers explicit args over env vars
+    and validates the bundle before instantiating CertificateCredential."""
+
+    _TENANT_ID = "12345678-1234-1234-1234-123456789012"
+    _STALE_TENANT_ID = "99999999-9999-9999-9999-999999999999"
+    _CLIENT_ID = "87654321-4321-4321-4321-210987654321"
+
+    def _region_config(self):
+        return AzureProvider.setup_region_config("AzureCloud")
+
+    def test_explicit_tenant_id_wins_over_env_tenant_id(self, monkeypatch, tmp_path):
+        certificate_path = tmp_path / "prowler-cert.pem"
+        certificate_path.write_bytes(b"env cert bundle")
+        monkeypatch.setenv("AZURE_CLIENT_ID", self._CLIENT_ID)
+        monkeypatch.setenv("AZURE_TENANT_ID", self._STALE_TENANT_ID)
+
+        with (
+            patch("prowler.providers.azure.azure_provider.validate_certificate_bundle"),
+            patch(
+                "prowler.providers.azure.azure_provider._build_certificate_credential"
+            ) as build_certificate_credential,
+        ):
+            AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=True,
+                certificate_path=str(certificate_path),
+                tenant_id=self._TENANT_ID,
+                azure_credentials=None,
+                region_config=self._region_config(),
+            )
+
+        _, kwargs = build_certificate_credential.call_args
+        assert kwargs["tenant_id"] == self._TENANT_ID
+
+    def test_env_var_branch_validates_bundle_before_building_credential(
+        self, monkeypatch, tmp_path
+    ):
+        # A malformed base64/bundle must raise a certificate-specific error
+        # BEFORE CertificateCredential is instantiated so the audit loop
+        # never runs against a bad bundle.
+        certificate_path = tmp_path / "prowler-cert.pem"
+        certificate_path.write_bytes(b"not a real cert bundle")
+        monkeypatch.setenv("AZURE_CLIENT_ID", self._CLIENT_ID)
+        monkeypatch.setenv("AZURE_TENANT_ID", self._TENANT_ID)
+
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider._build_certificate_credential"
+            ) as build_certificate_credential,
+            pytest.raises(AzureSetUpSessionError),
+        ):
+            AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=True,
+                certificate_path=str(certificate_path),
+                tenant_id=None,
+                azure_credentials=None,
+                region_config=self._region_config(),
+            )
+
+        build_certificate_credential.assert_not_called()
+
+
+class TestValidateCertificateBundleOrdering:
+    """PEM bundles can arrive with the intermediate CA before the leaf. The
+    validator must find the certificate that actually pairs with the private
+    key instead of trusting the first block."""
+
+    def _self_signed(self):
+        from datetime import datetime, timedelta, timezone
+
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Prowler")])
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .sign(private_key, hashes.SHA256())
+        )
+        cert_pem = certificate.public_bytes(serialization.Encoding.PEM)
+        key_pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        return cert_pem, key_pem
+
+    def test_accepts_intermediate_before_leaf(self):
+        from prowler.providers.azure.lib.certificate import (
+            validate_certificate_bundle,
+        )
+
+        leaf_cert_pem, leaf_key_pem = self._self_signed()
+        other_cert_pem, _ = self._self_signed()
+
+        bundle = other_cert_pem + leaf_cert_pem + leaf_key_pem
+
+        # No exception: `validate_certificate_bundle` walks every cert block
+        # and pairs the private key with the one that actually matches.
+        validate_certificate_bundle(bundle)
 
 
 def serialization_no_encryption():

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
+import requests
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
 from azure.identity import DefaultAzureCredential
@@ -17,6 +18,7 @@ from prowler.providers.azure.azure_provider import AzureProvider
 from prowler.providers.azure.exceptions.exceptions import (
     AzureBrowserAuthNoTenantIDError,
     AzureConfigCredentialsError,
+    AzureCredentialsUnavailableError,
     AzureEnvironmentVariableError,
     AzureHTTPResponseError,
     AzureInvalidProviderIdError,
@@ -1365,6 +1367,19 @@ class TestAzureProviderCertificateAuth:
         # Should not raise
         AzureProvider.check_certificate_creds_env_vars(check_certificate_content=False)
 
+    def test_check_certificate_creds_env_vars_explicit_tenant_replaces_missing_env(
+        self, monkeypatch
+    ):
+        # Reproduces the original failure: `--tenant-id` on the CLI must let
+        # the certificate flow work even when AZURE_TENANT_ID is not set.
+        monkeypatch.setenv("AZURE_CLIENT_ID", self._CLIENT_ID)
+        monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+        monkeypatch.setenv("AZURE_CERTIFICATE_CONTENT", "unused-by-this-check")
+        AzureProvider.check_certificate_creds_env_vars(
+            check_certificate_content=True,
+            tenant_id=self._TENANT_ID,
+        )
+
     def test_validate_static_credentials_rejects_non_base64_cert_content(self):
         with pytest.raises(AzureNotValidCertificateContentError):
             AzureProvider.validate_static_credentials(
@@ -1985,6 +2000,48 @@ class TestAzureProviderCertificateAuth:
                 certificate_path=certificate_path,
             )
 
+    def test_verify_client_client_secret_timeout_translates_to_credentials_unavailable(
+        self,
+    ):
+        # A hung Entra ID token endpoint must surface as a typed Azure error
+        # instead of leaking `requests.exceptions.Timeout`; API and UI
+        # consumers rely on the typed error to render "credentials
+        # unavailable" instead of a raw transport exception.
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider.requests.post",
+                side_effect=requests.exceptions.Timeout("token endpoint hung"),
+            ),
+            pytest.raises(AzureCredentialsUnavailableError),
+        ):
+            AzureProvider.verify_client(
+                self._TENANT_ID,
+                self._CLIENT_ID,
+                "some-secret",
+                self._region_config(),
+            )
+
+    def test_test_connection_client_secret_timeout_returns_credentials_unavailable_error(
+        self,
+    ):
+        # `raise_on_exception=False` is the API contract: consumers must get
+        # `Connection(error=AzureCredentialsUnavailableError)` when the
+        # token endpoint stalls, never the raw `requests.exceptions.Timeout`.
+        with patch(
+            "prowler.providers.azure.azure_provider.requests.post",
+            side_effect=requests.exceptions.Timeout("token endpoint hung"),
+        ):
+            connection = AzureProvider.test_connection(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret="some-secret",
+                region="AzureCloud",
+                raise_on_exception=False,
+            )
+
+        assert connection.is_connected is False
+        assert isinstance(connection.error, AzureCredentialsUnavailableError)
+
     def test_verify_client_without_credential_material_returns(self):
         assert (
             AzureProvider.verify_client(
@@ -2455,6 +2512,80 @@ class TestValidateCertificateBundleOrdering:
         assert normalized.startswith(leaf_cert_pem)
         assert leaf_key_pem in normalized
         assert other_cert_pem not in normalized
+
+    def test_certificate_credential_receives_leaf_first_bundle(self, tmp_path):
+        # Bundles with the intermediate CA before the leaf must reach
+        # `CertificateCredential` with the leaf first — otherwise the
+        # thumbprint that azure-identity computes is the intermediate's
+        # and real authentication silently fails.
+        leaf_cert_pem, leaf_key_pem = self._self_signed()
+        other_cert_pem, _ = self._self_signed()
+        bundle = other_cert_pem + leaf_cert_pem + leaf_key_pem
+
+        import base64
+
+        from prowler.providers.azure.azure_provider import AzureProvider
+
+        certificate_path = tmp_path / "prowler-cert.pem"
+        certificate_path.write_bytes(bundle)
+
+        region_config = AzureProvider.setup_region_config("AzureCloud")
+
+        # Env-var / --certificate-path branch.
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider.CertificateCredential"
+            ) as cert_credential_env,
+            patch.dict(
+                "os.environ",
+                {
+                    "AZURE_CLIENT_ID": "87654321-4321-4321-4321-210987654321",
+                    "AZURE_TENANT_ID": "12345678-1234-1234-1234-123456789012",
+                },
+                clear=False,
+            ),
+        ):
+            AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=True,
+                certificate_path=str(certificate_path),
+                tenant_id=None,
+                azure_credentials=None,
+                region_config=region_config,
+            )
+
+        certificate_data = cert_credential_env.call_args.kwargs["certificate_data"]
+        assert certificate_data.startswith(leaf_cert_pem)
+        assert other_cert_pem not in certificate_data
+
+        # azure_credentials (API/UI) branch, certificate_content variant.
+        with patch(
+            "prowler.providers.azure.azure_provider.CertificateCredential"
+        ) as cert_credential_api:
+            AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=False,
+                certificate_path=None,
+                tenant_id=None,
+                azure_credentials={
+                    "tenant_id": "12345678-1234-1234-1234-123456789012",
+                    "client_id": "87654321-4321-4321-4321-210987654321",
+                    "client_secret": None,
+                    "certificate_content": base64.b64encode(bundle).decode(),
+                    "certificate_path": None,
+                },
+                region_config=region_config,
+            )
+
+        api_certificate_data = cert_credential_api.call_args.kwargs["certificate_data"]
+        assert api_certificate_data.startswith(leaf_cert_pem)
+        assert other_cert_pem not in api_certificate_data
 
     def test_rejects_password_protected_pem_key(self):
         from cryptography.hazmat.primitives import serialization

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -1298,7 +1298,7 @@ class TestAzureProviderCertificateAuth:
             )
         assert "not both" in exception.value.args[0]
 
-    def test_validate_arguments_rejects_cert_content_and_path_together(self):
+    def test_validate_arguments_rejects_cert_content_and_path_together(self, tmp_path):
         with pytest.raises(AzureConfigCredentialsError) as exception:
             AzureProvider.validate_arguments(
                 az_cli_auth=False,
@@ -1310,7 +1310,7 @@ class TestAzureProviderCertificateAuth:
                 client_id=self._CLIENT_ID,
                 client_secret=None,
                 certificate_content=self._CERT_CONTENT_B64,
-                certificate_path="/tmp/anything",
+                certificate_path=str(tmp_path / "anything"),
             )
         assert "not both" in exception.value.args[0]
 
@@ -1483,14 +1483,14 @@ class TestAzureProviderCertificateAuth:
                 region_config=self._region_config(),
             )
 
-    def test_validate_static_credentials_rejects_missing_cert_file(self):
+    def test_validate_static_credentials_rejects_missing_cert_file(self, tmp_path):
         with pytest.raises(AzureNotValidCertificatePathError):
             AzureProvider.validate_static_credentials(
                 tenant_id=self._TENANT_ID,
                 client_id=self._CLIENT_ID,
                 client_secret=None,
                 certificate_content=None,
-                certificate_path="/tmp/does-not-exist-prowler-cert.pem",
+                certificate_path=str(tmp_path / "does-not-exist-prowler-cert.pem"),
                 region_config=self._region_config(),
             )
 
@@ -2246,7 +2246,9 @@ class TestAzureProviderValidateArguments:
     _TENANT_ID = "12345678-1234-1234-1234-123456789012"
     _CLIENT_ID = "87654321-4321-4321-4321-210987654321"
 
-    def test_certificate_path_without_certificate_auth_or_static_trio_fails(self):
+    def test_certificate_path_without_certificate_auth_or_static_trio_fails(
+        self, tmp_path
+    ):
         # `--browser-auth --certificate-path X` used to parse cleanly and
         # silently drop the certificate in setup_session; now it fails fast.
         with pytest.raises(AzureConfigCredentialsError, match="--certificate-auth"):
@@ -2260,7 +2262,7 @@ class TestAzureProviderValidateArguments:
                 client_id=None,
                 client_secret=None,
                 certificate_content=None,
-                certificate_path="/tmp/prowler-cert.pem",
+                certificate_path=str(tmp_path / "prowler-cert.pem"),
             )
 
     def test_certificate_auth_with_only_tenant_id_does_not_raise(self):
@@ -2279,7 +2281,7 @@ class TestAzureProviderValidateArguments:
             certificate_path=None,
         )
 
-    def test_certificate_auth_with_certificate_path_only_does_not_raise(self):
+    def test_certificate_auth_with_certificate_path_only_does_not_raise(self, tmp_path):
         # The documented env-var + --certificate-path combination: setup_session
         # reads AZURE_TENANT_ID / AZURE_CLIENT_ID and loads the file from disk.
         AzureProvider.validate_arguments(
@@ -2292,7 +2294,7 @@ class TestAzureProviderValidateArguments:
             client_id=None,
             client_secret=None,
             certificate_content=None,
-            certificate_path="/tmp/prowler-cert.pem",
+            certificate_path=str(tmp_path / "prowler-cert.pem"),
         )
 
 
@@ -2349,7 +2351,7 @@ class TestAzureProviderSetupSessionCertificateOverrides:
             patch(
                 "prowler.providers.azure.azure_provider._build_certificate_credential"
             ) as build_certificate_credential,
-            pytest.raises(AzureSetUpSessionError),
+            pytest.raises(AzureNotValidCertificatePathError),
         ):
             AzureProvider.setup_session(
                 az_cli_auth=False,

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -1644,9 +1644,15 @@ class TestAzureProviderCertificateAuth:
         # When the credentials dict carries a certificate_content, setup_session
         # must instantiate CertificateCredential (not ClientSecretCredential)
         # with the decoded bytes.
-        with patch(
-            "prowler.providers.azure.azure_provider.CertificateCredential"
-        ) as mock_cert_cred:
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider.validate_certificate_bundle",
+                side_effect=lambda data: data,
+            ),
+            patch(
+                "prowler.providers.azure.azure_provider.CertificateCredential"
+            ) as mock_cert_cred,
+        ):
             AzureProvider.setup_session(
                 az_cli_auth=False,
                 sp_env_auth=False,
@@ -1678,10 +1684,16 @@ class TestAzureProviderCertificateAuth:
         certificate_path.write_bytes(b"certificate bundle")
         expected_credentials = MagicMock()
 
-        with patch(
-            "prowler.providers.azure.azure_provider._build_certificate_credential",
-            return_value=expected_credentials,
-        ) as build_certificate_credential:
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider.validate_certificate_bundle",
+                side_effect=lambda data: data,
+            ),
+            patch(
+                "prowler.providers.azure.azure_provider._build_certificate_credential",
+                return_value=expected_credentials,
+            ) as build_certificate_credential,
+        ):
             credentials = AzureProvider.setup_session(
                 az_cli_auth=False,
                 sp_env_auth=False,
@@ -1713,7 +1725,10 @@ class TestAzureProviderCertificateAuth:
         monkeypatch.setenv("AZURE_TENANT_ID", self._TENANT_ID)
         monkeypatch.setenv("AZURE_CERTIFICATE_CONTENT", self._CERT_CONTENT_B64)
         with (
-            patch("prowler.providers.azure.azure_provider.validate_certificate_bundle"),
+            patch(
+                "prowler.providers.azure.azure_provider.validate_certificate_bundle",
+                side_effect=lambda data: data,
+            ),
             patch(
                 "prowler.providers.azure.azure_provider.CertificateCredential"
             ) as mock_cert_cred,
@@ -1744,7 +1759,10 @@ class TestAzureProviderCertificateAuth:
         expected_credentials = MagicMock()
 
         with (
-            patch("prowler.providers.azure.azure_provider.validate_certificate_bundle"),
+            patch(
+                "prowler.providers.azure.azure_provider.validate_certificate_bundle",
+                side_effect=lambda data: data,
+            ),
             patch(
                 "prowler.providers.azure.azure_provider._build_certificate_credential",
                 return_value=expected_credentials,
@@ -1810,7 +1828,10 @@ class TestAzureProviderCertificateAuth:
             # fail fast on unparseable bytes; this test isolates the
             # authentication-error translation path, so keep the placeholder
             # base64 payload from tripping the bundle check.
-            patch("prowler.providers.azure.azure_provider.validate_certificate_bundle"),
+            patch(
+                "prowler.providers.azure.azure_provider.validate_certificate_bundle",
+                side_effect=lambda data: data,
+            ),
             patch(
                 "prowler.providers.azure.azure_provider._build_certificate_credential",
                 side_effect=ClientAuthenticationError("invalid certificate"),
@@ -1873,9 +1894,15 @@ class TestAzureProviderCertificateAuth:
     def test_verify_client_certificate_content_acquires_graph_token(self):
         import base64
 
-        with patch(
-            "prowler.providers.azure.azure_provider.CertificateCredential"
-        ) as certificate_credential:
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider.CertificateCredential"
+            ) as certificate_credential,
+            patch(
+                "prowler.providers.azure.azure_provider.validate_certificate_bundle",
+                side_effect=lambda data: data,
+            ),
+        ):
             AzureProvider.verify_client(
                 self._TENANT_ID,
                 self._CLIENT_ID,
@@ -1898,9 +1925,15 @@ class TestAzureProviderCertificateAuth:
         certificate_path = tmp_path / "prowler-cert.pem"
         certificate_path.write_bytes(b"certificate bundle")
 
-        with patch(
-            "prowler.providers.azure.azure_provider.CertificateCredential"
-        ) as certificate_credential:
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider.CertificateCredential"
+            ) as certificate_credential,
+            patch(
+                "prowler.providers.azure.azure_provider.validate_certificate_bundle",
+                side_effect=lambda data: data,
+            ),
+        ):
             AzureProvider.verify_client(
                 self._TENANT_ID,
                 self._CLIENT_ID,
@@ -1936,6 +1969,10 @@ class TestAzureProviderCertificateAuth:
             patch(
                 "prowler.providers.azure.azure_provider.CertificateCredential",
                 side_effect=ClientAuthenticationError("invalid certificate"),
+            ),
+            patch(
+                "prowler.providers.azure.azure_provider.validate_certificate_bundle",
+                side_effect=lambda data: data,
             ),
             pytest.raises(expected_error),
         ):

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -1391,6 +1391,37 @@ class TestAzureProviderCertificateAuth:
                 region_config=self._region_config(),
             )
 
+    def test_validate_static_credentials_accepts_wrapped_base64_cert_content(self):
+        # `openssl base64 -in cert.pfx` wraps at 64 columns by default and
+        # every shell command substitution adds a trailing newline. The
+        # UX target is that both are accepted without the operator having
+        # to strip whitespace by hand — strict `validate=True` decoding
+        # would otherwise reject perfectly valid payloads with a
+        # misleading `binascii.Error`.
+        import base64
+        import textwrap
+
+        bundle = self._leaf_first_bundle()
+        wrapped_with_trailing_newline = (
+            textwrap.fill(base64.b64encode(bundle).decode("ascii"), width=64) + "\n"
+        )
+
+        with patch.object(AzureProvider, "verify_client"):
+            credentials = AzureProvider.validate_static_credentials(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                client_secret=None,
+                certificate_content=wrapped_with_trailing_newline,
+                certificate_path=None,
+                region_config=self._region_config(),
+            )
+
+        # `validate_static_credentials` re-encodes the normalized bundle
+        # into `certificate_content`; the returned value must decode
+        # cleanly with strict validation and match the original bundle.
+        stored = base64.b64decode(credentials["certificate_content"], validate=True)
+        assert stored == bundle
+
     def test_validate_static_credentials_rejects_key_only_pem(self):
         import base64
 
@@ -2214,6 +2245,47 @@ class TestAzureProviderCertificateAuth:
                     self._leaf_first_bundle()
                 ).decode(),
             )
+
+    def test_verify_client_certificate_cleanup_failure_still_closes_transport(self):
+        # When `credential.close()` fails, `verify_client` must still fall
+        # back to closing the underlying `RequestsTransport`; otherwise the
+        # transport (and its connection pool + retry thread) leaks for the
+        # lifetime of the worker every time Entra ID misbehaves.
+        import base64
+
+        from azure.core.pipeline.transport import RequestsTransport
+
+        with (
+            patch.object(
+                requests.Session,
+                "request",
+                side_effect=requests.ConnectTimeout("hung transport"),
+            ),
+            patch(
+                "azure.identity.CertificateCredential.close",
+                side_effect=RuntimeError("close boom"),
+            ),
+            patch.object(
+                RequestsTransport,
+                "close",
+                autospec=True,
+            ) as transport_close,
+            pytest.raises(AzureCredentialsUnavailableError),
+        ):
+            AzureProvider.verify_client(
+                self._TENANT_ID,
+                self._CLIENT_ID,
+                client_secret=None,
+                region_config=self._region_config(),
+                certificate_content=base64.b64encode(
+                    self._leaf_first_bundle()
+                ).decode(),
+            )
+
+        assert transport_close.called, (
+            "transport.close() must be invoked as a fallback when "
+            "credential.close() fails, otherwise the transport leaks"
+        )
 
     def test_verify_client_without_credential_material_returns(self):
         assert (
@@ -3063,6 +3135,35 @@ class TestAzureProviderSignatureCompatibility:
             assert (
                 parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
             ), f"setup_session: {name} must be keyword-only"
+
+    def test_setup_identity_positional_call_still_binds_subscription_ids(self):
+        import inspect
+
+        # Master signature: `self, az_cli_auth, sp_env_auth, browser_auth,
+        # managed_identity_auth, subscription_ids, client_id`. Inserting
+        # `certificate_auth` as a positional between `managed_identity_auth`
+        # and `subscription_ids` would silently rebind existing callers.
+        signature = inspect.signature(AzureProvider.setup_identity)
+        bound = signature.bind(
+            None,  # self
+            False,  # az_cli_auth
+            False,  # sp_env_auth
+            False,  # browser_auth
+            False,  # managed_identity_auth
+            ["sub-a"],  # subscription_ids
+            self._CLIENT_ID,  # client_id
+        )
+
+        assert bound.arguments["subscription_ids"] == ["sub-a"]
+        assert bound.arguments["client_id"] == self._CLIENT_ID
+        assert "certificate_auth" not in bound.arguments
+
+        # `certificate_auth` is the only certificate parameter in
+        # `setup_identity`; assert it is keyword-only.
+        parameters = inspect.signature(AzureProvider.setup_identity).parameters
+        assert (
+            parameters["certificate_auth"].kind is inspect.Parameter.KEYWORD_ONLY
+        ), "setup_identity: certificate_auth must be keyword-only"
 
 
 class TestValidateCertificateBundleMultiKey:

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -3004,6 +3004,142 @@ class TestAzureProviderSignatureCompatibility:
                 parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
             ), f"validate_static_credentials: {name} must be keyword-only"
 
+    def test_validate_arguments_positional_call_still_binds_tenant_and_client(self):
+        import inspect
+
+        # Master signature: `..., managed_identity_auth, tenant_id, client_id,
+        # client_secret`. Any external caller passing everything positionally
+        # must keep binding those three slots to the right names.
+        signature = inspect.signature(AzureProvider.validate_arguments)
+        bound = signature.bind(
+            False,  # az_cli_auth
+            False,  # sp_env_auth
+            False,  # browser_auth
+            False,  # managed_identity_auth
+            self._TENANT_ID,  # tenant_id
+            self._CLIENT_ID,  # client_id
+            "some-secret",  # client_secret
+        )
+
+        assert bound.arguments["tenant_id"] == self._TENANT_ID
+        assert bound.arguments["client_id"] == self._CLIENT_ID
+        assert bound.arguments["client_secret"] == "some-secret"
+        assert "certificate_auth" not in bound.arguments
+        assert "certificate_content" not in bound.arguments
+        assert "certificate_path" not in bound.arguments
+
+        self._assert_certificate_kwargs_are_keyword_only(
+            AzureProvider.validate_arguments
+        )
+
+    def test_setup_session_positional_call_still_binds_tenant_and_credentials(self):
+        import inspect
+
+        # Master signature: `..., managed_identity_auth, tenant_id,
+        # azure_credentials, region_config`. Callers passing the pre-cert
+        # positional shape must not rebind those slots.
+        signature = inspect.signature(AzureProvider.setup_session)
+        region_config = AzureProvider.setup_region_config("AzureCloud")
+        bound = signature.bind(
+            False,  # az_cli_auth
+            False,  # sp_env_auth
+            False,  # browser_auth
+            False,  # managed_identity_auth
+            self._TENANT_ID,  # tenant_id
+            {"tenant_id": self._TENANT_ID},  # azure_credentials
+            region_config,  # region_config
+        )
+
+        assert bound.arguments["tenant_id"] == self._TENANT_ID
+        assert bound.arguments["azure_credentials"] == {"tenant_id": self._TENANT_ID}
+        assert bound.arguments["region_config"] is region_config
+        assert "certificate_auth" not in bound.arguments
+        assert "certificate_path" not in bound.arguments
+
+        # Only the two certificate parameters are keyword-only in
+        # `setup_session` — `certificate_content` is not part of its shape.
+        parameters = inspect.signature(AzureProvider.setup_session).parameters
+        for name in ("certificate_auth", "certificate_path"):
+            assert (
+                parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+            ), f"setup_session: {name} must be keyword-only"
+
+
+class TestValidateCertificateBundleMultiKey:
+    """A PEM bundle may legitimately carry more than one private key block
+    (e.g. legacy tools that export both RSA and PKCS#8 encodings). The
+    normalizer must locate the key that actually pairs with the leaf
+    certificate, not stop at the first `-----BEGIN PRIVATE KEY-----`."""
+
+    def _self_signed(self):
+        from datetime import datetime, timedelta, timezone
+
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Prowler")])
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .sign(private_key, hashes.SHA256())
+        )
+        cert_pem = certificate.public_bytes(serialization.Encoding.PEM)
+        key_pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        return cert_pem, key_pem
+
+    def test_normalizes_when_matching_key_is_second_in_bundle(self):
+        from prowler.providers.azure.lib.certificate import (
+            validate_certificate_bundle,
+        )
+
+        _, unrelated_key_pem = self._self_signed()
+        leaf_cert_pem, leaf_key_pem = self._self_signed()
+
+        # First private key belongs to an unrelated pair; the leaf's key is
+        # the second block. `.search` used to stop at the first match and
+        # falsely reject the bundle.
+        bundle = leaf_cert_pem + unrelated_key_pem + leaf_key_pem
+
+        normalized = validate_certificate_bundle(bundle)
+
+        assert normalized.startswith(leaf_cert_pem)
+        assert leaf_key_pem in normalized
+
+    def test_encrypted_single_key_still_raises_type_error(self):
+        # Guardrail for the multi-key iteration: an encrypted single key
+        # must still surface `TypeError`, which the SDK caller relies on to
+        # route to `AzureNotValidCertificateContentError`.
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        from prowler.providers.azure.lib.certificate import (
+            validate_certificate_bundle,
+        )
+
+        cert_pem, _ = self._self_signed()
+        encrypted_key_pem = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048
+        ).private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.BestAvailableEncryption(b"prowler"),
+        )
+
+        with pytest.raises(TypeError):
+            validate_certificate_bundle(cert_pem + encrypted_key_pem)
+
 
 def serialization_no_encryption():
     # Kept out of the test method so the PKCS#12 test reads cleanly. Wraps

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -2075,25 +2075,25 @@ class TestAzureProviderCertificateAuth:
             encryption_algorithm=serialization.NoEncryption(),
         )
 
-    def test_verify_client_certificate_content_timeout_translates_to_credentials_unavailable(
+    def test_verify_client_certificate_content_connect_timeout_translates_to_credentials_unavailable(
         self,
     ):
-        # The certificate path enforces the deadline on the HTTP transport,
-        # so a hung Entra ID endpoint surfaces as `ServiceRequestError`.
-        # `verify_client` must translate it to the typed Azure error.
+        # Exercise the full pipeline: real `CertificateCredential`,
+        # real `RequestsTransport`, only the underlying `requests.Session`
+        # is stubbed. `azure.identity` decorates `_request_token` with
+        # `wrap_exceptions`, so the transport's `ConnectTimeout` reaches
+        # `verify_client` as `ClientAuthenticationError` with the
+        # `ServiceRequestError` cause preserved via `__cause__`.
         import base64
 
-        from azure.core.exceptions import ServiceRequestError
-
         with (
-            patch(
-                "prowler.providers.azure.azure_provider.CertificateCredential"
-            ) as cert_credential_cls,
+            patch.object(
+                requests.Session,
+                "request",
+                side_effect=requests.ConnectTimeout("hung transport"),
+            ) as session_request,
             pytest.raises(AzureCredentialsUnavailableError),
         ):
-            cert_credential_cls.return_value.get_token.side_effect = (
-                ServiceRequestError("hung transport")
-            )
             AzureProvider.verify_client(
                 self._TENANT_ID,
                 self._CLIENT_ID,
@@ -2104,23 +2104,27 @@ class TestAzureProviderCertificateAuth:
                 ).decode(),
             )
 
-    def test_verify_client_certificate_path_timeout_translates_to_credentials_unavailable(
+        # `retry_total=0` on the credential — Azure Core must not replay
+        # the failed transport request.
+        assert session_request.call_count == 1
+
+    def test_verify_client_certificate_path_read_timeout_translates_to_credentials_unavailable(
         self, tmp_path
     ):
-        from azure.core.exceptions import ServiceRequestError
-
+        # `requests.ReadTimeout` becomes `ServiceResponseError` in Azure
+        # Core (not `ServiceRequestError`), so this test also covers the
+        # `ServiceResponseError` branch of the cause-chain walk.
         certificate_path = tmp_path / "prowler-cert.pem"
         certificate_path.write_bytes(self._leaf_first_bundle())
 
         with (
-            patch(
-                "prowler.providers.azure.azure_provider.CertificateCredential"
-            ) as cert_credential_cls,
+            patch.object(
+                requests.Session,
+                "request",
+                side_effect=requests.ReadTimeout("read timed out"),
+            ) as session_request,
             pytest.raises(AzureCredentialsUnavailableError),
         ):
-            cert_credential_cls.return_value.get_token.side_effect = (
-                ServiceRequestError("hung transport")
-            )
             AzureProvider.verify_client(
                 self._TENANT_ID,
                 self._CLIENT_ID,
@@ -2129,7 +2133,9 @@ class TestAzureProviderCertificateAuth:
                 certificate_path=str(certificate_path),
             )
 
-    def test_test_connection_certificate_content_timeout_returns_credentials_unavailable_error(
+        assert session_request.call_count == 1
+
+    def test_test_connection_certificate_content_transport_timeout_returns_credentials_unavailable_error(
         self,
     ):
         # `raise_on_exception=False` is the API contract for the certificate
@@ -2137,14 +2143,11 @@ class TestAzureProviderCertificateAuth:
         # `Connection(error=AzureCredentialsUnavailableError)`.
         import base64
 
-        from azure.core.exceptions import ServiceRequestError
-
-        with patch(
-            "prowler.providers.azure.azure_provider.CertificateCredential"
-        ) as cert_credential_cls:
-            cert_credential_cls.return_value.get_token.side_effect = (
-                ServiceRequestError("hung transport")
-            )
+        with patch.object(
+            requests.Session,
+            "request",
+            side_effect=requests.ConnectTimeout("hung transport"),
+        ) as session_request:
             connection = AzureProvider.test_connection(
                 tenant_id=self._TENANT_ID,
                 client_id=self._CLIENT_ID,
@@ -2158,21 +2161,19 @@ class TestAzureProviderCertificateAuth:
 
         assert connection.is_connected is False
         assert isinstance(connection.error, AzureCredentialsUnavailableError)
+        assert session_request.call_count == 1
 
-    def test_test_connection_certificate_path_timeout_returns_credentials_unavailable_error(
+    def test_test_connection_certificate_path_transport_timeout_returns_credentials_unavailable_error(
         self, tmp_path
     ):
-        from azure.core.exceptions import ServiceRequestError
-
         certificate_path = tmp_path / "prowler-cert.pem"
         certificate_path.write_bytes(self._leaf_first_bundle())
 
-        with patch(
-            "prowler.providers.azure.azure_provider.CertificateCredential"
-        ) as cert_credential_cls:
-            cert_credential_cls.return_value.get_token.side_effect = (
-                ServiceRequestError("hung transport")
-            )
+        with patch.object(
+            requests.Session,
+            "request",
+            side_effect=requests.ReadTimeout("read timed out"),
+        ) as session_request:
             connection = AzureProvider.test_connection(
                 tenant_id=self._TENANT_ID,
                 client_id=self._CLIENT_ID,
@@ -2184,6 +2185,35 @@ class TestAzureProviderCertificateAuth:
 
         assert connection.is_connected is False
         assert isinstance(connection.error, AzureCredentialsUnavailableError)
+        assert session_request.call_count == 1
+
+    def test_verify_client_certificate_cleanup_failure_preserves_typed_error(self):
+        # A failure in `credential.close()` must not replace the primary
+        # `AzureCredentialsUnavailableError`: the caller has to see the
+        # actionable transport error, not a cleanup traceback.
+        import base64
+
+        with (
+            patch.object(
+                requests.Session,
+                "request",
+                side_effect=requests.ConnectTimeout("hung transport"),
+            ),
+            patch(
+                "azure.identity.CertificateCredential.close",
+                side_effect=RuntimeError("close boom"),
+            ),
+            pytest.raises(AzureCredentialsUnavailableError),
+        ):
+            AzureProvider.verify_client(
+                self._TENANT_ID,
+                self._CLIENT_ID,
+                client_secret=None,
+                region_config=self._region_config(),
+                certificate_content=base64.b64encode(
+                    self._leaf_first_bundle()
+                ).decode(),
+            )
 
     def test_verify_client_without_credential_material_returns(self):
         assert (
@@ -2866,6 +2896,113 @@ class TestValidateCertificateBundleOrdering:
         stored_bundle = base64.b64decode(credentials["certificate_content"])
         assert stored_bundle.startswith(leaf_cert_pem)
         assert other_cert_pem not in stored_bundle
+
+
+class TestAzureProviderSignatureCompatibility:
+    """Every public entry point the certificate work touched has to preserve
+    the previous positional layout — inserting the cert kwargs anywhere
+    ahead of an existing positional parameter silently rebinds callers.
+    Freeze that contract with `inspect.signature(...).bind(...)`."""
+
+    _TENANT_ID = "12345678-1234-1234-1234-123456789012"
+    _CLIENT_ID = "87654321-4321-4321-4321-210987654321"
+
+    def _assert_certificate_kwargs_are_keyword_only(self, callable_):
+        import inspect
+
+        parameters = inspect.signature(callable_).parameters
+        for name in ("certificate_auth", "certificate_content", "certificate_path"):
+            if name in parameters:
+                assert (
+                    parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+                ), f"{callable_.__qualname__}: {name} must be keyword-only"
+
+    def test_azure_provider_init_positional_call_still_binds_resource_groups(self):
+        import inspect
+
+        # Master signature: `..., client_id, client_secret, resource_groups`.
+        # A caller passing everything positionally must still land
+        # `["rg-a"]` on `resource_groups`, not on any cert flag.
+        signature = inspect.signature(AzureProvider.__init__)
+        bound = signature.bind(
+            None,  # self
+            False,  # az_cli_auth
+            False,  # sp_env_auth
+            False,  # browser_auth
+            False,  # managed_identity_auth
+            self._TENANT_ID,  # tenant_id
+            "AzureCloud",  # region
+            [],  # subscription_ids
+            None,  # config_path
+            None,  # config_content
+            {},  # fixer_config
+            None,  # mutelist_path
+            None,  # mutelist_content
+            self._CLIENT_ID,  # client_id
+            "some-secret",  # client_secret
+            ["rg-a"],  # resource_groups
+        )
+
+        assert bound.arguments["resource_groups"] == ["rg-a"]
+        assert "certificate_auth" not in bound.arguments
+        assert "certificate_content" not in bound.arguments
+        assert "certificate_path" not in bound.arguments
+
+        self._assert_certificate_kwargs_are_keyword_only(AzureProvider.__init__)
+
+    def test_test_connection_positional_call_still_binds_provider_id(self):
+        import inspect
+
+        # Master signature: `..., client_id, client_secret, provider_id`.
+        signature = inspect.signature(AzureProvider.test_connection)
+        bound = signature.bind(
+            False,  # az_cli_auth
+            False,  # sp_env_auth
+            False,  # browser_auth
+            False,  # managed_identity_auth
+            self._TENANT_ID,  # tenant_id
+            "AzureCloud",  # region
+            True,  # raise_on_exception
+            self._CLIENT_ID,  # client_id
+            "some-secret",  # client_secret
+            "sub-id",  # provider_id
+        )
+
+        assert bound.arguments["provider_id"] == "sub-id"
+        assert "certificate_auth" not in bound.arguments
+        assert "certificate_content" not in bound.arguments
+        assert "certificate_path" not in bound.arguments
+
+        self._assert_certificate_kwargs_are_keyword_only(AzureProvider.test_connection)
+
+    def test_validate_static_credentials_positional_call_still_binds_region_config(
+        self,
+    ):
+        import inspect
+
+        # Master signature: `tenant_id, client_id, client_secret, region_config`.
+        signature = inspect.signature(AzureProvider.validate_static_credentials)
+        region_config = AzureProvider.setup_region_config("AzureCloud")
+        bound = signature.bind(
+            self._TENANT_ID,  # tenant_id
+            self._CLIENT_ID,  # client_id
+            "some-secret",  # client_secret
+            region_config,  # region_config
+        )
+
+        assert bound.arguments["region_config"] is region_config
+        assert "certificate_content" not in bound.arguments
+        assert "certificate_path" not in bound.arguments
+
+        # Only the certificate content/path are keyword-only here;
+        # `certificate_auth` is not part of this signature.
+        parameters = inspect.signature(
+            AzureProvider.validate_static_credentials
+        ).parameters
+        for name in ("certificate_content", "certificate_path"):
+            assert (
+                parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+            ), f"validate_static_credentials: {name} must be keyword-only"
 
 
 def serialization_no_encryption():

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -2448,9 +2448,36 @@ class TestValidateCertificateBundleOrdering:
 
         bundle = other_cert_pem + leaf_cert_pem + leaf_key_pem
 
-        # No exception: `validate_certificate_bundle` walks every cert block
-        # and pairs the private key with the one that actually matches.
-        validate_certificate_bundle(bundle)
+        normalized = validate_certificate_bundle(bundle)
+
+        # The matching leaf must come first: azure-identity uses the first
+        # BEGIN CERTIFICATE block to compute the credential thumbprint.
+        assert normalized.startswith(leaf_cert_pem)
+        assert leaf_key_pem in normalized
+        assert other_cert_pem not in normalized
+
+    def test_rejects_password_protected_pem_key(self):
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        from prowler.providers.azure.lib.certificate import (
+            validate_certificate_bundle,
+        )
+
+        cert_pem, _ = self._self_signed()
+        encrypted_key_pem = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048
+        ).private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.BestAvailableEncryption(b"prowler"),
+        )
+
+        # `load_pem_private_key(password=None)` raises TypeError for
+        # encrypted keys; the caller relies on that exception type to route
+        # to the typed certificate errors.
+        with pytest.raises(TypeError):
+            validate_certificate_bundle(cert_pem + encrypted_key_pem)
 
 
 def serialization_no_encryption():

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -2042,6 +2042,154 @@ class TestAzureProviderCertificateAuth:
         assert connection.is_connected is False
         assert isinstance(connection.error, AzureCredentialsUnavailableError)
 
+    @staticmethod
+    def _leaf_first_bundle():
+        # Reuse the leaf-first helper from the ordering suite so certificate
+        # timeout tests exercise a real bundle instead of the tiny DER blob.
+        from datetime import datetime, timedelta, timezone
+
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Prowler")])
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .sign(private_key, hashes.SHA256())
+        )
+        return certificate.public_bytes(
+            serialization.Encoding.PEM
+        ) + private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+    def test_verify_client_certificate_content_timeout_translates_to_credentials_unavailable(
+        self,
+    ):
+        # The certificate path runs token acquisition on a
+        # `ThreadPoolExecutor` because `get_token` has no native timeout.
+        # A hung Entra ID endpoint surfaces as `FuturesTimeoutError` and
+        # must be translated to the typed Azure error.
+        import base64
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        with (
+            patch("prowler.providers.azure.azure_provider.CertificateCredential"),
+            patch(
+                "prowler.providers.azure.azure_provider.ThreadPoolExecutor"
+            ) as executor_cls,
+            pytest.raises(AzureCredentialsUnavailableError),
+        ):
+            executor_cls.return_value.submit.return_value.result.side_effect = (
+                FuturesTimeoutError()
+            )
+            AzureProvider.verify_client(
+                self._TENANT_ID,
+                self._CLIENT_ID,
+                client_secret=None,
+                region_config=self._region_config(),
+                certificate_content=base64.b64encode(
+                    self._leaf_first_bundle()
+                ).decode(),
+            )
+
+    def test_verify_client_certificate_path_timeout_translates_to_credentials_unavailable(
+        self, tmp_path
+    ):
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        certificate_path = tmp_path / "prowler-cert.pem"
+        certificate_path.write_bytes(self._leaf_first_bundle())
+
+        with (
+            patch("prowler.providers.azure.azure_provider.CertificateCredential"),
+            patch(
+                "prowler.providers.azure.azure_provider.ThreadPoolExecutor"
+            ) as executor_cls,
+            pytest.raises(AzureCredentialsUnavailableError),
+        ):
+            executor_cls.return_value.submit.return_value.result.side_effect = (
+                FuturesTimeoutError()
+            )
+            AzureProvider.verify_client(
+                self._TENANT_ID,
+                self._CLIENT_ID,
+                client_secret=None,
+                region_config=self._region_config(),
+                certificate_path=str(certificate_path),
+            )
+
+    def test_test_connection_certificate_content_timeout_returns_credentials_unavailable_error(
+        self,
+    ):
+        # `raise_on_exception=False` is the API contract for the certificate
+        # path too: consumers must receive
+        # `Connection(error=AzureCredentialsUnavailableError)`.
+        import base64
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        with (
+            patch("prowler.providers.azure.azure_provider.CertificateCredential"),
+            patch(
+                "prowler.providers.azure.azure_provider.ThreadPoolExecutor"
+            ) as executor_cls,
+        ):
+            executor_cls.return_value.submit.return_value.result.side_effect = (
+                FuturesTimeoutError()
+            )
+            connection = AzureProvider.test_connection(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                certificate_auth=True,
+                certificate_content=base64.b64encode(
+                    self._leaf_first_bundle()
+                ).decode(),
+                region="AzureCloud",
+                raise_on_exception=False,
+            )
+
+        assert connection.is_connected is False
+        assert isinstance(connection.error, AzureCredentialsUnavailableError)
+
+    def test_test_connection_certificate_path_timeout_returns_credentials_unavailable_error(
+        self, tmp_path
+    ):
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        certificate_path = tmp_path / "prowler-cert.pem"
+        certificate_path.write_bytes(self._leaf_first_bundle())
+
+        with (
+            patch("prowler.providers.azure.azure_provider.CertificateCredential"),
+            patch(
+                "prowler.providers.azure.azure_provider.ThreadPoolExecutor"
+            ) as executor_cls,
+        ):
+            executor_cls.return_value.submit.return_value.result.side_effect = (
+                FuturesTimeoutError()
+            )
+            connection = AzureProvider.test_connection(
+                tenant_id=self._TENANT_ID,
+                client_id=self._CLIENT_ID,
+                certificate_auth=True,
+                certificate_path=str(certificate_path),
+                region="AzureCloud",
+                raise_on_exception=False,
+            )
+
+        assert connection.is_connected is False
+        assert isinstance(connection.error, AzureCredentialsUnavailableError)
+
     def test_verify_client_without_credential_material_returns(self):
         assert (
             AzureProvider.verify_client(
@@ -2609,6 +2757,136 @@ class TestValidateCertificateBundleOrdering:
         # to the typed certificate errors.
         with pytest.raises(TypeError):
             validate_certificate_bundle(cert_pem + encrypted_key_pem)
+
+    def test_setup_session_azure_credentials_certificate_path_receives_leaf_first_bundle(
+        self, tmp_path
+    ):
+        # `setup_session` has a distinct branch for the API/UI path when the
+        # bundle is delivered as a file path instead of inline base64. It
+        # must also normalize before instantiating `CertificateCredential`.
+        leaf_cert_pem, leaf_key_pem = self._self_signed()
+        other_cert_pem, _ = self._self_signed()
+        bundle = other_cert_pem + leaf_cert_pem + leaf_key_pem
+
+        certificate_path = tmp_path / "prowler-cert.pem"
+        certificate_path.write_bytes(bundle)
+
+        region_config = AzureProvider.setup_region_config("AzureCloud")
+
+        with patch(
+            "prowler.providers.azure.azure_provider.CertificateCredential"
+        ) as cert_credential:
+            AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                certificate_auth=False,
+                certificate_path=None,
+                tenant_id=None,
+                azure_credentials={
+                    "tenant_id": "12345678-1234-1234-1234-123456789012",
+                    "client_id": "87654321-4321-4321-4321-210987654321",
+                    "client_secret": None,
+                    "certificate_content": None,
+                    "certificate_path": str(certificate_path),
+                },
+                region_config=region_config,
+            )
+
+        certificate_data = cert_credential.call_args.kwargs["certificate_data"]
+        assert certificate_data.startswith(leaf_cert_pem)
+        assert other_cert_pem not in certificate_data
+
+    def test_verify_client_certificate_content_receives_leaf_first_bundle(self):
+        # `verify_client` builds its own `CertificateCredential` (not via
+        # `_build_certificate_credential`), so the leaf-first invariant must
+        # be verified here too.
+        import base64
+
+        leaf_cert_pem, leaf_key_pem = self._self_signed()
+        other_cert_pem, _ = self._self_signed()
+        bundle = other_cert_pem + leaf_cert_pem + leaf_key_pem
+
+        region_config = AzureProvider.setup_region_config("AzureCloud")
+
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider.CertificateCredential"
+            ) as cert_credential,
+            patch(
+                "prowler.providers.azure.azure_provider.ThreadPoolExecutor"
+            ) as executor_cls,
+        ):
+            executor_cls.return_value.submit.return_value.result.return_value = (
+                MagicMock()
+            )
+            AzureProvider.verify_client(
+                "12345678-1234-1234-1234-123456789012",
+                "87654321-4321-4321-4321-210987654321",
+                client_secret=None,
+                region_config=region_config,
+                certificate_content=base64.b64encode(bundle).decode(),
+            )
+
+        certificate_data = cert_credential.call_args.kwargs["certificate_data"]
+        assert certificate_data.startswith(leaf_cert_pem)
+        assert other_cert_pem not in certificate_data
+
+    def test_verify_client_certificate_path_receives_leaf_first_bundle(self, tmp_path):
+        leaf_cert_pem, leaf_key_pem = self._self_signed()
+        other_cert_pem, _ = self._self_signed()
+        bundle = other_cert_pem + leaf_cert_pem + leaf_key_pem
+
+        certificate_path = tmp_path / "prowler-cert.pem"
+        certificate_path.write_bytes(bundle)
+
+        region_config = AzureProvider.setup_region_config("AzureCloud")
+
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider.CertificateCredential"
+            ) as cert_credential,
+            patch(
+                "prowler.providers.azure.azure_provider.ThreadPoolExecutor"
+            ) as executor_cls,
+        ):
+            executor_cls.return_value.submit.return_value.result.return_value = (
+                MagicMock()
+            )
+            AzureProvider.verify_client(
+                "12345678-1234-1234-1234-123456789012",
+                "87654321-4321-4321-4321-210987654321",
+                client_secret=None,
+                region_config=region_config,
+                certificate_path=str(certificate_path),
+            )
+
+        certificate_data = cert_credential.call_args.kwargs["certificate_data"]
+        assert certificate_data.startswith(leaf_cert_pem)
+        assert other_cert_pem not in certificate_data
+
+    def test_validate_static_credentials_returns_leaf_first_certificate_content(self):
+        # `validate_static_credentials` re-encodes the certificate_content
+        # after normalization so downstream `CertificateCredential` calls
+        # never re-parse the un-normalized bundle. The persisted value must
+        # decode back to leaf-first bytes.
+        import base64
+
+        leaf_cert_pem, leaf_key_pem = self._self_signed()
+        other_cert_pem, _ = self._self_signed()
+        bundle = other_cert_pem + leaf_cert_pem + leaf_key_pem
+
+        with patch.object(AzureProvider, "verify_client"):
+            credentials = AzureProvider.validate_static_credentials(
+                tenant_id="12345678-1234-1234-1234-123456789012",
+                client_id="87654321-4321-4321-4321-210987654321",
+                certificate_content=base64.b64encode(bundle).decode(),
+            )
+
+        stored_bundle = base64.b64decode(credentials["certificate_content"])
+        assert stored_bundle.startswith(leaf_cert_pem)
+        assert other_cert_pem not in stored_bundle
 
 
 def serialization_no_encryption():


### PR DESCRIPTION
### Context

Part of [PROWLER-2378](https://prowlerpro.atlassian.net/browse/PROWLER-2378): Deploy-to-Azure quick-start with certificate-based authentication for the Azure provider.

This is the **first PR of a stack of three**:

1. **This PR** — SDK changes (Azure provider, CLI flags, key-pair validation, tests)
2. #12527 — API changes (serializer, validator, OpenAPI schema — closes #12518)
3. #12528 — UI wizard, Bicep template, and documentation

### Description

Add certificate-based Service Principal authentication to the Azure provider, mirroring the M365 provider flow.

**SDK changes:**
- `AzureProvider` accepts a certificate credential (base64 content or file path) and authenticates via `azure.identity.CertificateCredential`
- New `prowler/providers/azure/lib/certificate.py` — validates PEM and PKCS#12 bundles, rejects malformed input or key-only files
- CLI flags: `--certificate-auth`, `--certificate-content`, `--certificate-path`
- Env var support: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CERTIFICATE_CONTENT`
- `test_connection` extended to accept the new certificate parameters (keyword-only)

### Steps to review

1. Verify the certificate authentication code path in `prowler/providers/azure/azure_provider.py` and helper module `prowler/providers/azure/lib/certificate.py`
2. Confirm CLI flags in `prowler/providers/azure/lib/arguments/arguments.py`
3. Run the unit tests:
   ```console
   cd tests/providers/azure && pytest azure_provider_test.py -v
   ```
4. Try authentication locally:
   ```console
   export AZURE_CLIENT_ID="..."
   export AZURE_TENANT_ID="..."
   export AZURE_CERTIFICATE_CONTENT="<base64 PEM bundle>"
   prowler azure --certificate-auth
   ```

### Checklist

- [x] Unit tests added and passing
- [x] Changelog fragment added (`prowler/changelog.d/azure-certificate-authentication.added.md`)
- [x] No breaking changes to existing authentication paths


[PROWLER-2378]: https://prowlerpro.atlassian.net/browse/PROWLER-2378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure service principal authentication using certificates.
  * Certificates can be supplied as base64-encoded content, file paths, or supported environment variables.
  * Added the `--certificate-auth` and `--certificate-path` command-line options.
  * Azure identity details now include certificate thumbprints.

* **Bug Fixes**
  * Added validation and clearer errors for invalid, missing, or mismatched certificate bundles.
  * Enforced valid authentication option combinations.
  * Improved Azure connection and credential verification, including more reliable token requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->