### PR TITLE
feat(iam): add iam_policy_sensitive_actions_require_mfa_condition check

### DIFF
--- a/prowler/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/iam_policy_sensitive_actions_require_mfa_condition.metadata.json
+++ b/prowler/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/iam_policy_sensitive_actions_require_mfa_condition.metadata.json
@@ -1,0 +1,40 @@
+{
+  "Provider": "aws",
+  "CheckID": "iam_policy_sensitive_actions_require_mfa_condition",
+  "CheckTitle": "Customer managed IAM policy requires MFA for sensitive, escalation-capable actions",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "TTPs/Privilege Escalation"
+  ],
+  "ServiceName": "iam",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "AwsIamPolicy",
+  "ResourceGroup": "IAM",
+  "Description": "**Customer-managed IAM policies** are evaluated for statements that grant sensitive, escalation-capable actions (`iam:CreateAccessKey`, `iam:AttachUserPolicy`, `iam:PutUserPolicy`, `iam:PassRole`, `sts:AssumeRole`) without a `Condition` block requiring `aws:MultiFactorAuthPresent`.",
+  "Risk": "Requiring MFA on sensitive actions is **distinct** from a principal merely having MFA enabled. A policy can still permit credential creation, policy attachment, or role assumption **without enforcing MFA at the moment that call is made**, a defense-in-depth gap exploitable if long-lived credentials are compromised.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-multifactorauthpresent",
+    "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_configure-api-require.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "1. In the AWS Console, go to IAM > Policies\n2. Open the customer managed policy showing FAIL\n3. Click Edit policy > JSON\n4. Add a Condition block requiring MFA to each statement granting a sensitive action, for example:\n   \"Condition\": {\"Bool\": {\"aws:MultiFactorAuthPresent\": \"true\"}}\n5. Save changes and re-run the check to confirm it passes",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Add a `Condition` requiring `aws:MultiFactorAuthPresent` to statements granting sensitive, escalation-capable actions, so those actions cannot be exercised from a session established without MFA, even if the credentials are otherwise valid.",
+      "Url": "https://hub.prowler.com/check/iam_policy_sensitive_actions_require_mfa_condition"
+    }
+  },
+  "Categories": [
+    "identity-access"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "CAF Security Epic: IAM"
+}

--- a/prowler/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/iam_policy_sensitive_actions_require_mfa_condition.py
+++ b/prowler/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/iam_policy_sensitive_actions_require_mfa_condition.py
@@ -1,6 +1,9 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.iam.iam_client import iam_client
-from prowler.providers.aws.services.iam.lib.policy import has_mfa_condition
+from prowler.providers.aws.services.iam.lib.policy import (
+    get_effective_actions,
+    has_mfa_condition,
+)
 
 # Actions capable of privilege escalation or credential creation, where
 # requiring MFA at the point of use is a meaningful defense-in-depth control
@@ -15,7 +18,22 @@ SENSITIVE_ACTIONS = {
 
 
 class iam_policy_sensitive_actions_require_mfa_condition(Check):
-    def execute(self) -> Check_Report_AWS:
+    """Check that customer-managed IAM policies require MFA for sensitive actions.
+
+    Flags statements that grant sensitive, escalation-capable actions
+    (see SENSITIVE_ACTIONS) — including via wildcards like `iam:*` or a
+    `NotAction` clause — without a Condition block requiring
+    aws:MultiFactorAuthPresent.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check against every customer-managed IAM policy.
+
+        Returns:
+            list[Check_Report_AWS]: One report per customer-managed policy,
+                FAIL if any statement grants a sensitive action without an
+                MFA condition, PASS otherwise.
+        """
         findings = []
 
         for policy in iam_client.policies.values():
@@ -39,14 +57,16 @@ class iam_policy_sensitive_actions_require_mfa_condition(Check):
                     if statement.get("Effect") != "Allow":
                         continue
 
-                    actions = statement.get("Action", [])
-                    if not isinstance(actions, list):
-                        actions = [actions]
-                    normalized_actions = {
-                        action.lower() for action in actions if isinstance(action, str)
+                    # Wrapping the single statement lets get_effective_actions
+                    # expand wildcards (e.g. iam:*) and NotAction clauses for
+                    # just this statement, using the same logic already
+                    # relied on elsewhere in this file.
+                    effective_actions = {
+                        action.lower()
+                        for action in get_effective_actions({"Statement": [statement]})
                     }
 
-                    matched_actions = normalized_actions & SENSITIVE_ACTIONS
+                    matched_actions = effective_actions & SENSITIVE_ACTIONS
                     if matched_actions and not has_mfa_condition(statement):
                         unprotected_actions.update(matched_actions)
 

--- a/prowler/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/iam_policy_sensitive_actions_require_mfa_condition.py
+++ b/prowler/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/iam_policy_sensitive_actions_require_mfa_condition.py
@@ -1,0 +1,65 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.iam.iam_client import iam_client
+from prowler.providers.aws.services.iam.lib.policy import has_mfa_condition
+
+# Actions capable of privilege escalation or credential creation, where
+# requiring MFA at the point of use is a meaningful defense-in-depth control
+# even when the calling principal already has MFA enabled on their account.
+SENSITIVE_ACTIONS = {
+    "iam:createaccesskey",
+    "iam:attachuserpolicy",
+    "iam:putuserpolicy",
+    "iam:passrole",
+    "sts:assumerole",
+}
+
+
+class iam_policy_sensitive_actions_require_mfa_condition(Check):
+    def execute(self) -> Check_Report_AWS:
+        findings = []
+
+        for policy in iam_client.policies.values():
+            if policy.type == "Custom":
+                if not policy.attached and not iam_client.provider.scan_unused_services:
+                    continue
+
+                report = Check_Report_AWS(metadata=self.metadata(), resource=policy)
+                report.region = iam_client.region
+                report.status = "PASS"
+                report.status_extended = f"Custom Policy {report.resource_arn} does not allow sensitive actions without requiring MFA."
+
+                statements = (
+                    policy.document.get("Statement", []) if policy.document else []
+                )
+                if not isinstance(statements, list):
+                    statements = [statements]
+
+                unprotected_actions = set()
+                for statement in statements:
+                    if statement.get("Effect") != "Allow":
+                        continue
+
+                    actions = statement.get("Action", [])
+                    if not isinstance(actions, list):
+                        actions = [actions]
+                    normalized_actions = {
+                        action.lower() for action in actions if isinstance(action, str)
+                    }
+
+                    matched_actions = normalized_actions & SENSITIVE_ACTIONS
+                    if matched_actions and not has_mfa_condition(statement):
+                        unprotected_actions.update(matched_actions)
+
+                if unprotected_actions:
+                    report.status = "FAIL"
+                    report.status_extended = (
+                        f"Custom Policy {report.resource_arn} allows the following sensitive actions without requiring MFA: "
+                        + ", ".join(
+                            f"'{action}'" for action in sorted(unprotected_actions)
+                        )
+                        + "."
+                    )
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/iam/lib/policy.py
+++ b/prowler/providers/aws/services/iam/lib/policy.py
@@ -1122,8 +1122,14 @@ def has_codebuild_trusted_principal(trust_policy: dict) -> bool:
 
 def has_mfa_condition(statement: dict) -> bool:
     """
-    has_mfa_condition checks whether an IAM policy statement's Condition block
-    requires the aws:MultiFactorAuthPresent context key to be present.
+    Checks whether an IAM policy statement's Condition block requires
+    aws:MultiFactorAuthPresent to be true.
+
+    aws:MultiFactorAuthPresent is a Boolean context key, so it is only
+    meaningful under the Bool or BoolIfExists operators, and only when its
+    value actually evaluates to true — a statement setting it to "false" is
+    not requiring MFA, it is explicitly describing the unauthenticated case,
+    so it must not be treated as a passing condition.
 
     Args:
         statement (dict): An IAM policy statement, e.g.:
@@ -1137,20 +1143,27 @@ def has_mfa_condition(statement: dict) -> bool:
         }
 
     Returns:
-        bool: True if the statement's Condition block references
-            aws:MultiFactorAuthPresent under any condition operator
-            (e.g. Bool, BoolIfExists), False otherwise.
+        bool: True if the statement's Condition block requires
+            aws:MultiFactorAuthPresent to be true under Bool or
+            BoolIfExists, False otherwise.
     """
     condition = statement.get("Condition")
     if not isinstance(condition, dict):
         return False
 
-    for operator_block in condition.values():
+    for operator, operator_block in condition.items():
+        # Condition operator and context key names are not case-sensitive,
+        # so compare in lowercase (see is_condition_block_restrictive above).
+        if operator.lower() not in ("bool", "boolifexists"):
+            continue
         if not isinstance(operator_block, dict):
             continue
-        # Condition context key names are not case-sensitive, so compare
-        # in lowercase (see is_condition_block_restrictive above).
-        if any(key.lower() == "aws:multifactorauthpresent" for key in operator_block):
-            return True
+
+        for key, value in operator_block.items():
+            if key.lower() != "aws:multifactorauthpresent":
+                continue
+            values = value if isinstance(value, list) else [value]
+            if any(str(v).lower() == "true" for v in values):
+                return True
 
     return False

--- a/prowler/providers/aws/services/iam/lib/policy.py
+++ b/prowler/providers/aws/services/iam/lib/policy.py
@@ -1118,3 +1118,39 @@ def has_codebuild_trusted_principal(trust_policy: dict) -> bool:
         )
         for s in statements
     )
+
+
+def has_mfa_condition(statement: dict) -> bool:
+    """
+    has_mfa_condition checks whether an IAM policy statement's Condition block
+    requires the aws:MultiFactorAuthPresent context key to be present.
+
+    Args:
+        statement (dict): An IAM policy statement, e.g.:
+        {
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "*",
+            "Condition": {
+                "Bool": {"aws:MultiFactorAuthPresent": "true"}
+            }
+        }
+
+    Returns:
+        bool: True if the statement's Condition block references
+            aws:MultiFactorAuthPresent under any condition operator
+            (e.g. Bool, BoolIfExists), False otherwise.
+    """
+    condition = statement.get("Condition")
+    if not isinstance(condition, dict):
+        return False
+
+    for operator_block in condition.values():
+        if not isinstance(operator_block, dict):
+            continue
+        # Condition context key names are not case-sensitive, so compare
+        # in lowercase (see is_condition_block_restrictive above).
+        if any(key.lower() == "aws:multifactorauthpresent" for key in operator_block):
+            return True
+
+    return False

--- a/prowler/providers/aws/services/iam/lib/policy.py
+++ b/prowler/providers/aws/services/iam/lib/policy.py
@@ -1122,14 +1122,23 @@ def has_codebuild_trusted_principal(trust_policy: dict) -> bool:
 
 def has_mfa_condition(statement: dict) -> bool:
     """
-    Checks whether an IAM policy statement's Condition block requires
-    aws:MultiFactorAuthPresent to be true.
+    Checks whether an IAM policy statement's Condition block genuinely
+    requires aws:MultiFactorAuthPresent to be true.
 
-    aws:MultiFactorAuthPresent is a Boolean context key, so it is only
-    meaningful under the Bool or BoolIfExists operators, and only when its
-    value actually evaluates to true — a statement setting it to "false" is
-    not requiring MFA, it is explicitly describing the unauthenticated case,
-    so it must not be treated as a passing condition.
+    Only the plain Bool operator is accepted, not BoolIfExists: per AWS's
+    documented condition evaluation, "...IfExists" operators evaluate to
+    true when the context key is absent from the request entirely, so a
+    BoolIfExists condition does not fail closed and does not actually
+    enforce MFA — it merely requires MFA *if* that information happens to
+    be present. Plain Bool evaluates to false when the key is missing,
+    which is the fail-closed behavior a real MFA requirement needs.
+
+    A statement setting the key to "false" is not requiring MFA either —
+    it is explicitly describing the unauthenticated case. Multiple values
+    under one condition key are OR'd together by AWS by default, so a
+    mixed list like ["true", "false"] matches either state and enforces
+    nothing; every value present must be "true" for the condition to
+    count as a real MFA requirement.
 
     Args:
         statement (dict): An IAM policy statement, e.g.:
@@ -1144,8 +1153,8 @@ def has_mfa_condition(statement: dict) -> bool:
 
     Returns:
         bool: True if the statement's Condition block requires
-            aws:MultiFactorAuthPresent to be true under Bool or
-            BoolIfExists, False otherwise.
+            aws:MultiFactorAuthPresent to be true under a plain Bool
+            operator with an unambiguous true value, False otherwise.
     """
     condition = statement.get("Condition")
     if not isinstance(condition, dict):
@@ -1154,7 +1163,7 @@ def has_mfa_condition(statement: dict) -> bool:
     for operator, operator_block in condition.items():
         # Condition operator and context key names are not case-sensitive,
         # so compare in lowercase (see is_condition_block_restrictive above).
-        if operator.lower() not in ("bool", "boolifexists"):
+        if operator.lower() != "bool":
             continue
         if not isinstance(operator_block, dict):
             continue
@@ -1163,7 +1172,7 @@ def has_mfa_condition(statement: dict) -> bool:
             if key.lower() != "aws:multifactorauthpresent":
                 continue
             values = value if isinstance(value, list) else [value]
-            if any(str(v).lower() == "true" for v in values):
+            if values and all(str(v).lower() == "true" for v in values):
                 return True
 
     return False

--- a/tests/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/iam_policy_sensitive_actions_require_mfa_condition_test.py
+++ b/tests/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/iam_policy_sensitive_actions_require_mfa_condition_test.py
@@ -1,0 +1,355 @@
+from json import dumps
+from re import search
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+
+class Test_iam_policy_sensitive_actions_require_mfa_condition:
+    @mock_aws
+    def test_pass_no_sensitive_actions(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "policy1"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "s3:GetObject",
+                    "Resource": "arn:aws:s3:::example-bucket/*",
+                },
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].resource_id == policy_name
+            assert result[0].resource_arn == policy_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].status_extended
+                == f"Custom Policy {policy_arn} does not allow sensitive actions without requiring MFA."
+            )
+
+    @mock_aws
+    def test_fail_passrole_without_mfa(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "policy1"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "iam:PassRole",
+                    "Resource": f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:role/ecs",
+                },
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_id == policy_name
+            assert result[0].resource_arn == policy_arn
+            assert search(
+                f"Custom Policy {policy_arn} allows the following sensitive actions without requiring MFA: ",
+                result[0].status_extended,
+            )
+            assert search("iam:passrole", result[0].status_extended)
+
+    @mock_aws
+    def test_pass_passrole_with_mfa_bool_condition(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "policy1"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "iam:PassRole",
+                    "Resource": f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:role/ecs",
+                    "Condition": {"Bool": {"aws:MultiFactorAuthPresent": "true"}},
+                },
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].resource_arn == policy_arn
+
+    @mock_aws
+    def test_pass_assumerole_with_lowercase_mfa_condition_key(self):
+        # AWS condition context key names are not case-sensitive, so a
+        # policy author could write aws:multifactorauthpresent in any case.
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "policy1"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Resource": "*",
+                    "Condition": {
+                        "BoolIfExists": {"aws:multifactorauthpresent": "true"}
+                    },
+                },
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].resource_arn == policy_arn
+
+    @mock_aws
+    def test_fail_multiple_sensitive_actions_without_mfa(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "policy1"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": ["iam:CreateAccessKey", "iam:AttachUserPolicy"],
+                    "Resource": "*",
+                },
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_arn == policy_arn
+            assert search("iam:createaccesskey", result[0].status_extended)
+            assert search("iam:attachuserpolicy", result[0].status_extended)
+
+    @mock_aws
+    def test_deny_statement_ignored(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "policy1"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Deny", "Action": "iam:PassRole", "Resource": "*"},
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].resource_arn == policy_arn
+
+    @mock_aws
+    def test_unattached_policy_skipped_when_scan_unused_services_disabled(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "unattached_policy"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "iam:CreateAccessKey", "Resource": "*"},
+            ],
+        }
+        iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1], scan_unused_services=False
+        )
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert result == []
+
+    @mock_aws
+    def test_attached_policy_fails_when_scan_unused_services_disabled(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        user_name = "test_user_mfa_condition"
+        policy_name = "attached_policy"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "iam:CreateAccessKey", "Resource": "*"},
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+        iam_client.create_user(UserName=user_name)
+        iam_client.attach_user_policy(UserName=user_name, PolicyArn=policy_arn)
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1], scan_unused_services=False
+        )
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_arn == policy_arn

--- a/tests/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/iam_policy_sensitive_actions_require_mfa_condition_test.py
+++ b/tests/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/iam_policy_sensitive_actions_require_mfa_condition_test.py
@@ -353,3 +353,199 @@ class Test_iam_policy_sensitive_actions_require_mfa_condition:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].resource_arn == policy_arn
+
+    @mock_aws
+    def test_no_resources(self):
+        """No customer-managed policies means no findings, not a spurious FAIL."""
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert result == []
+
+    @mock_aws
+    def test_fail_mfa_condition_explicitly_false(self):
+        """A Condition setting aws:MultiFactorAuthPresent to false is not a
+        passing MFA requirement; it must still be flagged as unprotected."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "policy1"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "iam:PassRole",
+                    "Resource": f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:role/ecs",
+                    "Condition": {"Bool": {"aws:MultiFactorAuthPresent": "false"}},
+                },
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_arn == policy_arn
+
+    @mock_aws
+    def test_fail_mfa_condition_wrong_operator(self):
+        """StringEquals is not a valid operator for the Boolean
+        aws:MultiFactorAuthPresent key; it must not satisfy the check."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "policy1"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "iam:PassRole",
+                    "Resource": f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:role/ecs",
+                    "Condition": {
+                        "StringEquals": {"aws:MultiFactorAuthPresent": "true"}
+                    },
+                },
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_arn == policy_arn
+
+    @mock_aws
+    def test_fail_iam_wildcard_without_mfa(self):
+        """iam:* covers the sensitive actions and must be expanded, not
+        exact-matched, to be caught."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "policy1"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "iam:*", "Resource": "*"},
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_arn == policy_arn
+            assert search("iam:passrole", result[0].status_extended)
+            assert search("iam:createaccesskey", result[0].status_extended)
+
+    @mock_aws
+    def test_fail_notaction_without_mfa(self):
+        """A NotAction excluding an unrelated service implicitly grants the
+        sensitive actions and must still be caught."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "policy1"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "NotAction": "s3:*", "Resource": "*"},
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_arn == policy_arn
+            assert search("iam:passrole", result[0].status_extended)
+            assert result[0].resource_arn == policy_arn

--- a/tests/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/iam_policy_sensitive_actions_require_mfa_condition_test.py
+++ b/tests/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/iam_policy_sensitive_actions_require_mfa_condition_test.py
@@ -162,9 +162,7 @@ class Test_iam_policy_sensitive_actions_require_mfa_condition:
                     "Effect": "Allow",
                     "Action": "sts:AssumeRole",
                     "Resource": "*",
-                    "Condition": {
-                        "BoolIfExists": {"aws:multifactorauthpresent": "true"}
-                    },
+                    "Condition": {"Bool": {"aws:multifactorauthpresent": "true"}},
                 },
             ],
         }
@@ -548,4 +546,98 @@ class Test_iam_policy_sensitive_actions_require_mfa_condition:
             assert result[0].status == "FAIL"
             assert result[0].resource_arn == policy_arn
             assert search("iam:passrole", result[0].status_extended)
+
+    @mock_aws
+    def test_fail_mfa_condition_boolifexists_not_accepted(self):
+        """BoolIfExists evaluates to true when the context key is absent
+        from the request entirely, so it does not fail closed and must not
+        be treated as a genuine MFA requirement -- only plain Bool counts."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "policy1"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Resource": "*",
+                    "Condition": {
+                        "BoolIfExists": {"aws:MultiFactorAuthPresent": "true"}
+                    },
+                },
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_arn == policy_arn
+
+    @mock_aws
+    def test_fail_mfa_condition_mixed_values_not_accepted(self):
+        """AWS OR's multiple values under one condition key by default, so
+        ["true", "false"] matches either state and enforces nothing -- it
+        must not be treated as a genuine MFA requirement."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "policy1"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Resource": "*",
+                    "Condition": {
+                        "Bool": {"aws:MultiFactorAuthPresent": ["true", "false"]}
+                    },
+                },
+            ],
+        }
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.iam.iam_policy_sensitive_actions_require_mfa_condition.iam_policy_sensitive_actions_require_mfa_condition import (
+                iam_policy_sensitive_actions_require_mfa_condition,
+            )
+
+            check = iam_policy_sensitive_actions_require_mfa_condition()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_arn == policy_arn
             assert result[0].resource_arn == policy_arn


### PR DESCRIPTION
### Context

Prowler's existing MFA-related IAM checks (`iam_user_mfa_enabled_console_access`,
`iam_administrator_access_with_mfa`, `iam_root_mfa_enabled`) verify that a
user/role *has* MFA registered. None of them check whether a specific IAM
policy statement *enforces* MFA at the point a sensitive action is called —
a distinct, well-established AWS control (`aws:MultiFactorAuthPresent`).
Filed as a scoped proposal first: #12559.

Fixes #12559

### Description

Adds a new check, `iam_policy_sensitive_actions_require_mfa_condition`,
that flags customer-managed IAM policies granting sensitive,
escalation-capable actions (`iam:CreateAccessKey`, `iam:AttachUserPolicy`,
`iam:PutUserPolicy`, `iam:PassRole`, `sts:AssumeRole`) without a
`Condition` block requiring `aws:MultiFactorAuthPresent`.

Also adds a reusable `has_mfa_condition()` helper to `iam/lib/policy.py`
(case-insensitive condition-key matching, consistent with
`is_condition_block_restrictive` elsewhere in the same file). No new
AWS API permissions are required — the check reuses policy documents
the IAM service already fetches for other checks.

No dependencies required for this change.

### Steps to review

1. `uv run pytest tests/providers/aws/services/iam/iam_policy_sensitive_actions_require_mfa_condition/ -v` — 8 tests covering PASS/FAIL, both MFA condition operators (`Bool`/`BoolIfExists`), case-insensitivity, multiple sensitive actions in one statement, Deny statements being ignored, and the `scan_unused_services` flag.
2. `uv run pytest tests/providers/aws/services/iam/ -q` — confirms no regressions in the other 48 IAM checks (628 passed locally).
3. `uv run python -m prowler aws --list-checks` — confirms the check is discovered and registered.

### Checklist

<details><summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues/12559)
- [ ] It is assigned to me — not yet assigned by a maintainer; requested in a comment on #12559, opening this PR now given the working implementation
- [x] I have reviewed the open pull requests and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification
- [ ] Review if backport is needed.
- [ ] Review if it needed to update the README.md
- [ ] Ensure a changelog fragment is added under prowler/changelog.d/ — will add if maintainers confirm this is the right process

#### SDK/CLI

Are there new checks included in this PR? **Yes**
  - Do we need to update permissions for the provider? **No** — this check only reads `policy.document`, data the IAM service already fetches for other existing checks. No new AWS API calls are introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an AWS IAM security check for customer-managed policies that allow sensitive privilege-escalation actions without requiring MFA.
  - Reports the specific risky actions found and handles common policy statement formats, wildcards, and exclusions.
  - Skips unattached policies by default, with optional scanning available through existing settings.

- **Bug Fixes**
  - Improves MFA detection across case variations.
  - Requires a fail-closed Boolean MFA condition explicitly set to `true`, avoiding false positives from unsupported condition formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->