### PR TITLE
[CHAIN] feat(ui): support async Registry artifact installation

### DIFF
--- a/ui/actions/registry/registry.adapter.test.ts
+++ b/ui/actions/registry/registry.adapter.test.ts
@@ -10,7 +10,7 @@ import {
   adaptRegistryCredentialStatus,
   classifyRegistryFailure,
   collectCompleteRegistryCatalog,
-  parseRegistryCredentialSubmission,
+  parseRegistryArtifactSubmission,
 } from "./registry.adapter";
 
 const credentialPayload = {
@@ -88,7 +88,7 @@ describe("Registry adapter", () => {
     });
   });
 
-  it("accepts only a matching 202 task and fixed Content-Location path", async () => {
+  it("accepts only a matching artifact 202 task and fixed Content-Location path", async () => {
     // Given
     const response = new Response(
       JSON.stringify({ data: { type: "tasks", id: "task-123" } }),
@@ -99,7 +99,7 @@ describe("Registry adapter", () => {
     );
 
     // When
-    const result = await parseRegistryCredentialSubmission(response);
+    const result = await parseRegistryArtifactSubmission(response);
 
     // Then
     expect(result).toEqual({
@@ -119,8 +119,8 @@ describe("Registry adapter", () => {
 
     // When
     const results = await Promise.all([
-      parseRegistryCredentialSubmission(wrongStatus),
-      parseRegistryCredentialSubmission(wrongLocation),
+      parseRegistryArtifactSubmission(wrongStatus),
+      parseRegistryArtifactSubmission(wrongLocation),
     ]);
 
     // Then

--- a/ui/actions/registry/registry.adapter.ts
+++ b/ui/actions/registry/registry.adapter.ts
@@ -10,7 +10,7 @@ import {
   type RegistryCatalogArtifact,
   type RegistryCatalogResult,
   type RegistryCredentialStatus,
-  type RegistryCredentialSubmissionResult,
+  type RegistryTaskSubmissionResult,
   type RegistryEndpoint,
   type RegistryFailureResult,
   type RegistryMutationResult,
@@ -115,9 +115,19 @@ export class RegistryCatalogPageError extends Error {
   }
 }
 
-export async function parseRegistryCredentialSubmission(
+export const parseRegistryCredentialSubmission = (
   response: Response,
-): Promise<RegistryCredentialSubmissionResult> {
+): Promise<RegistryTaskSubmissionResult> =>
+  parseRegistryTaskSubmission(response);
+
+export const parseRegistryArtifactSubmission = (
+  response: Response,
+): Promise<RegistryTaskSubmissionResult> =>
+  parseRegistryTaskSubmission(response);
+
+async function parseRegistryTaskSubmission(
+  response: Response,
+): Promise<RegistryTaskSubmissionResult> {
   if (response.status !== 202) return { status: REGISTRY_SUBMISSION.ERROR };
 
   const parsed = taskSubmissionSchema.safeParse(

--- a/ui/actions/registry/registry.test.ts
+++ b/ui/actions/registry/registry.test.ts
@@ -553,21 +553,17 @@ describe("Registry guarded reads", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
-  it("confirms an exact Add only after My artifacts reports the artifact", async () => {
+  it("returns an accepted Add task without reading My artifacts", async () => {
     // Given
-    fetchMock
-      .mockResolvedValueOnce(new Response(null, { status: 201 }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          data: [
-            {
-              type: "registry-artifacts",
-              id: "later-guard",
-              attributes: { version_spec: "2.0.0" },
-            },
-          ],
-        }),
-      );
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ data: { type: "tasks", id: "artifact-task" } }),
+        {
+          status: 202,
+          headers: { "Content-Location": "/api/v1/tasks/artifact-task" },
+        },
+      ),
+    );
 
     // When
     const result = await addRegistryArtifact({
@@ -576,12 +572,8 @@ describe("Registry guarded reads", () => {
     });
 
     // Then
-    expect(result).toEqual({
-      status: "confirmed",
-      tenantArtifacts: [
-        { normalizedName: "later-guard", versionSpec: "2.0.0" },
-      ],
-    });
+    expect(result).toEqual({ status: "submitted", taskId: "artifact-task" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       "https://api.test/api/v1/registry/artifacts",
@@ -603,24 +595,21 @@ describe("Registry guarded reads", () => {
 
   it("defaults Add to latest", async () => {
     // Given
-    fetchMock
-      .mockResolvedValueOnce(new Response(null, { status: 201 }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          data: [
-            {
-              type: "registry-artifacts",
-              id: "later-guard",
-              attributes: { version_spec: "latest" },
-            },
-          ],
-        }),
-      );
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ data: { type: "tasks", id: "artifact-task" } }),
+        {
+          status: 202,
+          headers: { "Content-Location": "/api/v1/tasks/artifact-task" },
+        },
+      ),
+    );
 
     // When
-    await addRegistryArtifact({ normalizedName: "later-guard" });
+    const result = await addRegistryArtifact({ normalizedName: "later-guard" });
 
     // Then
+    expect(result).toEqual({ status: "submitted", taskId: "artifact-task" });
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       "https://api.test/api/v1/registry/artifacts",
@@ -636,6 +625,61 @@ describe("Registry guarded reads", () => {
         }),
       }),
     );
+  });
+
+  it("rejects invalid accepted task bindings without reading My artifacts", async () => {
+    // Given
+    const document = JSON.stringify({
+      data: { type: "tasks", id: "artifact-task" },
+    });
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { type: "tasks" } }), {
+          status: 202,
+          headers: { "Content-Location": "/api/v1/tasks/artifact-task" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(document, { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { type: "other", id: "artifact-task" } }),
+          {
+            status: 202,
+            headers: { "Content-Location": "/api/v1/tasks/artifact-task" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(document, {
+          status: 202,
+          headers: { "Content-Location": "/api/v1/tasks/other" },
+        }),
+      );
+
+    // When
+    const outcomes = await Promise.all(
+      ["missing-id", "missing-location", "wrong-type", "wrong-location"].map(
+        () => addRegistryArtifact({ normalizedName: "later-guard" }),
+      ),
+    );
+
+    // Then
+    expect(outcomes).toEqual(Array(4).fill({ status: "error" }));
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("keeps a missing Registry credential synchronous", async () => {
+    // Given
+    fetchMock.mockResolvedValueOnce(jsonResponse({ errors: [] }, 409));
+
+    // When
+    const outcome = await addRegistryArtifact({
+      normalizedName: "later-guard",
+    });
+
+    // Then
+    expect(outcome).toEqual({ status: "onboarding" });
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -691,6 +735,8 @@ describe("Registry guarded reads", () => {
       "Add",
       () => addRegistryArtifact({ normalizedName: "later-guard" }),
       { data: [] },
+      { status: "error" },
+      1,
     ],
     [
       "Remove",
@@ -704,10 +750,12 @@ describe("Registry guarded reads", () => {
           },
         ],
       },
+      { status: "refresh_failed" },
+      2,
     ],
   ])(
     "keeps membership unchanged when %s refresh contradicts acceptance",
-    async (_name, mutate, refreshedArtifacts) => {
+    async (_name, mutate, refreshedArtifacts, expected, calls) => {
       // Given
       fetchMock
         .mockResolvedValueOnce(new Response(null, { status: 204 }))
@@ -717,8 +765,8 @@ describe("Registry guarded reads", () => {
       const result = await mutate();
 
       // Then
-      expect(result).toEqual({ status: "refresh_failed" });
-      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result).toEqual(expected);
+      expect(fetchMock).toHaveBeenCalledTimes(calls);
     },
   );
 });

--- a/ui/actions/registry/registry.ts
+++ b/ui/actions/registry/registry.ts
@@ -5,6 +5,7 @@ import { apiBaseUrl } from "@/lib";
 import { REGISTRY_ACCESS } from "@/lib/registry/access";
 import { evaluateRegistryAccess } from "@/lib/registry/access.server";
 import {
+  REGISTRY_ARTIFACT_ACTION,
   REGISTRY_BOOTSTRAP_STATE,
   REGISTRY_CATALOG,
   REGISTRY_CREDENTIAL_ACTION,
@@ -12,6 +13,7 @@ import {
   REGISTRY_ENDPOINT,
   REGISTRY_FAILURE,
   REGISTRY_SUBMISSION,
+  type RegistryAddArtifactInput,
   type RegistryBootstrapResult,
   type RegistryBootstrapState,
   type RegistryCollectionsResult,
@@ -30,14 +32,10 @@ import {
   classifyRegistryMutationRefusal,
   collectCompleteRegistryCatalog,
   isRegistryCollection,
+  parseRegistryArtifactSubmission,
   parseRegistryCredentialSubmission,
   RegistryCatalogPageError,
 } from "./registry.adapter";
-
-interface RegistryAddArtifactInput {
-  normalizedName: string;
-  versionSpec?: string;
-}
 
 async function getRegistryAccess(): Promise<string | null> {
   const accessToken = (await auth())?.accessToken;
@@ -322,6 +320,9 @@ export async function addRegistryArtifact({
   if (response.status === 401 || response.status === 403) {
     return { status: REGISTRY_FAILURE.ACCESS_DENIED } as const;
   }
+  if (response.status === 409) {
+    return { status: REGISTRY_FAILURE.ONBOARDING };
+  }
   if (!response.ok) {
     return (
       (await classifyRegistryMutationRefusal(response)) ?? {
@@ -330,6 +331,17 @@ export async function addRegistryArtifact({
     );
   }
 
+  const submission = await parseRegistryArtifactSubmission(response);
+  return submission.status === REGISTRY_SUBMISSION.PENDING
+    ? { status: REGISTRY_ARTIFACT_ACTION.SUBMITTED, taskId: submission.taskId }
+    : { status: REGISTRY_FAILURE.ERROR };
+}
+
+export async function confirmRegistryArtifactAddition(
+  normalizedName: string,
+): Promise<RegistryMutationResult> {
+  const access = await getRegistryAccess();
+  if (!access) return { status: REGISTRY_FAILURE.ACCESS_DENIED };
   return confirmRegistryMutation(access, normalizedName, true);
 }
 

--- a/ui/lib/registry-artifact-execution.test.ts
+++ b/ui/lib/registry-artifact-execution.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { executeRegistryArtifactAddition } from "./registry-artifact-execution";
+
+// prettier-ignore
+const { addRegistryArtifactMock, confirmRegistryArtifactAdditionMock, trackAndPollTaskMock } = vi.hoisted(() => ({ addRegistryArtifactMock: vi.fn(), confirmRegistryArtifactAdditionMock: vi.fn(), trackAndPollTaskMock: vi.fn() }));
+
+// prettier-ignore
+vi.mock("@/actions/registry/registry", () => ({ addRegistryArtifact: addRegistryArtifactMock, confirmRegistryArtifactAddition: confirmRegistryArtifactAdditionMock }));
+
+// prettier-ignore
+vi.mock("@/store/task-watcher/store", () => ({ TASK_WATCHER_STATUS: { READY: "ready", ERROR: "error" }, trackAndPollTask: trackAndPollTaskMock }));
+
+const artifactInput = { normalizedName: "prowler-aws", versionSpec: "2.0.0" };
+
+describe("executeRegistryArtifactAddition", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addRegistryArtifactMock.mockResolvedValue({
+      status: "submitted",
+      taskId: "artifact-task",
+    });
+    trackAndPollTaskMock.mockResolvedValue({
+      status: "ready",
+      result: { installed: true, error: null },
+    });
+    confirmRegistryArtifactAdditionMock.mockResolvedValue({
+      status: "confirmed",
+      tenantArtifacts: [],
+    });
+  });
+
+  // prettier-ignore
+  it.each([["This version cannot be installed.", "This version cannot be installed."], [null, "The artifact could not be installed."], ["", "The artifact could not be installed."], ["   ", "The artifact could not be installed."]])("returns a safe task refusal for error %j without confirmation", async (error, message) => {
+    // Given
+    trackAndPollTaskMock.mockResolvedValue({ status: "ready", result: { installed: false, error } });
+    // When
+    const outcome = await executeRegistryArtifactAddition(artifactInput);
+    // Then
+    expect(outcome).toEqual({ status: "refused", message });
+    expect(confirmRegistryArtifactAdditionMock).not.toHaveBeenCalled();
+  });
+
+  // prettier-ignore
+  it.each([["an otherwise valid result with an extra field", { installed: true, error: null, reason: "private deployment detail" }], ["an installed result with an error", { installed: true, error: "unexpected failure" }]])("returns error for %s without confirmation", async (_case, result) => {
+    // Given
+    trackAndPollTaskMock.mockResolvedValue({ status: "ready", result });
+    // When
+    const outcome = await executeRegistryArtifactAddition(artifactInput);
+    // Then
+    expect(outcome).toEqual({ status: "error" });
+    expect(confirmRegistryArtifactAdditionMock).not.toHaveBeenCalled();
+  });
+
+  it("maps failed tasks to unavailable without confirmation", async () => {
+    // Given
+    trackAndPollTaskMock.mockResolvedValue({
+      status: "error",
+      error: "failed",
+    });
+    // When
+    const outcome = await executeRegistryArtifactAddition(artifactInput);
+    // Then
+    expect(outcome).toEqual({ status: "unavailable" });
+    expect(confirmRegistryArtifactAdditionMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the error catch when polling throws", async () => {
+    // Given
+    trackAndPollTaskMock.mockRejectedValue(new Error("watcher crashed"));
+    // When
+    const outcome = await executeRegistryArtifactAddition(artifactInput);
+    // Then
+    expect(outcome).toEqual({ status: "error" });
+    expect(confirmRegistryArtifactAdditionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not poll a synchronous 409 onboarding outcome", async () => {
+    // Given
+    addRegistryArtifactMock.mockResolvedValue({ status: "onboarding" });
+    // When
+    const outcome = await executeRegistryArtifactAddition(artifactInput);
+    // Then
+    expect(outcome).toEqual({ status: "onboarding" });
+    expect(confirmRegistryArtifactAdditionMock).not.toHaveBeenCalled();
+    expect(trackAndPollTaskMock).not.toHaveBeenCalled();
+  });
+
+  it("confirms presence after a completed installed task", async () => {
+    // Given
+    // When
+    const outcome = await executeRegistryArtifactAddition(artifactInput);
+    // Then
+    expect(outcome).toEqual({ status: "confirmed", tenantArtifacts: [] });
+    expect(trackAndPollTaskMock).toHaveBeenCalledWith({
+      taskId: "artifact-task",
+      kind: "registry-artifact-add",
+      meta: {},
+      notifyHandler: false,
+    });
+    expect(confirmRegistryArtifactAdditionMock).toHaveBeenCalledOnce();
+    expect(confirmRegistryArtifactAdditionMock).toHaveBeenCalledWith(
+      "prowler-aws",
+    );
+  });
+});

--- a/ui/lib/registry-artifact-execution.ts
+++ b/ui/lib/registry-artifact-execution.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+import {
+  addRegistryArtifact,
+  confirmRegistryArtifactAddition,
+} from "@/actions/registry/registry";
+import {
+  TASK_WATCHER_STATUS,
+  trackAndPollTask,
+} from "@/store/task-watcher/store";
+import {
+  REGISTRY_ARTIFACT_ACTION,
+  REGISTRY_FAILURE,
+  REGISTRY_MUTATION,
+  type RegistryAddArtifactInput,
+  type RegistryArtifactTaskResult,
+  type RegistryMutationResult,
+} from "@/types/registry";
+
+export const REGISTRY_ARTIFACT_TASK_KIND = "registry-artifact-add";
+
+const artifactTaskResultSchema = z
+  .object({ installed: z.boolean(), error: z.string().nullable() })
+  .strict();
+
+export async function executeRegistryArtifactAddition(
+  input: RegistryAddArtifactInput,
+): Promise<RegistryMutationResult> {
+  let submitted;
+  try {
+    submitted = await addRegistryArtifact(input);
+  } catch {
+    return { status: REGISTRY_FAILURE.ERROR };
+  }
+  if (submitted.status !== REGISTRY_ARTIFACT_ACTION.SUBMITTED) {
+    return submitted;
+  }
+
+  let tracked;
+  try {
+    tracked = await trackAndPollTask<RegistryArtifactTaskResult>({
+      taskId: submitted.taskId,
+      kind: REGISTRY_ARTIFACT_TASK_KIND,
+      meta: {},
+      notifyHandler: false,
+    });
+  } catch {
+    return { status: REGISTRY_FAILURE.ERROR };
+  }
+  if (tracked.status !== TASK_WATCHER_STATUS.READY) {
+    return { status: REGISTRY_FAILURE.UNAVAILABLE };
+  }
+
+  const result = artifactTaskResultSchema.safeParse(tracked.result);
+  if (
+    !result.success ||
+    (result.data.installed && result.data.error !== null)
+  ) {
+    return { status: REGISTRY_FAILURE.ERROR };
+  }
+  if (!result.data.installed) {
+    return {
+      status: REGISTRY_MUTATION.REFUSED,
+      message:
+        result.data.error?.trim() || "The artifact could not be installed.",
+    };
+  }
+
+  try {
+    return await confirmRegistryArtifactAddition(input.normalizedName);
+  } catch {
+    return { status: REGISTRY_FAILURE.ERROR };
+  }
+}

--- a/ui/types/registry.ts
+++ b/ui/types/registry.ts
@@ -28,12 +28,33 @@ export const REGISTRY_SUBMISSION = {
   ERROR: "error",
 } as const;
 
-export type RegistryCredentialSubmissionResult =
+export type RegistryTaskSubmissionResult =
   | {
       status: typeof REGISTRY_SUBMISSION.PENDING;
       taskId: string;
     }
   | { status: typeof REGISTRY_SUBMISSION.ERROR };
+
+export type RegistryCredentialSubmissionResult = RegistryTaskSubmissionResult;
+
+export interface RegistryArtifactTaskResult {
+  installed: boolean;
+  error: string | null;
+}
+
+export interface RegistryAddArtifactInput {
+  normalizedName: string;
+  versionSpec?: string;
+}
+
+export const REGISTRY_ARTIFACT_ACTION = {
+  SUBMITTED: "submitted",
+} as const;
+
+export type RegistryArtifactSubmitResult = {
+  status: typeof REGISTRY_ARTIFACT_ACTION.SUBMITTED;
+  taskId: string;
+};
 
 export interface RegistryCredentialStatus {
   configured: boolean;
@@ -187,6 +208,7 @@ export type RegistryMutationResult =
       status: typeof REGISTRY_MUTATION.REFUSED;
       message: string;
     }
+  | RegistryArtifactSubmitResult
   | RegistryFailureResult;
 
 export const REGISTRY_BOOTSTRAP_STATE = {


### PR DESCRIPTION
### Context

This is PR 10 in the Dynamic Provider Registry UI chain and is stacked on #12524.

Registry artifact installation now follows the asynchronous task contract introduced by `prowler-cloud/prowler-cloud#5631`. This child establishes the internal submission, polling, result validation, and authoritative confirmation boundary before the explorer is wired in the next child.

Prowler App task: PROWLER-2414.

### Description

- Parse and strictly bind successful `202` artifact task submissions.
- Poll the submitted task and accept only the exact `{ installed, error }` result contract.
- Return safe refusal/error states for malformed, contradictory, failed, or thrown task results.
- Confirm Registry membership only after an explicit successful installation result.
- Keep synchronous `409` handling and Registry artifact removal unchanged.
- Add focused adapter, action, executor, and credential-regression unit coverage.

The new executor intentionally has no production UI caller in this child. Explorer wiring, integration/E2E coverage, and the user-facing changelog remain in the next PR so this review stays below the 400-line budget.

### Steps to review

1. Review the strict task submission binding in `ui/actions/registry/registry.adapter.ts`.
2. Review task-result parsing and outcome mapping in `ui/lib/registry-artifact-execution.ts`.
3. Verify `confirmRegistryArtifactAddition` runs exactly once after `{ installed: true, error: null }` and never after a synchronous `409`.
4. Run:

```bash
cd ui
pnpm exec vitest run --project unit \
  actions/registry/registry.adapter.test.ts \
  actions/registry/registry.test.ts \
  lib/registry-artifact-execution.test.ts \
  lib/registry-credential-execution.test.ts
pnpm run test:unit
pnpm run typecheck
pnpm run lint:check
pnpm run format:check
```

Validation evidence:

- Focused unit tests: 67 passed.
- Full unit suite: 3,153 passed.
- Typecheck, lint, format, and diff checks passed.
- No new lint errors; one unrelated pre-existing warning remains in `ui/components/registry/registry-artifact-card.tsx`.
- Exact change budget: 374 lines across seven files.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This work is tracked internally as PROWLER-2414.
- [ ] Confirm assignment for the internal task.
- [x] I reviewed open pull requests and found no duplicate implementation for this chain child.

</details>

- [x] The code is covered by focused and full unit tests.
- [x] No additional code documentation is required for this internal boundary.
- [x] No backport is needed.
- [x] No README change is needed.
- [ ] The user-facing changelog is intentionally deferred to the explorer-wiring child.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] End-to-end task requirements are completed in the next explorer-wiring child.
- [x] No npm dependencies were added or updated.
- [x] Screenshots are not applicable because this child does not wire production UI.
- [ ] The user-facing changelog is intentionally deferred to the next child.

#### API
- [x] Not applicable; this PR consumes the existing API task contract.

#### MCP Server
- [x] Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
