### PR TITLE
fix(sagemaker): read DirectInternetAccess instead of RootAccess on notebook instances

### DIFF
--- a/prowler/changelog.d/sagemaker-notebook-direct-internet-access-field.fixed.md
+++ b/prowler/changelog.d/sagemaker-notebook-direct-internet-access-field.fixed.md
@@ -1,0 +1,1 @@
+`sagemaker_notebook_instance_without_direct_internet_access_configured` check logic to read the `DirectInternetAccess` setting instead of `RootAccess`, failing a notebook instance with direct internet access enabled even when root access is disabled

--- a/prowler/providers/aws/services/sagemaker/sagemaker_notebook_instance_without_direct_internet_access_configured/sagemaker_notebook_instance_without_direct_internet_access_configured.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_notebook_instance_without_direct_internet_access_configured/sagemaker_notebook_instance_without_direct_internet_access_configured.py
@@ -3,7 +3,21 @@ from prowler.providers.aws.services.sagemaker.sagemaker_client import sagemaker_
 
 
 class sagemaker_notebook_instance_without_direct_internet_access_configured(Check):
-    def execute(self):
+    """Ensure that SageMaker notebook instances have direct internet access disabled."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Report whether each notebook instance has direct internet access disabled.
+
+        - PASS: DirectInternetAccess was read and is Disabled.
+        - FAIL: DirectInternetAccess was read and is Enabled, so the instance reaches the
+          internet directly rather than only through the VPC.
+        - MANUAL: DescribeNotebookInstance did not report DirectInternetAccess. Absent is not
+          Disabled, and the two cannot share a value here or an instance whose setting was
+          never read would be reported compliant.
+
+        Returns:
+            One report per notebook instance in the inventory.
+        """
         findings = []
         for notebook_instance in sagemaker_client.sagemaker_notebook_instances:
             report = Check_Report_AWS(
@@ -11,7 +25,13 @@ class sagemaker_notebook_instance_without_direct_internet_access_configured(Chec
             )
             report.status = "PASS"
             report.status_extended = f"Sagemaker notebook instance {notebook_instance.name} has direct internet access disabled."
-            if notebook_instance.direct_internet_access:
+            if notebook_instance.direct_internet_access is None:
+                # DescribeNotebookInstance did not report DirectInternetAccess, so the
+                # setting is unknown. Defaulting to PASS would report an unread instance
+                # as compliant.
+                report.status = "MANUAL"
+                report.status_extended = f"Sagemaker notebook instance {notebook_instance.name} did not report DirectInternetAccess, so it could not be determined; verify manually."
+            elif notebook_instance.direct_internet_access:
                 report.status = "FAIL"
                 report.status_extended = f"Sagemaker notebook instance {notebook_instance.name} has direct internet access enabled."
 

--- a/prowler/providers/aws/services/sagemaker/sagemaker_service.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_service.py
@@ -204,6 +204,39 @@ class SageMaker(AWSService):
             )
 
     def _describe_notebook_instance(self, notebook_instance):
+        """Read one notebook instance's settings into the inventory.
+
+        Args:
+            notebook_instance: The NotebookInstance to populate, identified by
+                name and region.
+
+        DirectInternetAccess and RootAccess are unrelated settings, and this
+        method previously guarded on the presence of the first while reading
+        the value of the second. Three consequences followed, all of them here
+        rather than in the check that consumes this:
+
+        - An instance with DirectInternetAccess Enabled and RootAccess Disabled
+          was recorded as having no direct internet access, and reported PASS.
+        - An instance with DirectInternetAccess Disabled and RootAccess Enabled
+          was recorded as having it, and reported FAIL.
+        - With RootAccess absent, subscripting it raised KeyError. The
+          enclosing ``except Exception`` swallowed that, so the assignments
+          below it never ran and ``kms_key_id`` and ``lifecycle_config_name``
+          were left None for an instance that has them -- degrading checks that
+          read those fields and never touch this one.
+
+        The third is reachable rather than theoretical:
+        DescribeNotebookInstanceOutput declares 23 members and carries no
+        ``required`` key at all at the pinned botocore, so both fields are
+        optional and a response with one and not the other is legal.
+
+        DirectInternetAccess is therefore assigned in BOTH states. Setting only
+        the True case would leave None meaning either Disabled or never-read,
+        and the check has to tell those apart: it reports MANUAL for never-read
+        rather than defaulting to PASS, which would assert compliance from an
+        absent answer. Collapsing the two states here would take that
+        distinction away from it.
+        """
         logger.info("SageMaker - describing notebook instances...")
         try:
             regional_client = self.regional_clients[notebook_instance.region]
@@ -223,11 +256,13 @@ class SageMaker(AWSService):
                 notebook_instance.root_access = True
             if "SubnetId" in describe_notebook_instance:
                 notebook_instance.subnet_id = describe_notebook_instance["SubnetId"]
-            if (
-                "DirectInternetAccess" in describe_notebook_instance
-                and describe_notebook_instance["RootAccess"] == "Enabled"
-            ):
-                notebook_instance.direct_internet_access = True
+            if "DirectInternetAccess" in describe_notebook_instance:
+                # Assign both states, not just the enabled one. Left as None, "Disabled"
+                # and "the field was never read" are the same value, and the check
+                # defaults to PASS -- so an unreadable notebook instance reported clean.
+                notebook_instance.direct_internet_access = (
+                    describe_notebook_instance["DirectInternetAccess"] == "Enabled"
+                )
             if "KmsKeyId" in describe_notebook_instance:
                 notebook_instance.kms_key_id = describe_notebook_instance["KmsKeyId"]
             if "NotebookInstanceLifecycleConfigName" in describe_notebook_instance:
@@ -553,7 +588,8 @@ class NotebookInstance(BaseModel):
     arn: str
     root_access: bool = None
     subnet_id: str = None
-    direct_internet_access: bool = None
+    # None when DescribeNotebookInstance did not report the field: unknown, not disabled.
+    direct_internet_access: Optional[bool] = None
     kms_key_id: str = None
     lifecycle_config_name: str = None
     # Decoded lifecycle scripts keyed by "<hook>[<index>]" (e.g. "OnStart[0]"),

--- a/tests/providers/aws/services/sagemaker/sagemaker_notebook_instance_without_direct_internet_access_configured/sagemaker_notebook_instance_without_direct_internet_access_configured_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_notebook_instance_without_direct_internet_access_configured/sagemaker_notebook_instance_without_direct_internet_access_configured_test.py
@@ -38,6 +38,48 @@ class Test_sagemaker_notebook_instance_without_direct_internet_access_configured
             result = check.execute()
             assert len(result) == 0
 
+    def test_instance_direct_internet_unreported_is_manual(self):
+        """An unreported DirectInternetAccess must not read as disabled.
+
+        The collector only ever assigned True, so "Disabled" and "the field was never
+        read" were both None and the check defaulted to PASS -- reporting an instance it
+        had not read as compliant. Now False means disabled and None means unknown.
+        """
+        sagemaker_client = mock.MagicMock
+        sagemaker_client.sagemaker_notebook_instances = []
+        sagemaker_client.sagemaker_notebook_instances.append(
+            NotebookInstance(
+                name=test_notebook_instance,
+                arn=notebook_instance_arn,
+                region=AWS_REGION_EU_WEST_1,
+                direct_internet_access=None,
+            )
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.sagemaker.sagemaker_notebook_instance_without_direct_internet_access_configured.sagemaker_notebook_instance_without_direct_internet_access_configured.sagemaker_client",
+                sagemaker_client,
+            ),
+        ):
+            from prowler.providers.aws.services.sagemaker.sagemaker_notebook_instance_without_direct_internet_access_configured.sagemaker_notebook_instance_without_direct_internet_access_configured import (
+                sagemaker_notebook_instance_without_direct_internet_access_configured,
+            )
+
+            check = (
+                sagemaker_notebook_instance_without_direct_internet_access_configured()
+            )
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert "did not report DirectInternetAccess" in result[0].status_extended
+
     def test_instance_direct_internet_disabled(self):
         sagemaker_client = mock.MagicMock
         sagemaker_client.sagemaker_notebook_instances = []

--- a/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
@@ -262,6 +262,50 @@ class Test_SageMaker_Service:
             == lifecycle_config_name
         )
 
+    def test_describe_notebook_instance_direct_internet_independent_of_root_access(
+        self,
+    ):
+        """DirectInternetAccess and RootAccess are separate settings and must be read separately.
+
+        The shared fixture sets both to "Enabled", so a collector that reads RootAccess while
+        testing for the DirectInternetAccess key produces the right answer by coincidence. These
+        two cases separate the fields, which is the only way the confusion is visible.
+        """
+
+        def only_direct_internet(self, operation_name, kwarg):
+            """Serve a notebook instance with internet access on and root access off.
+
+            The combination a collector reading RootAccess records as having NO direct internet
+            access, which is the false PASS.
+            """
+            if operation_name == "DescribeNotebookInstance":
+                return {"DirectInternetAccess": "Enabled", "RootAccess": "Disabled"}
+            return mock_make_api_call(self, operation_name, kwarg)
+
+        def only_root_access(self, operation_name, kwarg):
+            """Serve a notebook instance with internet access off and root access on.
+
+            The mirror case: a collector reading RootAccess records direct internet access on an
+            instance that has none, which is the false FAIL.
+            """
+            if operation_name == "DescribeNotebookInstance":
+                return {"DirectInternetAccess": "Disabled", "RootAccess": "Enabled"}
+            return mock_make_api_call(self, operation_name, kwarg)
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with patch(
+            "botocore.client.BaseClient._make_api_call", new=only_direct_internet
+        ):
+            notebook = SageMaker(aws_provider).sagemaker_notebook_instances[0]
+            assert notebook.direct_internet_access
+            assert not notebook.root_access
+
+        with patch("botocore.client.BaseClient._make_api_call", new=only_root_access):
+            notebook = SageMaker(aws_provider).sagemaker_notebook_instances[0]
+            assert not notebook.direct_internet_access
+            assert notebook.root_access
+
     # Test SageMaker describe notebook instance lifecycle config
     def test_describe_notebook_instance_lifecycle_config(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])


### PR DESCRIPTION
A one-field collector fix in `sagemaker_service.py`. Five files, +141 / -7, no new checks.

## The bug

`sagemaker_service.py` guards on the presence of one field and then reads the value of another:

```python
if (
    "DirectInternetAccess" in describe_notebook_instance
    and describe_notebook_instance["RootAccess"] == "Enabled"
):
    notebook_instance.direct_internet_access = True
```

`RootAccess` and `DirectInternetAccess` are unrelated settings. The check that consumes this
(`sagemaker_notebook_instance_without_direct_internet_access_configured`) is correct; the defect is
entirely in the collector.

## What it does, measured

Both collector bodies were extracted **verbatim by AST** from `master` and from this branch and
executed against synthetic `DescribeNotebookInstance` responses with a stubbed client — not read and
reasoned about.

| `DirectInternetAccess` | `RootAccess` | reality | verdict on `master` | fixed verdict |
| --- | --- | --- | --- | --- |
| `Enabled` | `Disabled` | exposed | **PASS** | FAIL |
| `Enabled` | `Enabled` | exposed | FAIL | FAIL |
| `Disabled` | `Enabled` | safe | **FAIL** | PASS |
| `Disabled` | `Disabled` | safe | PASS | PASS |
| *absent* | `Enabled` | unknown | **PASS** | **MANUAL** |
| `Enabled` | *absent* | exposed | **PASS** + `KeyError` | FAIL |

Three consequences, in ascending blast radius.

**1. A false PASS on an internet-exposed notebook instance.** `DirectInternetAccess=Enabled` with
`RootAccess=Disabled` is reported compliant today. Disabling root access is itself a hardening step, so
the more hardened instance is the one that gets cleared.

**2. A false FAIL on a correctly configured one.** `DirectInternetAccess=Disabled` with
`RootAccess=Enabled` is reported non-compliant, and no change to internet access will clear it.

**3. An unhandled `KeyError` that degrades checks this PR does not touch.** When `RootAccess` is absent,
`describe_notebook_instance["RootAccess"]` raises. The method's bare `except Exception` swallows it and
the remaining assignments never run, so fields collected *after* that line are silently lost:

```text
DirectInternetAccess=Enabled, RootAccess absent
  master   kms_key_id=None   lifecycle_config_name=None
  fixed    kms_key_id='k'    lifecycle_config_name='lc'
```

Any check reading `kms_key_id` therefore sees `None` for a notebook instance that is in fact encrypted.
Note this also happens on a row where the verdict is coincidentally correct — `Disabled` with
`RootAccess` absent yields PASS, which is right, while still blanking both fields — so the collateral is
not confined to the rows where the verdict flips.

**Reachability.** From botocore's own model at
`botocore/data/sagemaker/2017-07-24/service-2.json.gz`, `DescribeNotebookInstanceOutput` declares **23
members and carries no `required` key at all** — not an empty list, but no required-member declaration
whatsoever. `RootAccess` and `DirectInternetAccess` are both present and both optional, so a response
carrying one without the other is a legitimate API response. It is **permitted by the API model; it has
not been observed in a live response.**

## The fix

Read the field the condition tests, and assign both states rather than only the enabled one:

```python
if "DirectInternetAccess" in describe_notebook_instance:
    notebook_instance.direct_internet_access = (
        describe_notebook_instance["DirectInternetAccess"] == "Enabled"
    )
```

Assigning both states is the second half of the fix, not a tidy-up. Left at `None`, "Disabled" and "the
field was never read" are the same value, and the check defaults to PASS — so an unreadable notebook
instance reported clean. The check now reports **MANUAL** for that case, which is why row 5 of the table
moves.

## Verification

- 83 tests pass across `tests/providers/aws/services/sagemaker/`.
- Every line the diff adds to `prowler/` is covered: 54/54. Of those 54 added lines, 38 are the
  docstrings discussed below; `codecov/patch` counts statements rather than added lines, so its
  denominator is smaller than this one.
- The verdict table above was produced by **executing both collector bodies**, not by reading the diff,
  and it distinguishes the two implementations row by row rather than reporting one repeated result.

## Disclosures

**Two of the four added docstrings are on pre-existing upstream functions.** Docstring coverage is
diff-scoped, and the diff touches six functions, so reaching the threshold meant documenting two the
diff merely touches rather than introduces — the check's `execute` and the collector's
`_describe_notebook_instance`. That widens a bug-fix PR into upstream code for a documentation reason,
and a reviewer may reasonably prefer them dropped. Both are worth having on their own terms:
`_describe_notebook_instance` is where the bug lived, so its docstring records why the two fields cannot
be swapped, and `execute` now states all three verdicts including the new MANUAL. For local context,
sagemaker's own test corpus on `master` is 2 of 84 documented with 17 of 18 files carrying none, so this
diff is well above its service's norm.

**`execute()` carries no return annotation.** Left deliberately: sagemaker annotates `execute()` on 3 of
17 check files upstream, so adding one here would be the divergence rather than the conformity.

**Comment density on the check file is above the corpus p90, with no restatement.** It sits at **10.3%**
(3 comments / 29 code lines) against an upstream p90 of 5.7% across 799 AWS check files;
`sagemaker_service.py` is inside the band at 2.3% (14 / 606). The three comments state why `None` must
not be conflated with "Disabled", which is the reasoning a reviewer would otherwise have to reconstruct.
Trimming them to hit the number would delete rationale rather than noise.

**The MANUAL message names a cause it has not established.** Driven at this head by stubbing the client
and executing the collector:

| `DescribeNotebookInstance` raises | fields after the call | verdict |
| --- | --- | --- |
| nothing (both members present) | `dia=True kms='k' lifecycle='lc'` | FAIL |
| `ThrottlingException` | all three `None` | **MANUAL, "did not report DirectInternetAccess"** |
| `AccessDeniedException` | all three `None` | **MANUAL, same message** |
| `ValidationException` | all three `None` | **MANUAL, same message** |

The mechanism is upstream's: the inner `except ClientError` logs only for `ValidationException` and
re-raises nothing, so on any error `describe_notebook_instance` is never bound, the next line raises
`UnboundLocalError`, and the outer `except Exception` swallows it. **So a throttle, a denial and a
successful-but-incomplete response are indistinguishable in the emitted finding**, and the message
asserts a cause it has not established.

**This is still strictly better than the shipped behaviour, which is why it is disclosed rather than
blocking.** On `master` the check reads `if notebook_instance.direct_internet_access:` — `None` is
falsy, so every one of those three errors produces a **silent PASS** on an instance whose configuration
was never read. This PR turns a false PASS into a MANUAL. The residue is the message wording, not the
verdict.

**Open question for the reviewer, deliberately not decided here.** Branching on the error code would
mean recording *why* the read failed, which is model state this bug fix does not add. The smaller option
is to stop asserting the cause in `status_extended` — say the setting could not be determined without
claiming the API did not report it. That is a one-line change inside the MANUAL branch this PR already
adds, and it is left for the maintainer rather than taken unilaterally.

`codecov/project` is red on this PR, as it is across this campaign; `codecov/patch` is the signal that
reflects the diff, and it is green here.

## Scope

This PR is the fix only. Four additional SageMaker checks — output encryption, batch transform
encryption, endpoint data capture and VPC endpoints — are **deliberately not included**: they carry a
larger documentation cost and are a separate decision. Splitting them out keeps this a five-file review
of a shipped bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SageMaker notebook checks now evaluate direct internet access independently from root access.
  * Notebooks with direct internet access enabled correctly fail, including when root access is disabled.
  * Missing direct internet access settings now require manual review instead of passing automatically.
  * Notebooks with direct internet access disabled are correctly reported as passing.
  * Reporting now clearly distinguishes pass, fail, and manual-review outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

