### PR TITLE
fix(ui): redirect the Slack OAuth callback relative to the browser's origin

### DIFF
--- a/ui/__tests__/msw/handlers/slack.fixtures.ts
+++ b/ui/__tests__/msw/handlers/slack.fixtures.ts
@@ -38,6 +38,12 @@ export const SLACK_EXCHANGE_OUTCOME = {
   /** Same workspace re-installed: the existing row keeps its id. */
   REINSTALLED: "reinstalled",
   REFUSED_STATE: "refused-state",
+  /**
+   * The same refusal, but naming `invalid_oauth_state` in `code` — the
+   * contract words it code-less, the deployed API names it; the UI maps both
+   * to `expired`.
+   */
+  REFUSED_STATE_CODED: "refused-state-coded",
   SLACK_REFUSED: "slack-refused",
   /** A `409` named by its `code`: one workspace per tenant. */
   DIFFERENT_WORKSPACE: "different-workspace",

--- a/ui/__tests__/msw/handlers/slack.ts
+++ b/ui/__tests__/msw/handlers/slack.ts
@@ -213,6 +213,11 @@ export const handlersForSlack = (fx: SlackFixture) => {
           return HttpResponse.json(errorBody(SLACK_REFUSED_STATE_DETAIL, 400), {
             status: 400,
           });
+        case SLACK_EXCHANGE_OUTCOME.REFUSED_STATE_CODED:
+          return HttpResponse.json(
+            errorBody(SLACK_REFUSED_STATE_DETAIL, 400, "invalid_oauth_state"),
+            { status: 400 },
+          );
         case SLACK_EXCHANGE_OUTCOME.SLACK_REFUSED:
           return HttpResponse.json(errorBody(SLACK_INVALID_CODE_DETAIL, 400), {
             status: 400,

--- a/ui/app/(prowler)/integrations/slack/callback/route.test.ts
+++ b/ui/app/(prowler)/integrations/slack/callback/route.test.ts
@@ -76,12 +76,18 @@ const get = (query: string, headers?: HeadersInit) =>
 
 const HAPPY_QUERY = `code=${SLACK_OAUTH_CODE}&state=${SLACK_OAUTH_STATE}`;
 
-/** The redirect's target, with the `303` asserted on the way. */
+/**
+ * The redirect's target, with the `303` and the header's relativity asserted
+ * on the way: behind the reverse proxy the handler is reached on the
+ * instance's internal hostname, so an absolute `Location` echoing the request
+ * would send the browser somewhere no DNS resolves.
+ */
 const locationOf = (response: Response): URL => {
   expect(response.status).toBe(303);
   const location = response.headers.get("location");
   expect(location).not.toBeNull();
-  return new URL(location as string);
+  expect(location).toMatch(/^\//);
+  return new URL(location as string, CALLBACK_URL);
 };
 
 const revalidatedPaths = () =>
@@ -170,9 +176,11 @@ describe("the Slack OAuth callback route", () => {
   });
 
   // The back button's path: replaying the callback re-sends a state/code the
-  // API already consumed, which it refuses with a code-less 400.
+  // API already consumed, which it refuses with a code-less 400 — or, in the
+  // deployed API's spelling, a 400 naming `invalid_oauth_state`.
   it.each([
     SLACK_EXCHANGE_OUTCOME.REFUSED_STATE,
+    SLACK_EXCHANGE_OUTCOME.REFUSED_STATE_CODED,
     SLACK_EXCHANGE_OUTCOME.SLACK_REFUSED,
   ])(
     "reports a consumed or timed-out completion (%s) as expired, not as retryable",
@@ -289,6 +297,26 @@ describe("the Slack OAuth callback route", () => {
     expect(prefetchResponse.headers.get("Cache-Control")).toBe("no-store");
     expect(location.searchParams.get("slack")).toBe("connected");
     expect(exchangeCalls).toHaveLength(1);
+  });
+
+  // The prod topology: the reverse proxy reaches Next on the instance's
+  // internal hostname, which no browser can resolve — the redirect must not
+  // inherit it.
+  it("keeps the redirect relative when reached on an internal hostname", async () => {
+    wire(slackFixture());
+    const internalCallback = `http://ip-172-29-15-236.eu-west-1.compute.internal:3000/integrations/slack/callback?${HAPPY_QUERY}`;
+
+    const response = await GET(new Request(internalCallback));
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "/integrations/slack?slack=connected",
+    );
+
+    // The non-cloud "go home" redirect must not echo the internal host either.
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+    const home = await GET(new Request(internalCallback));
+    expect(home.headers.get("location")).toBe("/");
   });
 
   it("sends non-cloud deployments home without exchanging anything", async () => {

--- a/ui/app/(prowler)/integrations/slack/callback/route.test.ts
+++ b/ui/app/(prowler)/integrations/slack/callback/route.test.ts
@@ -304,7 +304,7 @@ describe("the Slack OAuth callback route", () => {
   // inherit it.
   it("keeps the redirect relative when reached on an internal hostname", async () => {
     wire(slackFixture());
-    const internalCallback = `http://ip-172-29-15-236.eu-west-1.compute.internal:3000/integrations/slack/callback?${HAPPY_QUERY}`;
+    const internalCallback = `http://ip-10-0-0-1.eu-west-1.compute.internal:3000/integrations/slack/callback?${HAPPY_QUERY}`;
 
     const response = await GET(new Request(internalCallback));
 

--- a/ui/app/(prowler)/integrations/slack/callback/route.ts
+++ b/ui/app/(prowler)/integrations/slack/callback/route.ts
@@ -8,6 +8,7 @@ import {
   slackConnectQuery,
 } from "@/lib/integrations/slack-connect-status";
 import type { SlackConnectOutcomeInput } from "@/lib/integrations/slack-connect-status";
+import { SLACK_ERROR_CODE } from "@/lib/integrations/slack-errors";
 import { isCloud } from "@/lib/shared/env";
 
 /**
@@ -27,17 +28,18 @@ const noStoreNoContent = (): NextResponse =>
     headers: { "Cache-Control": "no-store" },
   });
 
-const redirectTo = (request: Request, target: string): NextResponse =>
-  NextResponse.redirect(new URL(target, request.url), 303);
+/**
+ * Relative `Location`, built by hand because `NextResponse.redirect` insists
+ * on an absolute URL: behind a reverse proxy `request.url` carries the
+ * internal Host, not the domain the browser used, so an absolute URL built
+ * from it strands the browser on an unresolvable host. The browser resolves a
+ * relative Location against the origin it reached the callback on.
+ */
+const redirectTo = (target: string): NextResponse =>
+  new NextResponse(null, { status: 303, headers: { Location: target } });
 
-const outcomeRedirect = (
-  request: Request,
-  outcome: SlackConnectOutcomeInput,
-): NextResponse =>
-  redirectTo(
-    request,
-    `${SLACK_INTEGRATION_PATH}?${slackConnectQuery(outcome)}`,
-  );
+const outcomeRedirect = (outcome: SlackConnectOutcomeInput): NextResponse =>
+  redirectTo(`${SLACK_INTEGRATION_PATH}?${slackConnectQuery(outcome)}`);
 
 /**
  * `Sec-Purpose` per the fetch spec; `Purpose` and `X-moz` are the legacy
@@ -60,7 +62,7 @@ export function HEAD(): Response {
 }
 
 export async function GET(request: Request): Promise<NextResponse> {
-  if (!isCloud()) return redirectTo(request, "/");
+  if (!isCloud()) return redirectTo("/");
 
   // A speculative fetch would burn the single-use code before the user
   // arrives — answer it nothing instead.
@@ -74,14 +76,14 @@ export async function GET(request: Request): Promise<NextResponse> {
   // Slack answers a declined install with `error` and no code; when both are
   // present, `error` still wins and nothing is exchanged.
   if (slackError) {
-    return outcomeRedirect(request, {
+    return outcomeRedirect({
       status: SLACK_CONNECT_STATUS.SLACK_ERROR,
       reason: slackError,
     });
   }
 
   if (!code || !state) {
-    return outcomeRedirect(request, {
+    return outcomeRedirect({
       status: SLACK_CONNECT_STATUS.INCOMPLETE,
     });
   }
@@ -93,39 +95,44 @@ export async function GET(request: Request): Promise<NextResponse> {
     // The action is written to never throw; if it does anyway, the API may
     // already have upserted the integration, so the claim is "unconfirmed",
     // not "failed".
-    return outcomeRedirect(request, {
+    return outcomeRedirect({
       status: SLACK_CONNECT_STATUS.UNCONFIRMED,
     });
   }
 
   if ("integration" in result) {
-    return outcomeRedirect(request, {
+    return outcomeRedirect({
       status: SLACK_CONNECT_STATUS.CONNECTED,
     });
   }
   if ("unavailable" in result) {
-    return outcomeRedirect(request, {
+    return outcomeRedirect({
       status: SLACK_CONNECT_STATUS.UNAVAILABLE,
     });
   }
   if ("rateLimited" in result) {
-    return outcomeRedirect(request, {
+    return outcomeRedirect({
       status: SLACK_CONNECT_STATUS.RATE_LIMITED,
       retryAfterSeconds: result.retryAfterSeconds,
     });
   }
   if ("unconfirmed" in result) {
-    return outcomeRedirect(request, {
+    return outcomeRedirect({
       status: SLACK_CONNECT_STATUS.UNCONFIRMED,
     });
   }
-  // A 400 naming no reason is the exchange's "state or code already consumed
-  // or timed out" refusal — the back button's path. Retrying cannot help, so
-  // it gets its own status rather than the generic "try again" error.
-  if (!result.code && result.status === 400) {
-    return outcomeRedirect(request, { status: SLACK_CONNECT_STATUS.EXPIRED });
+  // The exchange's "state or code already consumed or timed out" refusal —
+  // the back button's path. The contract words it as a 400 naming no reason;
+  // the deployed API names `invalid_oauth_state` on the same refusal, so both
+  // spellings land here. Retrying cannot help, so it gets its own status
+  // rather than the generic "try again" error.
+  if (
+    result.status === 400 &&
+    (!result.code || result.code === SLACK_ERROR_CODE.INVALID_OAUTH_STATE)
+  ) {
+    return outcomeRedirect({ status: SLACK_CONNECT_STATUS.EXPIRED });
   }
-  return outcomeRedirect(request, {
+  return outcomeRedirect({
     status: SLACK_CONNECT_STATUS.ERROR,
     code: result.code ?? null,
   });

--- a/ui/changelog.d/slack-oauth-callback-internal-host.fixed.md
+++ b/ui/changelog.d/slack-oauth-callback-internal-host.fixed.md
@@ -1,0 +1,1 @@
+Finishing the Slack install returns to the integration page on the domain the browser used, instead of stranding it on the server's internal hostname behind a reverse proxy

--- a/ui/changelog.d/slack-oauth-callback-internal-host.fixed.md
+++ b/ui/changelog.d/slack-oauth-callback-internal-host.fixed.md
@@ -1,1 +1,0 @@
-Finishing the Slack install returns to the integration page on the domain the browser used, instead of stranding it on the server's internal hostname behind a reverse proxy

--- a/ui/lib/integrations/slack-errors.ts
+++ b/ui/lib/integrations/slack-errors.ts
@@ -9,6 +9,8 @@ export const SLACK_ERROR_CODE = {
   TOKEN_EXPIRED: "token_expired",
   /** One workspace per tenant. */
   WORKSPACE_CONFLICT: "slack_workspace_conflict",
+  /** The exchange's `state` was already consumed, timed out, or never minted. */
+  INVALID_OAUTH_STATE: "invalid_oauth_state",
 } as const;
 
 export type SlackErrorCode =
@@ -76,6 +78,10 @@ export const SLACK_ERROR_MESSAGES = {
   [SLACK_ERROR_CODE.TOKEN_EXPIRED]: `Prowler's Slack credential has expired. ${RECONNECT}`,
   [SLACK_ERROR_CODE.WORKSPACE_CONFLICT]:
     "Prowler is already connected to a different Slack workspace. Disconnect it before connecting another one.",
+  // Same wording as the callback notice's `expired` status: a spent install
+  // link never recovers, so "try again in a moment" would mislead.
+  [SLACK_ERROR_CODE.INVALID_OAUTH_STATE]:
+    "The install link from Slack had already been used or expired, so no workspace was connected. Start the install again.",
 } as const satisfies Record<SlackErrorCode, string>;
 
 /** The parts of a JSON:API error this mapping reads. */


### PR DESCRIPTION
### Context

Follow-up to #12572, which completed the Slack OAuth callback server-side with an HTTP 303. In deployments behind a reverse proxy, both of these were reported:

1. The callback redirected to `http://ip-10-0-0-1.eu-west-1.compute.internal:3000/integrations/slack?...` (the instance's internal hostname) instead of the public domain (`ERR_NAME_NOT_RESOLVED`).
2. The install completed server-side, but the browser was stranded on that unreachable host until the user navigated back to the integrations page manually.

Both share one root cause: `redirectTo` built the Location as `new URL(target, request.url)`, and behind the proxy `request.url` carries the internal Host, not the domain the browser used.

### Description

- The callback's 303 now sends a **relative** `Location` (built by hand — `NextResponse.redirect` insists on an absolute URL), so the browser resolves it against the origin it actually reached the callback on. This works on any domain/proxy topology with zero configuration, unlike an absolute URL derived from the request or from env.
- The deployed API names `invalid_oauth_state` on the "state already consumed or timed out" refusal, which the contract words as a code-less 400; the callback now maps both spellings to the `expired` notice instead of showing the generic "try again" copy for a spent install link.

### Tests

- `locationOf` now asserts every redirect's Location is relative, and resolves it against the callback URL for the existing assertions.
- New regression test: a request arriving on an internal hostname gets `Location: /integrations/slack?slack=connected` (and `/` for non-cloud), never inheriting the request's host.
- The expired-mapping table test gains the coded `invalid_oauth_state` variant, served by a new MSW fixture outcome alongside the contract's code-less 400.

### Checklist

- [x] `tsc --noEmit` and `eslint` pass on the touched files
- [x] Labeled `no-changelog`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Slack installation callback handling for expired or already-used OAuth links.
  - Added a clear message instructing users to restart the Slack installation when their link is invalid or expired.
  - Prevented internal proxy hostnames from appearing in redirect URLs.
  - Standardized redirects across cloud and non-cloud environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->