### PR TITLE
fix(mcp): patch the two high sqlite CVEs in the container image

### DIFF
--- a/.github/workflows/mcp-container-build-push.yml
+++ b/.github/workflows/mcp-container-build-push.yml
@@ -114,6 +114,8 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             auth.docker.io:443
+            dl-cdn.alpinelinux.org:443
+            dualstack.j.sni.global.fastly.net:443
             files.pythonhosted.org:443
             ghcr.io:443
             github.com:443

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -81,6 +81,8 @@ jobs:
             pkg-containers.githubusercontent.com:443
             files.pythonhosted.org:443
             pypi.org:443
+            dl-cdn.alpinelinux.org:443
+            dualstack.j.sni.global.fastly.net:443
             api.github.com:443
             mirror.gcr.io:443
             check.trivy.dev:443

--- a/mcp_server/Dockerfile
+++ b/mcp_server/Dockerfile
@@ -29,6 +29,16 @@ FROM python:3.13.14-alpine3.23@sha256:9fdbf2e3e82628351513560b121e2ee6ce31cac212
 
 LABEL maintainer="https://github.com/prowler-cloud"
 
+# CVE-2026-11822 and CVE-2026-11824, both high, are fixed in Alpine 3.23's
+# sqlite 3.53.4-r0. The base image pins python 3.13.14, which has not been
+# rebuilt since that package was published and still ships 3.51.2-r0, so the
+# upgrade is taken here rather than by moving the pin -- the newest published
+# python:3.13-alpine3.23 carries the same vulnerable version.
+# `>=` rather than `=`: Alpine keeps only the newest build of a package in a
+# branch's index, so an exact pin breaks this build the day 3.53.4-r0 is
+# superseded. Drop this once the base image ships 3.53.4-r0 or later.
+RUN apk add --no-cache --upgrade "sqlite-libs>=3.53.4-r0"
+
 # Create non-root user for security
 # Using specific UID/GID for consistency across environments
 RUN addgroup -g 1001 prowler && \

--- a/mcp_server/changelog.d/mcp-image-sqlite-cves.security.md
+++ b/mcp_server/changelog.d/mcp-image-sqlite-cves.security.md
@@ -1,0 +1,1 @@
+`sqlite-libs` upgraded to 3.53.4-r0 in the container image, patching CVE-2026-11822 and CVE-2026-11824


### PR DESCRIPTION
### Context

`mcp-container-build-and-scan` fails on every PR that touches `mcp_server/`:

```
Error: Found 2 vulnerabilities at severity high or above (0 critical, 2 high)
  High    CVE-2026-11822    sqlite-libs 3.51.2-r0
  High    CVE-2026-11824    sqlite-libs 3.51.2-r0
```

Both come from the Alpine `sqlite-libs` the base image ships, not from anything this repo installs. Alpine 3.23's security database fixes both in **sqlite 3.53.4-r0**, and that package is live in the branch index:

```
$ curl -s https://secdb.alpinelinux.org/v3.23/main.json | jq '.packages[].pkg | select(.name=="sqlite").secfixes'
  "3.53.4-r0": ["CVE-2026-11822", "CVE-2026-11824"]

$ # v3.23/main/x86_64 APKINDEX
  sqlite-libs 3.53.4-r0
```

**Bumping the base image pin does not fix this.** I pulled the apk database out of the current `python:3.13-alpine3.23` manifest straight from the registry:

```
tag 3.13-alpine3.23 -> sha256:7ea3f82de8ea6d4fb7e5d2bbe3fe3c9d931700b7a529f1fe5769e42abe514ca1
  sqlite-libs = 3.51.2-r0
```

The newest published official image carries the same vulnerable version — it has not been rebuilt since the Alpine package landed. So there is no pin to move to.

An `.grype.yaml` entry would also be wrong here. That file is documented as "every entry below has a published fix we cannot take", and this fix is one we can take.

### Description

One `RUN` in the final stage of `mcp_server/Dockerfile`, placed before the build drops to the non-root user:

```dockerfile
RUN apk add --no-cache --upgrade "sqlite-libs>=3.53.4-r0"
```

Two choices worth a sentence each:

- **`>=` rather than `=3.53.4-r0`.** Alpine keeps only the newest build of a package in a branch's index. An exact pin breaks this build on the day 3.53.4-r0 is superseded by the next security update — the failure mode the pin was supposed to prevent, inverted. `>=` expresses the actual requirement: at least the version that carries the fix.
- **`apk add --upgrade` rather than `apk upgrade`.** It keeps the required version visible in the Dockerfile and satisfies hadolint's DL3018, which `apk upgrade` sidesteps by not being an `apk add` at all.

The comment above it names both CVEs and says when to remove the line: once the base image itself ships 3.53.4-r0 or later.

Only `mcp_server/Dockerfile` is affected. The other images are Debian-slim (`Dockerfile`, `api/Dockerfile`) or `node:24-alpine` (`ui/Dockerfile`), and none of them reports this package. The builder stage is left alone — nothing from its Alpine tree is copied into the final image.

### Steps to review

1. Confirm the upgrade runs as root, before `USER prowler`.
2. Confirm the version constraint matches the Alpine secfix above.
3. `mcp-container-build-and-scan` on this PR is the real check: it builds the image and re-runs Grype, so a green run is the verification that the count goes to zero.

Locally I ran hadolint 2.14.0 with the same `--ignore=DL3013` this repo uses (clean), and verified DL3018 is actually active by re-running it against an unpinned control. I could not build the image — no Docker daemon on this machine — which is why point 3 is the one that matters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the container image’s SQLite library to address security vulnerabilities CVE-2026-11822 and CVE-2026-11824.
  - Improved container build and validation reliability by enabling required secure access during image operations.

- **Documentation**
  - Added a changelog entry documenting the SQLite security update and the affected vulnerabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->