### PR TITLE
feat(ui): add cancelled subscription variant to the trial sidebar banner

### DIFF
--- a/ui/changelog.d/trial-sidebar-banner-cancelled.added.md
+++ b/ui/changelog.d/trial-sidebar-banner-cancelled.added.md
@@ -1,0 +1,1 @@
+Cancelled-subscription variant in the sidebar trial banner (Prowler Cloud only)

--- a/ui/components/layout/app-sidebar/trial-sidebar-banner.test.tsx
+++ b/ui/components/layout/app-sidebar/trial-sidebar-banner.test.tsx
@@ -148,6 +148,29 @@ describe("TrialSidebarBanner", () => {
     ).toHaveAttribute("href", "/billing");
   });
 
+  it("renders the cancelled subscription card with the terminal treatment", () => {
+    // Given / When
+    render(
+      <TrialSidebarBanner variant={TRIAL_SIDEBAR_BANNER_VARIANT.CANCELLED} />,
+    );
+
+    // Then
+    const banner = screen.getByRole("status", {
+      name: "Cancelled subscription",
+    });
+    expect(banner).toHaveTextContent("Subscription cancelled");
+    expect(banner).toHaveTextContent("Subscription required");
+    expect(banner).toHaveTextContent(
+      "Scans are paused and your assessment data remains available. Subscribe again to continue scanning.",
+    );
+    expect(banner).toHaveAttribute("data-urgency", "critical");
+    expect(
+      screen.getByRole("link", {
+        name: "Explore plans after your cancelled subscription",
+      }),
+    ).toHaveAttribute("href", "/billing");
+  });
+
   it("invokes the sidebar selection callback from the billing CTA", async () => {
     // Given
     const user = userEvent.setup();

--- a/ui/components/layout/app-sidebar/trial-sidebar-banner.tsx
+++ b/ui/components/layout/app-sidebar/trial-sidebar-banner.tsx
@@ -20,6 +20,7 @@ export const TRIAL_SIDEBAR_BANNER_VARIANT = {
   ACTIVE_SCANS: "active_scans",
   ACTIVE_UNLIMITED: "active_unlimited",
   EXPIRED: "expired",
+  CANCELLED: "cancelled",
 } as const;
 
 interface TrialSidebarBannerBaseProps {
@@ -51,11 +52,17 @@ interface ExpiredTrialSidebarBannerProps extends TrialSidebarBannerBaseProps {
   remaining?: never;
 }
 
+interface CancelledTrialSidebarBannerProps extends TrialSidebarBannerBaseProps {
+  variant: typeof TRIAL_SIDEBAR_BANNER_VARIANT.CANCELLED;
+  remaining?: never;
+}
+
 export type TrialSidebarBannerProps =
   | ActiveDaysTrialSidebarBannerProps
   | ActiveScansTrialSidebarBannerProps
   | ActiveUnlimitedTrialSidebarBannerProps
-  | ExpiredTrialSidebarBannerProps;
+  | ExpiredTrialSidebarBannerProps
+  | CancelledTrialSidebarBannerProps;
 
 const TRIAL_URGENCY = {
   HEALTHY: "healthy",
@@ -115,6 +122,12 @@ const TRIAL_SIDEBAR_BANNER_COPY: Record<
     linkLabel: "Explore plans after your trial expired",
     cardLabel: "Expired trial",
   },
+  [TRIAL_SIDEBAR_BANNER_VARIANT.CANCELLED]: {
+    badge: "Subscription cancelled",
+    body: "Scans are paused and your assessment data remains available. Subscribe again to continue scanning.",
+    linkLabel: "Explore plans after your cancelled subscription",
+    cardLabel: "Cancelled subscription",
+  },
 };
 
 const TRIAL_SIDEBAR_BANNER_METER: Record<
@@ -150,7 +163,10 @@ const TRIAL_URGENCY_STYLES: Record<TrialUrgency, TrialUrgencyStyles> = {
 };
 
 const getTrialUrgency = (props: TrialSidebarBannerProps): TrialUrgency => {
-  if (props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.EXPIRED) {
+  if (
+    props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.EXPIRED ||
+    props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.CANCELLED
+  ) {
     return TRIAL_URGENCY.CRITICAL;
   }
   if (
@@ -181,7 +197,11 @@ const TILT_RANGE_Y = 2;
 const TILT_LIFT = -2;
 
 export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
-  const isExpired = props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.EXPIRED;
+  // Expired trial and cancelled subscription share the terminal treatment:
+  // error badge, error icon, "Subscription required" heading.
+  const isTerminal =
+    props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.EXPIRED ||
+    props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.CANCELLED;
   const isScanBased =
     props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_SCANS;
   // The backend keeps a scan-capped trial `active` once its quota is spent.
@@ -189,7 +209,7 @@ export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
   const urgency = getTrialUrgency(props);
   const urgencyStyles = TRIAL_URGENCY_STYLES[urgency];
   const copy = TRIAL_SIDEBAR_BANNER_COPY[props.variant];
-  const heading = isExpired
+  const heading = isTerminal
     ? "Subscription required"
     : props.variant === TRIAL_SIDEBAR_BANNER_VARIANT.ACTIVE_UNLIMITED
       ? "Trial active"
@@ -282,14 +302,16 @@ export const TrialSidebarBanner = (props: TrialSidebarBannerProps) => {
               <Sparkles
                 className={cn(
                   "size-4",
-                  isExpired ? "text-text-error-primary" : "text-button-primary",
+                  isTerminal
+                    ? "text-text-error-primary"
+                    : "text-button-primary",
                 )}
                 aria-hidden="true"
               />
             </span>
             <div className="flex min-w-0 flex-1 flex-col gap-1.5">
               <Badge
-                variant={isExpired || isExhausted ? "error" : "success"}
+                variant={isTerminal || isExhausted ? "error" : "success"}
                 size="sm"
                 className="w-fit"
               >

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -8,6 +8,14 @@ const { withSentryConfig } = require("@sentry/nextjs");
 // HTTP Security Headers
 const nextConfig = {
   poweredByHeader: false,
+  // Dev-only. Lets the dev server accept HMR/asset requests from a tunnel
+  // hostname (ngrok/cloudflared), needed when testing the local UI through a
+  // public tunnel or from an external device.
+  // Comma-separated, e.g. NEXT_ALLOWED_DEV_ORIGINS=foo.ngrok-free.dev
+  allowedDevOrigins: (process.env.NEXT_ALLOWED_DEV_ORIGINS || "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean),
   // Use standalone only in production deployments, not for CI/testing
   ...(process.env.NODE_ENV === "production" &&
     !process.env.CI && {


### PR DESCRIPTION
### Context

Prowler Cloud is adding AWS Marketplace as a billing provider (prowler-cloud/prowler-cloud#5473). When a Marketplace subscription is cancelled, scans pause and the sidebar must say so. The `TrialSidebarBanner` component lives in this repo since #12420 while Prowler Cloud only wires it to billing state, so the new variant belongs here — keeping the component identical across both repos and conflict-free for the OSS→Cloud sync.

### Description

- `TrialSidebarBanner` gains a `CANCELLED` variant: terminal treatment shared with `EXPIRED` (error badge, critical urgency, "Subscription required" heading) with its own copy. The wiring that produces the variant is cloud-only; in this repo the variant is inert, like the rest of the component.
- `next.config.js` reads `NEXT_ALLOWED_DEV_ORIGINS` into `allowedDevOrigins` (dev-only), so the dev server accepts HMR/asset requests arriving through a tunnel hostname (ngrok/cloudflared). With the variable unset the value is `[]`, behaviourally identical to the default.

### Steps to review

1. `ui/components/layout/app-sidebar/trial-sidebar-banner.tsx`: the `CANCELLED` variant reuses the terminal treatment of `EXPIRED` (`isExpired` renamed to `isTerminal`); copy, urgency and heading come from the same records as the other variants.
2. Run `pnpm vitest run components/layout/app-sidebar/trial-sidebar-banner.test.tsx` — 13 tests pass, including the new cancelled-card assertions.
3. `ui/next.config.js`: verify the `allowedDevOrigins` block is a no-op when `NEXT_ALLOWED_DEV_ORIGINS` is unset.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

Screenshots are not applicable: the `CANCELLED` variant is not reachable in this repo (no caller sets it, same as the rest of the component's variants).

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for development servers accessed through configured tunnel or external-device origins, including HMR and asset requests.
  - Added a cancelled-subscription state to the trial sidebar banner with clear status messaging and a billing action.

- **Documentation**
  - Documented support for allowed development origins and the cancelled-subscription banner state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->