### PR TITLE
feat(ui): add dynamic provider schema boundary

### DIFF
--- a/ui/actions/providers/index.ts
+++ b/ui/actions/providers/index.ts
@@ -1,1 +1,2 @@
+export * from "./provider-schemas";
 export * from "./providers";

--- a/ui/actions/providers/provider-schemas.adapter.test.ts
+++ b/ui/actions/providers/provider-schemas.adapter.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  adaptProviderSchemas,
+  normalizeProviderType,
+} from "./provider-schemas.adapter";
+
+describe("provider schemas adapter", () => {
+  it("adapts a matching provider schema resource without interpreting schema keywords", () => {
+    // Given
+    const payload = {
+      data: {
+        type: "provider-schemas",
+        id: "acme",
+        attributes: {
+          secret_types: {
+            credentials: {
+              type: "object",
+              properties: { access_key: { type: "string" } },
+            },
+          },
+        },
+      },
+    };
+
+    // When
+    const result = adaptProviderSchemas(payload, "acme");
+
+    // Then
+    expect(result).toEqual({
+      status: "success",
+      providerType: "acme",
+      secretTypes: payload.data.attributes.secret_types,
+    });
+  });
+
+  it.each([
+    ["null", null],
+    ["string scalar", "secret"],
+    ["number scalar", 1],
+    ["boolean scalar", true],
+  ])("rejects %s secret_types values", (_description, secretType) => {
+    // Given
+    const payload = {
+      data: {
+        type: "provider-schemas",
+        id: "acme",
+        attributes: { secret_types: { credentials: secretType } },
+      },
+    };
+
+    // When
+    const result = adaptProviderSchemas(payload, "acme");
+
+    // Then
+    expect(result).toBeNull();
+  });
+
+  it("rejects malformed or contradictory documents without reading schema keywords", () => {
+    // Given
+    const document = {
+      data: {
+        type: "provider-schemas",
+        id: "aws",
+        attributes: { secret_types: {} },
+      },
+    };
+
+    // When
+    const results = [
+      { ...document, errors: [] },
+      { data: { ...document.data, id: "aws " } },
+      { data: { ...document.data, type: "providers" } },
+      { data: { ...document.data, attributes: { secret_types: { key: [] } } } },
+    ].map((payload) => adaptProviderSchemas(payload, "aws"));
+
+    // Then
+    expect(results).toEqual([null, null, null, null]);
+    expect(normalizeProviderType(" AWS ")).toBe("aws");
+    expect(normalizeProviderType(" ")).toBeNull();
+    expect(normalizeProviderType("a".repeat(51))).toBeNull();
+  });
+});

--- a/ui/actions/providers/provider-schemas.adapter.ts
+++ b/ui/actions/providers/provider-schemas.adapter.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+import {
+  PROVIDER_SCHEMA_STATUS,
+  type ProviderSchemasSuccessResult,
+} from "@/types/provider-schema";
+
+const providerTypeSchema = z.string().trim().toLowerCase().min(1).max(50);
+const providerSchemasDocumentSchema = z.strictObject({
+  data: z.strictObject({
+    type: z.literal("provider-schemas"),
+    id: z.string().min(1).max(50),
+    attributes: z.strictObject({
+      secret_types: z.record(z.string(), z.record(z.string(), z.unknown())),
+    }),
+  }),
+});
+
+export function normalizeProviderType(value: unknown): string | null {
+  const parsed = providerTypeSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function adaptProviderSchemas(
+  payload: unknown,
+  normalizedProviderType: string,
+): ProviderSchemasSuccessResult | null {
+  const parsed = providerSchemasDocumentSchema.safeParse(payload);
+  if (!parsed.success || parsed.data.data.id !== normalizedProviderType) {
+    return null;
+  }
+
+  return {
+    status: PROVIDER_SCHEMA_STATUS.SUCCESS,
+    providerType: parsed.data.data.id,
+    secretTypes: parsed.data.data.attributes.secret_types,
+  };
+}

--- a/ui/actions/providers/provider-schemas.test.ts
+++ b/ui/actions/providers/provider-schemas.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authMock, fetchMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  fetchMock: vi.fn(),
+}));
+
+vi.mock("@/auth.config", () => ({ auth: authMock }));
+vi.mock("@/lib", () => ({ apiBaseUrl: "https://api.test/api/v1" }));
+
+import { getProviderSchemas } from "./provider-schemas";
+
+const schemaResponse = (providerType = "acme") =>
+  new Response(
+    JSON.stringify({
+      data: {
+        type: "provider-schemas",
+        id: providerType,
+        attributes: { secret_types: {} },
+      },
+    }),
+    { status: 200 },
+  );
+
+describe("getProviderSchemas", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    authMock.mockResolvedValue({ accessToken: "access-token" });
+    fetchMock.mockResolvedValue(schemaResponse());
+  });
+
+  it("requests the normalized provider schema with authenticated JSON:API headers", async () => {
+    // When
+    const result = await getProviderSchemas(" ACME ");
+
+    // Then
+    expect(result).toEqual({
+      status: "success",
+      providerType: "acme",
+      secretTypes: {},
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.test/api/v1/provider-schemas/acme",
+      {
+        cache: "no-store",
+        headers: {
+          Accept: "application/vnd.api+json",
+          Authorization: "Bearer access-token",
+        },
+      },
+    );
+  });
+
+  it("does not fetch invalid input and encodes a normalized path segment", async () => {
+    // Given
+    fetchMock.mockResolvedValueOnce(schemaResponse("acme/team"));
+
+    // When
+    const invalid = await Promise.all([
+      getProviderSchemas(" "),
+      getProviderSchemas("a".repeat(51)),
+    ]);
+    const encoded = await getProviderSchemas(" ACME/TEAM ");
+
+    // Then
+    expect(invalid).toEqual([{ status: "error" }, { status: "error" }]);
+    expect(encoded).toMatchObject({
+      status: "success",
+      providerType: "acme/team",
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.test/api/v1/provider-schemas/acme%2Fteam",
+      expect.any(Object),
+    );
+  });
+
+  it("denies an unauthenticated request without fetching", async () => {
+    // Given
+    authMock.mockResolvedValue({});
+
+    // When
+    const result = await getProviderSchemas("acme");
+
+    // Then
+    expect(result).toEqual({ status: "access_denied" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [401, { status: "access_denied" }],
+    [403, { status: "access_denied" }],
+    [404, { status: "not_found" }],
+    [409, { status: "unavailable" }],
+    [500, { status: "error" }],
+  ])("maps HTTP %i to a safe result", async (status, expected) => {
+    // Given
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ errors: [{ detail: "private detail" }] }), {
+        status,
+      }),
+    );
+
+    // When
+    const result = await getProviderSchemas("acme");
+
+    // Then
+    expect(result).toEqual(expected);
+    expect(JSON.stringify(result)).not.toContain("private detail");
+  });
+
+  it("returns a generic safe error when fetch rejects", async () => {
+    // Given
+    const rejection = new Error("connection detail must not leak");
+    fetchMock.mockRejectedValueOnce(rejection);
+
+    // When
+    const result = await getProviderSchemas("acme");
+
+    // Then
+    expect(result).toEqual({ status: "error" });
+    expect(JSON.stringify(result)).not.toContain(rejection.message);
+  });
+
+  it("distinguishes a malformed success document from a transport failure", async () => {
+    // Given
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ errors: [] })),
+    );
+
+    // When
+    const result = await getProviderSchemas("acme");
+
+    // Then
+    expect(result).toEqual({ status: "malformed" });
+  });
+});

--- a/ui/actions/providers/provider-schemas.ts
+++ b/ui/actions/providers/provider-schemas.ts
@@ -1,0 +1,61 @@
+"use server";
+
+import { auth } from "@/auth.config";
+import { apiBaseUrl } from "@/lib";
+import {
+  PROVIDER_SCHEMA_STATUS,
+  type ProviderSchemasResult,
+} from "@/types/provider-schema";
+
+import {
+  adaptProviderSchemas,
+  normalizeProviderType,
+} from "./provider-schemas.adapter";
+
+export async function getProviderSchemas(
+  providerType: unknown,
+): Promise<ProviderSchemasResult> {
+  const normalizedProviderType = normalizeProviderType(providerType);
+  if (!normalizedProviderType) return { status: PROVIDER_SCHEMA_STATUS.ERROR };
+
+  let accessToken: string | undefined;
+  try {
+    accessToken = (await auth())?.accessToken?.trim();
+  } catch {
+    return { status: PROVIDER_SCHEMA_STATUS.ERROR };
+  }
+  if (!accessToken) return { status: PROVIDER_SCHEMA_STATUS.ACCESS_DENIED };
+
+  let response: Response;
+  try {
+    response = await fetch(
+      `${apiBaseUrl}/provider-schemas/${encodeURIComponent(normalizedProviderType)}`,
+      {
+        cache: "no-store",
+        headers: {
+          Accept: "application/vnd.api+json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+  } catch {
+    return { status: PROVIDER_SCHEMA_STATUS.ERROR };
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    return { status: PROVIDER_SCHEMA_STATUS.ACCESS_DENIED };
+  }
+  if (response.status === 404) {
+    return { status: PROVIDER_SCHEMA_STATUS.NOT_FOUND };
+  }
+  if (response.status === 409) {
+    return { status: PROVIDER_SCHEMA_STATUS.UNAVAILABLE };
+  }
+  if (!response.ok) return { status: PROVIDER_SCHEMA_STATUS.ERROR };
+
+  const schema = adaptProviderSchemas(
+    await response.json().catch(() => undefined),
+    normalizedProviderType,
+  );
+  return schema ?? { status: PROVIDER_SCHEMA_STATUS.MALFORMED };
+}

--- a/ui/types/provider-schema.ts
+++ b/ui/types/provider-schema.ts
@@ -1,0 +1,33 @@
+export const PROVIDER_SCHEMA_STATUS = {
+  SUCCESS: "success",
+  NOT_FOUND: "not_found",
+  UNAVAILABLE: "unavailable",
+  ACCESS_DENIED: "access_denied",
+  ERROR: "error",
+  MALFORMED: "malformed",
+} as const;
+
+export interface ProviderSchemaObject {
+  readonly [keyword: string]: unknown;
+}
+
+export interface ProviderSecretTypes {
+  readonly [secretType: string]: ProviderSchemaObject;
+}
+
+export interface ProviderSchemasSuccessResult {
+  status: typeof PROVIDER_SCHEMA_STATUS.SUCCESS;
+  providerType: string;
+  secretTypes: ProviderSecretTypes;
+}
+
+export interface ProviderSchemasFailureResult {
+  status: Exclude<
+    (typeof PROVIDER_SCHEMA_STATUS)[keyof typeof PROVIDER_SCHEMA_STATUS],
+    typeof PROVIDER_SCHEMA_STATUS.SUCCESS
+  >;
+}
+
+export type ProviderSchemasResult =
+  | ProviderSchemasSuccessResult
+  | ProviderSchemasFailureResult;


### PR DESCRIPTION
## Context

This is PR 12 in the Registry UI chain and follows #12590.

The backend now exposes provider credential schemas through `GET /api/v1/provider-schemas/{type}`. The UI needs a narrow, defensive transport boundary before it can interpret or render dynamic provider onboarding forms.

## Description

- add strict TypeScript contracts for provider-schema responses
- add an authenticated, no-cache adapter for `/api/v1/provider-schemas/{type}`
- normalize and URI-encode provider types before transport
- validate the JSON:API envelope, resource type, normalized ID binding, and `secret_types` map
- preserve schema values as opaque objects while rejecting non-object values
- map authentication, HTTP, malformed-response, and rejected-fetch failures to safe action results
- export the new action from the providers action boundary
- cover adapter and action contracts with focused unit tests

This PR intentionally does **not** interpret JSON Schema or render onboarding forms. That work belongs to the next focused child.

### Chain

- Parent: #12590
- Current: provider-schema transport boundary
- Next: allowlisted schema parser and accessible renderer

## Steps to review

1. Review `ui/types/provider-schema.ts` for the transport contracts.
2. Review `ui/actions/providers/provider-schemas.adapter.ts` for URL construction, authentication, and cache behavior.
3. Review `ui/actions/providers/provider-schemas.ts` for fail-closed response validation and safe error mapping.
4. Review both focused test files for invalid provider input, authentication, HTTP failures, malformed envelopes, invalid schema values, and rejected fetches.

## Validation

- `pnpm exec vitest run --project unit actions/providers/provider-schemas.adapter.test.ts actions/providers/provider-schemas.test.ts` — 16/16 passed
- `pnpm run test:unit` — 442 files, 3,169 tests passed
- `pnpm run typecheck` — passed
- scoped ESLint — passed
- scoped Prettier check — passed
- primary LSP diagnostics — 0 findings across all six files
- `git diff --check 67aab39847` — clean
- pre-commit hooks — passed
- native RDD review — approved (`review-49e8c3c41f84f0cd`)

## Checklist

- [x] The PR title follows Conventional Commits.
- [x] Relevant tests were added and pass.
- [x] Type checking, linting, and formatting checks pass.
- [x] No screenshots are required because this PR has no visual changes.
- [x] No changelog entry is required for this intermediate chained PR.
