### PR TITLE
feat(sdk): add SageMaker VPC-only domain check

### DIFF
--- a/prowler/changelog.d/sagemaker-domain-vpc-only.added.md
+++ b/prowler/changelog.d/sagemaker-domain-vpc-only.added.md
@@ -1,0 +1,1 @@
+`sagemaker_domain_vpc_only_enabled` check for AWS provider, verifying that SageMaker Domains use VPC-only network access

--- a/prowler/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/sagemaker_domain_vpc_only_enabled.metadata.json
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/sagemaker_domain_vpc_only_enabled.metadata.json
@@ -8,7 +8,7 @@
   "ServiceName": "sagemaker",
   "SubServiceName": "",
   "ResourceIdTemplate": "",
-  "Severity": "medium",
+  "Severity": "high",
   "ResourceType": "Other",
   "ResourceGroup": "ai_ml",
   "Description": "Ensure that Amazon SageMaker Domains use VPC-only network access. The check validates that each SageMaker Domain has `AppNetworkAccessType` set to `VpcOnly`, preventing application traffic from using public internet access.",

--- a/prowler/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/sagemaker_domain_vpc_only_enabled.metadata.json
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/sagemaker_domain_vpc_only_enabled.metadata.json
@@ -1,0 +1,40 @@
+{
+  "Provider": "aws",
+  "CheckID": "sagemaker_domain_vpc_only_enabled",
+  "CheckTitle": "SageMaker domains use VPC-only network access",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices"
+  ],
+  "ServiceName": "sagemaker",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "Other",
+  "ResourceGroup": "ai_ml",
+  "Description": "Ensure that Amazon SageMaker Domains use VPC-only network access. The check validates that each SageMaker Domain has `AppNetworkAccessType` set to `VpcOnly`, preventing application traffic from using public internet access.",
+  "Risk": "SageMaker Domains configured with public internet access allow notebook and application traffic to traverse the public internet. This increases the attack surface and can bypass network controls such as VPC endpoints, security groups, and centralized egress inspection.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DescribeDomain.html",
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-vpc.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws sagemaker update-domain --domain-id <domain_id> --app-network-access-type VpcOnly",
+      "NativeIaC": "```yaml\nResources:\n  SageMakerDomain:\n    Type: AWS::SageMaker::Domain\n    Properties:\n      DomainName: <example_domain_name>\n      AuthMode: IAM\n      DefaultUserSettings:\n        ExecutionRole: <example_role_arn>\n      VpcId: <example_vpc_id>\n      SubnetIds:\n        - <example_subnet_id>\n      AppNetworkAccessType: VpcOnly\n```",
+      "Other": "Configure the SageMaker Domain to use VPC-only network access. Ensure the VPC has the required SageMaker VPC endpoints and routing before changing the setting.",
+      "Terraform": "```hcl\nresource \"aws_sagemaker_domain\" \"example\" {\n  domain_name             = \"<example_domain_name>\"\n  auth_mode               = \"IAM\"\n  vpc_id                  = \"<example_vpc_id>\"\n  subnet_ids              = [\"<example_subnet_id>\"]\n  app_network_access_type = \"VpcOnly\"\n\n  default_user_settings {\n    execution_role = \"<example_role_arn>\"\n  }\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Configure every SageMaker Domain with AppNetworkAccessType set to VpcOnly. Prepare the VPC networking and required endpoints before applying the change so that Studio applications continue to reach AWS services privately.",
+      "Url": "https://hub.prowler.com/check/sagemaker_domain_vpc_only_enabled"
+    }
+  },
+  "Categories": [
+    "internet-exposed",
+    "gen-ai"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/sagemaker_domain_vpc_only_enabled.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/sagemaker_domain_vpc_only_enabled.py
@@ -1,0 +1,31 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.sagemaker.sagemaker_client import (
+    sagemaker_client,
+)
+
+
+class sagemaker_domain_vpc_only_enabled(Check):
+    def execute(self):
+        findings = []
+
+        for domain in sagemaker_client.sagemaker_domains:
+            report = Check_Report_AWS(metadata=self.metadata(), resource=domain)
+
+            if not domain.details_retrieved:
+                report.status = "MANUAL"
+                report.status_extended = (
+                    f"SageMaker domain {domain.name} details could not be retrieved; "
+                    "manual review is required to verify VPC-only network access."
+                )
+            elif domain.app_network_access_type == "VpcOnly":
+                report.status = "PASS"
+                report.status_extended = (
+                    f"SageMaker domain {domain.name} uses VPC-only network access."
+                )
+            else:
+                report.status = "FAIL"
+                report.status_extended = f"SageMaker domain {domain.name} does not use VPC-only network access."
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/sagemaker_domain_vpc_only_enabled.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/sagemaker_domain_vpc_only_enabled.py
@@ -5,7 +5,14 @@ from prowler.providers.aws.services.sagemaker.sagemaker_client import (
 
 
 class sagemaker_domain_vpc_only_enabled(Check):
-    def execute(self):
+    """Ensure that SageMaker Domains use VPC-only network access."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Evaluate each SageMaker Domain network access configuration.
+
+        Returns:
+            list[Check_Report_AWS]: Findings for the discovered SageMaker Domains.
+        """
         findings = []
 
         for domain in sagemaker_client.sagemaker_domains:

--- a/prowler/providers/aws/services/sagemaker/sagemaker_service.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_service.py
@@ -451,6 +451,8 @@ class SageMaker(AWSService):
             domain.single_sign_on_application_arn = describe_domain.get(
                 "SingleSignOnApplicationArn"
             )
+            domain.app_network_access_type = describe_domain.get("AppNetworkAccessType")
+            domain.details_retrieved = True
         except Exception as error:
             logger.error(
                 f"{domain.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -617,6 +619,11 @@ class Domain(BaseModel):
     auth_mode: Optional[str] = None
     single_sign_on_managed_application_instance_id: Optional[str] = None
     single_sign_on_application_arn: Optional[str] = None
+    app_network_access_type: Optional[str] = None
+    # Set after DescribeDomain succeeds, even if a particular optional field is
+    # absent. Consumers use this to distinguish a missing configuration value
+    # from an API retrieval failure.
+    details_retrieved: bool = False
     tags: Optional[list] = []
 
 

--- a/prowler/providers/aws/services/sagemaker/sagemaker_service.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_service.py
@@ -439,6 +439,11 @@ class SageMaker(AWSService):
             )
 
     def _describe_domain(self, domain):
+        """Populate a SageMaker Domain with values from DescribeDomain.
+
+        The `details_retrieved` flag separates an unavailable response from a
+        response that successfully omits an optional domain setting.
+        """
         logger.info("SageMaker - describing domain...")
         try:
             regional_client = self.regional_clients[domain.region]

--- a/tests/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/sagemaker_domain_vpc_only_enabled_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/sagemaker_domain_vpc_only_enabled_test.py
@@ -1,0 +1,97 @@
+from unittest import mock
+
+from prowler.providers.aws.services.sagemaker.sagemaker_service import Domain
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_provider,
+)
+
+test_domain_name = "test-domain"
+test_domain_id = "d-testdomain123"
+domain_arn = f"arn:aws:sagemaker:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:domain/{test_domain_id}"
+
+
+def run_check(domain):
+    sagemaker_client = mock.MagicMock
+    sagemaker_client.sagemaker_domains = [] if domain is None else [domain]
+    aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+    with (
+        mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ),
+        mock.patch(
+            "prowler.providers.aws.services.sagemaker.sagemaker_domain_vpc_only_enabled.sagemaker_domain_vpc_only_enabled.sagemaker_client",
+            sagemaker_client,
+        ),
+    ):
+        from prowler.providers.aws.services.sagemaker.sagemaker_domain_vpc_only_enabled.sagemaker_domain_vpc_only_enabled import (
+            sagemaker_domain_vpc_only_enabled,
+        )
+
+        return sagemaker_domain_vpc_only_enabled().execute()
+
+
+class Test_sagemaker_domain_vpc_only_enabled:
+    def test_no_domains(self):
+        assert run_check(None) == []
+
+    def test_domain_with_vpc_only_network_access(self):
+        result = run_check(
+            Domain(
+                domain_id=test_domain_id,
+                name=test_domain_name,
+                arn=domain_arn,
+                region=AWS_REGION_EU_WEST_1,
+                app_network_access_type="VpcOnly",
+                details_retrieved=True,
+            )
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert (
+            result[0].status_extended
+            == f"SageMaker domain {test_domain_name} uses VPC-only network access."
+        )
+        assert result[0].resource_id == test_domain_name
+        assert result[0].resource_arn == domain_arn
+
+    def test_domain_with_public_or_missing_network_access(self):
+        for network_access_type in ("PublicInternetOnly", None):
+            result = run_check(
+                Domain(
+                    domain_id=test_domain_id,
+                    name=test_domain_name,
+                    arn=domain_arn,
+                    region=AWS_REGION_EU_WEST_1,
+                    app_network_access_type=network_access_type,
+                    details_retrieved=True,
+                )
+            )
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SageMaker domain {test_domain_name} does not use VPC-only network access."
+            )
+
+    def test_domain_with_unavailable_details_requires_manual_review(self):
+        result = run_check(
+            Domain(
+                domain_id=test_domain_id,
+                name=test_domain_name,
+                arn=domain_arn,
+                region=AWS_REGION_EU_WEST_1,
+            )
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+        assert (
+            result[0].status_extended
+            == f"SageMaker domain {test_domain_name} details could not be retrieved; manual review is required to verify VPC-only network access."
+        )

--- a/tests/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/sagemaker_domain_vpc_only_enabled_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/sagemaker_domain_vpc_only_enabled_test.py
@@ -13,6 +13,7 @@ domain_arn = f"arn:aws:sagemaker:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:dom
 
 
 def run_check(domain):
+    """Run the check with either one Domain or no Domain resources."""
     sagemaker_client = mock.MagicMock
     sagemaker_client.sagemaker_domains = [] if domain is None else [domain]
     aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
@@ -36,9 +37,11 @@ def run_check(domain):
 
 class Test_sagemaker_domain_vpc_only_enabled:
     def test_no_domains(self):
+        """Return no findings when the account has no SageMaker Domains."""
         assert run_check(None) == []
 
     def test_domain_with_vpc_only_network_access(self):
+        """Pass a Domain configured with VPC-only network access."""
         result = run_check(
             Domain(
                 domain_id=test_domain_id,
@@ -60,6 +63,7 @@ class Test_sagemaker_domain_vpc_only_enabled:
         assert result[0].resource_arn == domain_arn
 
     def test_domain_with_public_or_missing_network_access(self):
+        """Fail Domains with public or absent network access settings."""
         for network_access_type in ("PublicInternetOnly", None):
             result = run_check(
                 Domain(
@@ -80,6 +84,7 @@ class Test_sagemaker_domain_vpc_only_enabled:
             )
 
     def test_domain_with_unavailable_details_requires_manual_review(self):
+        """Require manual review when DescribeDomain could not return details."""
         result = run_check(
             Domain(
                 domain_id=test_domain_id,

--- a/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 import botocore
 
 from prowler.providers.aws.services.sagemaker.sagemaker_service import (
+    Domain,
     Model,
     SageMaker,
 )
@@ -350,6 +351,46 @@ class Test_SageMaker_Service:
             sagemaker.sagemaker_domains[0].single_sign_on_application_arn
             == test_sso_application_arn
         )
+
+    def test_describe_domain_network_access_type(self):
+        regional_client = MagicMock()
+        regional_client.region = AWS_REGION_EU_WEST_1
+        regional_client.describe_domain.return_value = {
+            "AppNetworkAccessType": "VpcOnly"
+        }
+        domain = Domain(
+            domain_id=test_domain_id,
+            name=test_domain_name,
+            arn=test_domain_arn,
+            region=AWS_REGION_EU_WEST_1,
+        )
+
+        with patch.object(SageMaker, "__init__", return_value=None):
+            sagemaker = SageMaker(MagicMock())
+            sagemaker.regional_clients = {AWS_REGION_EU_WEST_1: regional_client}
+            sagemaker._describe_domain(domain)
+
+        assert domain.app_network_access_type == "VpcOnly"
+        assert domain.details_retrieved is True
+
+    def test_describe_domain_network_access_type_retrieval_failure(self):
+        regional_client = MagicMock()
+        regional_client.region = AWS_REGION_EU_WEST_1
+        regional_client.describe_domain.side_effect = Exception("access denied")
+        domain = Domain(
+            domain_id=test_domain_id,
+            name=test_domain_name,
+            arn=test_domain_arn,
+            region=AWS_REGION_EU_WEST_1,
+        )
+
+        with patch.object(SageMaker, "__init__", return_value=None):
+            sagemaker = SageMaker(MagicMock())
+            sagemaker.regional_clients = {AWS_REGION_EU_WEST_1: regional_client}
+            sagemaker._describe_domain(domain)
+
+        assert domain.app_network_access_type is None
+        assert domain.details_retrieved is False
 
     # Test SageMaker _list_tags_for_resource
     def test_list_tags_for_resource_calls_client(self):

--- a/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
@@ -353,6 +353,7 @@ class Test_SageMaker_Service:
         )
 
     def test_describe_domain_network_access_type(self):
+        """Store the VPC-only network setting after a successful describe."""
         regional_client = MagicMock()
         regional_client.region = AWS_REGION_EU_WEST_1
         regional_client.describe_domain.return_value = {
@@ -374,6 +375,7 @@ class Test_SageMaker_Service:
         assert domain.details_retrieved is True
 
     def test_describe_domain_network_access_type_retrieval_failure(self):
+        """Keep the detail flag unset when DescribeDomain raises an error."""
         regional_client = MagicMock()
         regional_client.region = AWS_REGION_EU_WEST_1
         regional_client.describe_domain.side_effect = Exception("access denied")


### PR DESCRIPTION
### Context

Adds the SageMaker Domain VPC-only network access check requested in #12574.

Fixes #12574

### Description

- Collect `AppNetworkAccessType` from `DescribeDomain`.
- Add `sagemaker_domain_vpc_only_enabled` with PASS, FAIL, and MANUAL outcomes.
- Mark the result MANUAL when Domain details cannot be retrieved, avoiding a false PASS.
- Add unit coverage for check outcomes and service collection failures.

### Steps to review

1. Run `uv run pytest tests/providers/aws/services/sagemaker/sagemaker_service_test.py tests/providers/aws/services/sagemaker/sagemaker_domain_vpc_only_enabled/ -v`.
2. Confirm that `VpcOnly` passes, `PublicInternetOnly` and missing values fail after a successful describe, and a failed describe produces MANUAL.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature is listed in [the issue tracker](https://github.com/prowler-cloud/prowler/issues/12574).
- [x] I requested the issue through a comment on the issue.

</details>

- Are there new checks included in this PR? Yes
    - No permission update is needed: `sagemaker:DescribeDomain` is already used by the existing SageMaker Domain collector.
- [x] Review if the code is being covered by tests.
- [x] Review if code is documented following the Python style guide.
- [ ] Review if backport is needed.
- [ ] Review if it is needed to change the Readme.md.
- [x] Ensure a changelog fragment is added under `prowler/changelog.d/`.

#### SDK/CLI

- Are there new checks included in this PR? Yes
    - No permission update is needed; the existing collector already calls `DescribeDomain`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a security check to verify that SageMaker Domains use VPC-only network access.
  * Reports compliant domains as passing, publicly accessible domains as failing, and unavailable details for manual review.
  * Added remediation guidance for restricting SageMaker Domain network access.

* **Tests**
  * Added coverage for compliant, noncompliant, missing, and unavailable domain network configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->