### PR TITLE
feat(azure): add aks_cluster_node_os_upgrade_channel_enabled check

### DIFF
--- a/prowler/changelog.d/aks-cluster-node-os-upgrade-channel.added.md
+++ b/prowler/changelog.d/aks-cluster-node-os-upgrade-channel.added.md
@@ -1,0 +1,1 @@
+`aks_cluster_node_os_upgrade_channel_enabled` check for Azure provider, verifying that AKS clusters use an AKS-managed node OS auto-upgrade channel (`SecurityPatch` or `NodeImage`) so node operating system security updates are applied

--- a/prowler/providers/azure/services/aks/aks_cluster_node_os_upgrade_channel_enabled/aks_cluster_node_os_upgrade_channel_enabled.metadata.json
+++ b/prowler/providers/azure/services/aks/aks_cluster_node_os_upgrade_channel_enabled/aks_cluster_node_os_upgrade_channel_enabled.metadata.json
@@ -1,0 +1,38 @@
+{
+  "Provider": "azure",
+  "CheckID": "aks_cluster_node_os_upgrade_channel_enabled",
+  "CheckTitle": "AKS cluster has a managed node OS auto-upgrade channel enabled",
+  "CheckType": [],
+  "ServiceName": "aks",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "microsoft.containerservice/managedclusters",
+  "ResourceGroup": "container",
+  "Description": "**AKS clusters** are evaluated for a managed **node OS auto-upgrade channel**, meaning `SecurityPatch` or `NodeImage`. This channel controls how operating system security updates reach the node VMs and is independent of the cluster upgrade channel, which only moves the Kubernetes version. `None` and `Unmanaged` leave node OS patching outside AKS control.",
+  "Risk": "Nodes running an unpatched OS image keep **known CVEs** in the kernel and system packages that every pod on the host shares. A compromised container can then use a local privilege escalation to escape, gain root on the node, and take the kubelet credentials and the node's managed identity, turning one workload compromise into cluster-wide access.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-cluster",
+    "https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-node-os-image"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "az aks update --resource-group <RESOURCE_GROUP> --name <CLUSTER_NAME> --node-os-upgrade-channel NodeImage",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Set the node OS auto-upgrade channel to `NodeImage` or `SecurityPatch` so AKS applies operating system security updates on a managed cadence, and pair it with a planned maintenance window because both channels can reimage nodes. `NodeImage` ships weekly, carries bug fixes as well as security fixes, and adds no extra cost. `SecurityPatch` ships faster, carries security fixes only, and incurs VHD hosting cost in the node resource group. Avoid `None` and `Unmanaged` unless a documented exception and a manual patching process exist.",      
+      "Url": "https://hub.prowler.com/check/aks_cluster_node_os_upgrade_channel_enabled"
+    }
+  },
+  "Categories": [
+    "vulnerabilities",
+    "cluster-security"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "`Unmanaged` is reported as a finding alongside `None`. On that channel the operating system's own updater applies packages, AKS has no control over how or when they land, Microsoft recommends `SecurityPatch` over it, and on Windows node pools it behaves the same as `None`. Two operational caveats: channel changes can take up to 24 hours to take effect, and `SecurityPatch` is not supported on Windows node pools, so `NodeImage` is the option there."
+}

--- a/prowler/providers/azure/services/aks/aks_cluster_node_os_upgrade_channel_enabled/aks_cluster_node_os_upgrade_channel_enabled.py
+++ b/prowler/providers/azure/services/aks/aks_cluster_node_os_upgrade_channel_enabled/aks_cluster_node_os_upgrade_channel_enabled.py
@@ -1,0 +1,46 @@
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.services.aks.aks_client import aks_client
+
+MANAGED_NODE_OS_UPGRADE_CHANNELS = {"nodeimage", "securitypatch"}
+
+
+class aks_cluster_node_os_upgrade_channel_enabled(Check):
+    """
+    Ensure AKS clusters have a managed node OS auto-upgrade channel.
+
+    The node OS auto-upgrade channel controls how operating system security updates reach the node VMs, separately from the cluster upgrade channel that only moves the Kubernetes version. AKS applies the updates itself on the `SecurityPatch` and `NodeImage` channels. `Unmanaged` leaves delivery to the operating system's own updater, outside AKS control, and `None` applies nothing at all.
+
+    - PASS: The cluster uses the `SecurityPatch` or `NodeImage` channel.
+    - FAIL: The cluster uses `None` or `Unmanaged`, or has no channel configured.
+    """
+
+    def execute(self) -> list[Check_Report_Azure]:
+        """Check the node OS auto-upgrade channel configured on each cluster.
+
+        Returns:
+            One report per cluster, passing when the channel is one AKS manages.
+        """
+        findings = []
+
+        for subscription_id, clusters in aks_client.clusters.items():
+            subscription_name = aks_client.subscriptions.get(
+                subscription_id, subscription_id
+            )
+            for cluster in clusters.values():
+                report = Check_Report_Azure(metadata=self.metadata(), resource=cluster)
+                report.subscription = subscription_id
+
+                channel = (cluster.node_os_upgrade_channel or "").strip()
+                if channel.lower() in MANAGED_NODE_OS_UPGRADE_CHANNELS:
+                    report.status = "PASS"
+                    report.status_extended = f"Cluster '{cluster.name}' has AKS-managed node OS auto-upgrade channel '{channel}' in subscription '{subscription_name} ({subscription_id})'."
+                elif channel:
+                    report.status = "FAIL"
+                    report.status_extended = f"Cluster '{cluster.name}' has node OS auto-upgrade channel '{channel}', which is not applied by AKS, in subscription '{subscription_name} ({subscription_id})'."
+                else:
+                    report.status = "FAIL"
+                    report.status_extended = f"Cluster '{cluster.name}' does not have a node OS auto-upgrade channel configured in subscription '{subscription_name} ({subscription_id})'."
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/azure/services/aks/aks_service.py
+++ b/prowler/providers/azure/services/aks/aks_service.py
@@ -64,6 +64,11 @@ class AKS(AzureService):
                                         "upgrade_channel",
                                         None,
                                     ),
+                                    node_os_upgrade_channel=getattr(
+                                        getattr(cluster, "auto_upgrade_profile", None),
+                                        "node_os_upgrade_channel",
+                                        None,
+                                    ),
                                     defender_enabled=bool(
                                         getattr(
                                             getattr(
@@ -137,6 +142,7 @@ class Cluster:
     rbac_enabled: bool
     location: str
     auto_upgrade_channel: Optional[str] = None
+    node_os_upgrade_channel: Optional[str] = None
     defender_enabled: bool = False
     azure_monitor_enabled: bool = False
     local_accounts_disabled: bool = False

--- a/tests/providers/azure/services/aks/aks_cluster_node_os_upgrade_channel_enabled/aks_cluster_node_os_upgrade_channel_enabled_test.py
+++ b/tests/providers/azure/services/aks/aks_cluster_node_os_upgrade_channel_enabled/aks_cluster_node_os_upgrade_channel_enabled_test.py
@@ -1,0 +1,206 @@
+from unittest import mock
+
+import pytest
+
+from prowler.providers.azure.services.aks.aks_service import Cluster
+from tests.providers.azure.azure_fixtures import (
+    AZURE_SUBSCRIPTION_DISPLAY,
+    AZURE_SUBSCRIPTION_ID,
+    AZURE_SUBSCRIPTION_NAME,
+    set_mocked_azure_provider,
+)
+
+CHECK_PATH = "prowler.providers.azure.services.aks.aks_cluster_node_os_upgrade_channel_enabled.aks_cluster_node_os_upgrade_channel_enabled"
+
+
+def build_cluster(node_os_upgrade_channel):
+    return Cluster(
+        id="/sub/rg/cluster1",
+        name="test-cluster",
+        public_fqdn="test.azmk8s.io",
+        private_fqdn=None,
+        network_policy=None,
+        agent_pool_profiles=[],
+        rbac_enabled=True,
+        location="eastus",
+        node_os_upgrade_channel=node_os_upgrade_channel,
+    )
+
+
+class Test_aks_cluster_node_os_upgrade_channel_enabled:
+    def test_no_subscriptions(self):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_node_os_upgrade_channel_enabled.aks_cluster_node_os_upgrade_channel_enabled import (
+                aks_cluster_node_os_upgrade_channel_enabled,
+            )
+
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {}
+
+            check = aks_cluster_node_os_upgrade_channel_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    @pytest.mark.parametrize(
+        "node_os_upgrade_channel",
+        ["NodeImage", "SecurityPatch", "nodeimage", "  NodeImage  "],
+    )
+    def test_pass(self, node_os_upgrade_channel):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_node_os_upgrade_channel_enabled.aks_cluster_node_os_upgrade_channel_enabled import (
+                aks_cluster_node_os_upgrade_channel_enabled,
+            )
+
+            cluster = build_cluster(node_os_upgrade_channel=node_os_upgrade_channel)
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+
+            check = aks_cluster_node_os_upgrade_channel_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Cluster 'test-cluster' has AKS-managed node OS auto-upgrade channel '{node_os_upgrade_channel.strip()}' in subscription '{AZURE_SUBSCRIPTION_DISPLAY}'."
+            )
+            assert result[0].resource_name == "test-cluster"
+            assert result[0].resource_id == "/sub/rg/cluster1"
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].location == "eastus"
+
+    @pytest.mark.parametrize(
+        "node_os_upgrade_channel", ["None", "none", "Unmanaged", "unmanaged"]
+    )
+    def test_fail_channel_not_applied_by_aks(self, node_os_upgrade_channel):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_node_os_upgrade_channel_enabled.aks_cluster_node_os_upgrade_channel_enabled import (
+                aks_cluster_node_os_upgrade_channel_enabled,
+            )
+
+            cluster = build_cluster(node_os_upgrade_channel=node_os_upgrade_channel)
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+
+            check = aks_cluster_node_os_upgrade_channel_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Cluster 'test-cluster' has node OS auto-upgrade channel '{node_os_upgrade_channel}', which is not applied by AKS, in subscription '{AZURE_SUBSCRIPTION_DISPLAY}'."
+            )
+            assert result[0].resource_name == "test-cluster"
+            assert result[0].resource_id == "/sub/rg/cluster1"
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].location == "eastus"
+
+    @pytest.mark.parametrize("node_os_upgrade_channel", [None, "", "   "])
+    def test_fail_no_channel_configured(self, node_os_upgrade_channel):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_node_os_upgrade_channel_enabled.aks_cluster_node_os_upgrade_channel_enabled import (
+                aks_cluster_node_os_upgrade_channel_enabled,
+            )
+
+            cluster = build_cluster(node_os_upgrade_channel=node_os_upgrade_channel)
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+
+            check = aks_cluster_node_os_upgrade_channel_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Cluster 'test-cluster' does not have a node OS auto-upgrade channel configured in subscription '{AZURE_SUBSCRIPTION_DISPLAY}'."
+            )
+
+    def test_unknown_subscription_falls_back_to_id(self):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_node_os_upgrade_channel_enabled.aks_cluster_node_os_upgrade_channel_enabled import (
+                aks_cluster_node_os_upgrade_channel_enabled,
+            )
+
+            cluster = build_cluster(node_os_upgrade_channel="NodeImage")
+            aks_client.subscriptions = {}
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+
+            check = aks_cluster_node_os_upgrade_channel_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Cluster 'test-cluster' has AKS-managed node OS auto-upgrade channel 'NodeImage' in subscription '{AZURE_SUBSCRIPTION_ID} ({AZURE_SUBSCRIPTION_ID})'."
+            )
+
+    def test_multiple_clusters_mixed_channels(self):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.aks_client", new=aks_client),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_node_os_upgrade_channel_enabled.aks_cluster_node_os_upgrade_channel_enabled import (
+                aks_cluster_node_os_upgrade_channel_enabled,
+            )
+
+            passing = build_cluster(node_os_upgrade_channel="SecurityPatch")
+            failing = build_cluster(node_os_upgrade_channel="Unmanaged")
+            failing.id = "/sub/rg/cluster2"
+            failing.name = "test-cluster-2"
+            aks_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+            aks_client.clusters = {
+                AZURE_SUBSCRIPTION_ID: {
+                    passing.id: passing,
+                    failing.id: failing,
+                }
+            }
+
+            check = aks_cluster_node_os_upgrade_channel_enabled()
+            result = check.execute()
+            assert len(result) == 2
+            statuses = {report.resource_name: report.status for report in result}
+            assert statuses == {"test-cluster": "PASS", "test-cluster-2": "FAIL"}

--- a/tests/providers/azure/services/aks/aks_service_test.py
+++ b/tests/providers/azure/services/aks/aks_service_test.py
@@ -21,6 +21,7 @@ def mock_aks_get_clusters(_):
                 agent_pool_profiles=[],
                 location="westeurope",
                 rbac_enabled=True,
+                node_os_upgrade_channel="NodeImage",
             )
         }
     }
@@ -68,6 +69,10 @@ class Test_AKS_Service:
             aks.clusters[AZURE_SUBSCRIPTION_ID]["cluster_id-1"].location == "westeurope"
         )
         assert aks.clusters[AZURE_SUBSCRIPTION_ID]["cluster_id-1"].rbac_enabled
+        assert (
+            aks.clusters[AZURE_SUBSCRIPTION_ID]["cluster_id-1"].node_os_upgrade_channel
+            == "NodeImage"
+        )
 
 
 class Test_AKS_get_clusters:
@@ -82,6 +87,7 @@ class Test_AKS_get_clusters:
         mock_cluster.network_profile = None
         mock_cluster.agent_pool_profiles = []
         mock_cluster.enable_rbac = False
+        mock_cluster.auto_upgrade_profile.node_os_upgrade_channel = "SecurityPatch"
 
         mock_client = MagicMock()
         mock_client.managed_clusters.list.return_value = [mock_cluster]
@@ -101,6 +107,10 @@ class Test_AKS_get_clusters:
         mock_client.managed_clusters.list_by_resource_group.assert_not_called()
         assert AZURE_SUBSCRIPTION_ID in result
         assert "cluster_id-1" in result[AZURE_SUBSCRIPTION_ID]
+        assert (
+            result[AZURE_SUBSCRIPTION_ID]["cluster_id-1"].node_os_upgrade_channel
+            == "SecurityPatch"
+        )
 
     def test_get_clusters_with_resource_group(self):
         mock_cluster = MagicMock()


### PR DESCRIPTION
### Context

Fix #12656

AKS exposes two independent auto-upgrade settings on the same `autoUpgradeProfile` object. `upgradeChannel` moves the Kubernetes version and is already covered by `aks_cluster_auto_upgrade_enabled`. `nodeOsUpgradeChannel` controls how OS security updates reach the node VMs, and nothing in Prowler reads it.

These are different exposures. A cluster can run a fully supported Kubernetes version while its nodes boot from an image whose kernel and system packages carry known CVEs. Every pod on a node shares that kernel, so an unpatched node image is what turns a single compromised container into root on the node, and from there the kubelet credentials and the node's managed identity.

### Description

**New check:** `aks_cluster_node_os_upgrade_channel_enabled`

- **Severity:** `medium`, matching the existing `aks_cluster_auto_upgrade_enabled`
- **Service:** `aks`
- **Resource group:** `container`
- **Categories:** `vulnerabilities`, `cluster-security`
- **Configurable:** no
- No new dependencies

| Node OS upgrade channel | Result |
|---|---|
| `NodeImage` | PASS |
| `SecurityPatch` | PASS |
| `Unmanaged` | FAIL |
| `None` | FAIL |
| Not set | FAIL |

**Why `Unmanaged` fails.** It is a real channel value, so passing it would be defensible on the check name alone. But Microsoft documents it as OS-driven updates over which "AKS has no control", publishes a FAQ entry recommending `SecurityPatch` over it, and notes that on Windows node pools it behaves the same as `None`. Passing it would mean the check approves a configuration the docs advise against. The reasoning is in the check metadata `Notes` so it shows on Prowler Hub too.

**The comparison is case-insensitive.** The two sibling fields on the same object use different casing: `upgradeChannel` comes back lowercase (`none`), `nodeOsUpgradeChannel` comes back PascalCase (`NodeImage`). The check lowercases before comparing but reports the value as Azure spells it, so findings match what users see in the portal.

**Three status messages rather than one.** A finding distinguishes a channel explicitly set to a non-managed value from one that was never configured, since those need different fixes.

**A note on API versions.** `nodeOsUpgradeChannel` requires api-version `2023-06-01` or later, and `azure-mgmt-containerservice` resolves to `2024-10-01`, so the field is available to the SDK Prowler already pins. If you check a cluster with an older Azure CLI you will see no `nodeOsUpgradeChannel` in the output even when one is set, because the CLI requests an older api-version. That is the client, not the cluster. The unset branch is kept regardless, since the SDK types the field as `Optional`.

**Files changed:**

- `prowler/providers/azure/services/aks/aks_cluster_node_os_upgrade_channel_enabled/`: check, metadata, `__init__`
- `prowler/providers/azure/services/aks/aks_service.py`: adds `node_os_upgrade_channel` to the `Cluster` model. The service already fetches `auto_upgrade_profile` to populate `auto_upgrade_channel`, so this reads a sibling attribute off an object that is already in memory. No new API call.
- `prowler/changelog.d/aks-cluster-node-os-upgrade-channel.added.md`: changelog fragment
- `tests/providers/azure/services/aks/`: 14 new tests, plus assertions in the service tests

**Overlap with #12567.** That PR adds a different field to the same `Cluster` dataclass and constructor. Whichever merges second needs a small rebase, and I am happy to do it.

### Steps to review

1. Run the AKS suite:

   ```
   uv run pytest tests/providers/azure/services/aks/ -v
   ```

   59 tests pass, 14 of them new: both managed channels, mixed casing and surrounding whitespace, `None` and `Unmanaged` in either casing, an unset field, an empty string, a whitespace-only string, an unknown subscription falling back to the ID, and two clusters with different channels in one subscription.

2. Confirm the check is registered:

   ```
   uv run python prowler-cli.py azure --list-checks | grep aks_cluster_node_os_upgrade_channel_enabled
   ```

3. `tests/lib/check/` (3892 tests) also passes, which validates the new metadata against the `CheckMetadata` model.

I also ran it against a live subscription with `--az-cli-auth`. Three AKS clusters all came back `NodeImage` and reported PASS, with the channel rendered in Azure's casing. Setting one cluster to `None` temporarily produced a single FAIL naming the value, the other two unchanged, and I reverted it straight after. That confirms `nodeOsUpgradeChannel` comes back populated from the real SDK response, which the mocked tests cannot show on their own.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. No, this is a new check rather than a fix.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) No change needed.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **Yes**
    - If so, do we need to update permissions for the provider? **No.** The check reads `autoUpgradeProfile` from the same `managed_clusters.list` response the existing AKS checks already consume, which the built-in Reader role covers. `permissions/prowler-azure-custom-role.json` only lists actions Reader does not grant, so it is unchanged.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Azure AKS security check to verify that clusters use an AKS-managed node OS auto-upgrade channel.
  * Clusters configured with `SecurityPatch` or `NodeImage` pass the check.
  * Missing, unmanaged, or unsupported upgrade channels are reported for remediation.
* **Documentation**
  * Added guidance covering recommended upgrade channels, supported scenarios, risks, and remediation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->