### PR TITLE
[CHAIN] feat(ui): wire async Registry artifact installation

### DIFF
--- a/ui/components/registry/registry-explorer.integration.test.tsx
+++ b/ui/components/registry/registry-explorer.integration.test.tsx
@@ -8,16 +8,16 @@ import type { RegistryBootstrapState } from "@/types/registry";
 import { RegistryExplorer } from "./registry-explorer";
 
 const {
-  addRegistryArtifactMock,
   disconnectRegistryCredentialMock,
+  executeRegistryArtifactAdditionMock,
   refreshRegistryCollectionsMock,
   refreshRegistryCredentialMock,
   removeRegistryArtifactMock,
   submitRegistryCredentialMock,
   trackAndPollTaskMock,
 } = vi.hoisted(() => ({
-  addRegistryArtifactMock: vi.fn(),
   disconnectRegistryCredentialMock: vi.fn(),
+  executeRegistryArtifactAdditionMock: vi.fn(),
   refreshRegistryCollectionsMock: vi.fn(),
   refreshRegistryCredentialMock: vi.fn(),
   removeRegistryArtifactMock: vi.fn(),
@@ -26,7 +26,6 @@ const {
 }));
 
 vi.mock("@/actions/registry/registry", () => ({
-  addRegistryArtifact: addRegistryArtifactMock,
   disconnectRegistryCredential: disconnectRegistryCredentialMock,
   refreshRegistryCollections: refreshRegistryCollectionsMock,
   refreshRegistryCredential: refreshRegistryCredentialMock,
@@ -37,6 +36,10 @@ vi.mock("@/actions/registry/registry", () => ({
 // The credential flow watches its validation task through the house task
 // watcher; integration tests drive settlement through this mock the same way
 // `lib/jira-dispatch-execution.test.ts` does.
+vi.mock("@/lib/registry-artifact-execution", () => ({
+  executeRegistryArtifactAddition: executeRegistryArtifactAdditionMock,
+}));
+
 vi.mock("@/store/task-watcher/store", () => ({
   TASK_WATCHER_STATUS: { PENDING: "pending", READY: "ready", ERROR: "error" },
   trackAndPollTask: trackAndPollTaskMock,
@@ -170,8 +173,8 @@ function cardFor(name: string) {
 
 describe("RegistryExplorer", () => {
   beforeEach(() => {
-    addRegistryArtifactMock.mockReset();
     disconnectRegistryCredentialMock.mockReset();
+    executeRegistryArtifactAdditionMock.mockReset();
     refreshRegistryCollectionsMock.mockReset();
     refreshRegistryCredentialMock.mockReset();
     removeRegistryArtifactMock.mockReset();
@@ -708,7 +711,9 @@ describe("RegistryExplorer", () => {
   describe("when a Registry action loses authorization", () => {
     it("routes to Profile once when Add is denied", async () => {
       // Given
-      addRegistryArtifactMock.mockResolvedValue({ status: "access_denied" });
+      executeRegistryArtifactAdditionMock.mockResolvedValue({
+        status: "access_denied",
+      });
       const screen = await render(
         <RegistryExplorer initialState={readyState} />,
       );
@@ -1357,7 +1362,7 @@ describe("RegistryExplorer", () => {
 
   it("keeps ordinary Add errors local without redirecting to Profile", async () => {
     // Given
-    addRegistryArtifactMock.mockResolvedValue({ status: "error" });
+    executeRegistryArtifactAdditionMock.mockResolvedValue({ status: "error" });
     const screen = await render(<RegistryExplorer initialState={readyState} />);
 
     // When
@@ -1375,7 +1380,7 @@ describe("RegistryExplorer", () => {
 
   it("adds the latest version directly from the card once confirmed", async () => {
     // Given
-    addRegistryArtifactMock.mockResolvedValue({
+    executeRegistryArtifactAdditionMock.mockResolvedValue({
       status: "confirmed",
       tenantArtifacts: [
         { normalizedName: "aws-guard", versionSpec: "latest" },
@@ -1391,7 +1396,7 @@ describe("RegistryExplorer", () => {
 
     // Then
     await expect
-      .poll(() => addRegistryArtifactMock.mock.calls)
+      .poll(() => executeRegistryArtifactAdditionMock.mock.calls)
       .toEqual([[{ normalizedName: "cloud-guard" }]]);
     await expect
       .poll(() => document.body.textContent)
@@ -1407,7 +1412,9 @@ describe("RegistryExplorer", () => {
 
   it("keeps membership unchanged when an accepted Add cannot be confirmed", async () => {
     // Given
-    addRegistryArtifactMock.mockResolvedValue({ status: "refresh_failed" });
+    executeRegistryArtifactAdditionMock.mockResolvedValue({
+      status: "refresh_failed",
+    });
     const screen = await render(<RegistryExplorer initialState={readyState} />);
 
     // When
@@ -1427,7 +1434,7 @@ describe("RegistryExplorer", () => {
 
   it("keeps documented Add refusals local without redirecting to Profile", async () => {
     // Given
-    addRegistryArtifactMock.mockResolvedValue({
+    executeRegistryArtifactAdditionMock.mockResolvedValue({
       status: "refused",
       message: "This version is not verified and cannot be added.",
     });
@@ -1448,7 +1455,7 @@ describe("RegistryExplorer", () => {
 
   it("disables only the pending card while an Add confirmation is pending", async () => {
     // Given
-    addRegistryArtifactMock.mockReturnValue(new Promise(() => {}));
+    executeRegistryArtifactAdditionMock.mockReturnValue(new Promise(() => {}));
     const screen = await render(<RegistryExplorer initialState={readyState} />);
     const addCloudGuard = screen.getByRole("button", {
       name: "Add Cloud guard",
@@ -1463,7 +1470,7 @@ describe("RegistryExplorer", () => {
     await expect
       .element(screen.getByRole("button", { name: "Add Later guard" }))
       .toBeEnabled();
-    expect(addRegistryArtifactMock).toHaveBeenCalledTimes(1);
+    expect(executeRegistryArtifactAdditionMock).toHaveBeenCalledTimes(1);
   });
 
   it("requires confirmation before Remove and commits only after confirmation", async () => {

--- a/ui/components/registry/registry-explorer.tsx
+++ b/ui/components/registry/registry-explorer.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 import {
-  addRegistryArtifact,
   disconnectRegistryCredential,
   refreshRegistryCollections,
   removeRegistryArtifact,
@@ -19,6 +18,7 @@ import {
   TabsTrigger,
 } from "@/components/shadcn/tabs/tabs";
 import { toast } from "@/components/shadcn/toast/use-toast";
+import { executeRegistryArtifactAddition } from "@/lib/registry-artifact-execution";
 import { executeRegistryCredentialValidation } from "@/lib/registry-credential-execution";
 import {
   REGISTRY_BOOTSTRAP_STATE,
@@ -128,7 +128,7 @@ export function RegistryExplorer({ initialState }: RegistryExplorerProps) {
     const generation = operationGeneration.current;
     setOperationMessage(undefined);
     setPendingAddName(normalizedName);
-    const result = await addRegistryArtifact({ normalizedName });
+    const result = await executeRegistryArtifactAddition({ normalizedName });
     if (generation !== operationGeneration.current) return;
     if (result.status === REGISTRY_FAILURE.ACCESS_DENIED)
       return router.replace("/profile");

--- a/ui/tests/registry/controlled-registry-api.mts
+++ b/ui/tests/registry/controlled-registry-api.mts
@@ -6,6 +6,7 @@ import {
 
 const port = 4300;
 const taskId = "fixture-registry-validation-task";
+const artifactTaskId = "fixture-registry-artifact-task";
 const fixtureAccessToken = [
   base64UrlJson({ alg: "none", typ: "JWT" }),
   base64UrlJson({
@@ -20,6 +21,12 @@ type CredentialState = "active" | "onboarding" | "pending";
 type DiscoveryMode = "error" | "ready" | "reconnect" | "unavailable";
 
 interface FixtureState {
+  artifactEvents: string[];
+  artifactReadCount: number;
+  artifactSubmissionCount: number;
+  artifactTaskNormalizedName?: string;
+  artifactTaskReadCount: number;
+  artifactTaskVersionSpec?: string;
   credentialAccepted: boolean;
   credentialReadCount: number;
   credentialState: CredentialState;
@@ -30,6 +37,10 @@ interface FixtureState {
 }
 
 const initialState = (): FixtureState => ({
+  artifactEvents: [],
+  artifactReadCount: 0,
+  artifactSubmissionCount: 0,
+  artifactTaskReadCount: 0,
   credentialAccepted: false,
   credentialReadCount: 0,
   credentialState: "onboarding",
@@ -153,6 +164,10 @@ async function handleFixtureControl(
 
   if (pathname === "/__fixture__/registry/snapshot") {
     sendJson(response, 200, {
+      artifactEvents: state.artifactEvents,
+      artifactReadCount: state.artifactReadCount,
+      artifactSubmissionCount: state.artifactSubmissionCount,
+      artifactTaskReadCount: state.artifactTaskReadCount,
       credentialAccepted: state.credentialAccepted,
       credentialReadCount: state.credentialReadCount,
       taskReadCount: state.taskReadCount,
@@ -243,6 +258,8 @@ async function handleApiRequest(
   }
 
   if (method === "GET" && pathname === "/api/v1/registry/artifacts") {
+    state.artifactReadCount += 1;
+    state.artifactEvents.push("authoritative-read");
     sendJson(response, 200, tenantArtifactsDocument());
     return;
   }
@@ -269,9 +286,43 @@ async function handleApiRequest(
       });
       return;
     }
-    state.tenantArtifacts.set(normalizedName, versionSpec);
-    sendJson(response, 201, {
-      data: { id: normalizedName, type: "registry-artifacts" },
+    state.artifactEvents.push("submission");
+    state.artifactSubmissionCount += 1;
+    state.artifactTaskNormalizedName = normalizedName;
+    state.artifactTaskReadCount = 0;
+    state.artifactTaskVersionSpec = versionSpec;
+    sendJson(
+      response,
+      202,
+      { data: { id: artifactTaskId, type: "tasks" } },
+      { "Content-Location": `/api/v1/tasks/${artifactTaskId}` },
+    );
+    return;
+  }
+
+  if (method === "GET" && pathname === `/api/v1/tasks/${artifactTaskId}`) {
+    if (!state.artifactTaskNormalizedName || !state.artifactTaskVersionSpec) {
+      sendJson(response, 404, { errors: [{ code: "fixture_task_not_found" }] });
+      return;
+    }
+
+    state.artifactEvents.push("task-poll");
+    state.artifactTaskReadCount += 1;
+    const complete = state.artifactTaskReadCount >= 2;
+    if (complete) {
+      state.tenantArtifacts.set(
+        state.artifactTaskNormalizedName,
+        state.artifactTaskVersionSpec,
+      );
+    }
+    sendJson(response, 200, {
+      data: {
+        attributes: complete
+          ? { state: "completed", result: { installed: true, error: null } }
+          : { state: "executing" },
+        id: artifactTaskId,
+        type: "tasks",
+      },
     });
     return;
   }

--- a/ui/tests/registry/controlled-registry-fixture.ts
+++ b/ui/tests/registry/controlled-registry-fixture.ts
@@ -24,6 +24,10 @@ export const controlledRegistryFixture = {
 };
 
 interface FixtureSnapshot {
+  artifactEvents: string[];
+  artifactReadCount: number;
+  artifactSubmissionCount: number;
+  artifactTaskReadCount: number;
   credentialAccepted: boolean;
   credentialReadCount: number;
   taskReadCount: number;

--- a/ui/tests/registry/registry.md
+++ b/ui/tests/registry/registry.md
@@ -46,7 +46,7 @@
 **Priority:** `critical`
 **Tags:** @e2e, @registry
 
-**Expected Result:** Multi-page fixture catalog search/filter/Multi-provider behavior, card owner rows (logo and initial fallback), documented reconnect/unavailable/generic recovery states, direct card Add of the latest version, and confirmed Remove all use real UI and server-action paths.
+**Expected Result:** Multi-page fixture catalog search/filter/Multi-provider behavior, card owner rows (logo and initial fallback), documented reconnect/unavailable/generic recovery states, direct card Add submits a `202` task, polls it to completion, and confirms membership through an authoritative artifact read before rendering success; confirmed Remove uses the real UI and server-action paths.
 
 ## Test Case: `REGISTRY-E2E-006` - Pixel 5 Reduced-Motion Browsing
 

--- a/ui/tests/registry/registry.spec.ts
+++ b/ui/tests/registry/registry.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "@playwright/test";
 
-import { RegistryPage } from "./registry-page";
 import {
   controlledRegistryFixture,
   FIXTURE_REGISTRY_KEY,
 } from "./controlled-registry-fixture";
+import { RegistryPage } from "./registry-page";
 
 const fixtureMode = process.env.E2E_REGISTRY_ACCEPTANCE_MODE === "fixture";
 const enabledProject = "registry";
@@ -128,7 +128,21 @@ test.describe.serial("Registry", () => {
       await registryPage.dismissWelcomeDialog();
       await registryPage.verifyCompleteCatalogSearchAndFilters();
       await registryPage.verifyOwnerRows();
+      const artifactSnapshotBefore = await controlledRegistryFixture.snapshot();
       await registryPage.addLatest("Fixture network audit");
+      const artifactSnapshotAfter = await controlledRegistryFixture.snapshot();
+      expect(artifactSnapshotAfter.artifactSubmissionCount).toBe(
+        artifactSnapshotBefore.artifactSubmissionCount + 1,
+      );
+      expect(artifactSnapshotAfter.artifactTaskReadCount).toBe(2);
+      expect(artifactSnapshotAfter.artifactReadCount).toBeGreaterThan(
+        artifactSnapshotBefore.artifactReadCount,
+      );
+      expect(
+        artifactSnapshotAfter.artifactEvents.slice(
+          artifactSnapshotBefore.artifactEvents.length,
+        ),
+      ).toEqual(["submission", "task-poll", "task-poll", "authoritative-read"]);
       await registryPage.verifyAddedInMyArtifacts("Fixture network audit");
       await registryPage.removeArtifact("Fixture network audit");
       await page.reload();


### PR DESCRIPTION
### Context

This is PR 11 in the Dynamic Provider Registry UI chain and is stacked on #12579.

PR #12579 introduced the internal asynchronous artifact submission, polling, strict result validation, and authoritative confirmation boundary for the task contract from `prowler-cloud/prowler-cloud#5631`. This child connects that boundary to the production Registry explorer and proves the complete network lifecycle through controlled E2E evidence.

Prowler App task: PROWLER-2414.

### Description

- Route the Registry explorer Add flow through `executeRegistryArtifactAddition`.
- Preserve the existing direct, synchronous Remove flow.
- Keep pending, success, denied, error, refused, and refresh-failed explorer behavior covered through integration tests.
- Update the controlled Registry API to model `202` task submission, two task polls, completion-only membership mutation, and an authoritative artifact read.
- Extend fixture snapshots and `REGISTRY-E2E-005` with exact async lifecycle assertions.
- Align the Registry E2E documentation with the task-backed Add flow.

No provider wizard, credential schema, connection test, scan flow, dependency, or visual redesign changes are included.

### Steps to review

1. Review `RegistryExplorer.handleAdd` and confirm it delegates to `executeRegistryArtifactAddition({ normalizedName })` without duplicating task logic.
2. Confirm `handleRemove` remains synchronous and behaviorally unchanged.
3. Review the controlled API lifecycle in `ui/tests/registry/controlled-registry-api.mts`:
   - artifact POST returns `202` with `Content-Location`;
   - the task progresses from executing to completed;
   - membership changes only on completion;
   - the explorer performs an authoritative membership read.
4. Review `REGISTRY-E2E-005` for the exact event order: submission → poll → poll → authoritative read.
5. Run:

```bash
cd ui
pnpm exec vitest run components/registry/registry-explorer.integration.test.tsx
pnpm run test:unit
pnpm run typecheck
pnpm run lint:check
pnpm run format:check
pnpm run build
pnpm run test:e2e:registry
```

Validation evidence:

- Explorer integration: 56/56 passed.
- Full unit suite: 440 files, 3,153 tests passed.
- Typecheck, ESLint, Prettier, LSP, and diff checks passed.
- Next.js production build passed with 45 static pages.
- Registry Playwright: 8 passed, 17 skipped; `REGISTRY-E2E-005` passed.
- Exact change budget: 114 lines across six files.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This work is tracked internally as PROWLER-2414.
- [ ] Confirm assignment for the internal task.
- [x] I reviewed open pull requests and found no duplicate implementation for this chain child.

</details>

- [x] The code is covered by integration, full unit, and controlled E2E tests.
- [x] E2E documentation was updated with the asynchronous lifecycle.
- [x] No backport is needed.
- [x] No README change is needed.
- [x] The existing parent-chain `registry-artifact-transactions.added.md` fragment already describes the broader Add/Remove feature; no duplicate fragment is added here.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] The async artifact installation requirements work through the Registry explorer.
- [x] No npm dependencies were added or updated.
- [x] Screenshots are not applicable because this child changes behavior behind the existing explorer UI without a visual redesign.
- [x] The existing parent-chain changelog fragment covers this flow.

#### API
- [x] Not applicable; this PR consumes the existing API task contract.

#### MCP Server
- [x] Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
