### PR TITLE
feat: add a provider scaffold command

### DIFF
--- a/docs/developer-guide/provider-scaffold.mdx
+++ b/docs/developer-guide/provider-scaffold.mdx
@@ -2,11 +2,15 @@
 title: 'Provider Scaffold Command'
 ---
 
+import { VersionBadge } from "/snippets/version-badge.mdx"
+
 `prowler-dev provider create` writes the files a new provider needs in order to be discovered and loaded, so that the first thing you write is the part only you can write. It generates structure and `TODO` markers, and it never guesses authentication behavior, API semantics or security checks.
 
 The command is contributor tooling. Nothing it generates runs during a scan, and nothing in `prowler-dev` is used by the `prowler` CLI.
 
 ## Usage
+
+<VersionBadge version="5.40.0" />
 
 ```bash
 uv run prowler-dev provider create --name acmecloud --kind api --scope full-stack \
@@ -19,7 +23,7 @@ Add `--dry-run` to print the file list and exit without writing anything.
 
 Three inputs change what gets generated, so the command refuses to guess them.
 
-* **`--name`:** The provider name, lowercase letters and digits only. `Provider.get_class()` builds the class name with Python's `str.capitalize()`, so `acmecloud` resolves to `AcmecloudProvider`. A name containing an underscore, a hyphen or an inner capital cannot be discovered, and the command rejects it rather than generating a provider that silently fails to load.
+* **`--name`:** The provider name, starting with a lowercase letter and followed by lowercase letters or digits. `Provider.get_class()` builds the class name with Python's `str.capitalize()`, so `acmecloud` resolves to `AcmecloudProvider`. A name containing an underscore, a hyphen or an inner capital cannot be discovered, and the command rejects it rather than generating a provider that silently fails to load.
 * **`--kind`:** `sdk`, `api`, `tool` or `hybrid`, per [Classifying your Provider](./provider#classifying-your-provider). A `tool` provider wraps another binary rather than auditing a live API, so it gets no service layer, matching what `iac`, `image` and `llm` ship today.
 * **`--scope`:** How far the provider reaches. `builtin` generates a CLI/SDK provider inside this repository. `full-stack` does the same and sets `sdk_only = False`, which is what makes the API and UI list it. `external` generates a standalone package discovered through the `prowler.providers` entry point, outside this repository.
 
@@ -85,6 +89,8 @@ prowler <name> --help       # the provider shows its own arguments
 pytest tests/providers/<name>
 ```
 
-All three pass on a freshly generated provider, before any implementation work. The generated `setup_session` and `setup_identity` raise until you implement them, and the generated tests assert exactly that, so replace them as you go.
+All three pass on a freshly generated provider, before any implementation work and before the reported registrations are done. Both `--help` paths need only discovery and `init_parser`, which are generated.
+
+Running an actual scan is what needs the dispatch branch in `init_global_provider()`. Until you add it, `prowler <name>` cannot construct the provider. The generated `setup_session` and `setup_identity` raise until you implement them, and the generated tests assert exactly that, so replace them as you go.
 
 Generated Python is formatted with `black` when it is importable, which it is in a Prowler checkout. That keeps a freshly generated provider clean against the repository's own `black` and `flake8` gates before your first push.

--- a/docs/developer-guide/provider-scaffold.mdx
+++ b/docs/developer-guide/provider-scaffold.mdx
@@ -1,0 +1,90 @@
+---
+title: 'Provider Scaffold Command'
+---
+
+`prowler-dev provider create` writes the files a new provider needs in order to be discovered and loaded, so that the first thing you write is the part only you can write. It generates structure and `TODO` markers, and it never guesses authentication behavior, API semantics or security checks.
+
+The command is contributor tooling. Nothing it generates runs during a scan, and nothing in `prowler-dev` is used by the `prowler` CLI.
+
+## Usage
+
+```bash
+uv run prowler-dev provider create --name acmecloud --kind api --scope full-stack \
+    --regional false --auth token
+```
+
+Add `--dry-run` to print the file list and exit without writing anything.
+
+### Required Arguments
+
+Three inputs change what gets generated, so the command refuses to guess them.
+
+* **`--name`:** The provider name, lowercase letters and digits only. `Provider.get_class()` builds the class name with Python's `str.capitalize()`, so `acmecloud` resolves to `AcmecloudProvider`. A name containing an underscore, a hyphen or an inner capital cannot be discovered, and the command rejects it rather than generating a provider that silently fails to load.
+* **`--kind`:** `sdk`, `api`, `tool` or `hybrid`, per [Classifying your Provider](./provider#classifying-your-provider). A `tool` provider wraps another binary rather than auditing a live API, so it gets no service layer, matching what `iac`, `image` and `llm` ship today.
+* **`--scope`:** How far the provider reaches. `builtin` generates a CLI/SDK provider inside this repository. `full-stack` does the same and sets `sdk_only = False`, which is what makes the API and UI list it. `external` generates a standalone package discovered through the `prowler.providers` entry point, outside this repository.
+
+### Optional Arguments
+
+* **`--regional`:** `true` or `false`, default `false`. When true, the provider gets a `--region` argument, a `regions` property and a `validate_regions` stub.
+* **`--auth`:** `env`, `token`, `key-file` or `browser`, default `env`. This decides which credential arguments exist and what the `TODO` markers say. It does not decide how credentials are resolved. `token` also adds the flag to the provider's `SENSITIVE_ARGUMENTS` set, so its value is redacted in HTML output.
+* **`--path`:** Where to generate. For `builtin` and `full-stack`, the Prowler checkout to write into, auto-detected from the working directory when omitted. For `external`, the directory to create, defaulting to `./prowler-provider-<name>`.
+* **`--force`:** Overwrite files that already exist. The command refuses to overwrite by default.
+
+## What Gets Generated
+
+For a built-in provider, the command writes the provider package and its tests:
+
+```text
+prowler/providers/<name>/
+├── __init__.py
+├── <name>_provider.py            # <Name>Provider, with the abstract members stubbed
+├── models.py                     # <Name>Session, <Name>IdentityInfo, <Name>OutputOptions
+├── exceptions/exceptions.py      # provider exceptions in the next free code block
+├── lib/arguments/arguments.py    # init_parser, required for every built-in provider
+├── lib/mutelist/mutelist.py      # <Name>Mutelist
+├── lib/service/service.py        # base service class, omitted for --kind tool
+└── services/__init__.py          # package marker, omitted for --kind tool
+tests/providers/<name>/
+├── <name>_provider_test.py
+├── <name>_fixtures.py
+└── lib/arguments/<name>_arguments_test.py
+```
+
+`lib/arguments/arguments.py` is generated for every kind because it is not optional. `prowler/providers/common/arguments.py` imports that module for every built-in provider and calls `init_parser` on it, and when the provider being invoked fails to load its arguments the CLI exits. All current providers have it.
+
+Test files are named with the provider prefix so that they do not collide with another provider's tests, which CI checks for.
+
+For an external provider, the command writes a standalone package instead:
+
+```text
+pyproject.toml                    # declares the prowler.providers entry point
+prowler_provider_<name>/
+├── __init__.py
+├── provider.py                   # <Name>Provider, with init_parser and from_cli_args
+└── models.py
+tests/test_provider.py
+```
+
+An external provider carries two pieces of the contract that no built-in provider implements, so there is nothing in this repository to copy them from. `init_parser` is called by `prowler/providers/common/arguments.py` to build the CLI subparser, and `from_cli_args` is called by the dynamic fallback branch of `init_global_provider()` to build the instance. Both are generated.
+
+## What Is Reported Instead Of Generated
+
+Three registrations live in files shared by every provider. Editing those by code generation produces a diff nobody wants to review and a conflict for whoever runs the command next, so the command reports them with a ready-to-paste snippet:
+
+1. The dispatch branch in `init_global_provider()` (`prowler/providers/common/provider.py`), which parses the provider's arguments and instantiates it. The reported snippet already passes the credential and region arguments that match your flags.
+2. `CheckReport<Name>` in `prowler/lib/check/models.py`. The names in that file are not derived from the provider name, so the spelling is yours to pick.
+3. The exception code block. The command reads the highest code currently in use and suggests the next free block of 100, which is worth re-checking before you commit.
+
+The report also names the changelog fragment to add, the verification commands to run, and, for a full-stack provider, that the API and UI work is a separate scope.
+
+## Verifying A Generated Provider
+
+```bash
+prowler --help              # the provider is listed with its help text
+prowler <name> --help       # the provider shows its own arguments
+pytest tests/providers/<name>
+```
+
+All three pass on a freshly generated provider, before any implementation work. The generated `setup_session` and `setup_identity` raise until you implement them, and the generated tests assert exactly that, so replace them as you go.
+
+Generated Python is formatted with `black` when it is importable, which it is in a Prowler checkout. That keeps a freshly generated provider clean against the repository's own `black` and `flake8` gates before your first push.

--- a/docs/developer-guide/provider-scaffold.mdx
+++ b/docs/developer-guide/provider-scaffold.mdx
@@ -6,7 +6,7 @@ import { VersionBadge } from "/snippets/version-badge.mdx"
 
 `prowler-dev provider create` writes the files a new provider needs in order to be discovered and loaded, so that the first thing you write is the part only you can write. It generates structure and `TODO` markers, and it never guesses authentication behavior, API semantics or security checks.
 
-The command is contributor tooling. Nothing it generates runs during a scan, and nothing in `prowler-dev` is used by the `prowler` CLI.
+`prowler-dev` is contributor tooling. It never runs during a scan, and the `prowler` CLI does not use any part of it. What it generates is ordinary provider code, which does run during a scan once you have implemented it and added the registrations reported below.
 
 ## Usage
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -503,6 +503,7 @@
             "pages": [
               "developer-guide/introduction",
               "developer-guide/provider",
+              "developer-guide/provider-scaffold",
               "developer-guide/services",
               "developer-guide/checks",
               "developer-guide/secret-scanning-checks",

--- a/prowler/changelog.d/provider-scaffold-command.added.md
+++ b/prowler/changelog.d/provider-scaffold-command.added.md
@@ -1,1 +1,1 @@
-`prowler-dev provider create` scaffolds a new provider from explicit inputs (name, kind, scope, regional behavior and authentication mode), generating the structure discovery depends on plus its tests, and reporting the registrations that live in shared files rather than editing them
+`prowler-dev provider create` command that scaffolds a new provider from explicit inputs (name, kind, scope, regional behavior and authentication mode), generating the structure discovery depends on plus its tests and reporting the registrations that live in shared files

--- a/prowler/changelog.d/provider-scaffold-command.added.md
+++ b/prowler/changelog.d/provider-scaffold-command.added.md
@@ -1,0 +1,1 @@
+`prowler-dev provider create` scaffolds a new provider from explicit inputs (name, kind, scope, regional behavior and authentication mode), generating the structure discovery depends on plus its tests, and reporting the registrations that live in shared files rather than editing them

--- a/prowler/lib/dev/__init__.py
+++ b/prowler/lib/dev/__init__.py
@@ -1,0 +1,4 @@
+"""Contributor tooling for Prowler, exposed as the `prowler-dev` command.
+
+Nothing in this package runs during a scan.
+"""

--- a/prowler/lib/dev/__main__.py
+++ b/prowler/lib/dev/__main__.py
@@ -1,0 +1,8 @@
+"""Allow `python -m prowler.lib.dev` alongside the `prowler-dev` script."""
+
+import sys
+
+from prowler.lib.dev.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prowler/lib/dev/cli.py
+++ b/prowler/lib/dev/cli.py
@@ -1,0 +1,169 @@
+"""Command-line entry point for Prowler's development commands.
+
+Exposed as the ``prowler-dev`` console script. This is contributor tooling, so
+it is deliberately separate from the ``prowler`` CLI: nothing here runs during a
+scan.
+"""
+
+import sys
+from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
+from pathlib import Path
+from typing import List, Optional
+
+from prowler.lib.dev.provider_scaffold import (
+    AUTH_MODES,
+    KINDS,
+    SCOPES,
+    ProviderSpec,
+    ScaffoldError,
+    ScaffoldPlan,
+    build_plan,
+    write_plan,
+)
+
+PROVIDER_CREATE_EPILOG = """examples:
+  # A built-in CLI/SDK provider that reads credentials from the environment
+  prowler-dev provider create --name acmecloud --kind api --scope builtin
+
+  # A provider the API and UI also list, authenticating with a token
+  prowler-dev provider create --name acmecloud --kind api --scope full-stack \\
+      --regional false --auth token
+
+  # A provider distributed as its own package, discovered through entry points
+  prowler-dev provider create --name acmecloud --kind api --scope external
+
+The scaffold generates structure and TODO markers. It does not invent
+authentication behavior, API semantics or security checks. It does not edit
+the files shared by every provider either, and reports those as next steps
+with a snippet to paste.
+"""
+
+
+def build_parser() -> ArgumentParser:
+    """Build the prowler-dev argument parser."""
+    parser = ArgumentParser(
+        prog="prowler-dev",
+        description="Development commands for contributing to Prowler.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    provider = commands.add_parser(
+        "provider", help="Work on a Prowler provider"
+    ).add_subparsers(dest="provider_command", required=True)
+
+    create = provider.add_parser(
+        "create",
+        help="Scaffold the minimum consistent structure for a new provider",
+        epilog=PROVIDER_CREATE_EPILOG,
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+    create.add_argument(
+        "--name",
+        required=True,
+        help="Provider name, lowercase letters and digits only (e.g. acmecloud)",
+    )
+    create.add_argument(
+        "--kind",
+        required=True,
+        choices=KINDS,
+        help="Provider kind. A tool/wrapper provider gets no service layer.",
+    )
+    create.add_argument(
+        "--scope",
+        required=True,
+        choices=SCOPES,
+        help=(
+            "How far the provider reaches: builtin is CLI/SDK only, full-stack "
+            "is also listed by the API and UI, external is its own package."
+        ),
+    )
+    create.add_argument(
+        "--regional",
+        choices=("true", "false"),
+        default="false",
+        help="Whether findings are scoped per region. Default: false",
+    )
+    create.add_argument(
+        "--auth",
+        choices=AUTH_MODES,
+        default="env",
+        help="Which credential source the arguments expose. Default: env",
+    )
+    create.add_argument(
+        "--path",
+        type=Path,
+        default=None,
+        help=(
+            "Where to generate. For builtin and full-stack, the Prowler "
+            "checkout to write into, auto-detected when omitted. For external, "
+            "the directory to create, defaulting to ./prowler-provider-<name>."
+        ),
+    )
+    create.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the files that would be written and exit",
+    )
+    create.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite files that already exist",
+    )
+    create.set_defaults(handler=provider_create)
+    return parser
+
+
+def _print_plan(plan: ScaffoldPlan, spec: ProviderSpec, dry_run: bool) -> None:
+    """Print the files in a plan and what is left to do."""
+    verb = "Would create" if dry_run else "Created"
+    print(f"{verb} {len(plan.files)} files for provider '{spec.name}' in {plan.root}")
+    print()
+    for relative in plan.paths:
+        print(f"  {relative}")
+    print()
+    print(
+        f"Scope: {spec.scope}  Kind: {spec.kind}  "
+        f"Regional: {str(spec.regional).lower()}  Auth: {spec.auth}  "
+        f"sdk_only: {spec.sdk_only}"
+    )
+    print()
+    print("Next steps:")
+    for index, step in enumerate(plan.next_steps, start=1):
+        print(f"  {index}. {step}")
+
+
+def provider_create(arguments: Namespace) -> int:
+    """Handle `prowler-dev provider create`."""
+    spec = ProviderSpec(
+        name=arguments.name,
+        kind=arguments.kind,
+        scope=arguments.scope,
+        auth=arguments.auth,
+        regional=arguments.regional == "true",
+    )
+    plan = build_plan(spec, arguments.path)
+    if not arguments.dry_run:
+        write_plan(plan, force=arguments.force)
+    _print_plan(plan, spec, dry_run=arguments.dry_run)
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Run prowler-dev.
+
+    Args:
+        argv: Arguments to parse. Defaults to sys.argv[1:].
+
+    Returns:
+        The process exit code.
+    """
+    arguments = build_parser().parse_args(argv)
+    try:
+        return arguments.handler(arguments)
+    except ScaffoldError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prowler/lib/dev/provider_scaffold.py
+++ b/prowler/lib/dev/provider_scaffold.py
@@ -1,0 +1,753 @@
+"""Generate the minimum consistent structure for a new Prowler provider.
+
+The scaffold writes the files a provider needs in order to be discovered and
+loaded, and stops there. Authentication behavior, API semantics and security
+checks are left as explicit ``TODO`` markers, because those are decisions no
+template can make.
+
+Three registrations live in files shared by every provider, so the scaffold
+reports them as next steps with a ready-to-paste snippet instead of patching
+them. Editing a shared file by code generation produces a diff no reviewer
+wants to read, and a merge conflict for whoever runs the command next.
+"""
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from prowler.lib.dev import templates
+
+KINDS = ("sdk", "api", "tool", "hybrid")
+SCOPES = ("builtin", "external", "full-stack")
+AUTH_MODES = ("env", "token", "key-file", "browser")
+
+# Kinds that audit a live API need a service layer. A tool/wrapper provider
+# shells out to another binary instead, which is why `iac`, `image` and `llm`
+# ship with no `services/` or `lib/service/` at all.
+KINDS_WITH_SERVICES = ("sdk", "api", "hybrid")
+
+NAME_PATTERN = re.compile(r"^[a-z][a-z0-9]*$")
+
+# Provider.get_class() derives the class name with str.capitalize(), so the
+# scaffold refuses any name that would produce a class the loader cannot find.
+NAME_HELP = (
+    "A provider name must be lowercase letters and digits, starting with a "
+    "letter, with no underscores, hyphens or dots. Provider.get_class() builds "
+    "the class name with str.capitalize(), so `googleworkspace` resolves to "
+    "GoogleworkspaceProvider and a name like `acme_cloud` or `acmeCloud` "
+    "cannot be discovered."
+)
+
+# Each provider owns a block of 100 exception codes. The scaffold suggests the
+# next free block rather than reusing one.
+EXCEPTION_CODE_BLOCK = 100
+EXCEPTION_CODE_FLOOR = 18000
+
+
+class ScaffoldError(Exception):
+    """Raised when the requested provider cannot be scaffolded."""
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """The explicit inputs the generated structure is derived from."""
+
+    name: str
+    kind: str
+    scope: str
+    auth: str = "env"
+    regional: bool = False
+
+    @property
+    def class_prefix(self) -> str:
+        """The class-name prefix the provider loader will look for."""
+        return self.name.capitalize()
+
+    @property
+    def env_prefix(self) -> str:
+        """The prefix used for this provider's environment variables."""
+        return self.name.upper()
+
+    @property
+    def needs_services(self) -> bool:
+        return self.kind in KINDS_WITH_SERVICES
+
+    @property
+    def sdk_only(self) -> bool:
+        """Whether the API and UI list this provider.
+
+        `sdk_only` defaults to True on the base Provider, and only a provider
+        that sets it to False appears in Provider.get_app_providers(), which is
+        what the application enumerates.
+        """
+        return self.scope != "full-stack"
+
+
+@dataclass
+class ScaffoldPlan:
+    """The files a run would write, plus what is left for the contributor."""
+
+    root: Path
+    files: Dict[str, str] = field(default_factory=dict)
+    next_steps: List[str] = field(default_factory=list)
+
+    @property
+    def paths(self) -> List[str]:
+        return sorted(self.files)
+
+
+def validate_name(name: str) -> str:
+    """Check a provider name against the discovery contract.
+
+    Args:
+        name: The requested provider name.
+
+    Returns:
+        The validated name.
+
+    Raises:
+        ScaffoldError: If the name cannot be discovered by Prowler.
+    """
+    if not name:
+        raise ScaffoldError(f"A provider name is required. {NAME_HELP}")
+    if not NAME_PATTERN.match(name):
+        raise ScaffoldError(f"Invalid provider name '{name}'. {NAME_HELP}")
+    return name
+
+
+def find_repo_root(start: Optional[Path] = None) -> Path:
+    """Locate the Prowler repository root by walking up from ``start``.
+
+    Args:
+        start: Directory to start from. Defaults to the current directory.
+
+    Returns:
+        The repository root.
+
+    Raises:
+        ScaffoldError: If no Prowler checkout is found.
+    """
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / "prowler" / "providers" / "common" / "provider.py").is_file():
+            return candidate
+    raise ScaffoldError(
+        "No Prowler repository found. Run this from a Prowler checkout, or "
+        "pass --path pointing at one. To scaffold a provider that lives "
+        "outside this repository, use --scope external instead."
+    )
+
+
+def existing_builtin_names(repo_root: Path) -> List[str]:
+    """List the built-in provider directory names in a checkout.
+
+    This reads the directory tree rather than calling
+    Provider.get_available_providers() so that it reports the checkout being
+    written to, which is not necessarily the installed Prowler.
+
+    Args:
+        repo_root: The repository root.
+
+    Returns:
+        The built-in provider names, sorted.
+    """
+    providers_root = repo_root / "prowler" / "providers"
+    if not providers_root.is_dir():
+        return []
+    return sorted(
+        entry.name
+        for entry in providers_root.iterdir()
+        if entry.is_dir()
+        and entry.name != "common"
+        and (entry / "__init__.py").is_file()
+    )
+
+
+def next_exception_code_range(repo_root: Path) -> Tuple[int, int]:
+    """Suggest the next free block of provider exception codes.
+
+    Args:
+        repo_root: The repository root.
+
+    Returns:
+        The (start, end) of the suggested block.
+    """
+    highest = EXCEPTION_CODE_FLOOR - 1
+    providers_root = repo_root / "prowler" / "providers"
+    for exceptions_file in providers_root.glob("*/exceptions/exceptions.py"):
+        for match in re.finditer(r"\((\d{4,6}),", exceptions_file.read_text()):
+            highest = max(highest, int(match.group(1)))
+    start = ((highest // EXCEPTION_CODE_BLOCK) + 1) * EXCEPTION_CODE_BLOCK
+    return start, start + EXCEPTION_CODE_BLOCK - 1
+
+
+def _dynamic_fallback_line(repo_root: Path) -> Optional[int]:
+    """Find the line the built-in dispatch chain ends on.
+
+    Args:
+        repo_root: The repository root.
+
+    Returns:
+        The 1-indexed line of the dynamic fallback branch, or None.
+    """
+    provider_py = repo_root / "prowler" / "providers" / "common" / "provider.py"
+    if not provider_py.is_file():
+        return None
+    for index, line in enumerate(provider_py.read_text().splitlines(), start=1):
+        if "Dynamic fallback" in line:
+            return index
+    return None
+
+
+def _indent(block: str, spaces: int = 4) -> str:
+    """Indent every non-empty line of a rendered block."""
+    pad = " " * spaces
+    return "".join(
+        f"{pad}{line}" if line.strip() else line
+        for line in block.splitlines(keepends=True)
+    )
+
+
+def _auth_context(spec: ProviderSpec) -> dict:
+    """Build the auth-dependent half of the template context.
+
+    ``--auth`` decides which credential arguments exist and what the TODO
+    markers say. It never decides how credentials are resolved: that is the
+    contributor's call, and the generated `setup_session` raises until they
+    make it.
+    """
+    env = spec.env_prefix
+    name = spec.name
+    common = {
+        "sensitive_arguments": "",
+        "from_cli_args_extra": "",
+    }
+    if spec.auth == "env":
+        return {
+            **common,
+            "init_extra_params": "",
+            "init_extra_docs": "",
+            "session_def_params": "",
+            "session_call_args": "",
+            "session_test_args": "",
+            "test_connection_params": "",
+            "test_connection_docs": "",
+            "auth_label": "Environment variables",
+            "auth_docstring": (
+                f"Credentials come from the {env}_* environment variables, which "
+                "keeps secrets out of shell history and process listings."
+            ),
+            "auth_hint": (
+                f"Read the {env}_* environment variables and raise "
+                f"{spec.class_prefix}CredentialsError when they are missing."
+            ),
+            "auth_arguments": templates.ARGUMENTS_AUTH_ENV.substitute(env_prefix=env),
+        }
+    if spec.auth == "token":
+        return {
+            **common,
+            "sensitive_arguments": templates.SENSITIVE_ARGUMENTS.substitute(name=name),
+            "init_extra_params": "        token: str = None,\n",
+            "init_extra_docs": (
+                f"            token: {spec.class_prefix} API token, falling back "
+                f"to the {env}_TOKEN environment variable.\n"
+            ),
+            "session_def_params": "token: str = None",
+            "session_call_args": "token=token",
+            "session_test_args": 'token="not-a-real-token"',
+            "test_connection_params": "        token: str = None,\n",
+            "test_connection_docs": (
+                f"            token: {spec.class_prefix} API token.\n"
+            ),
+            "auth_label": "API token",
+            "auth_docstring": (
+                "The token is taken from the argument when given, and from the "
+                f"{env}_TOKEN environment variable otherwise."
+            ),
+            "auth_hint": (
+                f"Fall back to os.environ.get('{env}_TOKEN') and raise "
+                f"{spec.class_prefix}CredentialsError when neither is set."
+            ),
+            "auth_arguments": templates.ARGUMENTS_AUTH_TOKEN.substitute(
+                name=name, env_prefix=env, class_prefix=spec.class_prefix
+            ),
+            "from_cli_args_extra": (
+                f'            token=getattr(arguments, "{name}_token", None),\n'
+            ),
+        }
+    if spec.auth == "key-file":
+        return {
+            **common,
+            "init_extra_params": "        key_file: str = None,\n",
+            "init_extra_docs": (
+                "            key_file: Path to the credentials key file, "
+                f"falling back to the {env}_KEY_FILE environment variable.\n"
+            ),
+            "session_def_params": "key_file: str = None",
+            "session_call_args": "key_file=key_file",
+            "session_test_args": 'key_file="/nonexistent/key.json"',
+            "test_connection_params": "        key_file: str = None,\n",
+            "test_connection_docs": (
+                "            key_file: Path to the credentials key file.\n"
+            ),
+            "auth_label": "Key file",
+            "auth_docstring": (
+                "The key file path is taken from the argument when given, and "
+                f"from the {env}_KEY_FILE environment variable otherwise."
+            ),
+            "auth_hint": (
+                "Read and parse the key file, and raise "
+                f"{spec.class_prefix}CredentialsError when it is missing or malformed."
+            ),
+            "auth_arguments": templates.ARGUMENTS_AUTH_KEY_FILE.substitute(
+                name=name, env_prefix=env, class_prefix=spec.class_prefix
+            ),
+            "from_cli_args_extra": (
+                f'            key_file=getattr(arguments, "{name}_key_file", None),\n'
+            ),
+        }
+    # browser
+    return {
+        **common,
+        "init_extra_params": "        browser_auth: bool = False,\n",
+        "init_extra_docs": (
+            "            browser_auth: Whether to authenticate with the "
+            "interactive browser flow.\n"
+        ),
+        "session_def_params": "browser_auth: bool = False",
+        "session_call_args": "browser_auth=browser_auth",
+        "session_test_args": "browser_auth=False",
+        "test_connection_params": "        browser_auth: bool = False,\n",
+        "test_connection_docs": (
+            "            browser_auth: Whether to use the interactive browser flow.\n"
+        ),
+        "auth_label": "Interactive browser",
+        "auth_docstring": (
+            "The interactive browser flow is used when browser_auth is set, so "
+            "this path needs a human at a terminal and cannot run unattended."
+        ),
+        "auth_hint": (
+            "Start the browser flow when browser_auth is set, and raise "
+            f"{spec.class_prefix}CredentialsError when it is not."
+        ),
+        "auth_arguments": templates.ARGUMENTS_AUTH_BROWSER.substitute(
+            name=name, env_prefix=env, class_prefix=spec.class_prefix
+        ),
+        "from_cli_args_extra": (
+            f'            browser_auth=getattr(arguments, "{name}_browser_auth", False),\n'
+        ),
+    }
+
+
+def _regional_context(spec: ProviderSpec) -> dict:
+    """Build the region-dependent half of the template context."""
+    if not spec.regional:
+        return {
+            "regions_init": "",
+            "regions_property": "",
+            "validate_regions": "",
+            "regions_arguments": "",
+            "regions_param": "",
+            "regions_doc": "",
+            "regions_from_cli_args": "",
+        }
+    return {
+        "regions_init": templates.REGIONS_INIT.substitute(
+            class_prefix=spec.class_prefix
+        ),
+        "regions_property": templates.REGIONS_PROPERTY.substitute(),
+        "validate_regions": templates.VALIDATE_REGIONS.substitute(
+            class_prefix=spec.class_prefix
+        ),
+        "regions_arguments": templates.ARGUMENTS_REGIONS.substitute(
+            name=spec.name, class_prefix=spec.class_prefix
+        ),
+        "regions_param": "        regions: list = None,\n",
+        "regions_doc": (
+            "            regions: Region(s) to scan for regional resources. "
+            "None scans every region.\n"
+        ),
+        "regions_from_cli_args": (
+            '            regions=getattr(arguments, "region", None),\n'
+        ),
+    }
+
+
+def _template_context(spec: ProviderSpec, repo_root: Optional[Path]) -> dict:
+    """Assemble the full substitution context for one spec."""
+    auth = _auth_context(spec)
+    regional = _regional_context(spec)
+    code_start, code_end = (
+        next_exception_code_range(repo_root)
+        if repo_root is not None
+        else (EXCEPTION_CODE_FLOOR, EXCEPTION_CODE_FLOOR + EXCEPTION_CODE_BLOCK - 1)
+    )
+    # The parser local is only assigned when an argument actually uses it. A
+    # provider with environment-only auth and no region filter adds no
+    # arguments at all, and an unused local is an F841 in the tree CI lints.
+    uses_parser = spec.auth != "env" or spec.regional
+    return {
+        "name": spec.name,
+        "class_prefix": spec.class_prefix,
+        "env_prefix": spec.env_prefix,
+        "parser_assignment": f"{spec.name}_parser = " if uses_parser else "",
+        "sdk_only_attr": "" if spec.sdk_only else "    sdk_only: bool = False\n",
+        "sdk_only_value": "True" if spec.sdk_only else "False",
+        "code_start": code_start,
+        "code_end": code_end,
+        "code_credentials": code_start,
+        "code_session": code_start + 1,
+        "code_identity": code_start + 2,
+        **auth,
+        **regional,
+        # The auth params come first so that the credential arguments read
+        # before the region filter, matching the existing providers.
+        "init_extra_params": auth["init_extra_params"] + regional["regions_param"],
+        "init_extra_docs": auth["init_extra_docs"] + regional["regions_doc"],
+        "from_cli_args_extra": (
+            auth["from_cli_args_extra"] + regional["regions_from_cli_args"]
+        ),
+    }
+
+
+def _sorted_imports(*statements: str) -> str:
+    """Order `from` imports by module path, the way isort's black profile does.
+
+    Whether a provider's own imports sort before or after
+    `prowler.providers.common` depends on its name, so this cannot be baked
+    into the templates. The repository runs isort over `prowler/` and `tests/`
+    in pre-commit, and sorting here is what keeps a contributor's first
+    `prek run` from opening with a diff they did not write.
+
+    Sorting the handful of statements the templates emit is deliberate rather
+    than calling isort, which is only a transitive pin here and not a declared
+    development dependency.
+    """
+    return "\n".join(
+        sorted(
+            (statement.strip("\n") for statement in statements),
+            key=lambda statement: statement.split()[1],
+        )
+    )
+
+
+def _format_python(source: str) -> str:
+    """Format generated Python with black when it is importable.
+
+    Prowler's CI runs `black --check` over the repository, so a generated
+    provider has to be formatter-clean before the contributor's first push.
+    black is a declared development dependency and is present in a checkout.
+    When it is absent, which is the case for an external provider scaffolded
+    from an installed Prowler, the source is written as rendered.
+    """
+    try:
+        import black
+    except ImportError:
+        return source
+    try:
+        return black.format_str(source, mode=black.Mode())
+    except Exception:
+        # A template bug must surface as code to inspect, not a failed scaffold.
+        return source
+
+
+def _builtin_import_blocks(spec: ProviderSpec) -> dict:
+    """Build the import blocks whose order depends on the provider's name."""
+    name, cls = spec.name, spec.class_prefix
+    return {
+        "provider_class": _sorted_imports(
+            "from prowler.providers.common.models import Audit_Metadata, Connection",
+            "from prowler.providers.common.provider import Provider",
+            f"from prowler.providers.{name}.exceptions.exceptions import (\n"
+            f"    {cls}CredentialsError,\n"
+            f"    {cls}IdentityError,\n"
+            f"    {cls}SessionError,\n"
+            ")",
+            f"from prowler.providers.{name}.lib.mutelist.mutelist import {cls}Mutelist",
+            f"from prowler.providers.{name}.models import (\n"
+            f"    {cls}IdentityInfo,\n"
+            f"    {cls}Session,\n"
+            ")",
+        ),
+        "provider_test": _sorted_imports(
+            f"from prowler.providers.{name}.exceptions.exceptions import (\n"
+            f"    {cls}CredentialsError,\n"
+            f"    {cls}IdentityError,\n"
+            ")",
+            f"from prowler.providers.{name}.{name}_provider import {cls}Provider",
+        ),
+        "provider_fixtures": _sorted_imports(
+            f"from prowler.providers.{name}.{name}_provider import {cls}Provider",
+            f"from prowler.providers.{name}.models import (\n"
+            f"    {cls}IdentityInfo,\n"
+            f"    {cls}Session,\n"
+            ")",
+        ),
+    }
+
+
+def build_builtin_plan(spec: ProviderSpec, repo_root: Path) -> ScaffoldPlan:
+    """Plan the files for a provider that lives inside this repository."""
+    ctx = _template_context(spec, repo_root)
+    imports = _builtin_import_blocks(spec)
+    name = spec.name
+    base = f"prowler/providers/{name}"
+    tests_base = f"tests/providers/{name}"
+
+    files = {
+        f"{base}/__init__.py": "",
+        f"{base}/{name}_provider.py": _format_python(
+            templates.PROVIDER_CLASS.substitute(
+                **{**ctx, "provider_imports": imports["provider_class"]}
+            )
+        ),
+        f"{base}/models.py": _format_python(templates.MODELS.substitute(**ctx)),
+        f"{base}/exceptions/__init__.py": "",
+        f"{base}/exceptions/exceptions.py": _format_python(
+            templates.EXCEPTIONS.substitute(**ctx)
+        ),
+        f"{base}/lib/__init__.py": "",
+        f"{base}/lib/arguments/__init__.py": "",
+        f"{base}/lib/arguments/arguments.py": _format_python(
+            templates.ARGUMENTS.substitute(**ctx)
+        ),
+        f"{base}/lib/mutelist/__init__.py": "",
+        f"{base}/lib/mutelist/mutelist.py": _format_python(
+            templates.MUTELIST.substitute(**ctx)
+        ),
+        # tests/ must not contain __init__.py; scripts/check_test_init_files.py
+        # fails the build when one appears.
+        f"{tests_base}/{name}_provider_test.py": _format_python(
+            templates.PROVIDER_TEST.substitute(
+                **{**ctx, "provider_imports": imports["provider_test"]}
+            )
+        ),
+        f"{tests_base}/{name}_fixtures.py": _format_python(
+            templates.PROVIDER_FIXTURES.substitute(
+                **{**ctx, "provider_imports": imports["provider_fixtures"]}
+            )
+        ),
+        f"{tests_base}/lib/arguments/{name}_arguments_test.py": _format_python(
+            templates.ARGUMENTS_TEST.substitute(**ctx)
+        ),
+    }
+
+    if spec.needs_services:
+        files[f"{base}/lib/service/__init__.py"] = ""
+        files[f"{base}/lib/service/service.py"] = _format_python(
+            templates.SERVICE_BASE.substitute(**ctx)
+        )
+        files[f"{base}/services/__init__.py"] = templates.SERVICES_INIT.substitute()
+
+    plan = ScaffoldPlan(root=repo_root, files=files)
+    plan.next_steps = _builtin_next_steps(spec, repo_root, ctx)
+    return plan
+
+
+def _elif_snippet(spec: ProviderSpec, ctx: dict) -> str:
+    """Render the dispatch branch to paste into init_global_provider()."""
+    lines = [f'                elif arguments.provider == "{spec.name}":']
+    lines.append("                    provider_class(")
+    if spec.auth == "token":
+        lines.append(
+            f'                        token=getattr(arguments, "{spec.name}_token", None),'
+        )
+    elif spec.auth == "key-file":
+        lines.append(
+            f'                        key_file=getattr(arguments, "{spec.name}_key_file", None),'
+        )
+    elif spec.auth == "browser":
+        lines.append(
+            f'                        browser_auth=getattr(arguments, "{spec.name}_browser_auth", False),'
+        )
+    if spec.regional:
+        lines.append(
+            '                        regions=getattr(arguments, "region", None),'
+        )
+    lines.extend(
+        [
+            "                        config_path=arguments.config_file,",
+            "                        mutelist_path=arguments.mutelist_file,",
+            "                        fixer_config=fixer_config,",
+            "                    )",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _builtin_next_steps(spec: ProviderSpec, repo_root: Path, ctx: dict) -> List[str]:
+    """List the work the scaffold deliberately leaves to the contributor."""
+    fallback_line = _dynamic_fallback_line(repo_root)
+    location = (
+        f"prowler/providers/common/provider.py:{fallback_line}"
+        if fallback_line
+        else "prowler/providers/common/provider.py"
+    )
+    steps = [
+        "Search the generated files for TODO. Authentication, the identity "
+        "mapping and the checks are yours to write.",
+        "Wire argument parsing and instantiation into init_global_provider(). "
+        f"Add this branch immediately before the dynamic fallback at {location}:"
+        f"\n\n{_elif_snippet(spec, ctx)}\n",
+        f"Add CheckReport{spec.class_prefix} to prowler/lib/check/models.py, then "
+        f"annotate the finding argument in {spec.name}/lib/mutelist/mutelist.py "
+        "with it. The names in that file are not derived from the provider "
+        "name, so pick the spelling that matches its neighbours.",
+        f"Confirm exception codes {ctx['code_start']} to {ctx['code_end']} are "
+        "still free before you commit. The scaffold read the highest code in "
+        "use at generation time.",
+    ]
+    if spec.needs_services:
+        steps.append(
+            f"Add the first service under prowler/providers/{spec.name}/services/. "
+            "The scaffold stops at the package marker because a service name "
+            "and its API calls are provider-specific."
+        )
+    else:
+        steps.append(
+            "This kind has no service layer, matching iac, image and llm. Drop "
+            f"prowler/providers/{spec.name}/lib/mutelist/ too if this provider "
+            "reports findings that a mutelist cannot address, as those three do."
+        )
+    if not spec.sdk_only:
+        steps.append(
+            "sdk_only is False, so the API and UI list this provider. The API "
+            "and UI work is a separate scope: see the Full-Stack scope in the "
+            "developer guide, and note that the UI step of the provider guide "
+            "is still unwritten."
+        )
+    steps.extend(
+        [
+            "Add a changelog fragment, for example: echo 'Support for "
+            f"{spec.class_prefix} as a new provider' > prowler/changelog.d/"
+            f"{spec.name}-provider.added.md",
+            "Verify: `prowler --help` lists the provider with its help text, "
+            f"`prowler {spec.name} --help` shows its arguments, and "
+            f"`pytest tests/providers/{spec.name}` passes.",
+        ]
+    )
+    return steps
+
+
+def build_external_plan(spec: ProviderSpec, output_dir: Path) -> ScaffoldPlan:
+    """Plan the files for a provider distributed as its own package."""
+    ctx = _template_context(spec, None)
+    package = f"prowler_provider_{spec.name}"
+    files = {
+        "pyproject.toml": templates.EXTERNAL_PYPROJECT.substitute(**ctx),
+        "README.md": templates.EXTERNAL_README.substitute(**ctx),
+        f"{package}/__init__.py": "",
+        # The external provider builds its subparser inside a method, so the
+        # argument blocks need one extra level of indentation.
+        f"{package}/provider.py": _format_python(
+            templates.EXTERNAL_PROVIDER.substitute(
+                **{
+                    **ctx,
+                    "auth_arguments": _indent(ctx["auth_arguments"]),
+                    "regions_arguments": _indent(ctx["regions_arguments"]),
+                }
+            )
+        ),
+        f"{package}/models.py": _format_python(
+            templates.EXTERNAL_MODELS.substitute(**ctx)
+        ),
+        "tests/test_provider.py": _format_python(
+            templates.EXTERNAL_TEST.substitute(**ctx)
+        ),
+    }
+    plan = ScaffoldPlan(root=output_dir, files=files)
+    plan.next_steps = [
+        "Search the generated files for TODO. Authentication, the identity "
+        "mapping and the checks are yours to write.",
+        "Install it next to Prowler: `pip install -e .` in this directory.",
+        f"Verify discovery: `prowler --help` lists {spec.name}, and "
+        f"`prowler {spec.name} --help` shows its arguments.",
+        "Keep init_parser and from_cli_args. An external provider cannot join "
+        "the built-in dispatch chain, so those two are what make it usable "
+        "from the CLI, and no built-in provider implements them for you to "
+        "copy from.",
+        "Do not reuse a built-in provider name. Prowler ignores an "
+        "entry-point provider that collides with a built-in.",
+    ]
+    return plan
+
+
+def build_plan(spec: ProviderSpec, path: Optional[Path] = None) -> ScaffoldPlan:
+    """Plan a scaffold run for one spec.
+
+    Args:
+        spec: The validated provider spec.
+        path: For a built-in provider, the repository root, auto-detected when
+            omitted. For an external provider, the directory to create,
+            defaulting to ./prowler-provider-<name>.
+
+    Returns:
+        The plan, which writes nothing until write_plan() is called.
+
+    Raises:
+        ScaffoldError: If the target is not usable.
+    """
+    validate_name(spec.name)
+    if spec.kind not in KINDS:
+        raise ScaffoldError(
+            f"Invalid kind '{spec.kind}'. Choose one of: {', '.join(KINDS)}."
+        )
+    if spec.scope not in SCOPES:
+        raise ScaffoldError(
+            f"Invalid scope '{spec.scope}'. Choose one of: {', '.join(SCOPES)}."
+        )
+    if spec.auth not in AUTH_MODES:
+        raise ScaffoldError(
+            f"Invalid auth mode '{spec.auth}'. Choose one of: {', '.join(AUTH_MODES)}."
+        )
+
+    if spec.scope == "external":
+        output_dir = path or Path.cwd() / f"prowler-provider-{spec.name}"
+        return build_external_plan(spec, output_dir.resolve())
+
+    repo_root = find_repo_root(path) if path is None else path.resolve()
+    if not (repo_root / "prowler" / "providers" / "common" / "provider.py").is_file():
+        raise ScaffoldError(
+            f"'{repo_root}' does not look like a Prowler checkout: "
+            "prowler/providers/common/provider.py is missing."
+        )
+    if spec.name in existing_builtin_names(repo_root):
+        raise ScaffoldError(
+            f"Provider '{spec.name}' already exists at "
+            f"prowler/providers/{spec.name}. Pick another name."
+        )
+    return build_builtin_plan(spec, repo_root)
+
+
+def write_plan(plan: ScaffoldPlan, force: bool = False) -> List[Path]:
+    """Write a plan to disk.
+
+    Args:
+        plan: The plan to write.
+        force: Overwrite files that already exist.
+
+    Returns:
+        The written paths, sorted.
+
+    Raises:
+        ScaffoldError: If a target file exists and force is not set.
+    """
+    if not force:
+        clashes = [
+            relative for relative in plan.paths if (plan.root / relative).exists()
+        ]
+        if clashes:
+            raise ScaffoldError(
+                "Refusing to overwrite existing files:\n"
+                + "\n".join(f"  {clash}" for clash in clashes)
+                + "\nRe-run with --force to overwrite them."
+            )
+
+    written = []
+    for relative in plan.paths:
+        target = plan.root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(plan.files[relative])
+        written.append(target)
+    return written

--- a/prowler/lib/dev/provider_scaffold.py
+++ b/prowler/lib/dev/provider_scaffold.py
@@ -44,6 +44,10 @@ NAME_HELP = (
 EXCEPTION_CODE_BLOCK = 100
 EXCEPTION_CODE_FLOOR = 18000
 
+# The column limit black and isort share, which decides whether a generated
+# import fits on one line.
+IMPORT_LINE_LENGTH = 88
+
 
 class ScaffoldError(Exception):
     """Raised when the requested provider cannot be scaffolded."""
@@ -432,6 +436,21 @@ def _sorted_imports(*statements: str) -> str:
     )
 
 
+def _import_statement(module: str, *names: str) -> str:
+    """Render one `from ... import ...` the way isort and black would.
+
+    Both wrap at the same 88 columns, so a statement is one line when it fits
+    and a parenthesized block with a trailing comma when it does not. Whether a
+    given import fits depends on the provider's name, so hand-written statements
+    are canonical for some names and not others.
+    """
+    single_line = f"from {module} import {', '.join(names)}"
+    if len(single_line) <= IMPORT_LINE_LENGTH:
+        return single_line
+    body = "".join(f"    {name},\n" for name in names)
+    return f"from {module} import (\n{body})"
+
+
 def _format_python(source: str) -> str:
     """Format generated Python with black when it is importable.
 
@@ -453,36 +472,58 @@ def _format_python(source: str) -> str:
 
 
 def _builtin_import_blocks(spec: ProviderSpec) -> dict:
-    """Build the import blocks whose order depends on the provider's name."""
+    """Build the import blocks whose shape depends on the provider's name.
+
+    Both the order and the wrapping depend on the name, which is why neither
+    can live in the templates. `tests` is first-party to isort inside this
+    repository, so a generated test's fixture import belongs in the same block
+    as the `prowler` imports rather than beside `pytest`.
+    """
     name, cls = spec.name, spec.class_prefix
     return {
         "provider_class": _sorted_imports(
-            "from prowler.providers.common.models import Audit_Metadata, Connection",
-            "from prowler.providers.common.provider import Provider",
-            f"from prowler.providers.{name}.exceptions.exceptions import (\n"
-            f"    {cls}CredentialsError,\n"
-            f"    {cls}IdentityError,\n"
-            f"    {cls}SessionError,\n"
-            ")",
-            f"from prowler.providers.{name}.lib.mutelist.mutelist import {cls}Mutelist",
-            f"from prowler.providers.{name}.models import (\n"
-            f"    {cls}IdentityInfo,\n"
-            f"    {cls}Session,\n"
-            ")",
+            _import_statement(
+                "prowler.providers.common.models", "Audit_Metadata", "Connection"
+            ),
+            _import_statement("prowler.providers.common.provider", "Provider"),
+            _import_statement(
+                f"prowler.providers.{name}.exceptions.exceptions",
+                f"{cls}CredentialsError",
+                f"{cls}IdentityError",
+                f"{cls}SessionError",
+            ),
+            _import_statement(
+                f"prowler.providers.{name}.lib.mutelist.mutelist", f"{cls}Mutelist"
+            ),
+            _import_statement(
+                f"prowler.providers.{name}.models",
+                f"{cls}IdentityInfo",
+                f"{cls}Session",
+            ),
         ),
         "provider_test": _sorted_imports(
-            f"from prowler.providers.{name}.exceptions.exceptions import (\n"
-            f"    {cls}CredentialsError,\n"
-            f"    {cls}IdentityError,\n"
-            ")",
-            f"from prowler.providers.{name}.{name}_provider import {cls}Provider",
+            _import_statement(
+                f"prowler.providers.{name}.exceptions.exceptions",
+                f"{cls}CredentialsError",
+                f"{cls}IdentityError",
+            ),
+            _import_statement(
+                f"prowler.providers.{name}.{name}_provider", f"{cls}Provider"
+            ),
+            _import_statement(
+                f"tests.providers.{name}.{name}_fixtures",
+                f"set_mocked_{name}_provider",
+            ),
         ),
         "provider_fixtures": _sorted_imports(
-            f"from prowler.providers.{name}.{name}_provider import {cls}Provider",
-            f"from prowler.providers.{name}.models import (\n"
-            f"    {cls}IdentityInfo,\n"
-            f"    {cls}Session,\n"
-            ")",
+            _import_statement(
+                f"prowler.providers.{name}.{name}_provider", f"{cls}Provider"
+            ),
+            _import_statement(
+                f"prowler.providers.{name}.models",
+                f"{cls}IdentityInfo",
+                f"{cls}Session",
+            ),
         ),
     }
 

--- a/prowler/lib/dev/templates.py
+++ b/prowler/lib/dev/templates.py
@@ -1,0 +1,814 @@
+"""File templates used by the provider scaffold command.
+
+Placeholders use ``string.Template`` syntax (``$name``) rather than
+``str.format`` because the rendered output is Python source containing literal
+braces (dicts, f-strings, annotations) that ``str.format`` would try to
+interpret.
+
+Two constraints shape these templates:
+
+- Generated code lands in a contributor's working tree, where Prowler's own CI
+  runs ``black --check`` and ``flake8`` over it. Rendered output must therefore
+  already be formatter-clean and free of unused imports, which is why the
+  optional blocks below carry their own trailing newlines instead of relying on
+  the substitution site to get the blank lines right.
+- Every template stops where a provider-specific decision starts.
+  Authentication behavior, API semantics and security checks are marked
+  ``TODO`` rather than guessed.
+"""
+
+from string import Template
+
+PROVIDER_CLASS = Template('''import os
+
+from colorama import Fore, Style
+
+from prowler.config.config import (
+    default_config_file_path,
+    get_default_mute_file_path,
+    load_and_validate_config_file,
+)
+from prowler.lib.logger import logger
+from prowler.lib.utils.utils import print_boxes
+$provider_imports
+
+
+class ${class_prefix}Provider(Provider):
+    """$class_prefix provider."""
+
+    _type: str = "$name"
+    _session: ${class_prefix}Session
+    _identity: ${class_prefix}IdentityInfo
+    _audit_config: dict
+    _fixer_config: dict
+    _mutelist: ${class_prefix}Mutelist
+    _cli_help_text: str = "$class_prefix Provider"
+$sdk_only_attr    audit_metadata: Audit_Metadata
+
+    def __init__(
+        self,
+        config_path: str = None,
+        config_content: dict = None,
+        fixer_config: dict = None,
+        mutelist_path: str = None,
+        mutelist_content: dict = None,
+$init_extra_params    ):
+        """Initialize the ${class_prefix}Provider instance.
+
+        Args:
+            config_path: Path to the audit configuration file.
+            config_content: Audit configuration content, used instead of config_path.
+            fixer_config: Fixer configuration.
+            mutelist_path: Path to the mutelist file.
+            mutelist_content: Mutelist content, used instead of mutelist_path.
+$init_extra_docs
+        Raises:
+            ${class_prefix}CredentialsError: If no usable credentials are found.
+            ${class_prefix}SessionError: If the session cannot be established.
+            ${class_prefix}IdentityError: If the identity cannot be retrieved.
+        """
+        logger.info("Instantiating $class_prefix provider...")
+
+        if config_content:
+            self._audit_config = config_content
+        else:
+            if not config_path:
+                config_path = default_config_file_path
+            self._audit_config = load_and_validate_config_file(self._type, config_path)
+
+        self._session = ${class_prefix}Provider.setup_session($session_call_args)
+$regions_init
+        self._identity = ${class_prefix}Provider.setup_identity(self._session)
+
+        self._fixer_config = fixer_config if fixer_config is not None else {}
+
+        if mutelist_content:
+            self._mutelist = ${class_prefix}Mutelist(mutelist_content=mutelist_content)
+        else:
+            if not mutelist_path:
+                mutelist_path = get_default_mute_file_path(self.type)
+            self._mutelist = ${class_prefix}Mutelist(mutelist_path=mutelist_path)
+
+        Provider.set_global_provider(self)
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def session(self):
+        return self._session
+
+    @property
+    def identity(self):
+        return self._identity
+
+    @property
+    def audit_config(self):
+        return self._audit_config
+
+    @property
+    def fixer_config(self):
+        return self._fixer_config
+
+    @property
+    def mutelist(self) -> ${class_prefix}Mutelist:
+        return self._mutelist
+$regions_property
+    @staticmethod
+    def setup_session($session_def_params) -> ${class_prefix}Session:
+        """Build the authenticated $class_prefix session.
+
+        $auth_docstring
+
+        Returns:
+            ${class_prefix}Session: The initialized session.
+
+        Raises:
+            ${class_prefix}CredentialsError: If no usable credentials are found.
+            ${class_prefix}SessionError: If the client cannot be built.
+        """
+        # TODO: resolve credentials and build the client for this provider.
+        # $auth_hint
+        raise ${class_prefix}CredentialsError(
+            file=os.path.basename(__file__),
+            message="TODO: implement ${class_prefix}Provider.setup_session().",
+        )
+
+    @staticmethod
+    def setup_identity(session: ${class_prefix}Session) -> ${class_prefix}IdentityInfo:
+        """Read the identity of the audited $class_prefix target.
+
+        The fields returned here appear in Prowler's output, so they are this
+        provider's identity contract.
+
+        Args:
+            session: The $class_prefix session.
+
+        Returns:
+            ${class_prefix}IdentityInfo: The identity information.
+
+        Raises:
+            ${class_prefix}IdentityError: If the identity cannot be retrieved.
+        """
+        # TODO: call the API that identifies the audited target and map the
+        # response onto ${class_prefix}IdentityInfo.
+        raise ${class_prefix}IdentityError(
+            file=os.path.basename(__file__),
+            message="TODO: implement ${class_prefix}Provider.setup_identity().",
+        )
+$validate_regions
+    def print_credentials(self) -> None:
+        """Print the credentials Prowler is auditing with."""
+        report_title = (
+            f"{Style.BRIGHT}Using the $class_prefix credentials below:{Style.RESET_ALL}"
+        )
+        report_lines = [
+            f"Authentication: {Fore.YELLOW}$auth_label{Style.RESET_ALL}",
+        ]
+        # TODO: append the identity fields worth showing before a scan starts.
+        print_boxes(report_lines, report_title)
+
+    @staticmethod
+    def test_connection(
+$test_connection_params        raise_on_exception: bool = True,
+    ) -> Connection:
+        """Check whether Prowler can reach $class_prefix with these credentials.
+
+        Args:
+$test_connection_docs            raise_on_exception: Whether to raise instead of returning a failed Connection.
+
+        Returns:
+            Connection: The connection result.
+        """
+        try:
+            ${class_prefix}Provider.setup_session($session_call_args)
+            # TODO: make one cheap read-only call here to prove the credentials
+            # work before returning a successful Connection.
+            return Connection(is_connected=True)
+        except ${class_prefix}CredentialsError as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+            if raise_on_exception:
+                raise
+            return Connection(is_connected=False, error=error)
+        except Exception as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+            if raise_on_exception:
+                raise ${class_prefix}SessionError(
+                    file=os.path.basename(__file__),
+                    original_exception=error,
+                )
+            return Connection(is_connected=False, error=error)
+''')
+
+REGIONS_INIT = Template("""
+        # Region filter for regional resources. None means scan every region.
+        self._regions = ${class_prefix}Provider.validate_regions(self._session, regions)
+""")
+
+REGIONS_PROPERTY = Template('''
+    @property
+    def regions(self):
+        """Regions to scan for regional resources, or None for all of them."""
+        return self._regions
+''')
+
+VALIDATE_REGIONS = Template('''
+    @staticmethod
+    def validate_regions(session: ${class_prefix}Session, regions: list = None):
+        """Validate the requested regions against the ones $class_prefix offers.
+
+        Args:
+            session: The $class_prefix session.
+            regions: The region ids requested with --region, or None.
+
+        Returns:
+            The validated set of region ids, or None when no filter is given.
+        """
+        if not regions:
+            return None
+        # TODO: validate the requested ids against the live region list and
+        # raise a provider exception naming the invalid ones.
+        return set(regions)
+''')
+
+MODELS = Template('''from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from prowler.config.config import output_file_timestamp
+from prowler.providers.common.models import ProviderOutputOptions
+
+
+class ${class_prefix}Session(BaseModel):
+    """$class_prefix session information."""
+
+    # TODO: replace `client` with the concrete client type once the SDK or
+    # HTTP client for this provider is chosen.
+    client: Any = None
+
+
+class ${class_prefix}IdentityInfo(BaseModel):
+    """$class_prefix identity and scoping information.
+
+    These fields identify the audited target and appear in Prowler's output,
+    so they are this provider's identity contract.
+    """
+
+    # TODO: replace this with the fields that actually identify an audited
+    # $class_prefix target (account, organization, project, tenant, user).
+    account_id: Optional[str] = None
+
+
+class ${class_prefix}OutputOptions(ProviderOutputOptions):
+    """Customize output filenames for $class_prefix scans."""
+
+    def __init__(
+        self, arguments, bulk_checks_metadata, identity: ${class_prefix}IdentityInfo
+    ):
+        super().__init__(arguments, bulk_checks_metadata)
+        if (
+            not hasattr(arguments, "output_filename")
+            or arguments.output_filename is None
+        ):
+            account_fragment = identity.account_id or "$name"
+            self.output_filename = (
+                f"prowler-output-{account_fragment}-{output_file_timestamp}"
+            )
+        else:
+            self.output_filename = arguments.output_filename
+''')
+
+ARGUMENTS = Template('''${sensitive_arguments}def init_parser(self):
+    """Init the $class_prefix provider CLI parser."""
+    ${parser_assignment}self.subparsers.add_parser(
+        "$name",
+        parents=[self.common_providers_parser],
+        help="$class_prefix Provider",
+    )
+$auth_arguments$regions_arguments''')
+
+SENSITIVE_ARGUMENTS = Template(
+    """# Values passed to these flags are redacted in HTML output and trigger a
+# warning telling users to prefer the environment variable instead.
+SENSITIVE_ARGUMENTS = frozenset({"--$name-token"})
+
+
+"""
+)
+
+ARGUMENTS_AUTH_ENV = Template("""
+    # Authentication
+    # Credentials are read from the ${env_prefix}_* environment variables so
+    # that secrets never reach shell history or process listings. There are
+    # deliberately no credential CLI flags.
+    # TODO: name the environment variables this provider reads.
+""")
+
+ARGUMENTS_AUTH_TOKEN = Template("""
+    # Authentication
+    auth_subparser = ${name}_parser.add_argument_group(
+        "Authentication Modes",
+    )
+    auth_subparser.add_argument(
+        "--$name-token",
+        nargs="?",
+        default=None,
+        metavar="${env_prefix}_TOKEN",
+        help="$class_prefix API token. Use the ${env_prefix}_TOKEN environment "
+        "variable instead of passing the value directly.",
+    )
+""")
+
+ARGUMENTS_AUTH_KEY_FILE = Template("""
+    # Authentication
+    auth_subparser = ${name}_parser.add_argument_group(
+        "Authentication Modes",
+    )
+    auth_subparser.add_argument(
+        "--$name-key-file",
+        nargs="?",
+        default=None,
+        metavar="${env_prefix}_KEY_FILE",
+        help="Path to the $class_prefix credentials key file. Defaults to the "
+        "${env_prefix}_KEY_FILE environment variable.",
+    )
+""")
+
+ARGUMENTS_AUTH_BROWSER = Template("""
+    # Authentication
+    auth_subparser = ${name}_parser.add_argument_group(
+        "Authentication Modes",
+    )
+    auth_subparser.add_argument(
+        "--$name-browser-auth",
+        action="store_true",
+        default=False,
+        help="Authenticate against $class_prefix with the interactive browser flow.",
+    )
+""")
+
+ARGUMENTS_REGIONS = Template("""
+    # Regions
+    regions_subparser = ${name}_parser.add_argument_group(
+        "Regions",
+    )
+    regions_subparser.add_argument(
+        "--region",
+        "--filter-region",
+        "-f",
+        nargs="+",
+        default=None,
+        metavar="REGION",
+        help="$class_prefix region(s) to scan. Region-less resources are always "
+        "scanned. If omitted, every region is scanned.",
+    )
+""")
+
+EXCEPTIONS = Template('''from prowler.exceptions.exceptions import ProwlerException
+
+
+# Exception codes from $code_start to $code_end are reserved for $class_prefix exceptions
+class ${class_prefix}BaseException(ProwlerException):
+    """Base class for $class_prefix errors."""
+
+    ${env_prefix}_ERROR_CODES = {
+        ($code_credentials, "${class_prefix}CredentialsError"): {
+            "message": "$class_prefix credentials not found or invalid",
+            "remediation": "TODO: name the environment variables or flags that supply valid credentials.",
+        },
+        ($code_session, "${class_prefix}SessionError"): {
+            "message": "$class_prefix session setup failed",
+            "remediation": "TODO: name what to check when the client cannot be built.",
+        },
+        ($code_identity, "${class_prefix}IdentityError"): {
+            "message": "Unable to retrieve $class_prefix identity information",
+            "remediation": "TODO: name the permission or scope the identity call needs.",
+        },
+    }
+
+    def __init__(self, code, file=None, original_exception=None, message=None):
+        provider = "$class_prefix"
+        error_info = self.${env_prefix}_ERROR_CODES.get((code, self.__class__.__name__))
+        if error_info is None:
+            error_info = {
+                "message": message or "Unknown $class_prefix error",
+                "remediation": "Check the $class_prefix API documentation for more details.",
+            }
+        elif message:
+            error_info = error_info.copy()
+            error_info["message"] = message
+        super().__init__(
+            code=code,
+            source=provider,
+            file=file,
+            original_exception=original_exception,
+            error_info=error_info,
+        )
+
+
+class ${class_prefix}CredentialsError(${class_prefix}BaseException):
+    """Exception for $class_prefix credential errors."""
+
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            $code_credentials,
+            file=file,
+            original_exception=original_exception,
+            message=message,
+        )
+
+
+class ${class_prefix}SessionError(${class_prefix}BaseException):
+    """Exception for $class_prefix session setup errors."""
+
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            $code_session,
+            file=file,
+            original_exception=original_exception,
+            message=message,
+        )
+
+
+class ${class_prefix}IdentityError(${class_prefix}BaseException):
+    """Exception for $class_prefix identity errors."""
+
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            $code_identity,
+            file=file,
+            original_exception=original_exception,
+            message=message,
+        )
+''')
+
+MUTELIST = Template('''from prowler.lib.mutelist.mutelist import Mutelist
+from prowler.lib.outputs.utils import unroll_dict, unroll_tags
+
+
+class ${class_prefix}Mutelist(Mutelist):
+    """$class_prefix-specific mutelist helper."""
+
+    def is_finding_muted(self, finding, account_id: str) -> bool:
+        """Check whether a $class_prefix finding is muted.
+
+        Args:
+            finding: The check report for this provider. TODO: annotate this as
+                CheckReport$class_prefix once that class is added to
+                prowler/lib/check/models.py.
+            account_id: The $class_prefix account identifier.
+
+        Returns:
+            True if the finding is muted, False otherwise.
+        """
+        return self.is_muted(
+            account_id,
+            finding.check_metadata.CheckID,
+            finding.region or "global",
+            finding.resource_id or finding.resource_name,
+            unroll_dict(unroll_tags(finding.resource_tags)),
+        )
+''')
+
+SERVICE_BASE = Template('''from prowler.lib.logger import logger
+from prowler.providers.$name.${name}_provider import ${class_prefix}Provider
+
+
+class ${class_prefix}Service:
+    """Base class for $class_prefix services, sharing the provider context."""
+
+    def __init__(self, service: str, provider: ${class_prefix}Provider):
+        """Initialize the service with the provider context.
+
+        Args:
+            service: The $class_prefix service name.
+            provider: The ${class_prefix}Provider instance.
+        """
+        self.provider = provider
+        self.client = provider.session.client
+        self.audit_config = provider.audit_config
+        self.fixer_config = provider.fixer_config
+        self.service = service.lower() if not service.islower() else service
+
+    def _log_fetch_error(self, resource_label: str, error: Exception) -> None:
+        """Log a failed resource fetch without aborting the rest of the scan.
+
+        A single service losing access must not end the whole scan, so this
+        logs and returns instead of raising.
+
+        Args:
+            resource_label: The resources that could not be fetched.
+            error: The exception raised by the API call.
+        """
+        logger.error(
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: "
+            f"Unable to fetch $name {resource_label} -- {error}"
+        )
+''')
+
+SERVICES_INIT = Template("""# Each service lives in its own package next to this file:
+#
+#     services/<service>/<service>_service.py   resource fetcher
+#     services/<service>/<service>_client.py    module-level singleton
+#     services/<service>/<check>/<check>.py     one check per package
+#     services/<service>/<check>/<check>.metadata.json
+#
+# The scaffold stops here because a service name and its API calls are
+# provider-specific. See the prowler-sdk-check skill for the next step.
+""")
+
+PROVIDER_TEST = Template('''from unittest.mock import patch
+
+import pytest
+from tests.providers.$name.${name}_fixtures import set_mocked_${name}_provider
+
+$provider_imports
+
+
+class Test${class_prefix}Provider:
+    def test_provider_type(self):
+        """The provider reports the name the CLI dispatches on."""
+        assert ${class_prefix}Provider._type == "$name"
+
+    def test_provider_class_name_matches_discovery(self):
+        """Provider.get_class() builds the class name with str.capitalize().
+
+        A multi-word name spelled with inner capitals breaks discovery, so this
+        assertion is what keeps the provider loadable.
+        """
+        assert ${class_prefix}Provider.__name__ == "$name".capitalize() + "Provider"
+
+    def test_provider_application_exposure(self):
+        """sdk_only decides whether the API and UI list this provider."""
+        assert ${class_prefix}Provider.sdk_only is $sdk_only_value
+
+    def test_setup_session_is_not_implemented_yet(self):
+        """TODO: replace this with a test of the real session setup."""
+        with pytest.raises(${class_prefix}CredentialsError):
+            ${class_prefix}Provider.setup_session($session_test_args)
+
+    def test_setup_identity_is_not_implemented_yet(self):
+        """TODO: replace this with a test of the real identity mapping."""
+        with pytest.raises(${class_prefix}IdentityError):
+            ${class_prefix}Provider.setup_identity(None)
+
+    def test_print_credentials(self):
+        """print_credentials runs against a provider that makes no calls."""
+        provider = set_mocked_${name}_provider()
+        with patch(
+            "prowler.providers.$name.${name}_provider.print_boxes"
+        ) as mocked_print_boxes:
+            provider.print_credentials()
+        assert mocked_print_boxes.called
+''')
+
+PROVIDER_FIXTURES = Template('''from unittest.mock import MagicMock
+
+$provider_imports
+
+# TODO: replace this with a value that resembles a real audited target.
+${env_prefix}_ACCOUNT_ID = "$name-account-id"
+
+
+def set_mocked_${name}_provider(
+    audit_config: dict = None,
+    fixer_config: dict = None,
+) -> ${class_prefix}Provider:
+    """Build a ${class_prefix}Provider that performs no network calls.
+
+    Args:
+        audit_config: Audit configuration to expose on the provider.
+        fixer_config: Fixer configuration to expose on the provider.
+
+    Returns:
+        A MagicMock specced against ${class_prefix}Provider.
+    """
+    provider = MagicMock(spec=${class_prefix}Provider)
+    provider.type = "$name"
+    provider.session = ${class_prefix}Session(client=MagicMock())
+    provider.identity = ${class_prefix}IdentityInfo(account_id=${env_prefix}_ACCOUNT_ID)
+    provider.audit_config = audit_config if audit_config is not None else {}
+    provider.fixer_config = fixer_config if fixer_config is not None else {}
+    provider.print_credentials = lambda: ${class_prefix}Provider.print_credentials(
+        provider
+    )
+    return provider
+''')
+
+ARGUMENTS_TEST = Template(
+    '''from prowler.providers.$name.lib.arguments.arguments import init_parser
+
+
+class Test${class_prefix}Arguments:
+    def test_init_parser_is_callable(self):
+        """init_providers_parser() imports this module for every built-in.
+
+        prowler/providers/common/arguments.py calls init_parser on it, so a
+        missing or renamed function makes the provider unusable from the CLI.
+        """
+        assert callable(init_parser)
+'''
+)
+
+EXTERNAL_PYPROJECT = Template("""[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
+
+[project]
+name = "prowler-provider-$name"
+version = "0.1.0"
+description = "$class_prefix provider for Prowler"
+requires-python = ">=3.10"
+dependencies = ["prowler"]
+
+# Prowler discovers external providers through this entry point group. The name
+# on the left is what `prowler <name>` dispatches on, and the value must resolve
+# to a Provider subclass or Prowler rejects it.
+[project.entry-points."prowler.providers"]
+$name = "prowler_provider_${name}.provider:${class_prefix}Provider"
+
+[tool.hatch.build.targets.wheel]
+packages = ["prowler_provider_$name"]
+""")
+
+EXTERNAL_PROVIDER = Template(
+    '''"""$class_prefix provider, distributed as an external Prowler plug-in."""
+
+from argparse import Namespace
+
+from prowler.lib.logger import logger
+from prowler.providers.common.provider import Provider
+
+from prowler_provider_${name}.models import (
+    ${class_prefix}IdentityInfo,
+    ${class_prefix}Session,
+)
+
+
+class ${class_prefix}Provider(Provider):
+    """$class_prefix provider.
+
+    An external provider cannot join the `elif` chain in
+    `init_global_provider()`, so it owns two pieces of the contract that no
+    built-in provider implements:
+
+    - `init_parser`, which `prowler/providers/common/arguments.py` calls to
+      build this provider's CLI subparser.
+    - `from_cli_args`, which the dynamic fallback branch of
+      `init_global_provider()` calls to build the instance.
+    """
+
+    _type: str = "$name"
+    _cli_help_text: str = "$class_prefix Provider"
+$sdk_only_attr
+    def __init__(
+        self,
+        config_path: str = None,
+        fixer_config: dict = None,
+$init_extra_params    ):
+        logger.info("Instantiating $class_prefix provider...")
+        self._audit_config = {}
+        self._fixer_config = fixer_config if fixer_config is not None else {}
+        self._session = ${class_prefix}Provider.setup_session($session_call_args)
+        self._identity = ${class_prefix}IdentityInfo()
+        Provider.set_global_provider(self)
+
+    def init_parser(self):
+        """Build this provider's CLI subparser.
+
+        Called as `cls.init_parser(parser)`, so `self` here is Prowler's
+        argument parser rather than a provider instance. That mirrors the
+        module-level `init_parser(self)` that built-in providers define.
+        """
+        ${parser_assignment}self.subparsers.add_parser(
+            "$name",
+            parents=[self.common_providers_parser],
+            help="$class_prefix Provider",
+        )
+$auth_arguments$regions_arguments
+    @classmethod
+    def from_cli_args(cls, arguments: Namespace, fixer_config: dict) -> "Provider":
+        """Build the provider from the parsed CLI arguments.
+
+        Args:
+            arguments: The parsed CLI namespace.
+            fixer_config: The loaded fixer configuration.
+
+        Returns:
+            The provider instance.
+        """
+        return cls(
+            config_path=getattr(arguments, "config_file", None),
+            fixer_config=fixer_config,
+$from_cli_args_extra        )
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def session(self):
+        return self._session
+
+    @property
+    def identity(self):
+        return self._identity
+
+    @property
+    def audit_config(self):
+        return self._audit_config
+
+    @property
+    def fixer_config(self):
+        return self._fixer_config
+
+    @staticmethod
+    def setup_session($session_def_params) -> ${class_prefix}Session:
+        """Build the authenticated $class_prefix session.
+
+        $auth_docstring
+        """
+        # TODO: resolve credentials and build the client for this provider.
+        # $auth_hint
+        raise NotImplementedError(
+            "TODO: implement ${class_prefix}Provider.setup_session()."
+        )
+
+    def print_credentials(self) -> None:
+        """Print the credentials Prowler is auditing with."""
+        logger.info("Scanning $class_prefix with $auth_label")
+'''
+)
+
+EXTERNAL_MODELS = Template('''from typing import Any, Optional
+
+from pydantic import BaseModel
+
+
+class ${class_prefix}Session(BaseModel):
+    """$class_prefix session information."""
+
+    # TODO: replace `client` with the concrete client type.
+    client: Any = None
+
+
+class ${class_prefix}IdentityInfo(BaseModel):
+    """$class_prefix identity and scoping information."""
+
+    # TODO: replace this with the fields that identify an audited target.
+    account_id: Optional[str] = None
+''')
+
+EXTERNAL_README = Template("""# prowler-provider-$name
+
+External [Prowler](https://github.com/prowler-cloud/prowler) provider for
+$class_prefix, discovered at runtime through the `prowler.providers` entry
+point. It installs alongside Prowler instead of living in the Prowler
+repository.
+
+## Install
+
+```bash
+pip install prowler
+pip install -e .
+```
+
+## Verify Discovery
+
+```bash
+prowler --help          # $name appears in the provider list
+prowler $name --help    # $name shows its own arguments
+```
+
+A name that clashes with a built-in provider is ignored in favour of the
+built-in, so pick a name no built-in already uses.
+
+## What Is Left To Do
+
+Search this package for `TODO`. The scaffold generates structure only, so
+authentication, the identity mapping and the security checks are yours.
+""")
+
+EXTERNAL_TEST = Template('''from prowler.providers.common.provider import Provider
+
+from prowler_provider_${name}.provider import ${class_prefix}Provider
+
+
+class Test${class_prefix}Provider:
+    def test_provider_subclasses_provider(self):
+        """Prowler rejects an entry point that is not a Provider subclass."""
+        assert issubclass(${class_prefix}Provider, Provider)
+
+    def test_provider_declares_the_external_contract(self):
+        """An external provider needs both halves of the CLI contract."""
+        assert hasattr(${class_prefix}Provider, "init_parser")
+        assert hasattr(${class_prefix}Provider, "from_cli_args")
+
+    def test_provider_type(self):
+        assert ${class_prefix}Provider._type == "$name"
+''')

--- a/prowler/lib/dev/templates.py
+++ b/prowler/lib/dev/templates.py
@@ -525,7 +525,6 @@ SERVICES_INIT = Template("""# Each service lives in its own package next to this
 PROVIDER_TEST = Template('''from unittest.mock import patch
 
 import pytest
-from tests.providers.$name.${name}_fixtures import set_mocked_${name}_provider
 
 $provider_imports
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,8 @@ version = "5.40.0"
 
 [project.scripts]
 prowler = "prowler.__main__:prowler"
+# Contributor tooling, not part of a scan. See prowler/lib/dev/.
+prowler-dev = "prowler.lib.dev.cli:main"
 
 [project.urls]
 "Changelog" = "https://github.com/prowler-cloud/prowler/releases"

--- a/tests/lib/dev/cli_test.py
+++ b/tests/lib/dev/cli_test.py
@@ -1,0 +1,212 @@
+import pytest
+
+from prowler.lib.dev.cli import build_parser, main
+
+
+class Test_build_parser:
+    def test_parses_the_documented_invocation(self):
+        """The invocation the issue documents has to keep working."""
+        arguments = build_parser().parse_args(
+            [
+                "provider",
+                "create",
+                "--name",
+                "acmecloud",
+                "--kind",
+                "api",
+                "--scope",
+                "full-stack",
+                "--regional",
+                "false",
+                "--auth",
+                "token",
+            ]
+        )
+
+        assert arguments.name == "acmecloud"
+        assert arguments.kind == "api"
+        assert arguments.scope == "full-stack"
+        assert arguments.regional == "false"
+        assert arguments.auth == "token"
+
+    def test_defaults_to_environment_auth_and_no_regions(self):
+        arguments = build_parser().parse_args(
+            [
+                "provider",
+                "create",
+                "--name",
+                "acmecloud",
+                "--kind",
+                "api",
+                "--scope",
+                "builtin",
+            ]
+        )
+
+        assert arguments.auth == "env"
+        assert arguments.regional == "false"
+        assert arguments.path is None
+        assert arguments.dry_run is False
+        assert arguments.force is False
+
+    @pytest.mark.parametrize(
+        "missing",
+        [
+            ["provider", "create", "--kind", "api", "--scope", "builtin"],
+            ["provider", "create", "--name", "acmecloud", "--scope", "builtin"],
+            ["provider", "create", "--name", "acmecloud", "--kind", "api"],
+        ],
+    )
+    def test_the_three_explicit_inputs_are_required(self, missing):
+        """Name, kind and scope each change what gets generated, so the
+        command refuses to guess them."""
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(missing)
+
+    @pytest.mark.parametrize(
+        "invalid",
+        [
+            ["--kind", "serverless"],
+            ["--scope", "everything"],
+            ["--auth", "telepathy"],
+            ["--regional", "maybe"],
+        ],
+    )
+    def test_rejects_values_outside_the_documented_choices(self, invalid):
+        base = [
+            "provider",
+            "create",
+            "--name",
+            "acmecloud",
+            "--kind",
+            "api",
+            "--scope",
+            "builtin",
+        ]
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(base + invalid)
+
+
+class Test_main:
+    def test_dry_run_writes_nothing(self, tmp_path, capsys):
+        target = tmp_path / "out"
+
+        exit_code = main(
+            [
+                "provider",
+                "create",
+                "--name",
+                "acmecloud",
+                "--kind",
+                "api",
+                "--scope",
+                "external",
+                "--path",
+                str(target),
+                "--dry-run",
+            ]
+        )
+
+        assert exit_code == 0
+        assert not target.exists()
+        assert "Would create" in capsys.readouterr().out
+
+    def test_create_writes_the_files_and_reports_next_steps(self, tmp_path, capsys):
+        target = tmp_path / "out"
+
+        exit_code = main(
+            [
+                "provider",
+                "create",
+                "--name",
+                "acmecloud",
+                "--kind",
+                "api",
+                "--scope",
+                "external",
+                "--path",
+                str(target),
+            ]
+        )
+        output = capsys.readouterr().out
+
+        assert exit_code == 0
+        assert (target / "pyproject.toml").is_file()
+        assert (target / "prowler_provider_acmecloud" / "provider.py").is_file()
+        assert "Created" in output
+        assert "Next steps:" in output
+
+    def test_a_rejected_name_exits_nonzero_and_explains_why(self, tmp_path, capsys):
+        exit_code = main(
+            [
+                "provider",
+                "create",
+                "--name",
+                "acme_cloud",
+                "--kind",
+                "api",
+                "--scope",
+                "external",
+                "--path",
+                str(tmp_path / "out"),
+            ]
+        )
+
+        assert exit_code == 1
+        assert "str.capitalize()" in capsys.readouterr().err
+
+    def test_an_existing_provider_name_exits_nonzero(self, capsys):
+        exit_code = main(
+            [
+                "provider",
+                "create",
+                "--name",
+                "aws",
+                "--kind",
+                "api",
+                "--scope",
+                "builtin",
+            ]
+        )
+
+        assert exit_code == 1
+        assert "already exists" in capsys.readouterr().err
+
+    def test_refusing_to_overwrite_exits_nonzero(self, tmp_path, capsys):
+        arguments = [
+            "provider",
+            "create",
+            "--name",
+            "acmecloud",
+            "--kind",
+            "api",
+            "--scope",
+            "external",
+            "--path",
+            str(tmp_path / "out"),
+        ]
+        assert main(arguments) == 0
+        capsys.readouterr()
+
+        exit_code = main(arguments)
+
+        assert exit_code == 1
+        assert "Refusing to overwrite" in capsys.readouterr().err
+
+    def test_force_overwrites(self, tmp_path, capsys):
+        arguments = [
+            "provider",
+            "create",
+            "--name",
+            "acmecloud",
+            "--kind",
+            "api",
+            "--scope",
+            "external",
+            "--path",
+            str(tmp_path / "out"),
+        ]
+        assert main(arguments) == 0
+        capsys.readouterr()
+
+        assert main(arguments + ["--force"]) == 0

--- a/tests/lib/dev/provider_scaffold_test.py
+++ b/tests/lib/dev/provider_scaffold_test.py
@@ -1,0 +1,512 @@
+import importlib
+import pkgutil
+import re
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from prowler.lib.dev.provider_scaffold import (
+    AUTH_MODES,
+    KINDS,
+    ProviderSpec,
+    ScaffoldError,
+    build_builtin_plan,
+    build_external_plan,
+    build_plan,
+    existing_builtin_names,
+    find_repo_root,
+    next_exception_code_range,
+    validate_name,
+    write_plan,
+)
+from prowler.providers.common.provider import Provider
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def builtin_spec(**overrides) -> ProviderSpec:
+    defaults = {
+        "name": "acmecloud",
+        "kind": "api",
+        "scope": "builtin",
+        "auth": "env",
+        "regional": False,
+    }
+    defaults.update(overrides)
+    return ProviderSpec(**defaults)
+
+
+def discovered_builtin_names() -> set:
+    """Enumerate built-in providers the way get_available_providers() does.
+
+    Provider.get_available_providers() cannot be called from here in a full
+    test run. tests/lib/cli/parser_test.py starts a patch over it in
+    setup_method with no matching teardown, so its hardcoded 19-provider list
+    leaks into every test that runs afterwards. This walks
+    prowler.providers.__path__ with pkgutil.iter_modules, which is what the
+    real implementation does.
+    """
+    providers_package = importlib.import_module("prowler.providers")
+    return {
+        name
+        for _, name, is_package in pkgutil.iter_modules(providers_package.__path__)
+        if is_package and name != "common"
+    }
+
+
+class Test_validate_name:
+    @pytest.mark.parametrize(
+        "name",
+        ["acme_cloud", "acme-cloud", "acmeCloud", "AcmeCloud", "1acme", "acme.cloud"],
+    )
+    def test_rejects_names_discovery_cannot_resolve(self, name):
+        """Provider.get_class() derives the class name with str.capitalize().
+
+        `acme_cloud`.capitalize() is `Acme_cloud`, so a provider named that way
+        would have to define Acme_cloudProvider to be found. Rejecting the name
+        up front is cheaper than a provider that silently fails to load.
+        """
+        with pytest.raises(ScaffoldError):
+            validate_name(name)
+
+    def test_rejects_an_empty_name(self):
+        with pytest.raises(ScaffoldError):
+            validate_name("")
+
+    @pytest.mark.parametrize("name", ["aws", "acmecloud", "googleworkspace", "m365"])
+    def test_accepts_the_shapes_real_providers_use(self, name):
+        assert validate_name(name) == name
+
+
+class Test_ProviderSpec:
+    def test_class_prefix_matches_what_get_class_looks_up(self):
+        """A multi-word name gets one capital, matching str.capitalize()."""
+        assert builtin_spec(name="googleworkspace").class_prefix == "Googleworkspace"
+
+    def test_env_prefix(self):
+        assert builtin_spec(name="acmecloud").env_prefix == "ACMECLOUD"
+
+    def test_full_stack_is_not_sdk_only(self):
+        """Only a provider with sdk_only False is listed by the API and UI."""
+        assert builtin_spec(scope="full-stack").sdk_only is False
+
+    def test_builtin_and_external_are_sdk_only(self):
+        assert builtin_spec(scope="builtin").sdk_only is True
+        assert builtin_spec(scope="external").sdk_only is True
+
+    @pytest.mark.parametrize("kind", ["sdk", "api", "hybrid"])
+    def test_kinds_that_audit_an_api_need_services(self, kind):
+        assert builtin_spec(kind=kind).needs_services is True
+
+    def test_tool_kind_needs_no_services(self):
+        """iac, image and llm ship with no services/ at all."""
+        assert builtin_spec(kind="tool").needs_services is False
+
+
+class Test_build_builtin_plan:
+    @pytest.mark.parametrize("kind", KINDS)
+    def test_always_generates_the_arguments_module(self, kind):
+        """lib/arguments/arguments.py is required for every built-in provider.
+
+        prowler/providers/common/arguments.py imports it for every built-in and
+        calls init_parser on it, and a failure there exits the CLI when that
+        provider is the one invoked. All 23 current providers have it.
+        """
+        plan = build_builtin_plan(builtin_spec(kind=kind), REPO_ROOT)
+
+        assert "prowler/providers/acmecloud/lib/arguments/arguments.py" in plan.files
+        assert (
+            "def init_parser(self):"
+            in plan.files["prowler/providers/acmecloud/lib/arguments/arguments.py"]
+        )
+
+    @pytest.mark.parametrize("kind", KINDS)
+    def test_always_generates_the_files_discovery_depends_on(self, kind):
+        plan = build_builtin_plan(builtin_spec(kind=kind), REPO_ROOT)
+
+        for required in [
+            "prowler/providers/acmecloud/__init__.py",
+            "prowler/providers/acmecloud/acmecloud_provider.py",
+            "prowler/providers/acmecloud/models.py",
+        ]:
+            assert required in plan.files
+
+    def test_generates_the_class_name_discovery_looks_up(self):
+        plan = build_builtin_plan(builtin_spec(), REPO_ROOT)
+
+        source = plan.files["prowler/providers/acmecloud/acmecloud_provider.py"]
+        assert "class AcmecloudProvider(Provider):" in source
+
+    def test_api_kind_gets_a_service_layer(self):
+        plan = build_builtin_plan(builtin_spec(kind="api"), REPO_ROOT)
+
+        assert "prowler/providers/acmecloud/lib/service/service.py" in plan.files
+        assert "prowler/providers/acmecloud/services/__init__.py" in plan.files
+
+    def test_tool_kind_gets_no_service_layer(self):
+        plan = build_builtin_plan(builtin_spec(kind="tool"), REPO_ROOT)
+
+        assert "prowler/providers/acmecloud/lib/service/service.py" not in plan.files
+        assert "prowler/providers/acmecloud/services/__init__.py" not in plan.files
+
+    def test_full_stack_declares_application_exposure(self):
+        plan = build_builtin_plan(builtin_spec(scope="full-stack"), REPO_ROOT)
+
+        source = plan.files["prowler/providers/acmecloud/acmecloud_provider.py"]
+        assert "sdk_only: bool = False" in source
+
+    def test_builtin_leaves_sdk_only_at_its_default(self):
+        """The base Provider already defaults sdk_only to True."""
+        plan = build_builtin_plan(builtin_spec(scope="builtin"), REPO_ROOT)
+
+        source = plan.files["prowler/providers/acmecloud/acmecloud_provider.py"]
+        assert "sdk_only" not in source
+
+    def test_regional_adds_the_region_argument_and_filter(self):
+        plan = build_builtin_plan(builtin_spec(regional=True), REPO_ROOT)
+
+        arguments = plan.files["prowler/providers/acmecloud/lib/arguments/arguments.py"]
+        provider = plan.files["prowler/providers/acmecloud/acmecloud_provider.py"]
+        assert '"--region",' in arguments
+        assert "def regions(self):" in provider
+
+    def test_non_regional_adds_neither(self):
+        plan = build_builtin_plan(builtin_spec(regional=False), REPO_ROOT)
+
+        arguments = plan.files["prowler/providers/acmecloud/lib/arguments/arguments.py"]
+        provider = plan.files["prowler/providers/acmecloud/acmecloud_provider.py"]
+        assert '"--region",' not in arguments
+        assert "def regions(self):" not in provider
+
+    def test_token_auth_marks_the_flag_as_sensitive(self):
+        """The prowler-provider skill requires secret-bearing flags to be
+        listed in SENSITIVE_ARGUMENTS so their values are redacted."""
+        plan = build_builtin_plan(builtin_spec(auth="token"), REPO_ROOT)
+
+        arguments = plan.files["prowler/providers/acmecloud/lib/arguments/arguments.py"]
+        assert 'SENSITIVE_ARGUMENTS = frozenset({"--acmecloud-token"})' in arguments
+        assert 'metavar="ACMECLOUD_TOKEN"' in arguments
+
+    def test_env_auth_adds_no_credential_flag(self):
+        plan = build_builtin_plan(builtin_spec(auth="env"), REPO_ROOT)
+
+        arguments = plan.files["prowler/providers/acmecloud/lib/arguments/arguments.py"]
+        assert "add_argument" not in arguments
+
+    def test_generated_tests_carry_no_init_files(self):
+        """scripts/check_test_init_files.py fails the build on any
+        __init__.py under tests/."""
+        plan = build_builtin_plan(builtin_spec(), REPO_ROOT)
+
+        assert not [
+            path
+            for path in plan.paths
+            if path.startswith("tests/") and path.endswith("__init__.py")
+        ]
+
+    def test_generates_tests_for_the_provider_and_its_arguments(self):
+        plan = build_builtin_plan(builtin_spec(), REPO_ROOT)
+
+        assert "tests/providers/acmecloud/acmecloud_provider_test.py" in plan.files
+        assert "tests/providers/acmecloud/acmecloud_fixtures.py" in plan.files
+        assert (
+            "tests/providers/acmecloud/lib/arguments/acmecloud_arguments_test.py"
+            in plan.files
+        )
+
+    def test_reports_the_shared_registrations_it_does_not_patch(self):
+        """The dispatch chain, the check report class and the exception code
+        block live in files shared by every provider, so they are reported
+        rather than edited."""
+        plan = build_builtin_plan(builtin_spec(auth="token"), REPO_ROOT)
+        steps = "\n".join(plan.next_steps)
+
+        assert "init_global_provider()" in steps
+        assert 'elif arguments.provider == "acmecloud":' in steps
+        assert "CheckReportAcmecloud" in steps
+        assert "prowler/lib/check/models.py" in steps
+        assert "changelog.d" in steps
+
+    def test_the_reported_dispatch_snippet_passes_the_auth_argument(self):
+        plan = build_builtin_plan(builtin_spec(auth="token", regional=True), REPO_ROOT)
+        steps = "\n".join(plan.next_steps)
+
+        assert 'token=getattr(arguments, "acmecloud_token", None)' in steps
+        assert 'regions=getattr(arguments, "region", None)' in steps
+
+
+class Test_build_external_plan:
+    def test_declares_the_entry_point_prowler_discovers(self, tmp_path):
+        plan = build_external_plan(builtin_spec(scope="external"), tmp_path)
+
+        pyproject = plan.files["pyproject.toml"]
+        assert '[project.entry-points."prowler.providers"]' in pyproject
+        assert (
+            'acmecloud = "prowler_provider_acmecloud.provider:AcmecloudProvider"'
+            in pyproject
+        )
+
+    def test_implements_both_halves_of_the_external_cli_contract(self, tmp_path):
+        """An external provider cannot join the built-in dispatch chain, so it
+        needs init_parser for its subparser and from_cli_args for its
+        instantiation. No built-in provider implements either."""
+        plan = build_external_plan(builtin_spec(scope="external"), tmp_path)
+
+        source = plan.files["prowler_provider_acmecloud/provider.py"]
+        assert "def init_parser(self):" in source
+        assert (
+            "def from_cli_args(cls, arguments: Namespace, fixer_config: dict)" in source
+        )
+
+    def test_writes_outside_the_prowler_tree(self, tmp_path):
+        plan = build_external_plan(builtin_spec(scope="external"), tmp_path)
+
+        assert not [path for path in plan.paths if path.startswith("prowler/providers")]
+
+
+class Test_build_plan:
+    def test_rejects_a_name_that_already_exists(self):
+        with pytest.raises(ScaffoldError, match="already exists"):
+            build_plan(builtin_spec(name="aws"), REPO_ROOT)
+
+    def test_rejects_an_invalid_kind(self):
+        with pytest.raises(ScaffoldError, match="Invalid kind"):
+            build_plan(
+                ProviderSpec(name="acmecloud", kind="serverless", scope="builtin"),
+                REPO_ROOT,
+            )
+
+    def test_rejects_an_invalid_scope(self):
+        with pytest.raises(ScaffoldError, match="Invalid scope"):
+            build_plan(
+                ProviderSpec(name="acmecloud", kind="api", scope="everything"),
+                REPO_ROOT,
+            )
+
+    def test_rejects_an_invalid_auth_mode(self):
+        with pytest.raises(ScaffoldError, match="Invalid auth mode"):
+            build_plan(
+                ProviderSpec(
+                    name="acmecloud", kind="api", scope="builtin", auth="telepathy"
+                ),
+                REPO_ROOT,
+            )
+
+    def test_rejects_a_path_that_is_not_a_prowler_checkout(self, tmp_path):
+        with pytest.raises(ScaffoldError, match="does not look like a Prowler"):
+            build_plan(builtin_spec(), tmp_path)
+
+    def test_writes_nothing_until_write_plan_is_called(self, tmp_path):
+        plan = build_plan(builtin_spec(scope="external"), tmp_path / "out")
+
+        assert plan.files
+        assert not (tmp_path / "out").exists()
+
+
+class Test_write_plan:
+    def test_writes_every_planned_file(self, tmp_path):
+        plan = build_external_plan(builtin_spec(scope="external"), tmp_path)
+
+        written = write_plan(plan)
+
+        assert len(written) == len(plan.files)
+        for path in written:
+            assert path.is_file()
+
+    def test_refuses_to_overwrite_by_default(self, tmp_path):
+        plan = build_external_plan(builtin_spec(scope="external"), tmp_path)
+        write_plan(plan)
+
+        with pytest.raises(ScaffoldError, match="Refusing to overwrite"):
+            write_plan(plan)
+
+    def test_force_overwrites(self, tmp_path):
+        plan = build_external_plan(builtin_spec(scope="external"), tmp_path)
+        write_plan(plan)
+        target = tmp_path / "README.md"
+        target.write_text("edited")
+
+        write_plan(plan, force=True)
+
+        assert target.read_text() != "edited"
+
+
+class Test_repo_inspection:
+    def test_find_repo_root_walks_up_to_the_checkout(self):
+        assert find_repo_root(Path(__file__).parent) == REPO_ROOT
+
+    def test_find_repo_root_raises_outside_a_checkout(self, tmp_path):
+        with pytest.raises(ScaffoldError, match="No Prowler repository found"):
+            find_repo_root(tmp_path)
+
+    def test_existing_builtin_names_matches_discovery(self):
+        """The scaffold reads the tree to decide whether a name is taken, so
+        that view has to agree with the one discovery enumerates."""
+        assert set(existing_builtin_names(REPO_ROOT)) == discovered_builtin_names()
+
+    def test_every_discovered_provider_is_a_builtin(self):
+        for name in discovered_builtin_names():
+            assert Provider.is_builtin(name)
+
+    def test_next_exception_code_range_is_above_every_code_in_use(self):
+        start, end = next_exception_code_range(REPO_ROOT)
+
+        assert end == start + 99
+        highest = 0
+        for path in (REPO_ROOT / "prowler" / "providers").glob(
+            "*/exceptions/exceptions.py"
+        ):
+            for match in re.finditer(r"\((\d{4,6}),", path.read_text()):
+                highest = max(highest, int(match.group(1)))
+        assert start > highest
+
+
+class Test_generated_code_quality:
+    """Generated code lands in a contributor's tree, where Prowler's own CI
+    runs black and flake8 over it. A scaffold whose output fails those gates
+    hands the contributor a broken first push."""
+
+    SPECS = [
+        builtin_spec(kind=kind, scope=scope, auth=auth, regional=regional)
+        for kind in ("api", "tool")
+        for scope in ("builtin", "full-stack", "external")
+        for auth in AUTH_MODES
+        for regional in (True, False)
+    ]
+
+    @pytest.mark.parametrize(
+        "spec", SPECS, ids=lambda s: f"{s.kind}-{s.scope}-{s.auth}-{s.regional}"
+    )
+    def test_generated_python_is_syntactically_valid(self, spec, tmp_path):
+        plan = (
+            build_external_plan(spec, tmp_path)
+            if spec.scope == "external"
+            else build_builtin_plan(spec, REPO_ROOT)
+        )
+
+        for relative, source in plan.files.items():
+            if relative.endswith(".py"):
+                compile(source, relative, "exec")
+
+    @pytest.mark.parametrize(
+        "spec", SPECS, ids=lambda s: f"{s.kind}-{s.scope}-{s.auth}-{s.regional}"
+    )
+    def test_generated_python_is_black_clean(self, spec, tmp_path):
+        black = pytest.importorskip("black")
+        plan = (
+            build_external_plan(spec, tmp_path)
+            if spec.scope == "external"
+            else build_builtin_plan(spec, REPO_ROOT)
+        )
+
+        for relative, source in plan.files.items():
+            if relative.endswith(".py") and source:
+                assert source == black.format_str(
+                    source, mode=black.Mode()
+                ), f"{relative} is not black-clean"
+
+    IN_REPO_SPECS = [spec for spec in SPECS if spec.scope != "external"]
+
+    @pytest.mark.parametrize(
+        "spec",
+        IN_REPO_SPECS,
+        ids=lambda s: f"{s.kind}-{s.scope}-{s.auth}-{s.regional}",
+    )
+    def test_generated_python_is_import_sorted(self, spec):
+        """Whether a provider's own imports sort before or after
+        prowler.providers.common depends on its name, so the templates cannot
+        hardcode the order. External packages are excluded: they live outside
+        this repository and isort never runs on them here.
+        """
+        isort = pytest.importorskip("isort")
+        plan = build_builtin_plan(spec, REPO_ROOT)
+
+        for relative, source in plan.files.items():
+            if relative.endswith(".py") and source:
+                assert source == isort.code(
+                    source, profile="black"
+                ), f"{relative} is not import-sorted"
+
+    @pytest.mark.parametrize("name", ["acloud", "zcloud", "m365x"])
+    def test_import_order_holds_either_side_of_common(self, name):
+        """A name sorting before `common` and one sorting after it both have to
+        come out ordered."""
+        isort = pytest.importorskip("isort")
+        plan = build_builtin_plan(builtin_spec(name=name, auth="token"), REPO_ROOT)
+
+        provider = plan.files[f"prowler/providers/{name}/{name}_provider.py"]
+        assert provider == isort.code(provider, profile="black")
+
+
+class Test_generated_provider_is_loadable:
+    """The point of the scaffold is a provider Prowler can find and import.
+
+    Rather than writing into prowler/providers/, these tests extend
+    prowler.providers.__path__ with a temporary directory. Discovery iterates
+    that same __path__ (pkgutil.iter_modules in get_available_providers) and
+    get_class imports through it, so this exercises the real code path.
+    """
+
+    @staticmethod
+    @contextmanager
+    def scaffolded(spec, tmp_path):
+        """Write a plan to tmp_path and make it importable as a built-in.
+
+        prowler.providers is a namespace package, so its __path__ is a
+        _NamespacePath, which supports append but not remove. Swapping in a
+        plain list and restoring the original object afterwards leaves the
+        interpreter exactly as it was found.
+        """
+        plan = build_builtin_plan(spec, REPO_ROOT)
+        plan.root = tmp_path
+        write_plan(plan)
+
+        providers_package = importlib.import_module("prowler.providers")
+        original_path = providers_package.__path__
+        providers_package.__path__ = list(original_path) + [
+            str(tmp_path / "prowler" / "providers")
+        ]
+        try:
+            yield plan
+        finally:
+            providers_package.__path__ = original_path
+            for module in [
+                name
+                for name in sys.modules
+                if name.startswith(f"prowler.providers.{spec.name}")
+            ]:
+                del sys.modules[module]
+            Provider._ep_providers.pop(spec.name, None)
+
+    @pytest.mark.parametrize("scope", ["builtin", "full-stack"])
+    def test_generated_provider_is_discovered_and_imports(self, scope, tmp_path):
+        name = f"scaffolded{scope.replace('-', '')}"
+        spec = builtin_spec(name=name, scope=scope, auth="token", regional=True)
+
+        with self.scaffolded(spec, tmp_path):
+            # Layer one: the name is enumerated. Layer two: the module imports
+            # and the class lookup resolves.
+            assert name in discovered_builtin_names()
+
+            provider_class = Provider.get_class(name)
+
+            assert provider_class.__name__ == f"{name.capitalize()}Provider"
+            assert issubclass(provider_class, Provider)
+            assert provider_class.sdk_only is (scope != "full-stack")
+            assert provider_class._cli_help_text
+
+    def test_generated_arguments_module_builds_a_subparser(self, tmp_path):
+        """init_providers_parser() imports lib.arguments.arguments for every
+        built-in and calls init_parser on it."""
+        name = "scaffoldedargs"
+        spec = builtin_spec(name=name, auth="token", regional=True)
+
+        with self.scaffolded(spec, tmp_path):
+            module = importlib.import_module(
+                f"prowler.providers.{name}.lib.arguments.arguments"
+            )
+
+            assert callable(module.init_parser)
+            assert module.SENSITIVE_ARGUMENTS == frozenset({f"--{name}-token"})

--- a/tests/lib/dev/provider_scaffold_test.py
+++ b/tests/lib/dev/provider_scaffold_test.py
@@ -38,6 +38,27 @@ def builtin_spec(**overrides) -> ProviderSpec:
     return ProviderSpec(**defaults)
 
 
+def import_blocks(source: str) -> list:
+    """Split a module's imports into blocks, as the module paths they name.
+
+    isort groups imports into blank-line-separated blocks and sorts each block
+    by module path, so the blocks are the unit these assertions check.
+    """
+    blocks, current = [], []
+    for line in source.splitlines():
+        if line.startswith(("import ", "from ")):
+            current.append(line.split()[1])
+        elif not line.strip():
+            if current:
+                blocks.append(current)
+                current = []
+        elif not line.startswith((" ", ")")):
+            break
+    if current:
+        blocks.append(current)
+    return blocks
+
+
 def discovered_builtin_names() -> set:
     """Enumerate built-in providers the way get_available_providers() does.
 
@@ -414,30 +435,68 @@ class Test_generated_code_quality:
         IN_REPO_SPECS,
         ids=lambda s: f"{s.kind}-{s.scope}-{s.auth}-{s.regional}",
     )
-    def test_generated_python_is_import_sorted(self, spec):
-        """Whether a provider's own imports sort before or after
-        prowler.providers.common depends on its name, so the templates cannot
-        hardcode the order. External packages are excluded: they live outside
-        this repository and isort never runs on them here.
+    def test_generated_imports_are_ordered_within_each_block(self, spec):
+        """isort orders a block by module path, and whether a provider's own
+        imports fall before or after prowler.providers.common depends on its
+        name, so the templates cannot hardcode the order.
+
+        These assertions read the generated source rather than calling
+        isort.code(). isort's first-party detection depends on where a file
+        sits, and the string API cannot be told a path that does not exist yet,
+        so it disagrees with the pre-commit hook on exactly the import this
+        covers.
         """
-        isort = pytest.importorskip("isort")
         plan = build_builtin_plan(spec, REPO_ROOT)
 
         for relative, source in plan.files.items():
-            if relative.endswith(".py") and source:
-                assert source == isort.code(
-                    source, profile="black"
-                ), f"{relative} is not import-sorted"
+            if not relative.endswith(".py") or not source:
+                continue
+            for block in import_blocks(source):
+                assert block == sorted(block), f"{relative} has an unsorted block"
 
     @pytest.mark.parametrize("name", ["acloud", "zcloud", "m365x"])
     def test_import_order_holds_either_side_of_common(self, name):
         """A name sorting before `common` and one sorting after it both have to
         come out ordered."""
-        isort = pytest.importorskip("isort")
         plan = build_builtin_plan(builtin_spec(name=name, auth="token"), REPO_ROOT)
 
-        provider = plan.files[f"prowler/providers/{name}/{name}_provider.py"]
-        assert provider == isort.code(provider, profile="black")
+        source = plan.files[f"prowler/providers/{name}/{name}_provider.py"]
+        modules = [module for block in import_blocks(source) for module in block]
+        assert f"prowler.providers.{name}.models" in modules
+        assert "prowler.providers.common.provider" in modules
+        for block in import_blocks(source):
+            assert block == sorted(block)
+
+    def test_the_fixture_import_joins_the_first_party_block(self):
+        """`tests` is first-party to isort inside this repository, so the
+        fixture import belongs with the prowler imports and not beside pytest.
+        Placing it next to pytest is what the pre-commit hook rejects."""
+        plan = build_builtin_plan(builtin_spec(), REPO_ROOT)
+
+        source = plan.files["tests/providers/acmecloud/acmecloud_provider_test.py"]
+        blocks = import_blocks(source)
+        fixture = "tests.providers.acmecloud.acmecloud_fixtures"
+        first_party = [block for block in blocks if fixture in block]
+
+        assert len(first_party) == 1
+        assert any(module.startswith("prowler.") for module in first_party[0])
+        assert "pytest" not in first_party[0]
+
+    @pytest.mark.parametrize(
+        "spec", IN_REPO_SPECS, ids=lambda s: f"{s.kind}-{s.scope}-{s.auth}-{s.regional}"
+    )
+    def test_import_wrapping_matches_the_column_limit(self, spec):
+        """black and isort both wrap at 88 columns, so a generated import is
+        one line when it fits and parenthesized when it does not. Which one a
+        given import needs depends on the provider's name."""
+        plan = build_builtin_plan(spec, REPO_ROOT)
+
+        for relative, source in plan.files.items():
+            if not relative.endswith(".py") or not source:
+                continue
+            for line in source.splitlines():
+                if line.startswith("from ") and not line.endswith("("):
+                    assert len(line) <= 88, f"{relative} has an overlong import"
 
 
 class Test_generated_provider_is_loadable:


### PR DESCRIPTION
### Context

Phase 2 of #12026, the executable scaffold command. Phase 1 (the golden path documentation) is #12046, approved at `b4be05a`.

The issue phases Phase 2 as an independently reviewable pull request, and this one is built on `master` rather than on the Phase 1 branch. It touches none of the four files #12046 changes, so the two can merge in either order.

Fix #12026 is deliberately **not** used here. Phases 3 to 6 remain open.

### Description

`prowler-dev provider create` generates the minimum consistent structure for a new provider from explicit inputs, and stops where a provider-specific decision starts.

```bash
uv run prowler-dev provider create --name acmecloud --kind api --scope full-stack \
    --regional false --auth token
```

`--name`, `--kind` and `--scope` are required because each changes what gets generated. `--regional` and `--auth` default to `false` and `env`. `--dry-run` prints the file list without writing, and the command refuses to overwrite without `--force`.

**What it generates.** For `builtin` and `full-stack`, the provider package plus its tests. For `external`, a standalone package declaring the `prowler.providers` entry point. Authentication behavior, API semantics and security checks are `TODO` markers, never guessed. `--auth` decides which credential arguments exist and what those markers say, and nothing more.

**What it reports instead of generating.** Three registrations live in files shared by every provider, so the command prints them as next steps rather than patching them. Code generation into a shared 900 line file produces a diff nobody wants to review, and a conflict for whoever runs the command next.

1. The dispatch branch for `init_global_provider()`, printed as a ready-to-paste snippet that already passes the credential and region arguments matching the chosen flags, along with the current line number of the dynamic fallback it goes before.
2. `CheckReport<Name>` in `prowler/lib/check/models.py`. The names in that file are not derived from the provider name (`CheckReportE2eNetworks`, `CheckReportStackIT`, `CheckReportMongoDBAtlas`), so the spelling cannot be generated.
3. The exception code block. The command reads the highest code in use and suggests the next free block of 100.

**Three findings from the source that shaped the templates.**

`lib/arguments/arguments.py` is required for every built-in provider, not kind-dependent. `prowler/providers/common/arguments.py:38-67` imports that module for every built-in and calls `init_parser` on it, and `enforce_invoked_provider_loaded()` turns a failure into `sys.exit(1)` when that provider is the one invoked. All 23 current providers have it, so the scaffold always generates it. This refines what #12046's page currently says, which files `lib/` under "depends on the provider kind". Happy to correct that page in the follow-up described below rather than reopening an approved PR.

A name is rejected unless it matches `^[a-z][a-z0-9]*$`, because `Provider.get_class()` builds the class name with `str.capitalize()`. `acme_cloud` would need a class called `Acme_cloudProvider` to be found, so refusing the name is better than generating a provider that silently fails to load.

Only `sdk`, `api` and `hybrid` get a service layer. A `tool` provider wraps another binary, which is why `iac`, `image` and `llm` ship with no `services/` or `lib/service/`.

**On putting this in `prowler/` rather than `util/`, which is the one decision worth your opinion.** The issue's example invocation is `uv run prowler-dev ...`, which needs a console script. `[tool.hatch.build.targets.wheel] packages = ["prowler", "dashboard"]` (`pyproject.toml:160-161`) means a script pointing into `util/` would resolve to nothing in an installed Prowler, so the tool lives at `prowler/lib/dev/` and ships. That is also what makes it useful to the external-provider path, where the author has an installed Prowler and no checkout. Verified on the built wheel:

```
$ unzip -p dist/prowler-5.40.0-py3-none-any.whl '*/entry_points.txt'
[console_scripts]
prowler = prowler.__main__:prowler
prowler-dev = prowler.lib.dev.cli:main
```

If you would rather this not ship to end users, the alternative is `util/provider_dev/` invoked as `uv run python -m util.provider_dev`, which costs the external path and the documented invocation. Say which you prefer and I will move it.

### Steps to review

Generated code lands in a contributor's working tree, so it has to be clean against this repository's own gates before their first push. The command sorts the imports it emits and formats with `black` when `black` imports. Import order cannot be baked into the templates, because whether a provider's own imports sort before or after `prowler.providers.common` depends on its name.

**1. Generate a provider and confirm it is discoverable before any implementation work.**

```bash
uv run prowler-dev provider create --name acmecloud --kind api --scope full-stack \
    --regional true --auth token
uv run python prowler-cli.py --help | grep acmecloud
uv run python prowler-cli.py acmecloud --help
uv run pytest tests/providers/acmecloud
```

Observed:

```
    acmecloud           Acmecloud Provider

Authentication Modes:
  --acmecloud-token [ACMECLOUD_TOKEN]
                        Acmecloud API token. Use the ACMECLOUD_TOKEN
                        environment variable instead of passing the value
                        directly.

Regions:
  --region, --filter-region, -f REGION [REGION ...]

7 passed in 0.09s
```

**2. Confirm the generated code passes this repository's gates.**

```bash
uv run flake8 prowler/providers/acmecloud tests/providers/acmecloud \
    --ignore=E266,W503,E203,E501,W605,E128
uv run black --check prowler/providers/acmecloud tests/providers/acmecloud
uv run isort --check-only --profile black prowler/providers/acmecloud tests/providers/acmecloud
rm -rf prowler/providers/acmecloud tests/providers/acmecloud
```

All three are clean. I swept all 96 combinations of `--kind`, `--scope`, `--auth` and `--regional`: 0 flake8 findings, 1104 files black-clean, all 64 in-repo variants isort-clean, and every generated module compiles. Two bugs surfaced that way and are fixed. Environment-only auth with no region filter adds no arguments at all, which made the parser local an unused variable (`F841`), and the external provider was not receiving the region argument.

**3. Review the reported next steps rather than a patched shared file.**

`--dry-run` prints them without writing anything.

### Testing

`206 passed` in `tests/lib/dev`. Run as CI runs the lib job, `uv run pytest -n auto --cov=./prowler/lib tests/lib` gives `5212 passed, 3 skipped`, with `pytest-randomly` active. `tests/config` is `584 passed`.

The tests cover name validation against the `capitalize()` contract, the file set per kind and scope, the sensitive-argument and region wiring, the reported registrations, refusal to overwrite, and formatter and import-order cleanliness across every flag combination. The one worth reading is `Test_generated_provider_is_loadable`, which writes a generated provider to `tmp_path`, extends `prowler.providers.__path__` with it, and asserts the real discovery path enumerates the name and `Provider.get_class()` imports it and resolves the class. It restores `__path__` and purges `sys.modules` afterwards, so nothing is written into `prowler/providers/`.

I checked the tests actually catch regressions by mutating the implementation. Dropping the arguments module from the plan fails 9, accepting any provider name fails 7, and removing the import sort fails 33.

Other gates run locally: `python3 scripts/check_test_init_files.py .` passes (the generated tests carry no `__init__.py`), `uv lock --check` passes, `markdownlint` passes on the changelog fragment, `python3 docs/scripts/generate_provider_cards.py` produces no diff, and `prek` passes `autoflake`, `isort`, `black`, `flake8`, `pylint`, `bandit` and `vulture` on the changed files. `TruffleHog` could not run because the binary is not installed here, so that one is unverified rather than passing.

### Notes for reviewers

Three things you may want to weigh in on, plus one pre-existing issue.

The generated test file names are prefixed with the provider name, so `sdk-check-duplicate-test-names` stays satisfied for any generated provider.

A mutelist is generated for every kind even though `iac`, `image` and `llm` have none. The generated `is_finding_muted` leaves its `finding` argument unannotated with a `TODO`, so the package imports before `CheckReport<Name>` exists, and the reported next steps say a tool provider may drop the directory. Tell me if you would rather it were omitted for `--kind tool`.

This PR deliberately does not touch the four files #12046 changes, so it does not cross-link the scaffold from the golden path page or from `skills/prowler-provider/SKILL.md`. The issue's skill requirement asks for the latter. I would like to do both in a small follow-up once #12046 merges, together with the `lib/arguments` correction above. If you would rather see them here, I can rebase this onto the Phase 1 branch instead. The `docs/docs.json` nav entry is one line next to the one #12046 adds, so expect a one-line conflict for whichever merges second.

Pre-existing and worked around rather than fixed: `tests/lib/cli/parser_test.py:49-56` starts a `patch` over `Provider.get_available_providers` in `setup_method` with no matching teardown, so its hardcoded 19-provider list leaks into every test that runs afterwards in the same process. It initially broke three of my tests, which now enumerate `prowler.providers.__path__` directly and say why in a comment. Worth a separate fix, and I am happy to open one.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - No provider permissions change. Nothing in `prowler-dev` runs during a scan.

#### UI
- [ ] All issue/task requirements work as expected on the UI

No UI changes.

#### API
- [ ] All issue/task requirements work as expected on the API

No API changes.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server

No MCP Server changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `prowler-dev provider create` command for scaffolding built-in or external providers.
  - Supports configurable provider type, scope, authentication, regional behavior, output paths, dry runs, and forced overwrites.
  - Generates starter source files, tests, documentation, and next steps.
  - Added an alternative module-based way to run the development CLI.

- **Documentation**
  - Added a Developer Guide page covering provider creation, generated layouts, registrations, and verification.

- **Chores**
  - Added validation and safeguards against invalid names and accidental overwrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->