### PR TITLE
fix(api): apply findings partition max age in months, not days

### DIFF
--- a/api/changelog.d/findings-partition-max-age-unit.fixed.md
+++ b/api/changelog.d/findings-partition-max-age-unit.fixed.md
@@ -1,1 +1,1 @@
-`FINDINGS_TABLE_PARTITION_MAX_AGE_MONTHS` is now applied in months instead of days, and non-positive values keep partitions indefinitely
+`FINDINGS_TABLE_PARTITION_MAX_AGE_MONTHS` is now applied in months instead of days, and negative values are rejected

--- a/api/changelog.d/findings-partition-max-age-unit.fixed.md
+++ b/api/changelog.d/findings-partition-max-age-unit.fixed.md
@@ -1,0 +1,1 @@
+`FINDINGS_TABLE_PARTITION_MAX_AGE_MONTHS` is now applied in months instead of days, and non-positive values keep partitions indefinitely

--- a/api/src/backend/api/partitions.py
+++ b/api/src/backend/api/partitions.py
@@ -6,6 +6,7 @@ from api.rls import RowLevelSecurityConstraint
 from api.uuid_utils import datetime_to_uuid7
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from psqlextra.partitioning import (
     PostgresPartitioningError,
     PostgresPartitioningManager,
@@ -154,8 +155,14 @@ class PostgresUUIDv7PartitioningStrategy(PostgresRangePartitioningStrategy):
 
 
 def relative_months_or_none(value):
-    # A non-positive value keeps partitions indefinitely, like None.
-    if value is None or value <= 0:
+    # A negative value would set the cutoff in the future and delete every
+    # partition, so it is rejected rather than silently ignored.
+    if value is not None and value < 0:
+        raise ImproperlyConfigured(
+            "FINDINGS_TABLE_PARTITION_MAX_AGE_MONTHS must not be negative; "
+            "leave it unset or use 0 to keep partitions indefinitely"
+        )
+    if not value:
         return None
     return relativedelta(months=value)
 

--- a/api/src/backend/api/partitions.py
+++ b/api/src/backend/api/partitions.py
@@ -153,10 +153,11 @@ class PostgresUUIDv7PartitioningStrategy(PostgresRangePartitioningStrategy):
         )
 
 
-def relative_days_or_none(value):
-    if value is None:
+def relative_months_or_none(value):
+    # A non-positive value keeps partitions indefinitely, like None.
+    if value is None or value <= 0:
         return None
-    return relativedelta(days=value)
+    return relativedelta(months=value)
 
 
 #
@@ -173,7 +174,7 @@ manager = PostgresPartitioningManager(
                     months=settings.FINDINGS_TABLE_PARTITION_MONTHS
                 ),
                 count=settings.FINDINGS_TABLE_PARTITION_COUNT,
-                max_age=relative_days_or_none(
+                max_age=relative_months_or_none(
                     settings.FINDINGS_TABLE_PARTITION_MAX_AGE_MONTHS
                 ),
                 name_format="%Y_%b",
@@ -189,7 +190,7 @@ manager = PostgresPartitioningManager(
                     months=settings.FINDINGS_TABLE_PARTITION_MONTHS
                 ),
                 count=settings.FINDINGS_TABLE_PARTITION_COUNT,
-                max_age=relative_days_or_none(
+                max_age=relative_months_or_none(
                     settings.FINDINGS_TABLE_PARTITION_MAX_AGE_MONTHS
                 ),
                 name_format="%Y_%b",

--- a/api/src/backend/api/tests/test_partitions.py
+++ b/api/src/backend/api/tests/test_partitions.py
@@ -1,14 +1,29 @@
+from datetime import UTC, datetime
+from itertools import islice
+
 import pytest
-from api.partitions import relative_months_or_none
+from api.partitions import (
+    PostgresUUIDv7PartitioningStrategy,
+    relative_months_or_none,
+)
 from dateutil.relativedelta import relativedelta
+from django.core.exceptions import ImproperlyConfigured
+from psqlextra.partitioning import PostgresTimePartitionSize
+
+
+def build_strategy(max_age):
+    return PostgresUUIDv7PartitioningStrategy(
+        size=PostgresTimePartitionSize(months=1),
+        count=1,
+        start_date=datetime.now(UTC),
+        max_age=max_age,
+        name_format="%Y_%b",
+    )
 
 
 class TestRelativeMonthsOrNone:
-    def test_none_keeps_partitions_indefinitely(self):
-        assert relative_months_or_none(None) is None
-
-    @pytest.mark.parametrize("value", [0, -1])
-    def test_non_positive_keeps_partitions_indefinitely(self, value):
+    @pytest.mark.parametrize("value", [None, 0])
+    def test_unset_or_zero_keeps_partitions_indefinitely(self, value):
         assert relative_months_or_none(value) is None
 
     @pytest.mark.parametrize("months", [1, 3, 12])
@@ -17,3 +32,32 @@ class TestRelativeMonthsOrNone:
 
     def test_value_is_not_interpreted_as_days(self):
         assert relative_months_or_none(12) != relativedelta(days=12)
+
+    def test_negative_is_rejected(self):
+        with pytest.raises(ImproperlyConfigured):
+            relative_months_or_none(-12)
+
+
+class TestToDelete:
+    @pytest.mark.parametrize("max_age", [None, relative_months_or_none(0)])
+    def test_nothing_is_deleted_without_max_age(self, max_age):
+        strategy = build_strategy(max_age)
+
+        assert list(islice(strategy.to_delete(), 5)) == []
+
+    def test_first_deleted_partition_is_max_age_old(self):
+        months = 3
+        strategy = build_strategy(relative_months_or_none(months))
+
+        first = next(strategy.to_delete())
+
+        expected = strategy.get_start_datetime() - relativedelta(months=months)
+        assert first.name() == expected.strftime("%Y_%b").lower()
+
+    def test_deleted_partitions_go_further_back_in_time(self):
+        strategy = build_strategy(relative_months_or_none(3))
+
+        names = [p.name() for p in islice(strategy.to_delete(), 3)]
+        starts = [datetime.strptime(n, "%Y_%b") for n in names]
+
+        assert starts == sorted(starts, reverse=True)

--- a/api/src/backend/api/tests/test_partitions.py
+++ b/api/src/backend/api/tests/test_partitions.py
@@ -1,0 +1,20 @@
+import pytest
+from dateutil.relativedelta import relativedelta
+
+from api.partitions import relative_months_or_none
+
+
+class TestRelativeMonthsOrNone:
+    def test_none_keeps_partitions_indefinitely(self):
+        assert relative_months_or_none(None) is None
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_non_positive_keeps_partitions_indefinitely(self, value):
+        assert relative_months_or_none(value) is None
+
+    @pytest.mark.parametrize("months", [1, 3, 12])
+    def test_value_is_interpreted_as_months(self, months):
+        assert relative_months_or_none(months) == relativedelta(months=months)
+
+    def test_value_is_not_interpreted_as_days(self):
+        assert relative_months_or_none(12) != relativedelta(days=12)

--- a/api/src/backend/api/tests/test_partitions.py
+++ b/api/src/backend/api/tests/test_partitions.py
@@ -1,7 +1,6 @@
 import pytest
-from dateutil.relativedelta import relativedelta
-
 from api.partitions import relative_months_or_none
+from dateutil.relativedelta import relativedelta
 
 
 class TestRelativeMonthsOrNone:


### PR DESCRIPTION
## Description

`FINDINGS_TABLE_PARTITION_MAX_AGE_MONTHS` is applied as **days**, not months.

```python
def relative_days_or_none(value):
    if value is None:
        return None
    return relativedelta(days=value)      # days

max_age=relative_days_or_none(
    settings.FINDINGS_TABLE_PARTITION_MAX_AGE_MONTHS   # named, and documented, as months
)
```

`api/docs/partitions.md` describes the setting as "the number of months to keep partitions before deleting them", and the name says the same. Setting it to `12` to keep a year instead drops every partition older than **12 days**:

| value | cutoff before | cutoff after |
|---|---|---|
| 12 | 12 days | 12 months |
| 3 | 3 days | 3 months |

This only fires the first time a deployment enables retention, and the conservative-looking value is the destructive one, so it is worth correcting before anyone relies on it.

## Zero

An earlier revision of this description claimed `0` would delete every partition. That was wrong, as @josema-xyz pointed out. `relativedelta(days=0)` is falsy and `to_delete()` guards with `if not self.max_age: return`, so `0` has always meant "keep partitions indefinitely". That behaviour is unchanged here and is now covered by a test.

## Negative values

Negative values are a different matter. `to_delete()` sets the cutoff to `get_start_datetime() - max_age` and then walks backwards, so a negative value puts the cutoff in the future and starts offering partitions for deletion from there.

How much damage that does depends on the value, as @josema-xyz pointed out. The manager breaks at the first partition name it cannot find in the database, so a large negative lands beyond the pre-created window and stops harmlessly, while a small one lands inside it and works backwards through partitions that are actively in use. Either way the setting can select live data for deletion.

Silently coercing that to "keep everything" would hide a typo in a setting whose whole purpose is deletion, so it now raises `ImproperlyConfigured` instead.

## Changes

- `relative_days_or_none` → `relative_months_or_none`, returning `relativedelta(months=...)`
- Negative values raise `ImproperlyConfigured`; `None` and `0` keep partitions indefinitely, as before
- Tests for the helper, and for `to_delete()` itself — that nothing is yielded without a max age, that the first partition offered for deletion is exactly `max_age` old, and that the generator walks backwards in time

Both partitioning configs (`Finding` and `ResourceFindingMapping`) use the helper and are updated together. The default remains unset, so no deployment changes behaviour on upgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Partition retention settings are now interpreted in months rather than days.
  * Zero values keep partitions indefinitely, while negative values are rejected as invalid.

* **Tests**
  * Added coverage for month-based retention, indefinite storage, invalid values, and partition cleanup behavior.

* **Documentation**
  * Updated the changelog to describe the corrected retention setting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->