### PR TITLE
feat(api): add finding labels, finding URL and tenant info to Jira issues

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -59,5 +59,9 @@ DJANGO_GITHUB_OAUTH_CLIENT_ID=""
 DJANGO_GITHUB_OAUTH_CLIENT_SECRET=""
 DJANGO_GITHUB_OAUTH_CALLBACK_URL=""
 
+# Public base URL of the Prowler UI, used to link Jira issues back to findings.
+# Leave empty to omit the link.
+DJANGO_UI_BASE_URL=""
+
 # Deletion Task Batch Size
 DJANGO_DELETION_BATCH_SIZE=5000

--- a/api/changelog.d/jira-finding-labels-url.added.md
+++ b/api/changelog.d/jira-finding-labels-url.added.md
@@ -1,0 +1,1 @@
+Jira issues created from Prowler Cloud now carry `prowler-*` labels (provider, severity, check id and a sanitized finding UID), a link back to the finding when `DJANGO_UI_BASE_URL` is configured, and the tenant name

--- a/api/changelog.d/jira-finding-labels-url.added.md
+++ b/api/changelog.d/jira-finding-labels-url.added.md
@@ -1,1 +1,1 @@
-Jira issues created from Prowler Cloud now carry `prowler-*` labels (provider, severity, check id and a sanitized finding UID), a link back to the finding when `DJANGO_UI_BASE_URL` is configured, and the tenant name
+Jira issues created from Prowler Cloud now carry the `prowler`, `prowler-<provider>`, `prowler-<severity>`, `prowler-<check-id>`, and `prowler-finding-<finding-uid>` labels, a link back to the finding when `DJANGO_UI_BASE_URL` is configured, and the tenant name

--- a/api/src/backend/config/django/base.py
+++ b/api/src/backend/config/django/base.py
@@ -303,6 +303,11 @@ SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 
 DJANGO_DELETION_BATCH_SIZE = env.int("DJANGO_DELETION_BATCH_SIZE", 5000)
 
+# Public base URL of the Prowler UI (for example https://cloud.prowler.com). Used to
+# build links back to findings in outbound integrations such as Jira. Empty by
+# default, so self-hosted deployments emit no links unless they configure it.
+UI_BASE_URL = env.str("DJANGO_UI_BASE_URL", "").rstrip("/")
+
 # SAML requirement
 CSRF_COOKIE_SECURE = True
 SESSION_COOKIE_SECURE = True

--- a/api/src/backend/tasks/jobs/integrations.py
+++ b/api/src/backend/tasks/jobs/integrations.py
@@ -19,6 +19,7 @@ from prowler.lib.outputs.csv.csv import CSV
 from prowler.lib.outputs.finding import Finding as FindingOutput
 from prowler.lib.outputs.html.html import HTML
 from prowler.lib.outputs.jira.exceptions.exceptions import JiraBaseException
+from prowler.lib.outputs.jira.jira import Jira
 from prowler.lib.outputs.ocsf.ocsf import OCSF
 from prowler.providers.aws.aws_provider import AwsProvider
 from prowler.providers.aws.lib.s3.s3 import S3
@@ -481,32 +482,6 @@ def upload_security_hub_integration(
 
 
 JIRA_LABEL_PREFIX = "prowler"
-JIRA_LABEL_MAX_LENGTH = 255
-
-
-def sanitize_jira_label(label: str) -> str:
-    """Make a value safe to use as a Jira label.
-
-    Jira rejects labels containing whitespace or longer than 255 characters. The
-    transformation is deterministic so the same finding always yields the same
-    label: whitespace runs become a single underscore, control characters are
-    dropped and the result is truncated. Mirrors ``Jira.sanitize_label`` in the
-    SDK; kept local so the API does not depend on an unreleased SDK symbol.
-    """
-    if not label:
-        return ""
-    cleaned = "".join(ch for ch in str(label) if ch.isprintable() or ch.isspace())
-    return "_".join(cleaned.split())[:JIRA_LABEL_MAX_LENGTH]
-
-
-def sanitize_jira_labels(labels: list[str]) -> list[str]:
-    """Sanitize a list of labels, dropping empties and duplicates (order kept)."""
-    result: list[str] = []
-    for label in labels or []:
-        sanitized = sanitize_jira_label(label)
-        if sanitized and sanitized not in result:
-            result.append(sanitized)
-    return result
 
 
 def build_jira_finding_url(finding_uid: str) -> str:
@@ -535,9 +510,9 @@ def build_jira_issue_labels(
         f"{JIRA_LABEL_PREFIX}-{provider}" if provider else "",
         f"{JIRA_LABEL_PREFIX}-{severity}" if severity else "",
         f"{JIRA_LABEL_PREFIX}-{check_id}" if check_id else "",
-        f"{JIRA_LABEL_PREFIX}-finding-{finding_uid}" if finding_uid else "",
+        Jira.build_finding_label(finding_uid),
     ]
-    return sanitize_jira_labels(raw_labels)
+    return Jira.sanitize_labels(raw_labels)
 
 
 def get_tenant_name(tenant_id: str) -> str:

--- a/api/src/backend/tasks/jobs/integrations.py
+++ b/api/src/backend/tasks/jobs/integrations.py
@@ -2,13 +2,16 @@ import os
 import time
 from datetime import UTC, datetime
 from glob import glob
+from urllib.parse import quote
 
 from api.db_router import READ_REPLICA_ALIAS, MainRouter
 from api.db_utils import REPLICA_MAX_ATTEMPTS, REPLICA_RETRY_BASE_DELAY, rls_transaction
 from api.models import Finding, Integration, Provider
+from api.rls import Tenant
 from api.utils import initialize_prowler_integration, initialize_prowler_provider
 from celery.utils.log import get_task_logger
 from config.django.base import DJANGO_FINDINGS_BATCH_SIZE
+from django.conf import settings
 from django.db import OperationalError
 from prowler.lib.outputs.asff.asff import ASFF
 from prowler.lib.outputs.compliance.generic.generic import GenericCompliance
@@ -477,6 +480,81 @@ def upload_security_hub_integration(
         return False
 
 
+JIRA_LABEL_PREFIX = "prowler"
+JIRA_LABEL_MAX_LENGTH = 255
+
+
+def sanitize_jira_label(label: str) -> str:
+    """Make a value safe to use as a Jira label.
+
+    Jira rejects labels containing whitespace or longer than 255 characters. The
+    transformation is deterministic so the same finding always yields the same
+    label: whitespace runs become a single underscore, control characters are
+    dropped and the result is truncated. Mirrors ``Jira.sanitize_label`` in the
+    SDK; kept local so the API does not depend on an unreleased SDK symbol.
+    """
+    if not label:
+        return ""
+    cleaned = "".join(ch for ch in str(label) if ch.isprintable() or ch.isspace())
+    return "_".join(cleaned.split())[:JIRA_LABEL_MAX_LENGTH]
+
+
+def sanitize_jira_labels(labels: list[str]) -> list[str]:
+    """Sanitize a list of labels, dropping empties and duplicates (order kept)."""
+    result: list[str] = []
+    for label in labels or []:
+        sanitized = sanitize_jira_label(label)
+        if sanitized and sanitized not in result:
+            result.append(sanitized)
+    return result
+
+
+def build_jira_finding_url(finding_uid: str) -> str:
+    """Build the Prowler UI link for a finding, or "" when no UI base URL is set.
+
+    The link filters by the finding ``uid`` rather than the per-scan record id so
+    it keeps resolving after the finding is seen again in later scans.
+    """
+    base_url = getattr(settings, "UI_BASE_URL", "")
+    if not base_url or not finding_uid:
+        return ""
+    return f"{base_url}/findings?filter[uid]={quote(finding_uid, safe='')}"
+
+
+def build_jira_issue_labels(
+    finding_uid: str, provider: str, severity: str, check_id: str
+) -> list[str]:
+    """Build the deterministic label set written to every Jira issue.
+
+    Labels are prefixed to avoid colliding with customer labels and sanitized so
+    Jira never rejects them; the finding-uid label is what lets a ticket be traced
+    back (or JQL-filtered) to its finding.
+    """
+    raw_labels = [
+        JIRA_LABEL_PREFIX,
+        f"{JIRA_LABEL_PREFIX}-{provider}" if provider else "",
+        f"{JIRA_LABEL_PREFIX}-{severity}" if severity else "",
+        f"{JIRA_LABEL_PREFIX}-{check_id}" if check_id else "",
+        f"{JIRA_LABEL_PREFIX}-finding-{finding_uid}" if finding_uid else "",
+    ]
+    return sanitize_jira_labels(raw_labels)
+
+
+def get_tenant_name(tenant_id: str) -> str:
+    """Return the tenant name for the Jira issue "Tenant Info" row, or "" if unknown.
+
+    The name is informational only, so a lookup failure must never block the send.
+    """
+    try:
+        return (
+            Tenant.objects.filter(id=tenant_id).values_list("name", flat=True).first()
+            or ""
+        )
+    except Exception:
+        logger.warning("Could not resolve tenant name for %s", tenant_id)
+        return ""
+
+
 def send_findings_to_jira(
     tenant_id: str,
     integration_id: str,
@@ -487,6 +565,7 @@ def send_findings_to_jira(
     with rls_transaction(tenant_id):
         integration = Integration.objects.get(id=integration_id)
         jira_integration = initialize_prowler_integration(integration)
+        tenant_info = get_tenant_name(tenant_id)
 
     num_tickets_created = 0
     error_messages = []
@@ -519,6 +598,15 @@ def send_findings_to_jira(
             recommendation = remediation.get("recommendation", {})
             remediation_code = remediation.get("code", {})
 
+            provider_type = finding_instance.scan.provider.provider
+            issue_labels = build_jira_issue_labels(
+                finding_uid=finding_instance.uid,
+                provider=provider_type,
+                severity=finding_instance.severity,
+                check_id=finding_instance.check_id,
+            )
+            finding_url = build_jira_finding_url(finding_instance.uid)
+
             try:
                 # Send the individual finding to Jira
                 result = jira_integration.send_finding(
@@ -527,7 +615,7 @@ def send_findings_to_jira(
                     severity=finding_instance.severity,
                     status=finding_instance.status,
                     status_extended=finding_instance.status_extended or "",
-                    provider=finding_instance.scan.provider.provider,
+                    provider=provider_type,
                     region=region,
                     resource_uid=resource_uid,
                     resource_name=resource_name,
@@ -542,6 +630,9 @@ def send_findings_to_jira(
                     compliance=finding_instance.compliance or {},
                     project_key=project_key,
                     issue_type=issue_type,
+                    issue_labels=issue_labels,
+                    finding_url=finding_url,
+                    tenant_info=tenant_info,
                 )
             except JiraBaseException as error:
                 error_message = error.message or JIRA_GENERIC_SEND_ERROR
@@ -557,6 +648,11 @@ def send_findings_to_jira(
 
             if result:
                 num_tickets_created += 1
+                logger.info(
+                    "Finding %s sent to Jira as %s",
+                    finding_id,
+                    result.get("key") if isinstance(result, dict) else result,
+                )
             else:
                 error_message = JIRA_GENERIC_SEND_ERROR
                 logger.error(error_message)

--- a/api/src/backend/tasks/tests/test_integrations.py
+++ b/api/src/backend/tasks/tests/test_integrations.py
@@ -6,6 +6,7 @@ from api.db_router import READ_REPLICA_ALIAS, MainRouter
 from api.models import Integration
 from api.utils import prowler_integration_connection_test
 from django.db import OperationalError
+from django.test import override_settings
 from prowler.lib.outputs.jira.exceptions.exceptions import (
     JiraRefreshTokenError,
     JiraRequiredCustomFieldsError,
@@ -13,8 +14,13 @@ from prowler.lib.outputs.jira.exceptions.exceptions import (
 from prowler.providers.aws.lib.security_hub.security_hub import SecurityHubConnection
 from prowler.providers.common.models import Connection
 from tasks.jobs.integrations import (
+    build_jira_finding_url,
+    build_jira_issue_labels,
     get_s3_client_from_integration,
     get_security_hub_client_from_integration,
+    get_tenant_name,
+    sanitize_jira_label,
+    sanitize_jira_labels,
     send_findings_to_jira,
     upload_s3_integration,
     upload_security_hub_integration,
@@ -1696,6 +1702,7 @@ class TestJiraIntegration:
 
         finding1 = MagicMock()
         finding1.id = "finding-1"
+        finding1.uid = "prowler-aws-check_001-123456789012-us-east-1-my bucket"
         finding1.check_id = "check_001"
         finding1.severity = "high"
         finding1.status = "FAIL"
@@ -1724,6 +1731,7 @@ class TestJiraIntegration:
 
         finding2 = MagicMock()
         finding2.id = "finding-2"
+        finding2.uid = "prowler-azure-check_002-sub/resource"
         finding2.check_id = "check_002"
         finding2.severity = "medium"
         finding2.status = "PASS"
@@ -1748,9 +1756,13 @@ class TestJiraIntegration:
         ]
 
         # Call the function
-        result = send_findings_to_jira(
-            tenant_id, integration_id, project_key, issue_type, finding_ids
-        )
+        with (
+            override_settings(UI_BASE_URL="https://cloud.example.com"),
+            patch("tasks.jobs.integrations.get_tenant_name", return_value="Acme"),
+        ):
+            result = send_findings_to_jira(
+                tenant_id, integration_id, project_key, issue_type, finding_ids
+            )
 
         # Assertions
         assert result == {"created_count": 2, "failed_count": 0}
@@ -1773,12 +1785,36 @@ class TestJiraIntegration:
         assert first_call.kwargs["provider"] == "aws"
         assert first_call.kwargs["project_key"] == project_key
         assert first_call.kwargs["issue_type"] == issue_type
+        # Finding reference: labels, link back and tenant info
+        assert first_call.kwargs["issue_labels"] == [
+            "prowler",
+            "prowler-aws",
+            "prowler-high",
+            "prowler-check_001",
+            "prowler-finding-prowler-aws-check_001-123456789012-us-east-1-my_bucket",
+        ]
+        assert first_call.kwargs["finding_url"] == (
+            "https://cloud.example.com/findings?filter[uid]="
+            "prowler-aws-check_001-123456789012-us-east-1-my%20bucket"
+        )
+        assert first_call.kwargs["tenant_info"] == "Acme"
 
         # Verify second call
         second_call = mock_jira_integration.send_finding.call_args_list[1]
         assert second_call.kwargs["check_id"] == "check_002"
         assert second_call.kwargs["severity"] == "medium"
         assert second_call.kwargs["status"] == "PASS"
+        assert second_call.kwargs["issue_labels"] == [
+            "prowler",
+            "prowler-azure",
+            "prowler-medium",
+            "prowler-check_002",
+            "prowler-finding-prowler-azure-check_002-sub/resource",
+        ]
+        assert second_call.kwargs["finding_url"] == (
+            "https://cloud.example.com/findings?filter[uid]="
+            "prowler-azure-check_002-sub%2Fresource"
+        )
 
     @patch("tasks.jobs.integrations.rls_transaction")
     @patch("tasks.jobs.integrations.Finding")
@@ -2200,3 +2236,81 @@ class TestJiraIntegration:
         assert call_kwargs["remediation_code_cli"] == ""
         assert call_kwargs["remediation_code_other"] == ""
         assert call_kwargs["compliance"] == {}
+
+
+class TestJiraFindingReference:
+    """Helpers that give Jira issues a stable reference back to the finding."""
+
+    def test_sanitize_jira_label(self):
+        assert sanitize_jira_label("") == ""
+        assert sanitize_jira_label(None) == ""
+        assert sanitize_jira_label("   ") == ""
+        assert sanitize_jira_label("simple") == "simple"
+        assert sanitize_jira_label("with space") == "with_space"
+        assert sanitize_jira_label(" many   spaces \t tabs\nnewline ") == (
+            "many_spaces_tabs_newline"
+        )
+        assert sanitize_jira_label("ctrl\x00char\x07here") == "ctrlcharhere"
+        assert sanitize_jira_label("arn:aws:iam::123456789012:role/Admin") == (
+            "arn:aws:iam::123456789012:role/Admin"
+        )
+        assert sanitize_jira_label("x" * 300) == "x" * 255
+        # Deterministic and idempotent
+        once = sanitize_jira_label("a b\tc")
+        assert sanitize_jira_label(once) == once
+
+    def test_sanitize_jira_labels(self):
+        assert sanitize_jira_labels([]) == []
+        assert sanitize_jira_labels(None) == []
+        assert sanitize_jira_labels(["b", "a b", "b", "", "a_b"]) == ["b", "a_b"]
+
+    def test_build_jira_issue_labels(self):
+        assert build_jira_issue_labels(
+            finding_uid="prowler-aws-check-123-eu-west-1-hub/unknown",
+            provider="aws",
+            severity="critical",
+            check_id="iam_root_mfa",
+        ) == [
+            "prowler",
+            "prowler-aws",
+            "prowler-critical",
+            "prowler-iam_root_mfa",
+            "prowler-finding-prowler-aws-check-123-eu-west-1-hub/unknown",
+        ]
+
+    def test_build_jira_issue_labels_skips_empty_parts(self):
+        assert build_jira_issue_labels(
+            finding_uid="", provider="", severity="", check_id=""
+        ) == ["prowler"]
+
+    def test_build_jira_issue_labels_truncates_long_uid(self):
+        labels = build_jira_issue_labels(
+            finding_uid="u" * 300, provider="gcp", severity="low", check_id="c"
+        )
+        assert labels[-1] == ("prowler-finding-" + "u" * 300)[:255]
+        assert all(len(label) <= 255 for label in labels)
+
+    @override_settings(UI_BASE_URL="")
+    def test_build_jira_finding_url_without_base_url(self):
+        assert build_jira_finding_url("prowler-aws-check-1") == ""
+
+    @override_settings(UI_BASE_URL="https://cloud.example.com")
+    def test_build_jira_finding_url_with_base_url(self):
+        assert build_jira_finding_url("prowler-aws-check-1") == (
+            "https://cloud.example.com/findings?filter[uid]=prowler-aws-check-1"
+        )
+        # uid characters that would break the query string are encoded
+        assert build_jira_finding_url("a/b c&d") == (
+            "https://cloud.example.com/findings?filter[uid]=a%2Fb%20c%26d"
+        )
+        assert build_jira_finding_url("") == ""
+
+    @pytest.mark.django_db
+    def test_get_tenant_name(self, tenants_fixture):
+        tenant = tenants_fixture[0]
+        assert get_tenant_name(str(tenant.id)) == tenant.name
+
+    @pytest.mark.django_db
+    def test_get_tenant_name_unknown_or_invalid(self):
+        assert get_tenant_name("00000000-0000-0000-0000-000000000000") == ""
+        assert get_tenant_name("not-a-uuid") == ""

--- a/api/src/backend/tasks/tests/test_integrations.py
+++ b/api/src/backend/tasks/tests/test_integrations.py
@@ -11,6 +11,7 @@ from prowler.lib.outputs.jira.exceptions.exceptions import (
     JiraRefreshTokenError,
     JiraRequiredCustomFieldsError,
 )
+from prowler.lib.outputs.jira.jira import Jira
 from prowler.providers.aws.lib.security_hub.security_hub import SecurityHubConnection
 from prowler.providers.common.models import Connection
 from tasks.jobs.integrations import (
@@ -19,8 +20,6 @@ from tasks.jobs.integrations import (
     get_s3_client_from_integration,
     get_security_hub_client_from_integration,
     get_tenant_name,
-    sanitize_jira_label,
-    sanitize_jira_labels,
     send_findings_to_jira,
     upload_s3_integration,
     upload_security_hub_integration,
@@ -2241,29 +2240,6 @@ class TestJiraIntegration:
 class TestJiraFindingReference:
     """Helpers that give Jira issues a stable reference back to the finding."""
 
-    def test_sanitize_jira_label(self):
-        assert sanitize_jira_label("") == ""
-        assert sanitize_jira_label(None) == ""
-        assert sanitize_jira_label("   ") == ""
-        assert sanitize_jira_label("simple") == "simple"
-        assert sanitize_jira_label("with space") == "with_space"
-        assert sanitize_jira_label(" many   spaces \t tabs\nnewline ") == (
-            "many_spaces_tabs_newline"
-        )
-        assert sanitize_jira_label("ctrl\x00char\x07here") == "ctrlcharhere"
-        assert sanitize_jira_label("arn:aws:iam::123456789012:role/Admin") == (
-            "arn:aws:iam::123456789012:role/Admin"
-        )
-        assert sanitize_jira_label("x" * 300) == "x" * 255
-        # Deterministic and idempotent
-        once = sanitize_jira_label("a b\tc")
-        assert sanitize_jira_label(once) == once
-
-    def test_sanitize_jira_labels(self):
-        assert sanitize_jira_labels([]) == []
-        assert sanitize_jira_labels(None) == []
-        assert sanitize_jira_labels(["b", "a b", "b", "", "a_b"]) == ["b", "a_b"]
-
     def test_build_jira_issue_labels(self):
         assert build_jira_issue_labels(
             finding_uid="prowler-aws-check-123-eu-west-1-hub/unknown",
@@ -2283,12 +2259,55 @@ class TestJiraFindingReference:
             finding_uid="", provider="", severity="", check_id=""
         ) == ["prowler"]
 
-    def test_build_jira_issue_labels_truncates_long_uid(self):
-        labels = build_jira_issue_labels(
-            finding_uid="u" * 300, provider="gcp", severity="low", check_id="c"
-        )
-        assert labels[-1] == ("prowler-finding-" + "u" * 300)[:255]
-        assert all(len(label) <= 255 for label in labels)
+    def test_build_jira_issue_labels_sanitizes_metadata(self):
+        assert build_jira_issue_labels(
+            finding_uid=" uid\x00 with spaces ",
+            provider="aws cloud",
+            severity="high severity",
+            check_id="check id",
+        ) == [
+            "prowler",
+            "prowler-aws_cloud",
+            "prowler-high_severity",
+            "prowler-check_id",
+            "prowler-finding-uid_with_spaces",
+        ]
+
+    def test_build_jira_issue_labels_preserves_maximum_length_uid(self):
+        finding_uid = "u" * (Jira.LABEL_MAX_LENGTH - len(Jira.FINDING_LABEL_PREFIX) - 1)
+        finding_label = build_jira_issue_labels(
+            finding_uid=finding_uid,
+            provider="gcp",
+            severity="low",
+            check_id="check",
+        )[-1]
+
+        assert finding_label == f"{Jira.FINDING_LABEL_PREFIX}-{finding_uid}"
+        assert len(finding_label) == Jira.LABEL_MAX_LENGTH
+
+    def test_build_jira_issue_labels_distinguishes_long_uids(self):
+        common_prefix = "u" * 300
+        first_uid = f"{common_prefix}-first"
+        second_uid = f"{common_prefix}-second"
+
+        first_label = build_jira_issue_labels(
+            finding_uid=first_uid,
+            provider="gcp",
+            severity="low",
+            check_id="check",
+        )[-1]
+        second_label = build_jira_issue_labels(
+            finding_uid=second_uid,
+            provider="gcp",
+            severity="low",
+            check_id="check",
+        )[-1]
+
+        assert first_label == Jira.build_finding_label(first_uid)
+        assert second_label == Jira.build_finding_label(second_uid)
+        assert first_label != second_label
+        assert len(first_label) == Jira.LABEL_MAX_LENGTH
+        assert len(second_label) == Jira.LABEL_MAX_LENGTH
 
     @override_settings(UI_BASE_URL="")
     def test_build_jira_finding_url_without_base_url(self):

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -4835,8 +4835,8 @@ wheels = [
 
 [[package]]
 name = "prowler"
-version = "5.40.0"
-source = { git = "https://github.com/prowler-cloud/prowler.git?rev=master#b6e9967da6bebd6c7b8b237317a2a95e2e0c65bc" }
+version = "5.41.0"
+source = { git = "https://github.com/prowler-cloud/prowler.git?rev=master#f05a490cd74a2c0f11a5d66d8ce29d03fa5c64a2" }
 dependencies = [
     { name = "alibabacloud-actiontrail20200706" },
     { name = "alibabacloud-credentials" },
@@ -4928,9 +4928,12 @@ dependencies = [
     { name = "stackit-iaas" },
     { name = "stackit-objectstorage" },
     { name = "stackit-resourcemanager" },
+    { name = "stackit-ske" },
     { name = "tabulate" },
+    { name = "truststore" },
     { name = "tzlocal" },
     { name = "uuid6" },
+    { name = "zstandard" },
 ]
 
 [[package]]
@@ -6118,6 +6121,21 @@ wheels = [
 ]
 
 [[package]]
+name = "stackit-ske"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "stackit-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/9e/df3ad585cb96d028354f4253568e9879d81bb9395d5ebfa268fa9350e2df/stackit_ske-1.12.0.tar.gz", hash = "sha256:62814279f3b7fb2387648f92d14453a8905ad60115c07579f2741ddb7d1fcc94", size = 37239, upload-time = "2026-06-30T11:18:49.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/37/dc54fb7185a2d4da37308322ea1a7b992312030b2e37262de4eb4003f5c7/stackit_ske-1.12.0-py3-none-any.whl", hash = "sha256:45bd8084d87f14f818b3d7e824450248c8784ed204ca1b2dc108f491dcbdb1a3", size = 93142, upload-time = "2026-06-30T11:18:48.233Z" },
+]
+
+[[package]]
 name = "statsd"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -6223,6 +6241,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]
@@ -6619,6 +6646,48 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/91/af/502601f0395ce84dff622f63cab47488657a04d0065547df42bee3a680ff/zope_interface-8.2-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2bf9cf275468bafa3c72688aad8cfcbe3d28ee792baf0b228a1b2d93bd1d541a", size = 264859, upload-time = "2026-01-09T08:05:22.234Z" },
     { url = "https://files.pythonhosted.org/packages/89/0c/d2f765b9b4814a368a7c1b0ac23b68823c6789a732112668072fe596945d/zope_interface-8.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0009d2d3c02ea783045d7804da4fd016245e5c5de31a86cebba66dd6914d59a2", size = 264398, upload-time = "2026-01-09T08:05:23.853Z" },
     { url = "https://files.pythonhosted.org/packages/4a/81/2f171fbc4222066957e6b9220c4fb9146792540102c37e6d94e5d14aad97/zope_interface-8.2-cp312-cp312-win_amd64.whl", hash = "sha256:845d14e580220ae4544bd4d7eb800f0b6034fe5585fc2536806e0a26c2ee6640", size = 212444, upload-time = "2026-01-09T08:05:25.148Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/83/c3ca27c363d104980f1c9cee1101cc8ba724ac8c28a033ede6aab89585b1/zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c", size = 795254, upload-time = "2025-09-14T22:16:26.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4d/e66465c5411a7cf4866aeadc7d108081d8ceba9bc7abe6b14aa21c671ec3/zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f", size = 640559, upload-time = "2025-09-14T22:16:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/12/56/354fe655905f290d3b147b33fe946b0f27e791e4b50a5f004c802cb3eb7b/zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431", size = 5348020, upload-time = "2025-09-14T22:16:29.523Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/13/2b7ed68bd85e69a2069bcc72141d378f22cae5a0f3b353a2c8f50ef30c1b/zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a", size = 5058126, upload-time = "2025-09-14T22:16:31.811Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/fdaf0674f4b10d92cb120ccff58bbb6626bf8368f00ebfd2a41ba4a0dc99/zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc", size = 5405390, upload-time = "2025-09-14T22:16:33.486Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/67/354d1555575bc2490435f90d67ca4dd65238ff2f119f30f72d5cde09c2ad/zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6", size = 5452914, upload-time = "2025-09-14T22:16:35.277Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/e9cfd801a3f9190bf3e759c422bbfd2247db9d7f3d54a56ecde70137791a/zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072", size = 5559635, upload-time = "2025-09-14T22:16:37.141Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/5ba550f797ca953a52d708c8e4f380959e7e3280af029e38fbf47b55916e/zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277", size = 5048277, upload-time = "2025-09-14T22:16:38.807Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c0/ca3e533b4fa03112facbe7fbe7779cb1ebec215688e5df576fe5429172e0/zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313", size = 5574377, upload-time = "2025-09-14T22:16:40.523Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9b/3fb626390113f272abd0799fd677ea33d5fc3ec185e62e6be534493c4b60/zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097", size = 4961493, upload-time = "2025-09-14T22:16:43.3Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d3/23094a6b6a4b1343b27ae68249daa17ae0651fcfec9ed4de09d14b940285/zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778", size = 5269018, upload-time = "2025-09-14T22:16:45.292Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a7/bb5a0c1c0f3f4b5e9d5b55198e39de91e04ba7c205cc46fcb0f95f0383c1/zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065", size = 5443672, upload-time = "2025-09-14T22:16:47.076Z" },
+    { url = "https://files.pythonhosted.org/packages/27/22/503347aa08d073993f25109c36c8d9f029c7d5949198050962cb568dfa5e/zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa", size = 5822753, upload-time = "2025-09-14T22:16:49.316Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/be/94267dc6ee64f0f8ba2b2ae7c7a2df934a816baaa7291db9e1aa77394c3c/zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7", size = 5366047, upload-time = "2025-09-14T22:16:51.328Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a3/732893eab0a3a7aecff8b99052fecf9f605cf0fb5fb6d0290e36beee47a4/zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4", size = 436484, upload-time = "2025-09-14T22:16:55.005Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a3/c6155f5c1cce691cb80dfd38627046e50af3ee9ddc5d0b45b9b063bfb8c9/zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2", size = 506183, upload-time = "2025-09-14T22:16:52.753Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/8945ab86a0820cc0e0cdbf38086a92868a9172020fdab8a03ac19662b0e5/zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137", size = 462533, upload-time = "2025-09-14T22:16:53.878Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
 ]
 
 [[package]]

--- a/docs/user-guide/tutorials/prowler-app-jira-integration.mdx
+++ b/docs/user-guide/tutorials/prowler-app-jira-integration.mdx
@@ -124,6 +124,16 @@ To manually send individual Findings to Jira:
 
     ![Send to Jira modal](/images/prowler-app/jira/send-to-jira-modal.png)
 
+### Finding Reference in the Jira Issue
+
+Every Jira issue created from a single Finding carries a stable reference back to that Finding, so issues can be filtered, searched with Jira Query Language (JQL), or matched by automation:
+
+* **Labels**: `prowler`, `prowler-<provider>`, `prowler-<severity>`, `prowler-<check-id>` and `prowler-finding-<finding-uid>`. Labels are sanitized deterministically: whitespace becomes `_`, control characters are removed, and values are truncated to Jira's 255-character label limit.
+* **Finding URL**: a link that opens the Finding in Prowler App, filtered by its unique identifier (UID) so it keeps working after later scans.
+* **Tenant Info**: the name of the Prowler organization that sent the Finding.
+
+Prowler Cloud always includes the Finding URL. In a self-hosted Prowler App, set `DJANGO_UI_BASE_URL` in the API environment (for example, `https://prowler.example.com`) to enable it. When the variable is empty, the issue is created without the link.
+
 ## Integration Status
 
 Monitor and manage your Jira integrations through the management interface:

--- a/docs/user-guide/tutorials/prowler-app-jira-integration.mdx
+++ b/docs/user-guide/tutorials/prowler-app-jira-integration.mdx
@@ -126,13 +126,15 @@ To manually send individual Findings to Jira:
 
 ### Finding Reference in the Jira Issue
 
+<VersionBadge version="5.41.0" />
+
 Every Jira issue created from a single Finding carries a stable reference back to that Finding, so issues can be filtered, searched with Jira Query Language (JQL), or matched by automation:
 
 * **Labels**: `prowler`, `prowler-<provider>`, `prowler-<severity>`, `prowler-<check-id>` and `prowler-finding-<finding-uid>`. Labels are sanitized deterministically: whitespace becomes `_`, control characters are removed, and values are truncated to Jira's 255-character label limit.
-* **Finding URL**: a link that opens the Finding in Prowler App, filtered by its unique identifier (UID) so it keeps working after later scans.
+* **Finding URL**: a link that opens the Finding in Prowler, filtered by its unique identifier (UID) so it keeps working after later scans.
 * **Tenant Info**: the name of the Prowler organization that sent the Finding.
 
-Prowler Cloud always includes the Finding URL. In a self-hosted Prowler App, set `DJANGO_UI_BASE_URL` in the API environment (for example, `https://prowler.example.com`) to enable it. When the variable is empty, the issue is created without the link.
+Prowler Cloud always includes the Finding URL. In Prowler Local Server, set `DJANGO_UI_BASE_URL` in the API environment (for example, `https://prowler.example.com`) to enable it. When the variable is empty, the issue is created without the link.
 
 ## Integration Status
 


### PR DESCRIPTION
> **Stack (1/3).** SDK foundation #12539 is merged. Stack: this PR → API deduplication #12541 → Findings UI #12542. Epic PROWLER-2431, task PROWLER-2432.

### Context

Jira issues created by the Prowler Cloud integration only carry a human-readable summary (`[Prowler] SEVERITY - check_id - resource_uid`). They cannot be reliably filtered or traced back to a stable finding, and they do not include a link to the finding in Prowler.

The merged SDK foundation in #12539 provides the label sanitization and collision-safe finding label helpers required by this PR.

### Description

- `send_findings_to_jira()` now passes:
  - `issue_labels`: `prowler`, `prowler-{provider}`, `prowler-{severity}`, `prowler-{check_id}`, and a stable `prowler-finding-{sanitized uid}` label.
    - Labels use the SDK's `Jira.sanitize_labels()` and `Jira.build_finding_label()` helpers.
    - Whitespace is replaced, control characters are removed, and labels are limited to 255 characters.
    - Long finding labels retain a readable prefix and append a SHA-256 hash of the complete raw UID to prevent collisions between UIDs with identical prefixes.
  - `finding_url`: `{UI_BASE_URL}/findings?filter[uid]={uid}`. The URL uses the stable finding UID rather than the per-scan finding ID, so it continues resolving after later scans.
  - `tenant_info`: the tenant name. Lookup failure logs a warning and sends the issue without tenant information.
- Adds `UI_BASE_URL = env.str("DJANGO_UI_BASE_URL", "")` to the API settings and `.env.example`.
  - Self-hosted deployments omit the finding link when the setting is empty.
  - Prowler Cloud configures this value.
- Updates `api/uv.lock` to a merged `master` revision containing #12539. No feature-branch SDK dependency remains.
- Adds the "Finding Reference in the Jira Issue" section to the Jira integration tutorial.

This PR keeps the existing `JiraCreationResult` truthiness compatibility path. Explicit typed outcome handling and Jira issue persistence belong to #12541.

### Steps to review

1. Run the full test suite.
2. With a Jira integration configured and `DJANGO_UI_BASE_URL=https://<your-ui>` set, send a finding through `POST /api/v1/integrations/{id}/jira/dispatches`.
   Confirm that the Jira issue contains:
   - The five `prowler-*` labels.
   - A Finding URL that opens the finding filtered by UID.
   - The tenant name.
3. Unset `DJANGO_UI_BASE_URL` and send another finding. Confirm that the labels and tenant information remain present, with no Finding URL and no delivery error.

### Checklist

- Are there new checks included in this PR? No.
- [x] The code is covered by tests.
- [x] The code follows the Python documentation conventions.
- [ ] Review whether a backport is needed.
- [x] README changes are not required.
- [x] An API changelog fragment is included.

#### API

- [x] All issue and task requirements work as expected.
- [x] Endpoint response output is not applicable because this PR adds no endpoint.
- [x] `EXPLAIN ANALYZE` evidence is not applicable because this PR adds no query or index.
- [x] Performance evidence is not applicable.
- [ ] Attach a screenshot of a created Jira issue before removing draft status.
- [x] API specification regeneration is not required because this PR adds no endpoint or schema.
- [x] `api/uv.lock` resolves a merged SDK revision containing #12539.
- [x] An API changelog fragment is included under `api/changelog.d/`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jira issues created from findings now include provider, severity, check ID, and finding reference labels.
  * Issues include tenant information and a direct link back to the finding when configured.
  * Finding links support self-hosted Prowler UI deployments.
  * Labels use consistent formatting to make Jira issues easier to identify and organize.

* **Documentation**
  * Added guidance on finding references included in Jira issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->