### PR TITLE
feat(sagemaker): add sagemaker_full_access_policy_attached check

### DIFF
--- a/prowler/changelog.d/sagemaker-full-access-policy-attached.added.md
+++ b/prowler/changelog.d/sagemaker-full-access-policy-attached.added.md
@@ -1,0 +1,1 @@
+`sagemaker_full_access_policy_attached` checks that no IAM role has the AWS managed `AmazonSageMakerFullAccess` policy attached, excluding service-linked roles

--- a/prowler/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached.metadata.json
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached.metadata.json
@@ -1,0 +1,44 @@
+{
+  "Provider": "aws",
+  "CheckID": "sagemaker_full_access_policy_attached",
+  "CheckTitle": "IAM role does not have AmazonSageMakerFullAccess managed policy attached",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices"
+  ],
+  "ServiceName": "sagemaker",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "AwsIamRole",
+  "ResourceGroup": "IAM",
+  "Description": "**IAM roles** (excluding service roles) are evaluated for attachment of the AWS-managed `AmazonSageMakerFullAccess` policy.\n\nThis policy grants broad access to Amazon SageMaker actions along with supporting permissions on other services such as S3, ECR, CloudWatch Logs and IAM `PassRole`.",
+  "Risk": "The `AmazonSageMakerFullAccess` policy grants far more than SageMaker itself. If a role carrying it is compromised, an attacker could:\n- Run arbitrary code via notebooks, training jobs or endpoints\n- Reach training data and model artifacts in the S3 buckets it allows\n- Use `iam:PassRole` to escalate to a more privileged role\n- Incur significant cost through unrestricted capacity",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/security_iam_id-based-policy-examples.html#security_iam_service-with-iam-policy-best-practices",
+    "https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws iam detach-role-policy --role-name <ROLE_NAME> --policy-arn arn:aws:iam::aws:policy/AmazonSageMakerFullAccess",
+      "NativeIaC": "```yaml\n# CloudFormation: IAM Role without AmazonSageMakerFullAccess\nResources:\n  <example_resource_name>:\n    Type: AWS::IAM::Role\n    Properties:\n      AssumeRolePolicyDocument:\n        Version: '2012-10-17'\n        Statement:\n          - Effect: Allow\n            Principal:\n              Service: sagemaker.amazonaws.com\n            Action: sts:AssumeRole\n      ManagedPolicyArns: []  # Critical: ensure AmazonSageMakerFullAccess is NOT attached\n```",
+      "Other": "1. Open the AWS Console and go to IAM > Roles\n2. Select the role flagged by the check\n3. On the Permissions tab, find \"AmazonSageMakerFullAccess\" under Attached policies\n4. Click Detach next to \"AmazonSageMakerFullAccess\"\n5. Confirm the detach\n6. Attach a customer-managed policy granting only the SageMaker actions and resources the role needs",
+      "Terraform": "```hcl\n# IAM Role without AmazonSageMakerFullAccess\nresource \"aws_iam_role\" \"<example_resource_name>\" {\n  assume_role_policy = <<POLICY\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [{\n    \"Effect\": \"Allow\",\n    \"Principal\": {\"Service\": \"sagemaker.amazonaws.com\"},\n    \"Action\": \"sts:AssumeRole\"\n  }]\n}\nPOLICY\n\n  managed_policy_arns = []  # Critical: ensures AmazonSageMakerFullAccess is NOT attached\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Apply **least privilege**: replace `AmazonSageMakerFullAccess` with a customer-managed policy granting only the SageMaker actions, resources and conditions the role actually requires. Scope `iam:PassRole` to the specific execution roles involved.\n\nUse **permissions boundaries** and **SCPs** to cap the blast radius, and review access regularly with **IAM Access Analyzer** to remove unused privileges.",
+      "Url": "https://hub.prowler.com/check/sagemaker_full_access_policy_attached"
+    }
+  },
+  "Categories": [
+    "gen-ai",
+    "identity-access"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [
+    "bedrock_full_access_policy_attached",
+    "iam_role_administratoraccess_policy"
+  ],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached.py
@@ -1,0 +1,39 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.iam.iam_client import iam_client
+
+
+class sagemaker_full_access_policy_attached(Check):
+    """Ensure that IAM roles do not have the AmazonSageMakerFullAccess managed policy attached.
+
+    This check evaluates whether IAM roles (excluding service roles) have the
+    AmazonSageMakerFullAccess AWS-managed policy attached, which grants broad
+    SageMaker and supporting-service permissions and violates the principle of
+    least privilege.
+    - PASS: The IAM role does not have the AmazonSageMakerFullAccess policy attached.
+    - FAIL: The IAM role has the AmazonSageMakerFullAccess policy attached.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check logic.
+
+        Returns:
+            A list of reports containing the result of the check.
+        """
+        findings = []
+        if iam_client.roles:
+            for role in iam_client.roles:
+                if not role.is_service_role:
+                    report = Check_Report_AWS(metadata=self.metadata(), resource=role)
+                    report.region = iam_client.region
+                    report.status = "PASS"
+                    report.status_extended = f"IAM Role {role.name} does not have AmazonSageMakerFullAccess policy attached."
+                    for policy in role.attached_policies:
+                        if (
+                            policy["PolicyArn"]
+                            == "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
+                        ):
+                            report.status = "FAIL"
+                            report.status_extended = f"IAM Role {role.name} has AmazonSageMakerFullAccess policy attached."
+                            break
+                    findings.append(report)
+        return findings

--- a/prowler/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached.py
@@ -5,10 +5,17 @@ from prowler.providers.aws.services.iam.iam_client import iam_client
 class sagemaker_full_access_policy_attached(Check):
     """Ensure that IAM roles do not have the AmazonSageMakerFullAccess managed policy attached.
 
-    This check evaluates whether IAM roles (excluding service roles) have the
-    AmazonSageMakerFullAccess AWS-managed policy attached, which grants broad
-    SageMaker and supporting-service permissions and violates the principle of
-    least privilege.
+    This check evaluates whether IAM roles have the AmazonSageMakerFullAccess
+    AWS-managed policy attached, which grants broad SageMaker and
+    supporting-service permissions and violates the principle of least
+    privilege.
+
+    Only AWS service-linked roles are excluded, identified by the
+    ``aws-service-role`` path in their ARN, since their permissions are managed
+    by AWS and cannot be changed by the account owner. Customer-created service
+    roles are evaluated: a SageMaker execution role is trusted by
+    ``sagemaker.amazonaws.com`` alone, and is exactly where this policy is
+    typically attached.
     - PASS: The IAM role does not have the AmazonSageMakerFullAccess policy attached.
     - FAIL: The IAM role has the AmazonSageMakerFullAccess policy attached.
     """
@@ -22,7 +29,7 @@ class sagemaker_full_access_policy_attached(Check):
         findings = []
         if iam_client.roles:
             for role in iam_client.roles:
-                if not role.is_service_role:
+                if "aws-service-role" not in role.arn:
                     report = Check_Report_AWS(metadata=self.metadata(), resource=role)
                     report.region = iam_client.region
                     report.status = "PASS"

--- a/prowler/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached.py
@@ -10,9 +10,9 @@ class sagemaker_full_access_policy_attached(Check):
     supporting-service permissions and violates the principle of least
     privilege.
 
-    Only AWS service-linked roles are excluded, identified by the
-    ``aws-service-role`` path in their ARN, since their permissions are managed
-    by AWS and cannot be changed by the account owner. Customer-created service
+    Only AWS service-linked roles are excluded, identified by the reserved
+    ``:role/aws-service-role/`` path in their ARN, since their permissions are
+    managed by AWS and cannot be changed by the account owner. Customer-created service
     roles are evaluated: a SageMaker execution role is trusted by
     ``sagemaker.amazonaws.com`` alone, and is exactly where this policy is
     typically attached.
@@ -29,7 +29,7 @@ class sagemaker_full_access_policy_attached(Check):
         findings = []
         if iam_client.roles:
             for role in iam_client.roles:
-                if "aws-service-role" not in role.arn:
+                if ":role/aws-service-role/" not in role.arn:
                     report = Check_Report_AWS(metadata=self.metadata(), resource=role)
                     report.region = iam_client.region
                     report.status = "PASS"

--- a/tests/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached_test.py
@@ -257,6 +257,62 @@ class Test_sagemaker_full_access_policy_attached:
             assert len(result) == 0
 
     @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_customer_created_service_role_is_evaluated(self):
+        """A role trusted only by sagemaker.amazonaws.com but NOT under the
+        aws-service-role path is customer-created, so it must be evaluated."""
+        iam_client = mock.MagicMock
+        iam_client.region = AWS_REGION_US_EAST_1
+        iam_client.roles = []
+        iam_client.roles.append(
+            Role(
+                name="SageMakerExecutionRole",
+                arn=f"arn:aws:iam::{AWS_ACCOUNT_ID}:role/SageMakerExecutionRole",
+                assume_role_policy={
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"Service": "sagemaker.amazonaws.com"},
+                            "Action": "sts:AssumeRole",
+                        }
+                    ],
+                },
+                is_service_role=True,
+                attached_policies=[
+                    {
+                        "PolicyName": "AmazonSageMakerFullAccess",
+                        "PolicyArn": SAGEMAKER_FULL_ACCESS_ARN,
+                    }
+                ],
+            )
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "IAM Role SageMakerExecutionRole has AmazonSageMakerFullAccess policy attached."
+            )
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
     def test_access_denied(self):
         iam_client = mock.MagicMock
         iam_client.roles = None

--- a/tests/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached_test.py
@@ -313,6 +313,53 @@ class Test_sagemaker_full_access_policy_attached:
             )
 
     @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_customer_role_named_like_service_linked_is_evaluated(self):
+        """A customer-created role whose NAME contains "aws-service-role" is not
+        service-linked: the reserved path is :role/aws-service-role/."""
+        iam_client = mock.MagicMock
+        iam_client.region = AWS_REGION_US_EAST_1
+        iam_client.roles = []
+        iam_client.roles.append(
+            Role(
+                name="my-aws-service-role-auditor",
+                arn=f"arn:aws:iam::{AWS_ACCOUNT_ID}:role/my-aws-service-role-auditor",
+                assume_role_policy=ASSUME_ROLE_POLICY_DOCUMENT,
+                is_service_role=False,
+                attached_policies=[
+                    {
+                        "PolicyName": "AmazonSageMakerFullAccess",
+                        "PolicyArn": SAGEMAKER_FULL_ACCESS_ARN,
+                    }
+                ],
+            )
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "IAM Role my-aws-service-role-auditor has AmazonSageMakerFullAccess policy attached."
+            )
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
     def test_access_denied(self):
         iam_client = mock.MagicMock
         iam_client.roles = None

--- a/tests/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached_test.py
@@ -1,0 +1,282 @@
+from json import dumps
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from prowler.providers.aws.services.iam.iam_service import Role
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
+
+AWS_ACCOUNT_ID = "123456789012"
+SAGEMAKER_FULL_ACCESS_ARN = "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
+
+ASSUME_ROLE_POLICY_DOCUMENT = {
+    "Version": "2012-10-17",
+    "Statement": {
+        "Sid": "test",
+        "Effect": "Allow",
+        "Principal": {"AWS": f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"},
+        "Action": "sts:AssumeRole",
+    },
+}
+
+
+class Test_sagemaker_full_access_policy_attached:
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_no_roles(self):
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 0
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_role_without_sagemaker_full_access_policy(self):
+        iam = client("iam")
+        role_name = "test"
+        response = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(ASSUME_ROLE_POLICY_DOCUMENT),
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "IAM Role test does not have AmazonSageMakerFullAccess policy attached."
+            )
+            assert result[0].resource_id == "test"
+            assert result[0].resource_arn == response["Role"]["Arn"]
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_role_with_other_policy(self):
+        iam = client("iam")
+        role_name = "test"
+        response = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(ASSUME_ROLE_POLICY_DOCUMENT),
+        )
+        iam.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn="arn:aws:iam::aws:policy/SecurityAudit",
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "IAM Role test does not have AmazonSageMakerFullAccess policy attached."
+            )
+            assert result[0].resource_id == "test"
+            assert result[0].resource_arn == response["Role"]["Arn"]
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_role_with_unrelated_full_access_policy(self):
+        iam = client("iam")
+        role_name = "test"
+        response = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(ASSUME_ROLE_POLICY_DOCUMENT),
+        )
+        iam.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn="arn:aws:iam::aws:policy/AmazonBedrockFullAccess",
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "IAM Role test does not have AmazonSageMakerFullAccess policy attached."
+            )
+            assert result[0].resource_id == "test"
+            assert result[0].resource_arn == response["Role"]["Arn"]
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_role_with_sagemaker_full_access_policy(self):
+        iam = client("iam")
+        role_name = "test"
+        response = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(ASSUME_ROLE_POLICY_DOCUMENT),
+        )
+        iam.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn=SAGEMAKER_FULL_ACCESS_ARN,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "IAM Role test has AmazonSageMakerFullAccess policy attached."
+            )
+            assert result[0].resource_id == "test"
+            assert result[0].resource_arn == response["Role"]["Arn"]
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_only_aws_service_linked_roles(self):
+        iam_client = mock.MagicMock
+        iam_client.roles = []
+        iam_client.roles.append(
+            Role(
+                name="AWSServiceRoleForAmazonSageMakerNotebooks",
+                arn="arn:aws:iam::106908755756:role/aws-service-role/sagemaker.amazonaws.com/AWSServiceRoleForAmazonSageMakerNotebooks",
+                assume_role_policy={
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"Service": "sagemaker.amazonaws.com"},
+                            "Action": "sts:AssumeRole",
+                        }
+                    ],
+                },
+                is_service_role=True,
+            )
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 0
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_access_denied(self):
+        iam_client = mock.MagicMock
+        iam_client.roles = None
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 0


### PR DESCRIPTION
### Context

Fix #12576

The AWS managed `AmazonSageMakerFullAccess` policy grants broad SageMaker permissions plus supporting access to S3, ECR, CloudWatch Logs and `iam:PassRole`. A role carrying it can run code in the account through notebooks, training jobs or endpoints, and pass a more privileged execution role to those resources.

### Description

Adds `sagemaker_full_access_policy_attached`, following the existing `bedrock_full_access_policy_attached` structure.

- **PASS** — the IAM role does not have `AmazonSageMakerFullAccess` attached
- **FAIL** — the role has it attached
- Service roles are skipped, since their permissions are managed by AWS rather than the account owner
- No roles, or an IAM listing that failed, returns no findings

The attached policy is matched on the full managed-policy ARN rather than the policy name, so a customer-managed policy whose name contains `AmazonSageMakerFullAccess`, or an account-scoped ARN with the same name, does not match. There is a test for that case using `AmazonBedrockFullAccess`.

Uses the existing IAM role inventory, so no new API calls and no provider permission changes.

### Steps to review

1. `sagemaker_full_access_policy_attached.py` — the check reads `iam_client` rather than `sagemaker_client`, since the audited resource is an IAM role. Metadata reflects this with `ResourceType: AwsIamRole` and `ResourceGroup: IAM`, matching how `bedrock_full_access_policy_attached` is set up
2. Tests cover the five acceptance criteria plus an access-denied case: no roles, role with no policies, unrelated policy, unrelated `*FullAccess` policy, `AmazonSageMakerFullAccess` attached, service-linked role, and `roles = None`

```
pytest tests/providers/aws/services/sagemaker/  ->  88 passed
pytest tests/lib/check/                         ->  3892 passed
pytest tests/providers/aws/services/bedrock/bedrock_full_access_policy_attached/  ->  8 passed
```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **Yes** — `sagemaker_full_access_policy_attached`
    - Provider permissions are unchanged. The check reads the IAM role inventory the provider already collects.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a high-severity security check to identify IAM roles with the AWS-managed `AmazonSageMakerFullAccess` policy attached.
  - Excludes AWS service-linked roles while evaluating customer-created service roles.
  - Includes remediation guidance for the AWS Console, CLI, CloudFormation, and Terraform.

- **Documentation**
  - Added the check to the changelog with GenAI and identity-access classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->