### PR TITLE
feat(azure): add aks_cluster_uses_a_supported_version check

### DIFF
--- a/docs/user-guide/cli/tutorials/configuration_file.mdx
+++ b/docs/user-guide/cli/tutorials/configuration_file.mdx
@@ -710,8 +710,9 @@ azure:
   # Azure Kubernetes Service
   # azure.aks_cluster_uses_a_supported_version
   # AKS clusters must run this Kubernetes minor version or higher. AKS gives
-  # community support to the latest GA minor version and the two before it.
-  # Lower this value if your clusters are enrolled in long-term support.
+  # community support to the latest generally available (GA) minor version and
+  # the two before it. Lower this value if your clusters are enrolled in
+  # long-term support.
   aks_cluster_oldest_version_supported: "1.34"
 
   # Azure App Service

--- a/docs/user-guide/cli/tutorials/configuration_file.mdx
+++ b/docs/user-guide/cli/tutorials/configuration_file.mdx
@@ -207,6 +207,7 @@ The following list includes all the Azure checks with configurable variables tha
 
 | Check Name                                               | Value                                           | Type            | Default                                                    |
 |----------------------------------------------------------|-------------------------------------------------|-----------------|------------------------------------------------------------|
+| `aks_cluster_uses_a_supported_version`                   | `aks_cluster_oldest_version_supported`          | String          | `"1.34"`                                                   |
 | `apim_threat_detection_llm_jacking`                      | `apim_threat_detection_llm_jacking_actions`     | List of Strings | See `config.yaml`                                          |
 | `apim_threat_detection_llm_jacking`                      | `apim_threat_detection_llm_jacking_minutes`     | Integer         | `1440`                                                     |
 | `apim_threat_detection_llm_jacking`                      | `apim_threat_detection_llm_jacking_threshold`   | Float           | `0.1`                                                      |
@@ -705,6 +706,13 @@ azure:
   # azure.network_public_ip_shodan
   # TODO: create common config
   shodan_api_key: null
+
+  # Azure Kubernetes Service
+  # azure.aks_cluster_uses_a_supported_version
+  # AKS clusters must run this Kubernetes minor version or higher. AKS gives
+  # community support to the latest GA minor version and the two before it.
+  # Lower this value if your clusters are enrolled in long-term support.
+  aks_cluster_oldest_version_supported: "1.34"
 
   # Azure App Service
   # azure.app_ensure_php_version_is_latest

--- a/prowler/changelog.d/aks-cluster-uses-a-supported-version.added.md
+++ b/prowler/changelog.d/aks-cluster-uses-a-supported-version.added.md
@@ -1,0 +1,1 @@
+`aks_cluster_uses_a_supported_version` checks that every AKS cluster runs a Kubernetes minor version at or above the configured baseline, which defaults to the oldest version in AKS community support

--- a/prowler/changelog.d/aks-cluster-uses-a-supported-version.added.md
+++ b/prowler/changelog.d/aks-cluster-uses-a-supported-version.added.md
@@ -1,1 +1,1 @@
-`aks_cluster_uses_a_supported_version` checks that every AKS cluster runs a Kubernetes minor version at or above the configured baseline, which defaults to the oldest version in AKS community support
+`aks_cluster_uses_a_supported_version` check for Azure provider, verifying that AKS clusters run a Kubernetes minor version at or above the configured baseline, which defaults to the oldest version in AKS community support

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -529,6 +529,13 @@ azure:
   # TODO: create common config
   shodan_api_key: null
 
+  # Azure Kubernetes Service
+  # azure.aks_cluster_uses_a_supported_version
+  # AKS clusters must run this Kubernetes minor version or higher. AKS gives
+  # community support to the latest GA minor version and the two before it.
+  # Lower this value if your clusters are enrolled in long-term support.
+  aks_cluster_oldest_version_supported: "1.34"
+
   # Configurable minimal risk level for attack path notifications
   # azure.defender_attack_path_notifications_properly_configured
   defender_attack_path_minimal_risk_level: "High"

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -532,8 +532,9 @@ azure:
   # Azure Kubernetes Service
   # azure.aks_cluster_uses_a_supported_version
   # AKS clusters must run this Kubernetes minor version or higher. AKS gives
-  # community support to the latest GA minor version and the two before it.
-  # Lower this value if your clusters are enrolled in long-term support.
+  # community support to the latest generally available (GA) minor version and
+  # the two before it. Lower this value if your clusters are enrolled in
+  # long-term support.
   aks_cluster_oldest_version_supported: "1.34"
 
   # Configurable minimal risk level for attack path notifications

--- a/prowler/config/schema/azure.py
+++ b/prowler/config/schema/azure.py
@@ -25,6 +25,14 @@ class AzureProviderConfig(ProviderConfigBase):
         description="API key for Shodan lookups on Azure public IPs.",
     )
 
+    # --- AKS -------------------------------------------------------------
+    aks_cluster_oldest_version_supported: Annotated[
+        Optional[str], AfterValidator(_validate_dotted_version)
+    ] = Field(
+        default=None,
+        description='Oldest AKS Kubernetes version still considered supported, e.g. "1.34".',
+    )
+
     # --- Defender --------------------------------------------------------
     defender_attack_path_minimal_risk_level: Optional[
         Literal["Low", "Medium", "High", "Critical"]

--- a/prowler/config/schema/azure.py
+++ b/prowler/config/schema/azure.py
@@ -16,6 +16,9 @@ from prowler.config.schema.validators import make_dotted_version_validator
 # MAJOR.MINOR notation.
 _validate_dotted_version = make_dotted_version_validator(1, 2)
 
+# AKS reports "X.Y" minor versions, matching the EKS baseline in the AWS schema.
+_validate_aks_minor = make_dotted_version_validator(2, 2)
+
 
 class AzureProviderConfig(ProviderConfigBase):
     # --- Network ---------------------------------------------------------
@@ -27,10 +30,10 @@ class AzureProviderConfig(ProviderConfigBase):
 
     # --- AKS -------------------------------------------------------------
     aks_cluster_oldest_version_supported: Annotated[
-        Optional[str], AfterValidator(_validate_dotted_version)
+        Optional[str], AfterValidator(_validate_aks_minor)
     ] = Field(
         default=None,
-        description='Oldest AKS Kubernetes version still considered supported, e.g. "1.34".',
+        description='Oldest supported AKS minor version, expected as "X.Y".',
     )
 
     # --- Defender --------------------------------------------------------

--- a/prowler/providers/azure/services/aks/aks_cluster_uses_a_supported_version/aks_cluster_uses_a_supported_version.metadata.json
+++ b/prowler/providers/azure/services/aks/aks_cluster_uses_a_supported_version/aks_cluster_uses_a_supported_version.metadata.json
@@ -1,0 +1,40 @@
+{
+  "Provider": "azure",
+  "CheckID": "aks_cluster_uses_a_supported_version",
+  "CheckTitle": "AKS cluster uses a supported Kubernetes version",
+  "CheckType": [],
+  "ServiceName": "aks",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "Microsoft.ContainerService/managedClusters",
+  "ResourceGroup": "container",
+  "Description": "AKS clusters run a **supported Kubernetes version** at or above the configured baseline. AKS provides community support for the latest generally available minor version and the two that precede it, so the evaluation compares each cluster's minor version against the minimum supported level and highlights clusters running below that baseline.",
+  "Risk": "Running an **unsupported Kubernetes version** stops security patches from Microsoft and the upstream project, leaving clusters exposed to known CVEs and privilege escalation bugs (**confidentiality/integrity**). Deprecated or removed APIs can also break controllers and add-ons, causing outages (**availability**).",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions",
+    "https://learn.microsoft.com/en-us/azure/aks/long-term-support",
+    "https://learn.microsoft.com/en-us/azure/aks/upgrade-aks-cluster"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "az aks upgrade --resource-group <resource_group_name> --name <cluster_name> --kubernetes-version <supported_version>",
+      "NativeIaC": "```bicep\n// Bicep: deploy the AKS cluster on a supported Kubernetes version\nresource <example_resource_name> 'Microsoft.ContainerService/managedClusters@2024-09-01' = {\n  name: '<example_resource_name>'\n  location: resourceGroup().location\n  identity: {\n    type: 'SystemAssigned'\n  }\n  properties: {\n    kubernetesVersion: '<supported_version>' // Critical: set a supported Kubernetes version to pass the check\n    dnsPrefix: '<example_dns_prefix>'\n    agentPoolProfiles: [\n      {\n        name: 'systempool'\n        count: 3\n        vmSize: '<example_vm_size>'\n        mode: 'System'\n      }\n    ]\n  }\n}\n```",
+      "Other": "1. Open the Azure portal and go to Kubernetes services\n2. Select your cluster (<cluster_name>)\n3. Under Settings, select Cluster configuration\n4. Next to Kubernetes version, select Upgrade version\n5. Choose a supported version and confirm the upgrade\n6. Wait for the control plane and node pools to finish upgrading",
+      "Terraform": "```hcl\n# Terraform: keep the AKS cluster on a supported Kubernetes version\nresource \"azurerm_kubernetes_cluster\" \"<example_resource_name>\" {\n  name                = \"<example_resource_name>\"\n  location            = \"<example_location>\"\n  resource_group_name = \"<example_resource_group_name>\"\n  dns_prefix          = \"<example_dns_prefix>\"\n\n  kubernetes_version = \"<supported_version>\" # Critical: set a supported Kubernetes version to pass the check\n\n  default_node_pool {\n    name       = \"systempool\"\n    node_count = 3\n    vm_size    = \"<example_vm_size>\"\n  }\n\n  identity {\n    type = \"SystemAssigned\"\n  }\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Adopt a **version management policy**: keep clusters inside the AKS community support window, schedule regular upgrades, and test workloads for API deprecations. Enable an auto-upgrade channel, upgrade node pools alongside the control plane, and track the AKS release calendar. Long-term support can extend patching where an immediate upgrade is not possible.",
+      "Url": "https://hub.prowler.com/check/aks_cluster_uses_a_supported_version"
+    }
+  },
+  "Categories": [
+    "vulnerabilities"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [
+    "aks_cluster_auto_upgrade_enabled"
+  ],
+  "Notes": "The baseline is configurable through `aks_cluster_oldest_version_supported`. AKS releases a minor version roughly every four months, so the shipped default needs revisiting as the support window moves. Clusters enrolled in long-term support keep receiving patches beyond the community support window and can use a lower baseline."
+}

--- a/prowler/providers/azure/services/aks/aks_cluster_uses_a_supported_version/aks_cluster_uses_a_supported_version.py
+++ b/prowler/providers/azure/services/aks/aks_cluster_uses_a_supported_version/aks_cluster_uses_a_supported_version.py
@@ -2,6 +2,13 @@ from prowler.lib.check.models import Check, Check_Report_Azure
 from prowler.lib.logger import logger
 from prowler.providers.azure.services.aks.aks_client import aks_client
 
+DEFAULT_OLDEST_VERSION_SUPPORTED = "1.34"
+
+
+def _minor_version(version: str) -> tuple[int, int]:
+    major, minor = version.split(".")[:2]
+    return int(major), int(minor)
+
 
 class aks_cluster_uses_a_supported_version(Check):
     """
@@ -16,12 +23,20 @@ class aks_cluster_uses_a_supported_version(Check):
     def execute(self) -> list[Check_Report_Azure]:
         findings = []
 
-        aks_cluster_oldest_version_supported = aks_client.audit_config.get(
-            "aks_cluster_oldest_version_supported", "1.34"
+        # An explicit null in the config file survives .get(), so fall back here
+        # rather than relying on the default argument alone.
+        baseline = (
+            aks_client.audit_config.get("aks_cluster_oldest_version_supported")
+            or DEFAULT_OLDEST_VERSION_SUPPORTED
         )
-        oldest_supported_version = tuple(
-            map(int, aks_cluster_oldest_version_supported.split(".")[:2])
-        )
+        try:
+            oldest_supported_version = _minor_version(str(baseline))
+        except ValueError as error:
+            logger.error(
+                f"aks_cluster_oldest_version_supported: {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}. Falling back to {DEFAULT_OLDEST_VERSION_SUPPORTED}."
+            )
+            baseline = DEFAULT_OLDEST_VERSION_SUPPORTED
+            oldest_supported_version = _minor_version(baseline)
 
         for subscription_id, clusters in aks_client.clusters.items():
             subscription_name = aks_client.subscriptions.get(
@@ -32,12 +47,10 @@ class aks_cluster_uses_a_supported_version(Check):
                     continue
 
                 try:
-                    cluster_version = tuple(
-                        map(int, cluster.kubernetes_version.split(".")[:2])
-                    )
-                except ValueError:
+                    cluster_version = _minor_version(cluster.kubernetes_version)
+                except ValueError as error:
                     logger.error(
-                        f"Subscription ID: {subscription_id} -- Cluster {cluster.name} has an unparseable Kubernetes version: {cluster.kubernetes_version}"
+                        f"Subscription ID: {subscription_id} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                     continue
 
@@ -46,7 +59,7 @@ class aks_cluster_uses_a_supported_version(Check):
 
                 if cluster_version < oldest_supported_version:
                     report.status = "FAIL"
-                    report.status_extended = f"AKS cluster '{cluster.name}' is running an unsupported Kubernetes version {cluster.kubernetes_version} in subscription '{subscription_name} ({subscription_id})'. The oldest supported version is {aks_cluster_oldest_version_supported}."
+                    report.status_extended = f"AKS cluster '{cluster.name}' is running an unsupported Kubernetes version {cluster.kubernetes_version} in subscription '{subscription_name} ({subscription_id})'. The oldest supported version is {baseline}."
                 else:
                     report.status = "PASS"
                     report.status_extended = f"AKS cluster '{cluster.name}' is running a supported Kubernetes version {cluster.kubernetes_version} in subscription '{subscription_name} ({subscription_id})'."

--- a/prowler/providers/azure/services/aks/aks_cluster_uses_a_supported_version/aks_cluster_uses_a_supported_version.py
+++ b/prowler/providers/azure/services/aks/aks_cluster_uses_a_supported_version/aks_cluster_uses_a_supported_version.py
@@ -1,0 +1,56 @@
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.lib.logger import logger
+from prowler.providers.azure.services.aks.aks_client import aks_client
+
+
+class aks_cluster_uses_a_supported_version(Check):
+    """
+    Ensure AKS clusters run a supported Kubernetes version.
+
+    AKS gives community support to the latest generally available minor version and the two before it, so older versions stop receiving security patches. The baseline is configurable through `aks_cluster_oldest_version_supported`, which can be lowered for clusters enrolled in long-term support.
+
+    - PASS: The cluster runs a Kubernetes version at or above the baseline.
+    - FAIL: The cluster runs a Kubernetes version below the baseline.
+    """
+
+    def execute(self) -> list[Check_Report_Azure]:
+        findings = []
+
+        aks_cluster_oldest_version_supported = aks_client.audit_config.get(
+            "aks_cluster_oldest_version_supported", "1.34"
+        )
+        oldest_supported_version = tuple(
+            map(int, aks_cluster_oldest_version_supported.split(".")[:2])
+        )
+
+        for subscription_id, clusters in aks_client.clusters.items():
+            subscription_name = aks_client.subscriptions.get(
+                subscription_id, subscription_id
+            )
+            for cluster in clusters.values():
+                if not cluster.kubernetes_version:
+                    continue
+
+                try:
+                    cluster_version = tuple(
+                        map(int, cluster.kubernetes_version.split(".")[:2])
+                    )
+                except ValueError:
+                    logger.error(
+                        f"Subscription ID: {subscription_id} -- Cluster {cluster.name} has an unparseable Kubernetes version: {cluster.kubernetes_version}"
+                    )
+                    continue
+
+                report = Check_Report_Azure(metadata=self.metadata(), resource=cluster)
+                report.subscription = subscription_id
+
+                if cluster_version < oldest_supported_version:
+                    report.status = "FAIL"
+                    report.status_extended = f"AKS cluster '{cluster.name}' is running an unsupported Kubernetes version {cluster.kubernetes_version} in subscription '{subscription_name} ({subscription_id})'. The oldest supported version is {aks_cluster_oldest_version_supported}."
+                else:
+                    report.status = "PASS"
+                    report.status_extended = f"AKS cluster '{cluster.name}' is running a supported Kubernetes version {cluster.kubernetes_version} in subscription '{subscription_name} ({subscription_id})'."
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/azure/services/aks/aks_cluster_uses_a_supported_version/aks_cluster_uses_a_supported_version.py
+++ b/prowler/providers/azure/services/aks/aks_cluster_uses_a_supported_version/aks_cluster_uses_a_supported_version.py
@@ -21,6 +21,12 @@ class aks_cluster_uses_a_supported_version(Check):
     """
 
     def execute(self) -> list[Check_Report_Azure]:
+        """Compare each cluster's Kubernetes minor version against the configured baseline.
+
+        Returns:
+            One report per cluster with a parseable version. Clusters reporting no
+            version, or one that cannot be parsed, are skipped without a finding.
+        """
         findings = []
 
         # An explicit null in the config file survives .get(), so fall back here

--- a/prowler/providers/azure/services/aks/aks_service.py
+++ b/prowler/providers/azure/services/aks/aks_service.py
@@ -109,6 +109,9 @@ class AKS(AzureService):
                                             cluster, "disable_local_accounts", False
                                         )
                                     ),
+                                    kubernetes_version=getattr(
+                                        cluster, "kubernetes_version", None
+                                    ),
                                 )
                             }
                         )
@@ -140,3 +143,4 @@ class Cluster:
     defender_enabled: bool = False
     azure_monitor_enabled: bool = False
     local_accounts_disabled: bool = False
+    kubernetes_version: Optional[str] = None

--- a/tests/providers/azure/services/aks/aks_cluster_uses_a_supported_version/aks_cluster_uses_a_supported_version_test.py
+++ b/tests/providers/azure/services/aks/aks_cluster_uses_a_supported_version/aks_cluster_uses_a_supported_version_test.py
@@ -165,6 +165,34 @@ class Test_aks_cluster_uses_a_supported_version:
             assert len(result) == 1
             assert result[0].status == "FAIL"
 
+    # An explicit null in config.yaml survives audit_config.get(), so the check
+    # has to fall back on its own rather than crash on None.split()
+    @pytest.mark.parametrize("baseline", [None, "", "1", "not-a-version", 1])
+    def test_invalid_baseline_falls_back_to_default(self, baseline):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_uses_a_supported_version.aks_cluster_uses_a_supported_version import (
+                aks_cluster_uses_a_supported_version,
+            )
+
+            cluster = build_cluster(kubernetes_version="1.28.3")
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+            aks_client.audit_config = {"aks_cluster_oldest_version_supported": baseline}
+
+            check = aks_cluster_uses_a_supported_version()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "The oldest supported version is 1.34." in result[0].status_extended
+
     @pytest.mark.parametrize("kubernetes_version", [None, ""])
     def test_cluster_without_version_is_skipped(self, kubernetes_version):
         aks_client = mock.MagicMock

--- a/tests/providers/azure/services/aks/aks_cluster_uses_a_supported_version/aks_cluster_uses_a_supported_version_test.py
+++ b/tests/providers/azure/services/aks/aks_cluster_uses_a_supported_version/aks_cluster_uses_a_supported_version_test.py
@@ -1,0 +1,213 @@
+from unittest import mock
+
+import pytest
+
+from prowler.providers.azure.services.aks.aks_service import Cluster
+from tests.providers.azure.azure_fixtures import (
+    AZURE_SUBSCRIPTION_DISPLAY,
+    AZURE_SUBSCRIPTION_ID,
+    AZURE_SUBSCRIPTION_NAME,
+    set_mocked_azure_provider,
+)
+
+CHECK_PATH = "prowler.providers.azure.services.aks.aks_cluster_uses_a_supported_version.aks_cluster_uses_a_supported_version"
+
+
+def build_cluster(kubernetes_version):
+    return Cluster(
+        id="/sub/rg/cluster1",
+        name="test-cluster",
+        public_fqdn="test.azmk8s.io",
+        private_fqdn=None,
+        network_policy=None,
+        agent_pool_profiles=[],
+        rbac_enabled=True,
+        location="eastus",
+        kubernetes_version=kubernetes_version,
+    )
+
+
+class Test_aks_cluster_uses_a_supported_version:
+    def test_no_subscriptions(self):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_uses_a_supported_version.aks_cluster_uses_a_supported_version import (
+                aks_cluster_uses_a_supported_version,
+            )
+
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {}
+            aks_client.audit_config = {}
+
+            check = aks_cluster_uses_a_supported_version()
+            result = check.execute()
+            assert len(result) == 0
+
+    @pytest.mark.parametrize("kubernetes_version", ["1.34", "1.34.10", "1.35.7", "2.0"])
+    def test_pass(self, kubernetes_version):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_uses_a_supported_version.aks_cluster_uses_a_supported_version import (
+                aks_cluster_uses_a_supported_version,
+            )
+
+            cluster = build_cluster(kubernetes_version=kubernetes_version)
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+            aks_client.audit_config = {"aks_cluster_oldest_version_supported": "1.34"}
+
+            check = aks_cluster_uses_a_supported_version()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"AKS cluster 'test-cluster' is running a supported Kubernetes version {kubernetes_version} in subscription '{AZURE_SUBSCRIPTION_DISPLAY}'."
+            )
+            assert result[0].resource_name == "test-cluster"
+            assert result[0].resource_id == "/sub/rg/cluster1"
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].location == "eastus"
+
+    # 1.9 is below 1.34 numerically but above it as a string
+    @pytest.mark.parametrize(
+        "kubernetes_version", ["1.33", "1.33.5", "1.28", "1.9", "0.9"]
+    )
+    def test_fail(self, kubernetes_version):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_uses_a_supported_version.aks_cluster_uses_a_supported_version import (
+                aks_cluster_uses_a_supported_version,
+            )
+
+            cluster = build_cluster(kubernetes_version=kubernetes_version)
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+            aks_client.audit_config = {"aks_cluster_oldest_version_supported": "1.34"}
+
+            check = aks_cluster_uses_a_supported_version()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"AKS cluster 'test-cluster' is running an unsupported Kubernetes version {kubernetes_version} in subscription '{AZURE_SUBSCRIPTION_DISPLAY}'. The oldest supported version is 1.34."
+            )
+            assert result[0].resource_name == "test-cluster"
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+
+    def test_lowered_baseline(self):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_uses_a_supported_version.aks_cluster_uses_a_supported_version import (
+                aks_cluster_uses_a_supported_version,
+            )
+
+            cluster = build_cluster(kubernetes_version="1.31")
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+            aks_client.audit_config = {"aks_cluster_oldest_version_supported": "1.31"}
+
+            check = aks_cluster_uses_a_supported_version()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+
+    def test_unconfigured_baseline(self):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_uses_a_supported_version.aks_cluster_uses_a_supported_version import (
+                aks_cluster_uses_a_supported_version,
+            )
+
+            cluster = build_cluster(kubernetes_version="1.33")
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+            aks_client.audit_config = {}
+
+            check = aks_cluster_uses_a_supported_version()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+
+    @pytest.mark.parametrize("kubernetes_version", [None, ""])
+    def test_cluster_without_version_is_skipped(self, kubernetes_version):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_uses_a_supported_version.aks_cluster_uses_a_supported_version import (
+                aks_cluster_uses_a_supported_version,
+            )
+
+            cluster = build_cluster(kubernetes_version=kubernetes_version)
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+            aks_client.audit_config = {}
+
+            check = aks_cluster_uses_a_supported_version()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_unparseable_version_is_skipped(self):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_uses_a_supported_version.aks_cluster_uses_a_supported_version import (
+                aks_cluster_uses_a_supported_version,
+            )
+
+            cluster = build_cluster(kubernetes_version="not-a-version")
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+            aks_client.audit_config = {}
+
+            check = aks_cluster_uses_a_supported_version()
+            result = check.execute()
+            assert len(result) == 0

--- a/tests/providers/azure/services/aks/aks_service_test.py
+++ b/tests/providers/azure/services/aks/aks_service_test.py
@@ -21,6 +21,7 @@ def mock_aks_get_clusters(_):
                 agent_pool_profiles=[],
                 location="westeurope",
                 rbac_enabled=True,
+                kubernetes_version="1.34.0",
             )
         }
     }
@@ -68,6 +69,10 @@ class Test_AKS_Service:
             aks.clusters[AZURE_SUBSCRIPTION_ID]["cluster_id-1"].location == "westeurope"
         )
         assert aks.clusters[AZURE_SUBSCRIPTION_ID]["cluster_id-1"].rbac_enabled
+        assert (
+            aks.clusters[AZURE_SUBSCRIPTION_ID]["cluster_id-1"].kubernetes_version
+            == "1.34.0"
+        )
 
 
 class Test_AKS_get_clusters:
@@ -101,6 +106,9 @@ class Test_AKS_get_clusters:
         mock_client.managed_clusters.list_by_resource_group.assert_not_called()
         assert AZURE_SUBSCRIPTION_ID in result
         assert "cluster_id-1" in result[AZURE_SUBSCRIPTION_ID]
+        assert (
+            result[AZURE_SUBSCRIPTION_ID]["cluster_id-1"].kubernetes_version == "1.28.0"
+        )
 
     def test_get_clusters_with_resource_group(self):
         mock_cluster = MagicMock()


### PR DESCRIPTION
### Context

Fix #12566

AKS gives community support to the latest GA minor version and the two before it. Once a version leaves that window it stops receiving security patches — the N-3 platform support tier explicitly excludes "applying security patches" and "applying bug fixes" — so a cluster keeps running and scaling while accumulating unpatched CVEs. Prowler already has `eks_cluster_uses_a_supported_version` for AWS but had no equivalent on Azure.

### Description

**New check:** `aks_cluster_uses_a_supported_version`

- **Severity:** `high` (matches the EKS check)
- **Service:** `aks`
- **Resource group:** `container`
- **Category:** `vulnerabilities`
- **Configurable:** `aks_cluster_oldest_version_supported`, default `1.34`
- No new dependencies

| Cluster state | Result |
|---|---|
| Minor version at or above the baseline | PASS |
| Minor version below the baseline | FAIL |
| No version reported | skipped, no finding |
| Version that will not parse | skipped, logged as an error |

**Why `1.34` as the default.** AKS supports N, N-1 and N-2. With 1.36 as the current GA that puts 1.34 at the bottom of the window, and 1.33 reached end of life in July 2026. `az aks get-versions --location canadacentral` returns only 1.34.x, 1.35.x and 1.36.x, which matches the published calendar. It is configurable because long-term support keeps patching older versions — 1.31 until November 2026 — so teams on LTS can lower the baseline instead of seeing false positives. As with the EKS default, this value needs revisiting as the support window moves; that is called out in the check metadata `Notes`.

**Only major and minor are compared.** AKS reports three-part versions such as `1.34.9`, and patch level does not affect support status. Versions are compared as integer tuples rather than strings, so `1.9` correctly sorts below `1.34`.

**Files changed:**

- `prowler/providers/azure/services/aks/aks_cluster_uses_a_supported_version/` — check, metadata, `__init__`
- `prowler/providers/azure/services/aks/aks_service.py` — adds `kubernetes_version` to the `Cluster` model. The service was already reading this value from the SDK to decide whether to include a cluster at all and then discarding it, so nothing new is fetched.
- `prowler/config/config.yaml` and `prowler/config/schema/azure.py` — the configurable baseline, reusing the existing dotted-version validator
- `docs/user-guide/cli/tutorials/configuration_file.mdx` — documents the new variable
- `prowler/changelog.d/aks-cluster-uses-a-supported-version.added.md` — changelog fragment
- `tests/providers/azure/services/aks/` — 14 new tests

### Steps to review

1. Run the AKS suite:

   ```
   uv run pytest tests/providers/azure/services/aks/ -v
   ```

   60 tests pass, 14 of them new: PASS and FAIL across two- and three-part version strings, a lowered baseline, the unconfigured fallback, and skips for missing and unparseable versions.

2. Confirm the check is registered:

   ```
   uv run python prowler-cli.py azure --list-checks | grep aks_cluster_uses_a_supported_version
   ```

3. `tests/config/` (584 tests) and `tests/lib/check/` (3880 tests) also pass, and the shipped `config.yaml` round-trips through `AzureProviderConfig` with no validation warnings.

I also ran it against a live subscription with `--az-cli-auth`: three AKS clusters, one on 1.33.7 reported FAIL and two on 1.34.9 reported PASS, with the messages rendering as expected. That confirms `kubernetes_version` comes back populated from the real SDK as a three-part string, which the mocked tests cannot establish on their own.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. No — this is a new check rather than a fix.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) No change needed.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **Yes**
    - If so, do we need to update permissions for the provider? **No** — the check reads `kubernetes_version` from the same `managed_clusters.list` response the existing AKS checks already consume, which the built-in Reader role covers. `permissions/prowler-azure-custom-role.json` only lists actions Reader does not grant, so it is unchanged.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Azure AKS check to identify clusters running Kubernetes versions below the supported baseline.
  * Added configurable minimum AKS version support, defaulting to Kubernetes 1.34.
  * Included remediation guidance for updating unsupported cluster versions.

* **Documentation**
  * Updated configuration documentation and examples with the new AKS version setting.
  * Added changelog information for the new check.

* **Tests**
  * Added coverage for supported, unsupported, missing, invalid, and custom-baseline versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->