### PR TITLE
fix(container): patch the high OpenSSL CVEs for container img

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,20 @@ ARG POWERSHELL_SHA256_ARM64=2503b71da3e83635592b092df59a0aca4c3606b4d9b068217bb0
 ARG ZIZMOR_SHA256_AMD64=a8000f3c683319a523d3b20df0e75457ba591f049cfcbfa98966631b56733c03
 ARG ZIZMOR_SHA256_ARM64=d66e37ef8a375fb07939c630ebf9709a6e0f20242bdc3faf672a7ed97e0b768d
 
+# High CVEs fixed in Debian trixie-security but not yet in the pinned base image:
+#   openssl/libssl3t64/openssl-provider-legacy 3.5.7-1~deb13u2  CVE-2026-14456,
+#   -14457, -18798, -54874, -63072, -63073, -63074, -63075, -63076, -75803
+#   (image ships 3.5.6-1~deb13u2)
+# Taken as a targeted --only-upgrade rather than by moving the digest: the newest
+# published python:3.12-slim-trixie carries the same vulnerable version. The three
+# packages are all built from openssl and are flagged separately, so all are named.
+# Drop them once the base image ships 3.5.7-1~deb13u2 or later.
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget libicu76 libunwind8 libssl3 libcurl4 ca-certificates apt-transport-https gnupg \
     build-essential pkg-config libzstd-dev zlib1g-dev \
-    && apt-get install -y --no-install-recommends --only-upgrade util-linux \
+    && apt-get install -y --no-install-recommends --only-upgrade \
+       util-linux libssl3t64 openssl openssl-provider-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PowerShell

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -21,6 +21,14 @@ ARG POWERSHELL_SHA256_ARM64=2503b71da3e83635592b092df59a0aca4c3606b4d9b068217bb0
 ARG ZIZMOR_SHA256_AMD64=a8000f3c683319a523d3b20df0e75457ba591f049cfcbfa98966631b56733c03
 ARG ZIZMOR_SHA256_ARM64=d66e37ef8a375fb07939c630ebf9709a6e0f20242bdc3faf672a7ed97e0b768d
 
+# High CVEs fixed in Debian trixie-security but not yet in the pinned base image:
+#   openssl/libssl3t64/openssl-provider-legacy 3.5.7-1~deb13u2  CVE-2026-14456,
+#   -14457, -18798, -54874, -63072, -63073, -63074, -63075, -63076, -75803
+#   (image ships 3.5.6-1~deb13u2)
+# Taken as a targeted --only-upgrade rather than by moving the digest: the newest
+# published python:3.12-slim-trixie carries the same vulnerable version. The three
+# packages are all built from openssl and are flagged separately, so all are named.
+# Drop them once the base image ships 3.5.7-1~deb13u2 or later.
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
@@ -36,7 +44,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libtool \
     libxslt1-dev \
     python3-dev \
-    && apt-get install -y --no-install-recommends --only-upgrade util-linux \
+    && apt-get install -y --no-install-recommends --only-upgrade \
+       util-linux libssl3t64 openssl openssl-provider-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PowerShell

--- a/api/changelog.d/api-image-openssl-cves.security.md
+++ b/api/changelog.d/api-image-openssl-cves.security.md
@@ -1,0 +1,1 @@
+`openssl`, `libssl3t64` and `openssl-provider-legacy` upgraded to 3.5.7-1~deb13u2 in the API container image, patching ten high OpenSSL CVEs

--- a/prowler/changelog.d/sdk-image-openssl-cves.security.md
+++ b/prowler/changelog.d/sdk-image-openssl-cves.security.md
@@ -1,0 +1,1 @@
+`openssl`, `libssl3t64` and `openssl-provider-legacy` upgraded to 3.5.7-1~deb13u2 in the SDK container image, patching ten high OpenSSL CVEs

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -5,9 +5,26 @@ LABEL maintainer="https://github.com/prowler-cloud"
 
 # The build uses pnpm via corepack, so npm is unused — remove it (and npx) to drop
 # the bundled-npm CVE surface from every stage, incl. prod.
-# No apk upgrade: it resolves against Alpine's live repo, so the digest pin above
-# would not make the image reproducible. Move the digest forward instead.
+# No blanket apk upgrade: it resolves against Alpine's live repo, so the digest pin
+# above would not make the image reproducible. Move the digest forward instead, or
+# take a named package as the targeted exception below.
 RUN corepack enable && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+
+# High CVEs fixed in Alpine 3.24 but not yet in the pinned base image:
+#   libcrypto3/libssl3 3.5.8-r0  CVE-2026-14456, CVE-2026-14457, CVE-2026-18798,
+#                                CVE-2026-54874, CVE-2026-63072, CVE-2026-63075,
+#                                CVE-2026-63076  (image ships 3.5.7-r0)
+# The base image pins node 24.18.1, which has not been rebuilt since that package
+# was published, so the upgrade is taken here rather than by moving the pin -- the
+# newest published node:24-alpine (24.19.0, built 2026-08-03) predates the
+# 2026-08-13 advisory and carries the same vulnerable version. libcrypto3 and
+# libssl3 are both built from openssl and are flagged separately, so both are named.
+# `>=` rather than `=`: Alpine keeps only the newest build of a package in a
+# branch's index, so an exact pin breaks this build the day 3.5.8-r0 is superseded.
+# Drop this once the base image ships 3.5.8-r0 or later.
+RUN apk add --no-cache --upgrade \
+    "libcrypto3>=3.5.8-r0" \
+    "libssl3>=3.5.8-r0"
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/ui/changelog.d/ui-image-openssl-cves.security.md
+++ b/ui/changelog.d/ui-image-openssl-cves.security.md
@@ -1,0 +1,1 @@
+`libcrypto3` and `libssl3` upgraded to 3.5.8-r0 in the UI container image, patching seven high OpenSSL CVEs


### PR DESCRIPTION
### Context

`ui-container-build-and-scan` fails on master and on every PR that touches `ui/`:

```
Found 14 vulnerabilities at severity high or above (0 critical, 14 high)
  High    CVE-2026-14456    libcrypto3 3.5.7-r0
  High    CVE-2026-14456    libssl3 3.5.7-r0
  ...
```

They come from the OpenSSL the base image ships, not from anything we install. The same batch affects the API and SDK images, which are Debian instead of Alpine. Their checks have not run since the advisory landed, but they will fail the next time they do.

Moving the digest pins forward does not help. The advisory is from 2026-08-13 and the newest published `node:24-alpine` (24.19.0) was built on 2026-08-03, so it ships the same vulnerable version. Same for `python:3.12-slim-trixie`.

A `.trivyignore.yaml` or `.grype.yaml` entry would also be wrong. Both files are for findings with a published fix we cannot take, and here both Alpine and Debian publish one.

### Description

Targeted package upgrades, same approach as #12537 and #12547.

`ui/Dockerfile`, in the `base` stage so every stage inherits it:

```dockerfile
RUN apk add --no-cache --upgrade \
    "libcrypto3>=3.5.8-r0" \
    "libssl3>=3.5.8-r0"
```

`Dockerfile` and `api/Dockerfile`, extending the `--only-upgrade` line they already had:

```dockerfile
&& apt-get install -y --no-install-recommends --only-upgrade \
   util-linux libssl3t64 openssl openssl-provider-legacy \
```

`>=` rather than `=`: the distro index keeps only the newest build of a package, so an exact pin breaks the build the day it is superseded.

Alpine reports 7 CVEs and Debian 10, the extra ones being CVE-2026-63073, CVE-2026-63074 and CVE-2026-75803. Alpine fixes them in openssl 3.5.8-r0, Debian in 3.5.7-1~deb13u2 from trixie-security.

The comment in `ui/Dockerfile` said to avoid `apk upgrade` and move the digest forward instead. Reworded so it still rules out a blanket upgrade but allows a named package as a targeted exception, which is what the other images already do.

`mcp_server` is not included here, #12547 covers it.

### Steps to review

1. `ui-container-build-and-scan`, `api-container-build-and-scan` and `sdk-container-build-and-scan` are the real check. They rebuild the images and rescan, so a green run is the verification that the counts go to zero.
2. Confirm the version constraints match the distro security data: Alpine `openssl 3.5.8-r0`, Debian `3.5.7-1~deb13u2`.
3. Confirm the UI upgrade runs in `base`, before the build drops to the `nextjs` user.

I could not build the images locally, so point 1 is the one that matters.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated API and SDK container images with newer OpenSSL packages, addressing ten high-severity vulnerabilities.
  - Updated the UI container image’s cryptographic libraries, addressing seven high-severity OpenSSL vulnerabilities.
- **Chores**
  - Applied targeted security package upgrades while preserving the existing pinned base images and runtime versions.
  - Added release documentation for the container image security updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->