### PR TITLE
feat(sagemaker): add sagemaker_domain_encrypted_with_cmk check

### DIFF
--- a/prowler/changelog.d/sagemaker-domain-encrypted-with-cmk.added.md
+++ b/prowler/changelog.d/sagemaker-domain-encrypted-with-cmk.added.md
@@ -1,0 +1,1 @@
+`sagemaker_domain_encrypted_with_cmk` checks that every SageMaker Domain encrypts its EFS and EBS volumes with a customer-managed KMS key, and reports MANUAL when the domain details cannot be described

--- a/prowler/providers/aws/services/sagemaker/sagemaker_domain_encrypted_with_cmk/sagemaker_domain_encrypted_with_cmk.metadata.json
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_domain_encrypted_with_cmk/sagemaker_domain_encrypted_with_cmk.metadata.json
@@ -1,0 +1,45 @@
+{
+  "Provider": "aws",
+  "CheckID": "sagemaker_domain_encrypted_with_cmk",
+  "CheckTitle": "SageMaker domains encrypt their volumes with a customer-managed KMS key",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Effects/Data Exposure"
+  ],
+  "ServiceName": "sagemaker",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "Other",
+  "ResourceGroup": "ai_ml",
+  "Description": "**Amazon SageMaker Domains** are assessed for **at-rest encryption** of their attached EFS and EBS volumes using a **customer-managed KMS key**. The finding reflects whether a `KmsKeyId` is set on the domain, so that notebooks and user data stored in the domain volumes are encrypted with a key the account owner controls.",
+  "Risk": "A domain without `KmsKeyId` falls back to the **AWS managed key**, which cannot carry a custom key policy and whose **rotation**, **access** and **lifecycle** are outside the account owner's control. Notebook content and user data on the domain volumes then cannot be independently revoked, and grants to that data cannot be audited or restricted through a key policy.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/encryption-at-rest-studio.html",
+    "https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DescribeDomain.html",
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/key-management.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws sagemaker create-domain --domain-name <domain_name> --auth-mode SSO --vpc-id <vpc_id> --subnet-ids <subnet_id> --default-user-settings ExecutionRole=<role_arn> --kms-key-id <kms_key_id>",
+      "NativeIaC": "```yaml\n# CloudFormation: SageMaker Domain encrypted with a customer-managed KMS key\nResources:\n  <example_resource_name>:\n    Type: AWS::SageMaker::Domain\n    Properties:\n      DomainName: <example_domain_name>\n      AuthMode: SSO\n      VpcId: <example_vpc_id>\n      SubnetIds:\n        - <example_subnet_id>\n      KmsKeyId: <example_resource_id>  # Critical: encrypts the domain EFS and EBS volumes with a customer-managed key\n      DefaultUserSettings:\n        ExecutionRole: <example_role_arn>\n```",
+      "Other": "The KMS key of a SageMaker Domain is set at creation and cannot be changed afterwards. To remediate:\n1. Create a customer-managed KMS key with a least-privilege key policy and rotation enabled\n2. Create a new SageMaker Domain specifying that key as the KMS key\n3. Migrate user profiles and notebook content to the new domain\n4. Delete the original domain once the migration is verified",
+      "Terraform": "```hcl\n# SageMaker Domain encrypted with a customer-managed KMS key\nresource \"aws_sagemaker_domain\" \"<example_resource_name>\" {\n  domain_name = \"<example_domain_name>\"\n  auth_mode   = \"SSO\"\n  vpc_id      = \"<example_vpc_id>\"\n  subnet_ids  = [\"<example_subnet_id>\"]\n  kms_key_id  = \"<example_resource_arn>\" # Critical: encrypts the domain EFS and EBS volumes with a customer-managed key\n\n  default_user_settings {\n    execution_role = \"<example_role_arn>\"\n  }\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Set `KmsKeyId` on every SageMaker Domain at creation, using a **customer-managed KMS key** with a least-privilege key policy and **rotation** enabled. The key cannot be changed after the domain is created, so domains on the AWS managed key must be recreated and their user profiles migrated.",
+      "Url": "https://hub.prowler.com/check/sagemaker_domain_encrypted_with_cmk"
+    }
+  },
+  "Categories": [
+    "encryption",
+    "gen-ai"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [
+    "sagemaker_endpoint_config_kms_encryption_enabled",
+    "sagemaker_notebook_instance_encryption_enabled"
+  ],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/sagemaker/sagemaker_domain_encrypted_with_cmk/sagemaker_domain_encrypted_with_cmk.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_domain_encrypted_with_cmk/sagemaker_domain_encrypted_with_cmk.py
@@ -1,0 +1,35 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.sagemaker.sagemaker_client import sagemaker_client
+
+
+class sagemaker_domain_encrypted_with_cmk(Check):
+    """Ensure SageMaker domains encrypt their volumes with a customer-managed KMS key.
+
+    A SageMaker Domain stores notebooks and user data on EFS and EBS volumes.
+    When ``KmsKeyId`` is unset the domain falls back to the AWS managed key,
+    which cannot carry a custom key policy and whose rotation, access and
+    lifecycle are outside the account owner's control.
+
+    - PASS: The domain has a ``KmsKeyId`` set.
+    - FAIL: The domain has no ``KmsKeyId`` and therefore uses the AWS managed key.
+    - MANUAL: The domain details could not be described, so encryption cannot
+      be determined either way.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        findings = []
+        for domain in sagemaker_client.sagemaker_domains:
+            report = Check_Report_AWS(metadata=self.metadata(), resource=domain)
+            if domain.detail_fetch_error:
+                report.status = "MANUAL"
+                report.status_extended = f"SageMaker domain {domain.name} details could not be described ({domain.detail_fetch_error}); volume encryption cannot be verified."
+            elif domain.kms_key_id:
+                report.status = "PASS"
+                report.status_extended = f"SageMaker domain {domain.name} encrypts its EFS and EBS volumes with the customer-managed KMS key {domain.kms_key_id}."
+            else:
+                report.status = "FAIL"
+                report.status_extended = f"SageMaker domain {domain.name} does not encrypt its EFS and EBS volumes with a customer-managed KMS key."
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/sagemaker/sagemaker_service.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_service.py
@@ -451,7 +451,9 @@ class SageMaker(AWSService):
             domain.single_sign_on_application_arn = describe_domain.get(
                 "SingleSignOnApplicationArn"
             )
+            domain.kms_key_id = describe_domain.get("KmsKeyId")
         except Exception as error:
+            domain.detail_fetch_error = error.__class__.__name__
             logger.error(
                 f"{domain.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
@@ -617,6 +619,13 @@ class Domain(BaseModel):
     auth_mode: Optional[str] = None
     single_sign_on_managed_application_instance_id: Optional[str] = None
     single_sign_on_application_arn: Optional[str] = None
+    kms_key_id: Optional[str] = None
+    # Populated by _describe_domain on API failure. Distinguishes "domain uses
+    # the AWS managed key" (None + no error) from "domain details could not be
+    # described" (None + error class name). Checks that make security
+    # assertions from the domain details should emit MANUAL when this is set,
+    # rather than reporting a FAIL they cannot substantiate.
+    detail_fetch_error: Optional[str] = None
     tags: Optional[list] = []
 
 

--- a/tests/providers/aws/services/sagemaker/sagemaker_domain_encrypted_with_cmk/sagemaker_domain_encrypted_with_cmk_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_domain_encrypted_with_cmk/sagemaker_domain_encrypted_with_cmk_test.py
@@ -1,0 +1,163 @@
+from unittest import mock
+
+from prowler.providers.aws.services.sagemaker.sagemaker_service import Domain
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_provider,
+)
+
+test_domain_name = "test-domain"
+test_domain_id = "d-testdomain123"
+domain_arn = f"arn:aws:sagemaker:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:domain/{test_domain_id}"
+test_kms_key_id = (
+    f"arn:aws:kms:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:key/test-key-id"
+)
+
+
+class Test_sagemaker_domain_encrypted_with_cmk:
+    def test_no_domains(self):
+        sagemaker_client = mock.MagicMock
+        sagemaker_client.sagemaker_domains = []
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_domain_encrypted_with_cmk.sagemaker_domain_encrypted_with_cmk.sagemaker_client",
+                sagemaker_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_domain_encrypted_with_cmk.sagemaker_domain_encrypted_with_cmk import (
+                sagemaker_domain_encrypted_with_cmk,
+            )
+
+            check = sagemaker_domain_encrypted_with_cmk()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_domain_encrypted_with_cmk(self):
+        sagemaker_client = mock.MagicMock
+        sagemaker_client.sagemaker_domains = [
+            Domain(
+                domain_id=test_domain_id,
+                name=test_domain_name,
+                arn=domain_arn,
+                region=AWS_REGION_EU_WEST_1,
+                kms_key_id=test_kms_key_id,
+            )
+        ]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_domain_encrypted_with_cmk.sagemaker_domain_encrypted_with_cmk.sagemaker_client",
+                sagemaker_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_domain_encrypted_with_cmk.sagemaker_domain_encrypted_with_cmk import (
+                sagemaker_domain_encrypted_with_cmk,
+            )
+
+            check = sagemaker_domain_encrypted_with_cmk()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SageMaker domain {test_domain_name} encrypts its EFS and EBS volumes with the customer-managed KMS key {test_kms_key_id}."
+            )
+            assert result[0].resource_id == test_domain_name
+            assert result[0].resource_arn == domain_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_domain_not_encrypted_with_cmk(self):
+        sagemaker_client = mock.MagicMock
+        sagemaker_client.sagemaker_domains = [
+            Domain(
+                domain_id=test_domain_id,
+                name=test_domain_name,
+                arn=domain_arn,
+                region=AWS_REGION_EU_WEST_1,
+            )
+        ]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_domain_encrypted_with_cmk.sagemaker_domain_encrypted_with_cmk.sagemaker_client",
+                sagemaker_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_domain_encrypted_with_cmk.sagemaker_domain_encrypted_with_cmk import (
+                sagemaker_domain_encrypted_with_cmk,
+            )
+
+            check = sagemaker_domain_encrypted_with_cmk()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SageMaker domain {test_domain_name} does not encrypt its EFS and EBS volumes with a customer-managed KMS key."
+            )
+            assert result[0].resource_id == test_domain_name
+            assert result[0].resource_arn == domain_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_domain_details_not_retrieved(self):
+        sagemaker_client = mock.MagicMock
+        sagemaker_client.sagemaker_domains = [
+            Domain(
+                domain_id=test_domain_id,
+                name=test_domain_name,
+                arn=domain_arn,
+                region=AWS_REGION_EU_WEST_1,
+                detail_fetch_error="ClientError",
+            )
+        ]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_domain_encrypted_with_cmk.sagemaker_domain_encrypted_with_cmk.sagemaker_client",
+                sagemaker_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_domain_encrypted_with_cmk.sagemaker_domain_encrypted_with_cmk import (
+                sagemaker_domain_encrypted_with_cmk,
+            )
+
+            check = sagemaker_domain_encrypted_with_cmk()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"SageMaker domain {test_domain_name} details could not be described (ClientError); volume encryption cannot be verified."
+            )
+            assert result[0].resource_id == test_domain_name
+            assert result[0].resource_arn == domain_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
@@ -38,6 +38,9 @@ prod_variant_name = "Variant1"
 test_domain_name = "test-domain"
 test_domain_id = "d-testdomain123"
 test_domain_arn = f"arn:aws:sagemaker:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:domain/{test_domain_id}"
+test_domain_kms_key_id = (
+    f"arn:aws:kms:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:key/test-domain-key"
+)
 test_sso_instance_id = "app-test-instance-id"
 test_sso_application_arn = (
     f"arn:aws:sso::{AWS_ACCOUNT_NUMBER}:application/sagemaker/apl-test"
@@ -174,6 +177,7 @@ def mock_make_api_call(self, operation_name, kwarg):
             "AuthMode": "SSO",
             "SingleSignOnManagedApplicationInstanceId": test_sso_instance_id,
             "SingleSignOnApplicationArn": test_sso_application_arn,
+            "KmsKeyId": test_domain_kms_key_id,
         }
 
     return make_api_call(self, operation_name, kwarg)
@@ -350,6 +354,8 @@ class Test_SageMaker_Service:
             sagemaker.sagemaker_domains[0].single_sign_on_application_arn
             == test_sso_application_arn
         )
+        assert sagemaker.sagemaker_domains[0].kms_key_id == test_domain_kms_key_id
+        assert sagemaker.sagemaker_domains[0].detail_fetch_error is None
 
     # Test SageMaker _list_tags_for_resource
     def test_list_tags_for_resource_calls_client(self):


### PR DESCRIPTION
### Context

Fix #12575

A SageMaker Domain stores notebooks and user data on attached EFS and EBS volumes. When `KmsKeyId` is not set, the domain falls back to the AWS managed key, which cannot carry a custom key policy and whose rotation, access and lifecycle are outside the account owner's control.

### Description

Adds `sagemaker_domain_encrypted_with_cmk`.

- **PASS** — the domain has a `KmsKeyId` set
- **FAIL** — no `KmsKeyId`, so the domain uses the AWS managed key
- **MANUAL** — the domain details could not be described, so encryption cannot be determined
- No domains returns no findings

Service changes on the `Domain` model:

- `kms_key_id` — collected from the existing `DescribeDomain` call
- `detail_fetch_error` — set when `_describe_domain` raises

**On the MANUAL case.** `_describe_domain` previously caught and logged any API error and returned, leaving `kms_key_id` as `None`. That is indistinguishable from a domain that genuinely has no customer-managed key, so a throttled or denied `DescribeDomain` would have produced a FAIL the check cannot substantiate. `detail_fetch_error` separates the two, and the check tests it before `kms_key_id` so the failure path cannot fall through to FAIL. This follows the `policy_fetch_error` field already used on the KMS `Key` model for the same reason. Happy to drop it if you'd prefer a smaller change.

No new API calls are introduced — `ListDomains` and `DescribeDomain` were already being called for `sagemaker_domain_sso_configured`, so provider permissions are unchanged.

### Steps to review

1. `prowler/providers/aws/services/sagemaker/sagemaker_service.py` — two new fields on `Domain`, `KmsKeyId` collected via `.get()` since the field is absent rather than null when no key is set, and `detail_fetch_error` recorded in the existing `except`
2. `sagemaker_domain_encrypted_with_cmk.py` — note `detail_fetch_error` is checked before `kms_key_id`
3. Tests cover PASS, FAIL, MANUAL and no-domains

```
pytest tests/providers/aws/services/sagemaker/  ->  88 passed
pytest tests/lib/check/                         ->  3892 passed
```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **Yes** — `sagemaker_domain_encrypted_with_cmk`
    - Provider permissions are unchanged. The check reads an additional field from the `DescribeDomain` response that the service already requests.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a security check to verify that SageMaker Domains encrypt EFS and EBS volumes with customer-managed KMS keys.
  * Reports compliant, noncompliant, or manual-review results when domain details cannot be retrieved.
* **Tests**
  * Added coverage for compliant domains, missing encryption keys, unavailable details, and empty environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->