### PR TITLE
fix(wafv2): paginate ListWebACLs so scans do not stop at the first page

### DIFF
--- a/prowler/changelog.d/wafv2-list-web-acls-pagination.fixed.md
+++ b/prowler/changelog.d/wafv2-list-web-acls-pagination.fixed.md
@@ -1,0 +1,1 @@
+WAFv2 `ListWebACLs` pagination, so scans of accounts with more than one page of Web ACLs no longer stop at the first page

--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -25,10 +25,65 @@ class WAFv2(AWSService):
         self.__threading_call__(self._get_logging_configuration, self.web_acls.values())
         self.__threading_call__(self._list_tags, self.web_acls.values())
 
+    def _paginate_web_acls(self, client, scope):
+        """Yield every Web ACL summary in the given scope, following NextMarker to the last page.
+
+        ListWebACLs returns at most 100 Web ACLs per call and sets NextMarker while more remain,
+        so a single call silently drops every Web ACL past the first page. The rationale for the
+        hand-rolled loop and its two guards is in the comment below.
+        """
+        # ListWebACLs returns at most 100 Web ACLs per call and WAFv2 ships no botocore
+        # paginator (verified at pin 1.40.61), so hand-rolling is required. The documented
+        # contract (ListWebACLs API reference) states NextMarker appears only when more
+        # objects remain, so the loop follows the marker. The seen-set guard protects
+        # against a marker that never clears; the iteration cap (1000 pages = 100K Web ACLs
+        # max at the 100-per-page limit) can only fire on a misbehaving API, since the
+        # default WebACLs-per-region quota is far below that threshold.
+        next_marker = None
+        seen_markers = set()
+        max_iterations = 1000
+        iterations = 0
+
+        repeated_marker = False
+
+        while iterations < max_iterations:
+            iterations += 1
+            kwargs = {"Scope": scope}
+            if next_marker:
+                if next_marker in seen_markers:
+                    repeated_marker = True
+                    logger.error(
+                        f"WAFv2 - ListWebACLs pagination loop detected at marker {next_marker} for scope {scope}"
+                    )
+                    break
+                seen_markers.add(next_marker)
+                kwargs["NextMarker"] = next_marker
+
+            response = client.list_web_acls(**kwargs)
+            web_acls = response.get("WebACLs", [])
+            yield from web_acls
+
+            next_marker = response.get("NextMarker")
+            if not next_marker:
+                break
+
+        # Which exit happened has to be tracked, not inferred from the counter. A repeated marker seen
+        # on the 1000th entry increments iterations to the cap before breaking, and leaves next_marker
+        # truthy, so the count-and-marker test below fired too and the log named the page cap as the
+        # cause of a stop the loop guard had actually caused -- two contradictory errors for one exit,
+        # after 999 calls rather than 1000. The counter cannot distinguish the two exits because both
+        # reach it with the same values; only the flag can.
+        if not repeated_marker and iterations >= max_iterations and next_marker:
+            logger.error(
+                f"WAFv2 - ListWebACLs pagination hit the {max_iterations}-page cap for scope {scope}; "
+                "results may be truncated"
+            )
+
     def _list_web_acls_global(self):
+        """List CLOUDFRONT-scoped Web ACLs and populate the web_acls dictionary."""
         logger.info("WAFv2 - Listing Global Web ACLs...")
         try:
-            for wafv2 in self.client.list_web_acls(Scope="CLOUDFRONT")["WebACLs"]:
+            for wafv2 in self._paginate_web_acls(self.client, "CLOUDFRONT"):
                 if not self.audit_resources or (
                     is_resource_filtered(wafv2["ARN"], self.audit_resources)
                 ):
@@ -48,9 +103,10 @@ class WAFv2(AWSService):
             )
 
     def _list_web_acls_regional(self, regional_client):
+        """List REGIONAL-scoped Web ACLs for the given region and populate the web_acls dictionary."""
         logger.info("WAFv2 - Listing Regional Web ACLs...")
         try:
-            for wafv2 in regional_client.list_web_acls(Scope="REGIONAL")["WebACLs"]:
+            for wafv2 in self._paginate_web_acls(regional_client, "REGIONAL"):
                 if not self.audit_resources or (
                     is_resource_filtered(wafv2["ARN"], self.audit_resources)
                 ):

--- a/tests/providers/aws/services/wafv2/wafv2_service_test.py
+++ b/tests/providers/aws/services/wafv2/wafv2_service_test.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+
+import botocore
 from boto3 import client, resource
 from moto import mock_aws
 
@@ -7,6 +10,136 @@ from tests.providers.aws.utils import (
     AWS_REGION_US_EAST_1,
     set_mocked_aws_provider,
 )
+
+# Original botocore _make_api_call function
+orig = botocore.client.BaseClient._make_api_call
+
+PAGED_ACL_FIRST_NAME = "paged-web-acl-1"
+PAGED_ACL_SECOND_NAME = "paged-web-acl-2"
+PAGED_ACL_FIRST_ARN = (
+    "arn:aws:wafv2:us-east-1:123456789012:regional/webacl/paged-web-acl-1"
+)
+PAGED_ACL_SECOND_ARN = (
+    "arn:aws:wafv2:us-east-1:123456789012:regional/webacl/paged-web-acl-2"
+)
+
+
+def mock_make_api_call_list_web_acls_paginated(self, operation_name, kwarg):
+    """Serve ListWebACLs across two pages, keyed off NextMarker so no state is shared.
+
+    Page one carries a marker; page two carries none. Both pages return a Web ACL, so a
+    collector that reads only the first response sees half the inventory.
+    """
+    if operation_name == "ListWebACLs":
+        if not kwarg.get("NextMarker"):
+            return {
+                "WebACLs": [
+                    {
+                        "Name": PAGED_ACL_FIRST_NAME,
+                        "Id": "paged-1",
+                        "ARN": PAGED_ACL_FIRST_ARN,
+                    }
+                ],
+                "NextMarker": "page-two",
+            }
+        return {
+            "WebACLs": [
+                {
+                    "Name": PAGED_ACL_SECOND_NAME,
+                    "Id": "paged-2",
+                    "ARN": PAGED_ACL_SECOND_ARN,
+                }
+            ]
+        }
+    return orig(self, operation_name, kwarg)
+
+
+def mock_make_api_call_list_web_acls_empty_page_with_marker(
+    self, operation_name, kwarg
+):
+    """Serve an empty middle page that still carries a NextMarker.
+
+    WAFv2 returns a marker even when a page held everything, so an empty page is the only
+    reliable stop. Page one holds a Web ACL and a marker, page two is empty and still carries
+    a marker, page three holds a second Web ACL. A collector that stops on the empty page
+    reports one Web ACL; one that trusts the marker alone walks on and reports two.
+    """
+    if operation_name == "ListWebACLs":
+        marker = kwarg.get("NextMarker")
+        if not marker:
+            return {
+                "WebACLs": [
+                    {
+                        "Name": PAGED_ACL_FIRST_NAME,
+                        "Id": "paged-1",
+                        "ARN": PAGED_ACL_FIRST_ARN,
+                    }
+                ],
+                "NextMarker": "page-two",
+            }
+        if marker == "page-two":
+            return {"WebACLs": [], "NextMarker": "page-three"}
+        return {
+            "WebACLs": [
+                {
+                    "Name": PAGED_ACL_SECOND_NAME,
+                    "Id": "paged-2",
+                    "ARN": PAGED_ACL_SECOND_ARN,
+                }
+            ]
+        }
+    return orig(self, operation_name, kwarg)
+
+
+class ScriptedListWebACLs:
+    """A stand-in WAFv2 client that serves a scripted ListWebACLs page sequence.
+
+    moto cannot be driven to a thousand pages, and the paginator's page cap is a local rather
+    than a module constant so it cannot be lowered for a test, so a scripted client is the only
+    way to reach the cap at all. It costs nothing: the pages are plain dicts built in a list
+    comprehension and neither test below takes a measurable fraction of a second.
+    """
+
+    def __init__(self, pages: list):
+        """Take the pages to serve in order, and start the call counter at zero."""
+        self.pages = pages
+        self.calls = 0
+
+    def list_web_acls(self, **kwargs):
+        """Return the next scripted page, or an empty one once the script runs out."""
+        index = self.calls
+        self.calls += 1
+        return self.pages[index] if index < len(self.pages) else {"WebACLs": []}
+
+
+def _paged_acl(index: int) -> dict:
+    """Build one ListWebACLs summary entry."""
+    return {
+        "ARN": f"arn:aws:wafv2:us-east-1:123456789012:regional/webacl/paged-{index}",
+        "Name": f"paged-{index}",
+        "Id": f"paged-{index}",
+    }
+
+
+def mock_make_api_call_list_web_acls_infinite_loop(self, operation_name, kwarg):
+    """Return the same NextMarker forever to test the loop guard.
+
+    Every ListWebACLs call returns one Web ACL and the marker "loop-forever". A paginator
+    without a seen-set guard would spin indefinitely; one with the guard detects the
+    repeated marker, logs an error, and terminates.
+    """
+    if operation_name == "ListWebACLs":
+        return {
+            "WebACLs": [
+                {
+                    "Name": PAGED_ACL_FIRST_NAME,
+                    "Id": "paged-1",
+                    "ARN": PAGED_ACL_FIRST_ARN,
+                }
+            ],
+            "NextMarker": "loop-forever",
+        }
+    return orig(self, operation_name, kwarg)
 
 
 class Test_WAFv2_Service:
@@ -82,6 +215,158 @@ class Test_WAFv2_Service:
         assert wafv2.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert wafv2.web_acls[waf_arn].arn == waf["ARN"]
         assert wafv2.web_acls[waf_arn].id == waf["Id"]
+
+    # A single ListWebACLs call returns at most 100 Web ACLs. The documented contract
+    # states NextMarker signals more objects remain, so the paginator must follow it.
+    @patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=mock_make_api_call_list_web_acls_paginated,
+    )
+    @mock_aws
+    def test_list_web_acls_follows_next_marker(self):
+        """Pagination across two pages collects both Web ACLs."""
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        wafv2 = WAFv2(aws_provider)
+
+        assert len(wafv2.web_acls) == 2
+        assert PAGED_ACL_FIRST_ARN in wafv2.web_acls
+        assert PAGED_ACL_SECOND_ARN in wafv2.web_acls
+        assert wafv2.web_acls[PAGED_ACL_FIRST_ARN].name == PAGED_ACL_FIRST_NAME
+        assert wafv2.web_acls[PAGED_ACL_SECOND_ARN].name == PAGED_ACL_SECOND_NAME
+
+    # An empty middle page must not terminate collection when NextMarker points to more data.
+    # The documented contract states the marker signals more objects remain, so an empty page
+    # with a marker indicates the API will return data on the next call.
+    @patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=mock_make_api_call_list_web_acls_empty_page_with_marker,
+    )
+    @mock_aws
+    def test_list_web_acls_continues_past_an_empty_page_when_a_marker_remains(self):
+        """Pagination continues through an empty middle page to collect all Web ACLs."""
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        wafv2 = WAFv2(aws_provider)
+
+        assert len(wafv2.web_acls) == 2
+        assert PAGED_ACL_FIRST_ARN in wafv2.web_acls
+        assert PAGED_ACL_SECOND_ARN in wafv2.web_acls
+
+    # The seen-set guard must terminate on a repeating marker without hanging. A marker that
+    # never clears would spin indefinitely without this protection.
+    @patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=mock_make_api_call_list_web_acls_infinite_loop,
+    )
+    @mock_aws
+    def test_list_web_acls_terminates_on_repeating_marker(self):
+        """Pagination detects and breaks on a marker that repeats forever."""
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        # Patch logger to verify error is logged
+        with patch(
+            "prowler.providers.aws.services.wafv2.wafv2_service.logger"
+        ) as mock_logger:
+            wafv2 = WAFv2(aws_provider)
+
+            # Service must terminate (not hang)
+            assert len(wafv2.web_acls) == 1
+            assert PAGED_ACL_FIRST_ARN in wafv2.web_acls
+
+            # Loop detection must log an error for both CLOUDFRONT and REGIONAL scopes
+            assert mock_logger.error.call_count >= 2
+            error_messages = [call[0][0] for call in mock_logger.error.call_args_list]
+            pagination_errors = [
+                msg for msg in error_messages if "pagination loop detected" in msg
+            ]
+            assert len(pagination_errors) >= 2
+            assert any(
+                "loop-forever" in msg and "CLOUDFRONT" in msg
+                for msg in pagination_errors
+            )
+            assert any(
+                "loop-forever" in msg and "REGIONAL" in msg for msg in pagination_errors
+            )
+            # The repeating marker stops collection well below the page cap, so the cap's own
+            # warning must stay silent: gating it on the marker alone would report truncation
+            # here, on top of the loop-detected error that already names the real cause.
+            assert sum("hit the 1000-page cap" in msg for msg in error_messages) == 0
+
+    # The cap warning is gated on a pending marker, not on the iteration count alone, because
+    # `iterations` reaches the cap on the final pass whether or not that pass finished the scan.
+    @mock_aws
+    def test_pagination_cap_is_silent_when_the_last_page_completes_the_scan(self):
+        """A scope whose 1000th page carries no NextMarker is complete, so nothing is logged.
+
+        Warning here would tell an operator their inventory may be truncated when every Web ACL
+        was collected, which is the false positive the marker condition exists to prevent.
+        """
+        pages = [
+            {"WebACLs": [_paged_acl(i)], "NextMarker": f"m{i}"} for i in range(999)
+        ] + [{"WebACLs": [_paged_acl(999)]}]
+        scripted = ScriptedListWebACLs(pages)
+        wafv2 = WAFv2(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
+
+        with patch(
+            "prowler.providers.aws.services.wafv2.wafv2_service.logger"
+        ) as mock_logger:
+            collected = list(wafv2._paginate_web_acls(scripted, "REGIONAL"))
+
+        assert len(collected) == 1000
+        assert scripted.calls == 1000
+        assert mock_logger.error.call_count == 0
+
+    @mock_aws
+    def test_pagination_cap_warns_when_a_marker_is_still_pending(self):
+        """A scope still handing back a marker at the cap is truncated, so it must be logged.
+
+        The paginator stops at the cap rather than following the marker forever, so the Web ACLs
+        beyond it are genuinely missing from the scan and silence would hide that.
+        """
+        pages = [
+            {"WebACLs": [_paged_acl(i)], "NextMarker": f"m{i}"} for i in range(1100)
+        ]
+        scripted = ScriptedListWebACLs(pages)
+        wafv2 = WAFv2(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
+
+        with patch(
+            "prowler.providers.aws.services.wafv2.wafv2_service.logger"
+        ) as mock_logger:
+            collected = list(wafv2._paginate_web_acls(scripted, "REGIONAL"))
+
+        assert len(collected) == 1000
+        assert scripted.calls == 1000
+        assert mock_logger.error.call_count == 1
+        assert "hit the 1000-page cap" in mock_logger.error.call_args[0][0]
+
+    @mock_aws
+    def test_a_repeated_marker_on_the_final_entry_reports_only_the_loop(self):
+        """A repeated marker seen on the 1000th loop entry must not also report the page cap.
+
+        This is the one input where the two exits are indistinguishable by counter: the entry
+        increments iterations to the cap BEFORE the repeated-marker guard breaks, and it leaves
+        next_marker truthy, so a cap test written as `iterations >= max_iterations and next_marker`
+        fires as well. The operator then gets two contradictory causes for one stop, and the cap
+        message is the false one -- only 999 calls were made, and nothing was truncated by the cap.
+
+        The 999th page hands back a marker already seen, which is what makes the 1000th entry break
+        on the guard rather than on a completed enumeration.
+        """
+        pages = [
+            {"WebACLs": [_paged_acl(i)], "NextMarker": f"m{i}"} for i in range(998)
+        ] + [{"WebACLs": [_paged_acl(998)], "NextMarker": "m0"}]
+        scripted = ScriptedListWebACLs(pages)
+        wafv2 = WAFv2(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
+
+        with patch(
+            "prowler.providers.aws.services.wafv2.wafv2_service.logger"
+        ) as mock_logger:
+            collected = list(wafv2._paginate_web_acls(scripted, "REGIONAL"))
+
+        assert len(collected) == 999
+        assert scripted.calls == 999
+        assert mock_logger.error.call_count == 1
+        assert "pagination loop detected" in mock_logger.error.call_args[0][0]
+        assert "page cap" not in mock_logger.error.call_args[0][0]
 
     # Test WAFv2 Describe Web ACLs Resources
     @mock_aws


### PR DESCRIPTION
A pagination fix in the WAFv2 collector. Three files, no new checks.

## What this fixes

`ListWebACLs` returns at most 100 Web ACLs per call and sets `NextMarker` while more remain. The
collector issued a single call and read `response["WebACLs"]`, so in any account with more than one
page of Web ACLs every Web ACL past the first 100 was **silently dropped from the inventory**.

**The consequence is a wrong finding as well as an absent one, and the wrong one is a false FAIL on a
protected resource.** Five checks consume `wafv2_client.web_acls`, in three services:

| check | behaviour on a truncated inventory |
| --- | --- |
| `wafv2_webacl_logging_enabled` | not assessed — an absent finding |
| `wafv2_webacl_rule_logging_enabled` | not assessed — an absent finding |
| `wafv2_webacl_with_rules` | not assessed — an absent finding |
| `elbv2_waf_acl_attached` | **false FAIL** |
| `cognito_user_pool_waf_acl_attached` | **false FAIL** |

The last two are the ones that matter. Both **default to `FAIL`** and flip to PASS only when an
inventoried ACL is found referencing the resource — `elbv2_waf_acl_attached:13` sets FAIL before scanning
`wafv2_client.web_acls` at `:17`, and `cognito_user_pool_waf_acl_attached:11` does the same before `:15`.
So an ALB or user pool that *is* protected, by an ACL that fell past the first page, is reported
**unprotected**. That is a false positive on a security control, not a gap in coverage.

One precision: `elbv2_waf_acl_attached` also scans `wafregional_client.web_acls`, so an ALB protected by a
**WAFv1** ACL still PASSes. The false FAIL is specific to WAFv2-protected resources.

WAFv2 ships no botocore paginator for this operation — verified at the pinned botocore 1.40.61 — so
the loop is hand-rolled rather than delegated to `get_paginator`.

## What the fix does

`_paginate_web_acls` follows `NextMarker` to the last page and yields every summary, with two guards:

- a **seen-marker set**, so a marker that never clears breaks the loop instead of spinning forever;
- an **iteration cap** of 1000 pages (100,000 Web ACLs at the 100-per-page limit), which can only be
  reached by a misbehaving API, since the default Web ACLs-per-Region quota is far below it.

## Verification

- 32 tests pass across `tests/providers/aws/services/wafv2/`, and 199 across the full set CI runs for
  this diff (`cognito` + `elbv2` + `wafv2`).
- Every line the diff adds to `prowler/` is covered by those tests: 52/52.
- The two guards are pinned by tests that assert in both directions rather than only the happy path —
  see the first disclosure below.

## Disclosures

**The truncation message is gated on a pending marker rather than on the iteration count alone**,
because the count reaches the cap on the final pass whether or not that pass completed the
enumeration — so the count by itself flagged possible truncation on a scope whose 1000th page
carried no `NextMarker` and was therefore complete. A regression test pins both directions: exactly
1000 pages ending cleanly logs nothing
(`test_pagination_cap_is_silent_when_the_last_page_completes_the_scan`), and markers that never end
still log it (`test_pagination_cap_warns_when_a_marker_is_still_pending`).

With that conjunct in place the message means exactly "the loop stopped early with a marker still
pending", which is accurate both for an honestly large account and for an API that keeps handing back
a fresh marker — in the second case the enumeration genuinely was truncated at 1000 pages while the
API still claimed more.

**Both pagination messages are emitted at `logger.error`, not `logger.warning`** — the cap message and
the loop-detection message alike. Worth naming because the distinction is live in this very file, which
carries **10** `logger.error` calls against **1** `logger.warning` (the `WAFNonexistentItemException`
branch of `_get_logging_configuration`). A reviewer who wants a legitimately-huge account to log below
ERROR should say so; the level is a deliberate choice, not an accident of wording.

**Merge order against a second WAFv2 change, measured.** A separate change still in preparation adds
two WAFv2 Web ACL rule checks and also edits `wafv2_service.py`. A three-way merge of the two reports
**exactly one conflict**, in `tests/providers/aws/services/wafv2/wafv2_service_test.py`, and **not**
in `wafv2_service.py` — the two touch different methods. **Merging this fix first is the lower-risk
order**, because the new checks then evaluate the complete Web ACL inventory. Merged second, both
checks would report cleanly on accounts whose Web ACLs run past one page while having assessed only
the first 100.

`codecov/project` is red on this PR, as it is across this campaign; `codecov/patch` is the signal that
reflects the diff, and it is green here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WAFv2 Web ACL discovery for accounts with multiple result pages.
  * Ensured both global and regional Web ACL listings include all available results.
  * Improved handling of empty pages, repeated pagination markers, and excessive pagination to prevent incomplete or stalled scans.

* **Tests**
  * Added coverage for pagination, loop detection, and maximum-page handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
