### PR TITLE
fix(mcp): patch the high openssl CVE in the container image

### DIFF
--- a/mcp_server/Dockerfile
+++ b/mcp_server/Dockerfile
@@ -29,15 +29,21 @@ FROM python:3.13.14-alpine3.23@sha256:9fdbf2e3e82628351513560b121e2ee6ce31cac212
 
 LABEL maintainer="https://github.com/prowler-cloud"
 
-# CVE-2026-11822 and CVE-2026-11824, both high, are fixed in Alpine 3.23's
-# sqlite 3.53.4-r0. The base image pins python 3.13.14, which has not been
-# rebuilt since that package was published and still ships 3.51.2-r0, so the
-# upgrade is taken here rather than by moving the pin -- the newest published
-# python:3.13-alpine3.23 carries the same vulnerable version.
+# High CVEs fixed in Alpine 3.23 but not yet in the pinned base image:
+#   sqlite-libs 3.53.4-r0  CVE-2026-11822, CVE-2026-11824  (image ships 3.51.2-r0)
+#   libcrypto3/libssl3 3.5.8-r0  CVE-2026-14456            (image ships 3.5.7-r0)
+# The base image pins python 3.13.14, which has not been rebuilt since those
+# packages were published, so the upgrade is taken here rather than by moving
+# the pin -- the newest published python:3.13-alpine3.23 carries the same
+# vulnerable versions. libcrypto3 and libssl3 are both built from openssl and
+# are flagged separately, so both are named.
 # `>=` rather than `=`: Alpine keeps only the newest build of a package in a
-# branch's index, so an exact pin breaks this build the day 3.53.4-r0 is
-# superseded. Drop this once the base image ships 3.53.4-r0 or later.
-RUN apk add --no-cache --upgrade "sqlite-libs>=3.53.4-r0"
+# branch's index, so an exact pin breaks this build the day one of these is
+# superseded. Drop an entry once the base image ships that version or later.
+RUN apk add --no-cache --upgrade \
+    "sqlite-libs>=3.53.4-r0" \
+    "libcrypto3>=3.5.8-r0" \
+    "libssl3>=3.5.8-r0"
 
 # Create non-root user for security
 # Using specific UID/GID for consistency across environments

--- a/mcp_server/changelog.d/mcp-image-openssl-cve.security.md
+++ b/mcp_server/changelog.d/mcp-image-openssl-cve.security.md
@@ -1,0 +1,1 @@
+`libcrypto3` and `libssl3` upgraded to 3.5.8-r0 in the container image, patching CVE-2026-14456


### PR DESCRIPTION
### Context

`mcp-container-build-and-scan` fails on every PR that touches `mcp_server/`:

```
Error: Found 2 vulnerabilities at severity high or above (0 critical, 2 high)
  HIGH    CVE-2026-14456    libcrypto3 3.5.7-r0
  HIGH    CVE-2026-14456    libssl3 3.5.7-r0
```

One CVE, reported twice: `libcrypto3` and `libssl3` are both subpackages of Alpine's `openssl`. It comes from the base image, not from anything this repo installs. Alpine 3.23's security database fixes it in **openssl 3.5.8-r0**, and that package is live in the branch index:

```
$ curl -s https://secdb.alpinelinux.org/v3.23/main.json | jq '.packages[].pkg | select(.name=="openssl").secfixes'
  "3.5.8-r0": ["CVE-2026-14456", "CVE-2026-14457", ...]

$ # v3.23/main/x86_64 APKINDEX
  libcrypto3 3.5.8-r0
  libssl3    3.5.8-r0
```

**Bumping the base image pin does not fix this.** The newest published `python:3.13-alpine3.23` is the same digest as when #12537 landed, and still carries the vulnerable version:

```
tag 3.13-alpine3.23 -> sha256:7ea3f82de8ea6d4fb7e5d2bbe3fe3c9d931700b7a529f1fe5769e42abe514ca1
  libcrypto3 = 3.5.7-r0
  libssl3    = 3.5.7-r0
  sqlite-libs = 3.51.2-r0   # still, hence the existing line
```

It has not been rebuilt since the Alpine package landed, so there is no pin to move to.

A `.trivyignore.yaml` entry would also be wrong here. That file is for findings with a published fix we *cannot* take, and this fix is one we can take.

### Description

Same treatment as #12537, folded into the `RUN` that commit added rather than placed beside it:

```dockerfile
RUN apk add --no-cache --upgrade \
    "sqlite-libs>=3.53.4-r0" \
    "libcrypto3>=3.5.8-r0" \
    "libssl3>=3.5.8-r0"
```

Three notes:

- **Folded into the existing `RUN`, not added next to it.** A second consecutive `apk add` block raises hadolint `DL3059`. Consolidating keeps hadolint's output on this file byte-identical to `master`. That is why the diff touches the `sqlite-libs` line — the constraint itself is unchanged.
- **`>=` rather than `=3.5.8-r0`.** Unchanged rationale from #12537: Alpine keeps only the newest build of a package in a branch's index, so an exact pin breaks the build the day 3.5.8-r0 is superseded by the next security update.
- **Both subpackages named.** Trivy reports `libcrypto3` and `libssl3` as separate findings, so both are pinned explicitly rather than relying on `openssl` to pull them in.

The comment above the `RUN` now lists each package with its CVEs and the version the base image currently ships, and says when to remove an entry: once the base image itself ships that version or later.

No workflow changes this time — `dl-cdn.alpinelinux.org:443` and `dualstack.j.sni.global.fastly.net:443` were already added to both egress allowlists by #12537.

Only `mcp_server/Dockerfile` is affected. The other images are Debian-slim (`Dockerfile`, `api/Dockerfile`) or `node:24-alpine` (`ui/Dockerfile`), and none of them reports this package. The builder stage is left alone — nothing from its Alpine tree is copied into the final image.

### Steps to review

1. Confirm the upgrade still runs as root, before `USER prowler`.
2. Confirm the version constraint matches the Alpine secfix above.
3. `mcp-container-build-and-scan` on this PR is the real check: it builds the image and re-runs Trivy and Grype, so a green run is the verification that the count goes to zero.

Verified locally against the pinned base image digest:

```
$ docker run --rm --entrypoint sh python:3.13.14-alpine3.23@sha256:9fdbf2e3... -c \
    'apk add --no-cache --upgrade "sqlite-libs>=3.53.4-r0" "libcrypto3>=3.5.8-r0" "libssl3>=3.5.8-r0"'
(1/3) Upgrading libcrypto3 (3.5.7-r0 -> 3.5.8-r0)
(2/3) Upgrading sqlite-libs (3.51.2-r0 -> 3.53.4-r0)
(3/3) Upgrading libssl3 (3.5.7-r0 -> 3.5.8-r0)
```

Also ran hadolint 2.14.0 with the same `--ignore=DL3013` this repo uses: identical output to `master` (one pre-existing `DL3066` info on the `USER` line).

### Checklist

- [x] Review if the code is being covered by tests. — the container scan job is the test; no unit tests apply to a Dockerfile package constraint.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) — not needed.

#### SDK/CLI
- Are there new checks included in this PR? No

#### MCP Server
- [x] All issue/task requirements work as expected on the MCP Server
- [x] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable. — `mcp-image-openssl-cve.security.md`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated runtime dependencies to address known vulnerabilities in SQLite and OpenSSL libraries.
  * Upgraded OpenSSL components to a security-fixed version, addressing CVE-2026-14456.
* **Documentation**
  * Added a changelog entry documenting the security updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->