### PR TITLE
feat(sagemaker): add sagemaker_full_access_policy_attached check

### DIFF
--- a/prowler/changelog.d/sagemaker-full-access-policy-attached.added.md
+++ b/prowler/changelog.d/sagemaker-full-access-policy-attached.added.md
@@ -1,0 +1,1 @@
+`sagemaker_full_access_policy_attached` check for AWS provider, flagging IAM roles (excluding service roles) that have the AWS-managed `AmazonSageMakerFullAccess` policy attached

--- a/prowler/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached.metadata.json
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached.metadata.json
@@ -1,0 +1,44 @@
+{
+  "Provider": "aws",
+  "CheckID": "sagemaker_full_access_policy_attached",
+  "CheckTitle": "IAM role does not have AmazonSageMakerFullAccess managed policy attached",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices"
+  ],
+  "ServiceName": "sagemaker",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "AwsIamRole",
+  "ResourceGroup": "IAM",
+  "Description": "**IAM roles** (excluding service roles) are evaluated for attachment of the AWS-managed `AmazonSageMakerFullAccess` policy.\n\nThis policy grants unrestricted access to all Amazon SageMaker actions and many supporting services.",
+  "Risk": "The `AmazonSageMakerFullAccess` policy grants broad permissions across SageMaker and supporting services like S3 and ECR. If a compromised role has this policy, an attacker could create or delete notebooks, training jobs, and endpoints, access training data and model artifacts, and incur significant costs through unrestricted instance provisioning.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/security_iam_id-based-policy-examples.html#security_iam_service-with-iam-policy-best-practices",
+    "https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws iam detach-role-policy --role-name <ROLE_NAME> --policy-arn arn:aws:iam::aws:policy/AmazonSageMakerFullAccess",
+      "NativeIaC": "```yaml\n# CloudFormation: IAM Role without AmazonSageMakerFullAccess\nResources:\n  <example_resource_name>:\n    Type: AWS::IAM::Role\n    Properties:\n      AssumeRolePolicyDocument:\n        Version: '2012-10-17'\n        Statement:\n          - Effect: Allow\n            Principal:\n              Service: sagemaker.amazonaws.com\n            Action: sts:AssumeRole\n      ManagedPolicyArns: []  # Critical: ensure AmazonSageMakerFullAccess is NOT attached\n```",
+      "Other": "1. Open the AWS Console and go to IAM > Roles\n2. Select the role flagged by the check\n3. On the Permissions tab, find \"AmazonSageMakerFullAccess\" under Attached policies\n4. Click Detach next to \"AmazonSageMakerFullAccess\"\n5. Confirm the detach\n6. Attach a scoped policy granting only required SageMaker actions",
+      "Terraform": "```hcl\n# IAM Role without AmazonSageMakerFullAccess\nresource \"aws_iam_role\" \"<example_resource_name>\" {\n  assume_role_policy = <<POLICY\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [{\n    \"Effect\": \"Allow\",\n    \"Principal\": {\"Service\": \"sagemaker.amazonaws.com\"},\n    \"Action\": \"sts:AssumeRole\"\n  }]\n}\nPOLICY\n\n  managed_policy_arns = []  # Critical: ensures AmazonSageMakerFullAccess is NOT attached\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Apply **least privilege**: replace `AmazonSageMakerFullAccess` with a custom policy granting only the specific SageMaker actions required.\n\nUse **permissions boundaries** and **SCPs** to limit the scope of SageMaker permissions. Regularly review access with **IAM Access Analyzer** to identify and remove unused privileges.",
+      "Url": "https://hub.prowler.com/check/sagemaker_full_access_policy_attached"
+    }
+  },
+  "Categories": [
+    "gen-ai",
+    "identity-access"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [
+    "iam_role_administratoraccess_policy",
+    "bedrock_full_access_policy_attached"
+  ],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached.py
@@ -1,0 +1,38 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.iam.iam_client import iam_client
+
+
+class sagemaker_full_access_policy_attached(Check):
+    """Ensure that IAM roles do not have the AmazonSageMakerFullAccess managed policy attached.
+
+    This check evaluates whether IAM roles (excluding service roles) have the
+    AmazonSageMakerFullAccess AWS-managed policy attached, which grants excessive
+    permissions and violates the principle of least privilege.
+    - PASS: The IAM role does not have the AmazonSageMakerFullAccess policy attached.
+    - FAIL: The IAM role has the AmazonSageMakerFullAccess policy attached.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check logic.
+
+        Returns:
+            A list of reports containing the result of the check.
+        """
+        findings = []
+        if iam_client.roles:
+            for role in iam_client.roles:
+                if not role.is_service_role:
+                    report = Check_Report_AWS(metadata=self.metadata(), resource=role)
+                    report.region = iam_client.region
+                    report.status = "PASS"
+                    report.status_extended = f"IAM Role {role.name} does not have AmazonSageMakerFullAccess policy attached."
+                    for policy in role.attached_policies:
+                        if (
+                            policy["PolicyArn"]
+                            == "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
+                        ):
+                            report.status = "FAIL"
+                            report.status_extended = f"IAM Role {role.name} has AmazonSageMakerFullAccess policy attached."
+                            break
+                    findings.append(report)
+        return findings

--- a/tests/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/sagemaker_full_access_policy_attached_test.py
@@ -1,0 +1,357 @@
+from json import dumps
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from prowler.providers.aws.services.iam.iam_service import Role
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
+
+AWS_ACCOUNT_ID = "123456789012"
+
+ASSUME_ROLE_POLICY_DOCUMENT = {
+    "Version": "2012-10-17",
+    "Statement": {
+        "Sid": "test",
+        "Effect": "Allow",
+        "Principal": {"AWS": f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"},
+        "Action": "sts:AssumeRole",
+    },
+}
+
+
+class Test_sagemaker_full_access_policy_attached:
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_no_roles(self):
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 0
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_role_without_sagemaker_full_access_policy(self):
+        iam = client("iam")
+        role_name = "test"
+        response = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(ASSUME_ROLE_POLICY_DOCUMENT),
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "IAM Role test does not have AmazonSageMakerFullAccess policy attached."
+            )
+            assert result[0].resource_id == "test"
+            assert result[0].resource_arn == response["Role"]["Arn"]
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_role_with_other_policy(self):
+        iam = client("iam")
+        role_name = "test"
+        response = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(ASSUME_ROLE_POLICY_DOCUMENT),
+        )
+        iam.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn="arn:aws:iam::aws:policy/SecurityAudit",
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "IAM Role test does not have AmazonSageMakerFullAccess policy attached."
+            )
+            assert result[0].resource_id == "test"
+            assert result[0].resource_arn == response["Role"]["Arn"]
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_role_with_sagemaker_full_access_policy(self):
+        iam = client("iam")
+        role_name = "test"
+        response = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(ASSUME_ROLE_POLICY_DOCUMENT),
+        )
+        iam.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn="arn:aws:iam::aws:policy/AmazonSageMakerFullAccess",
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "IAM Role test has AmazonSageMakerFullAccess policy attached."
+            )
+            assert result[0].resource_id == "test"
+            assert result[0].resource_arn == response["Role"]["Arn"]
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_asterisk_principal_role_with_sagemaker_full_access_policy(self):
+        iam = client("iam")
+        role_name = "test"
+        assume_role_policy_document = {
+            "Version": "2012-10-17",
+            "Statement": {
+                "Sid": "test",
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": "sts:AssumeRole",
+            },
+        }
+        response = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(assume_role_policy_document),
+        )
+        iam.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn="arn:aws:iam::aws:policy/AmazonSageMakerFullAccess",
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "IAM Role test has AmazonSageMakerFullAccess policy attached."
+            )
+            assert result[0].resource_id == "test"
+            assert result[0].resource_arn == response["Role"]["Arn"]
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_multiple_roles_mixed_policies(self):
+        iam = client("iam")
+
+        # Create a compliant role (no AmazonSageMakerFullAccess)
+        compliant_response = iam.create_role(
+            RoleName="compliant-role",
+            AssumeRolePolicyDocument=dumps(ASSUME_ROLE_POLICY_DOCUMENT),
+        )
+        iam.attach_role_policy(
+            RoleName="compliant-role",
+            PolicyArn="arn:aws:iam::aws:policy/SecurityAudit",
+        )
+
+        # Create a non-compliant role (with AmazonSageMakerFullAccess)
+        non_compliant_response = iam.create_role(
+            RoleName="non-compliant-role",
+            AssumeRolePolicyDocument=dumps(ASSUME_ROLE_POLICY_DOCUMENT),
+        )
+        iam.attach_role_policy(
+            RoleName="non-compliant-role",
+            PolicyArn="arn:aws:iam::aws:policy/AmazonSageMakerFullAccess",
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 2
+
+            # Sort results by resource_id for deterministic assertions
+            result = sorted(result, key=lambda r: r.resource_id)
+
+            # Compliant role
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "IAM Role compliant-role does not have AmazonSageMakerFullAccess policy attached."
+            )
+            assert result[0].resource_id == "compliant-role"
+            assert result[0].resource_arn == compliant_response["Role"]["Arn"]
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+            # Non-compliant role
+            assert result[1].status == "FAIL"
+            assert (
+                result[1].status_extended
+                == "IAM Role non-compliant-role has AmazonSageMakerFullAccess policy attached."
+            )
+            assert result[1].resource_id == "non-compliant-role"
+            assert result[1].resource_arn == non_compliant_response["Role"]["Arn"]
+            assert result[1].region == AWS_REGION_US_EAST_1
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_only_aws_service_linked_roles(self):
+        iam_client = mock.MagicMock
+        iam_client.roles = []
+        iam_client.roles.append(
+            Role(
+                name="AWSServiceRoleForAmazonGuardDuty",
+                arn="arn:aws:iam::106908755756:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty",
+                assume_role_policy={
+                    "Version": "2008-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"Service": "ec2.amazonaws.com"},
+                            "Action": "sts:AssumeRole",
+                        }
+                    ],
+                },
+                is_service_role=True,
+            )
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 0
+
+    @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
+    def test_access_denied(self):
+        iam_client = mock.MagicMock
+        iam_client.roles = None
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached.iam_client",
+                new=iam_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_full_access_policy_attached.sagemaker_full_access_policy_attached import (
+                sagemaker_full_access_policy_attached,
+            )
+
+            check = sagemaker_full_access_policy_attached()
+            result = check.execute()
+            assert len(result) == 0


### PR DESCRIPTION
### Context

Fix #12576

### Description

Adds a new AWS check, `sagemaker_full_access_policy_attached`, that flags IAM roles (excluding service-linked roles) with the AWS-managed `AmazonSageMakerFullAccess` policy attached. This policy grants broad SageMaker and supporting-service permissions, so AWS recommends replacing it with a scoped customer-managed policy.

Implementation follows the existing `bedrock_full_access_policy_attached` check structure, as suggested in the issue.

### Steps to review

- `uv run pytest tests/providers/aws/services/sagemaker/sagemaker_full_access_policy_attached/ -v` — 8 tests covering: no roles, role without the policy, role with an unrelated policy, role with the policy attached, wildcard-principal role with the policy, multiple roles with mixed policies, service-linked roles excluded, and IAM access-denied (no false PASS).
- `uv run python prowler-cli.py aws --list-checks | grep sagemaker_full_access_policy_attached` confirms the check is auto-discovered.
- `flake8`, `black --check`, and `pylint` all pass on the new files.

### Checklist

- [x] This feature/issue is listed in the open issues
- [x] Requested assignment on the issue before opening this PR
- [x] Reviewed open PRs to confirm no duplicate implementation exists
- [x] Code is covered by tests
- [x] Changelog fragment added under `prowler/changelog.d/`

#### SDK/CLI
- Are there new checks included in this PR? Yes
    - No new IAM permissions are required — the check reuses the existing IAM role/attached-policy inventory already collected for `bedrock_full_access_policy_attached` and other checks.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an AWS security check that identifies non-service IAM roles with the `AmazonSageMakerFullAccess` policy attached.
  - Reports the affected roles as high-severity findings and provides remediation guidance across supported AWS management methods.

- **Tests**
  - Added comprehensive coverage for roles with and without the policy, service-linked roles, mixed configurations, and access-denied scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->