### PR TITLE
fix(azure): correct container registry network collection

### DIFF
--- a/prowler/changelog.d/azure-containerregistry-network-properties.fixed.md
+++ b/prowler/changelog.d/azure-containerregistry-network-properties.fixed.md
@@ -1,0 +1,1 @@
+`containerregistry_not_publicly_accessible` and `containerregistry_uses_private_link` checks no longer false-fail when Azure Container Registries disable public access and use Private Endpoints

--- a/prowler/providers/azure/services/containerregistry/containerregistry_service.py
+++ b/prowler/providers/azure/services/containerregistry/containerregistry_service.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 
-from azure.mgmt.containerregistry import ContainerRegistryManagementClient
+from azure.mgmt.containerregistry.v2023_11_01_preview import (
+    ContainerRegistryManagementClient,
+)
 
 from prowler.lib.logger import logger
 from prowler.providers.azure.azure_provider import AzureProvider
@@ -41,7 +43,7 @@ class ContainerRegistry(AzureService):
                                     False
                                     if getattr(
                                         registry,
-                                        "public_network_access_enabled",
+                                        "public_network_access",
                                         "Enabled",
                                     )
                                     == "Disabled"
@@ -62,6 +64,7 @@ class ContainerRegistry(AzureService):
                                     for pec in getattr(
                                         registry, "private_endpoint_connections", []
                                     )
+                                    or []
                                 ],
                             )
                         },

--- a/tests/providers/azure/services/containerregistry/containerregistry_service_test.py
+++ b/tests/providers/azure/services/containerregistry/containerregistry_service_test.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+from azure.mgmt.containerregistry.v2023_11_01_preview.models import Registry, Sku
+
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
     RESOURCE_GROUP,
@@ -10,6 +12,34 @@ from tests.providers.azure.azure_fixtures import (
 
 
 class TestContainerRegistryService:
+    def test_get_client_uses_api_version_with_network_properties(self):
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            patch(
+                "prowler.providers.azure.services.monitor.monitor_service.Monitor",
+                new=MagicMock(),
+            ),
+            patch(
+                "prowler.providers.azure.services.containerregistry.containerregistry_service.ContainerRegistry._get_container_registries",
+                return_value={},
+            ),
+        ):
+            from prowler.providers.azure.services.containerregistry.containerregistry_service import (
+                ContainerRegistry,
+            )
+
+            containerregistry_service = ContainerRegistry(set_mocked_azure_provider())
+
+        assert (
+            containerregistry_service.clients[
+                AZURE_SUBSCRIPTION_ID
+            ].registries._api_version
+            == "2023-11-01-preview"
+        )
+
     def test_get_container_registry(self):
         with (
             patch(
@@ -94,6 +124,103 @@ class TestContainerRegistryService:
 
 
 class Test_ContainerRegistry_get_registries:
+    @staticmethod
+    def _create_service(mock_client):
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            patch(
+                "prowler.providers.azure.services.monitor.monitor_service.Monitor",
+                new=MagicMock(),
+            ),
+            patch(
+                "prowler.providers.azure.services.containerregistry.containerregistry_service.ContainerRegistry._get_container_registries",
+                return_value={},
+            ),
+        ):
+            from prowler.providers.azure.services.containerregistry.containerregistry_service import (
+                ContainerRegistry,
+            )
+
+            containerregistry_service = ContainerRegistry(set_mocked_azure_provider())
+
+        containerregistry_service.clients = {AZURE_SUBSCRIPTION_ID: mock_client}
+        containerregistry_service.resource_groups = None
+        return containerregistry_service
+
+    def test_get_container_registries_maps_network_properties(self):
+        registry_id = (
+            f"/subscriptions/{AZURE_SUBSCRIPTION_ID}/resourceGroups/{RESOURCE_GROUP}"
+            "/providers/Microsoft.ContainerRegistry/registries/mock-registry"
+        )
+        registry = Registry(
+            location="westeurope",
+            sku=Sku(name="Premium"),
+            public_network_access="Disabled",
+        )
+        registry.id = registry_id
+        registry.name = "mock-registry"
+        registry.login_server = "mock-registry.azurecr.io"
+
+        private_endpoint_connection = MagicMock()
+        private_endpoint_connection.id = (
+            f"{registry_id}/privateEndpointConnections/pec-1"
+        )
+        private_endpoint_connection.name = "pec-1"
+        private_endpoint_connection.type = (
+            "Microsoft.ContainerRegistry/registries/privateEndpointConnections"
+        )
+        registry.private_endpoint_connections = [private_endpoint_connection]
+
+        mock_client = MagicMock()
+        mock_client.registries.list.return_value = [registry]
+        containerregistry_service = self._create_service(mock_client)
+
+        with patch.object(
+            containerregistry_service,
+            "_get_registry_monitor_settings",
+            return_value=[],
+        ):
+            result = containerregistry_service._get_container_registries()
+
+        registry_info = result[AZURE_SUBSCRIPTION_ID][registry_id]
+        assert not registry_info.public_network_access
+        assert len(registry_info.private_endpoint_connections) == 1
+        assert registry_info.private_endpoint_connections[0].id == (
+            private_endpoint_connection.id
+        )
+
+    def test_get_container_registries_without_private_endpoints(self):
+        registry_id = (
+            f"/subscriptions/{AZURE_SUBSCRIPTION_ID}/resourceGroups/{RESOURCE_GROUP}"
+            "/providers/Microsoft.ContainerRegistry/registries/public-registry"
+        )
+        registry = Registry(
+            location="westeurope",
+            sku=Sku(name="Basic"),
+            public_network_access="Enabled",
+        )
+        registry.id = registry_id
+        registry.name = "public-registry"
+        registry.login_server = "public-registry.azurecr.io"
+
+        mock_client = MagicMock()
+        mock_client.registries.list.return_value = [registry]
+        containerregistry_service = self._create_service(mock_client)
+
+        with patch.object(
+            containerregistry_service,
+            "_get_registry_monitor_settings",
+            return_value=[],
+        ):
+            result = containerregistry_service._get_container_registries()
+
+        registry_info = result[AZURE_SUBSCRIPTION_ID][registry_id]
+        assert registry_info.public_network_access
+        assert registry_info.private_endpoint_connections == []
+
     def test_get_container_registries_no_resource_groups(self):
         mock_client = MagicMock()
         mock_client.registries.list.return_value = []


### PR DESCRIPTION
### Context

Fix #12651

Azure Container Registry network checks can false-fail for registries that are already private. The collector currently uses the multi-API `ContainerRegistryManagementClient`, whose registry operations default to API `2019-05-01` in `azure-mgmt-containerregistry==12.0.0`. That model omits public-network-access and Private Endpoint fields.

The collector also reads `public_network_access_enabled`, while current Azure SDK registry models expose `public_network_access`. Together, these behaviors make `containerregistry_not_publicly_accessible` treat missing data as public access enabled and make `containerregistry_uses_private_link` see no Private Endpoint connections.

### Description

- use the explicit Azure Container Registry `2023-11-01-preview` client included in the existing SDK dependency so registry responses include network properties
- map `public_network_access` from the current registry model
- normalize a missing `private_endpoint_connections` collection to an empty list
- add service regression coverage using the real versioned Azure SDK models
- add an SDK changelog fragment for the two affected checks

No dependency or permission changes are required.

### Steps to review

1. Review `containerregistry_service.py` and confirm the selected API model exposes `public_network_access` and `private_endpoint_connections`.
2. Review `containerregistry_service_test.py` and confirm coverage for:
   - explicit ACR API version selection
   - a private registry with public access disabled and a Private Endpoint
   - a public registry whose SDK model returns `private_endpoint_connections=None`
3. Run:

```shell
uv run pytest -q tests/providers/azure/services/containerregistry
```

Expected result: `18 passed`.

4. Run the changed-file hooks:

```shell
uv run prek run --files \
  prowler/providers/azure/services/containerregistry/containerregistry_service.py \
  tests/providers/azure/services/containerregistry/containerregistry_service_test.py \
  prowler/changelog.d/azure-containerregistry-network-properties.fixed.md
```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues/12651).
- [ ] Is it assigned to me? Assignment has been requested on issue #12651.
- [x] I reviewed the open pull requests and confirmed there is no existing PR that implements the same outcome.

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. This fix is a candidate for the current v5.40 patch line.
- [x] Review if the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) needs to change. No README update is required.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI

- Are there new checks included in this PR? No.

#### UI

Not applicable.

#### API

Not applicable.

#### MCP Server

Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure Container Registry checks for registries with public access disabled.
  * Correctly recognizes registries using Private Endpoints, preventing false failures.
  * Improved handling of registries that do not have private endpoint connections configured.
* **Tests**
  * Added coverage for Azure’s preview API behavior and network access configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->