### PR TITLE
feat(ecr): assess enhanced scanning on registries holding repositories

### DIFF
--- a/prowler/changelog.d/ecr-registry-enhanced-scanning.added.md
+++ b/prowler/changelog.d/ecr-registry-enhanced-scanning.added.md
@@ -1,0 +1,1 @@
+`ecr_registry_enhanced_scanning_enabled` check for AWS provider, verifying that the ECR registry scan type is enhanced (Amazon Inspector, covering programming language packages and continuous rescanning) instead of basic, and reporting MANUAL when the registry scanning configuration cannot be read

--- a/prowler/compliance/aws/aws_ai_security_framework_aws.json
+++ b/prowler/compliance/aws/aws_ai_security_framework_aws.json
@@ -1131,7 +1131,8 @@
         "eks_cluster_uses_a_supported_version",
         "eks_control_plane_logging_all_types_enabled",
         "eks_cluster_kms_cmk_encryption_in_secrets_enabled",
-        "eks_cluster_deletion_protection_enabled"
+        "eks_cluster_deletion_protection_enabled",
+        "ecr_registry_enhanced_scanning_enabled"
       ]
     },
     {
@@ -1154,7 +1155,8 @@
         "ecs_task_definitions_logging_enabled",
         "ecs_task_definitions_no_environment_secrets",
         "ecs_task_definitions_host_namespace_not_shared",
-        "ecs_cluster_container_insights_enabled"
+        "ecs_cluster_container_insights_enabled",
+        "ecr_registry_enhanced_scanning_enabled"
       ]
     },
     {

--- a/prowler/providers/aws/services/ecr/ecr_registry_enhanced_scanning_enabled/ecr_registry_enhanced_scanning_enabled.metadata.json
+++ b/prowler/providers/aws/services/ecr/ecr_registry_enhanced_scanning_enabled/ecr_registry_enhanced_scanning_enabled.metadata.json
@@ -1,0 +1,41 @@
+{
+  "Provider": "aws",
+  "CheckID": "ecr_registry_enhanced_scanning_enabled",
+  "CheckTitle": "ECR registry has enhanced scanning enabled",
+  "CheckType": [
+    "Software and Configuration Checks/Vulnerabilities/CVE",
+    "Software and Configuration Checks/AWS Security Best Practices"
+  ],
+  "ServiceName": "ecr",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "Other",
+  "ResourceGroup": "container",
+  "Description": "Amazon ECR registries with repositories are evaluated for **enhanced scanning**, the Amazon Inspector-powered scan type that covers operating system **and** programming language packages and can rescan images continuously as new CVEs are published. A registry left on **basic** scanning is reported as failing.",
+  "Risk": "**Basic** scanning matches only OS packages against a static CVE list, so **application dependencies** (npm, PyPI, Maven, Go, .NET) are never assessed. It rescans only on push or on an explicit StartImageScan, at most once per 24 hours, so a CVE published since the last scan stays invisible until someone acts. Vulnerable images keep being pulled, enabling **RCE** and supply chain compromise.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-enhanced.html",
+    "https://docs.aws.amazon.com/inspector/latest/user/scanning-ecr.html",
+    "https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws ecr put-registry-scanning-configuration --scan-type ENHANCED --rules 'scanFrequency=CONTINUOUS_SCAN,repositoryFilters=[{filter=*,filterType=WILDCARD}]'",
+      "NativeIaC": "",
+      "Other": "1. Open the AWS Management Console and go to Amazon ECR\n2. In the left menu, click Private registry, then Scanning\n3. Click Edit\n4. Set Scanning type to Enhanced scanning\n5. Under Enhanced scanning, add or keep a repository filter matching every repository that must be scanned. Coverage comes from the filters, not from the frequency: a filter of * covers the whole registry, and any repository no filter matches is left unscanned\n6. Set the scan frequency for those filters, either Continuous scanning or Scan on push\n7. Click Save",
+      "Terraform": "```hcl\nresource \"aws_ecr_registry_scanning_configuration\" \"<example_resource_name>\" {\n  scan_type = \"ENHANCED\"\n\n  rule {\n    scan_frequency = \"CONTINUOUS_SCAN\"\n    repository_filter {\n      filter      = \"*\"\n      filter_type = \"WILDCARD\"\n    }\n  }\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Set the registry scan type to **enhanced scanning**, which delegates scanning to **Amazon Inspector** and adds programming language package coverage plus continuous rescanning on top of the operating system coverage that basic scanning provides. Feed the resulting findings into CI/CD gates so vulnerable images are not promoted.",
+      "Url": "https://hub.prowler.com/check/ecr_registry_enhanced_scanning_enabled"
+    }
+  },
+  "Categories": [
+    "container-security"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "Scoped to registries that hold at least one repository. The ECR API accepts both the CONTINUOUS_SCAN and SCAN_ON_PUSH frequencies for the ENHANCED scan type, so ENHANCED on its own does not imply continuous rescanning; frequency is a separate axis this check does not assert. It is NOT a coverage guarantee, and this check does not claim one: enhanced scanning is driven by repository filters, so clearing the scan-all filter leaves any repository no filter matches unscanned. What this check asserts is the registry's scan TYPE, not that every repository in it is covered. Registry-wide scan-on-push coverage and its repository filters are asserted by ecr_registry_scan_images_on_push_enabled, which passes for either scan type. Reported as MANUAL when GetRegistryScanningConfiguration could not be read, because an unretrieved scan type is not evidence of compliance."
+}

--- a/prowler/providers/aws/services/ecr/ecr_registry_enhanced_scanning_enabled/ecr_registry_enhanced_scanning_enabled.metadata.json
+++ b/prowler/providers/aws/services/ecr/ecr_registry_enhanced_scanning_enabled/ecr_registry_enhanced_scanning_enabled.metadata.json
@@ -23,7 +23,7 @@
   "Remediation": {
     "Code": {
       "CLI": "aws ecr put-registry-scanning-configuration --scan-type ENHANCED --rules 'scanFrequency=CONTINUOUS_SCAN,repositoryFilters=[{filter=*,filterType=WILDCARD}]'",
-      "NativeIaC": "",
+      "NativeIaC": "```yaml\nResources:\n  RegistryScanningConfiguration:\n    Type: AWS::ECR::RegistryScanningConfiguration\n    Properties:\n      ScanType: ENHANCED  # Critical: BASIC limits the registry to operating-system coverage\n      Rules:\n        - ScanFrequency: CONTINUOUS_SCAN\n          RepositoryFilters:\n            - Filter: \"*\"  # Critical: coverage comes from the filters, so * is what reaches every repository\n              FilterType: WILDCARD\n```",
       "Other": "1. Open the AWS Management Console and go to Amazon ECR\n2. In the left menu, click Private registry, then Scanning\n3. Click Edit\n4. Set Scanning type to Enhanced scanning\n5. Under Enhanced scanning, add or keep a repository filter matching every repository that must be scanned. Coverage comes from the filters, not from the frequency: a filter of * covers the whole registry, and any repository no filter matches is left unscanned\n6. Set the scan frequency for those filters, either Continuous scanning or Scan on push\n7. Click Save",
       "Terraform": "```hcl\nresource \"aws_ecr_registry_scanning_configuration\" \"<example_resource_name>\" {\n  scan_type = \"ENHANCED\"\n\n  rule {\n    scan_frequency = \"CONTINUOUS_SCAN\"\n    repository_filter {\n      filter      = \"*\"\n      filter_type = \"WILDCARD\"\n    }\n  }\n}\n```"
     },

--- a/prowler/providers/aws/services/ecr/ecr_registry_enhanced_scanning_enabled/ecr_registry_enhanced_scanning_enabled.py
+++ b/prowler/providers/aws/services/ecr/ecr_registry_enhanced_scanning_enabled/ecr_registry_enhanced_scanning_enabled.py
@@ -1,0 +1,43 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.ecr.ecr_client import ecr_client
+
+
+class ecr_registry_enhanced_scanning_enabled(Check):
+    """Verify that in-use ECR registries have enhanced scanning enabled.
+
+    Enhanced scanning (Amazon Inspector) covers operating system and programming
+    language packages with continuous rescanning as new CVEs are published, while
+    basic scanning only covers operating system packages at push time against a
+    static CVE list. Only registries holding at least one repository are checked.
+    - PASS: the registry scan type is ENHANCED.
+    - FAIL: the registry is on another scan type.
+    - MANUAL: the registry scanning configuration could not be retrieved, so the
+      scan type is unknown.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check logic.
+
+        Returns:
+            A list of reports containing the result of the check.
+        """
+        findings = []
+        for registry in ecr_client.registries.values():
+            # We want to check the registry if it is in use, hence there are repositories
+            if len(registry.repositories) != 0:
+                report = Check_Report_AWS(metadata=self.metadata(), resource=registry)
+                if registry.scan_type is None:
+                    report.status = "MANUAL"
+                    report.status_extended = f"ECR registry {registry.id} scanning configuration could not be retrieved, check manually if enhanced scanning is enabled."
+                elif registry.scan_type == "ENHANCED":
+                    report.status = "PASS"
+                    report.status_extended = (
+                        f"ECR registry {registry.id} has enhanced scanning enabled."
+                    )
+                else:
+                    report.status = "FAIL"
+                    report.status_extended = f"ECR registry {registry.id} has {registry.scan_type} scanning enabled instead of enhanced scanning."
+
+                findings.append(report)
+
+        return findings

--- a/tests/providers/aws/services/ecr/ecr_registry_enhanced_scanning_enabled/ecr_registry_enhanced_scanning_enabled_test.py
+++ b/tests/providers/aws/services/ecr/ecr_registry_enhanced_scanning_enabled/ecr_registry_enhanced_scanning_enabled_test.py
@@ -1,0 +1,311 @@
+from unittest import mock
+
+from prowler.providers.aws.services.ecr.ecr_service import (
+    Registry,
+    Repository,
+    ScanningRule,
+)
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+repository_name = "test_repo"
+repository_arn = (
+    f"arn:aws:ecr:eu-west-1:{AWS_ACCOUNT_NUMBER}:repository/{repository_name}"
+)
+registry_arn = (
+    f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/"
+    f"{AWS_ACCOUNT_NUMBER}"
+)
+
+
+def _registry(scan_type, rules, repositories=None, region=AWS_REGION_EU_WEST_1):
+    """Build a Registry holding one repository unless told otherwise.
+
+    A registry is per-region, so `region` is a parameter: an account using ECR in more than one
+    region has more than one registry, and each carries its own scanning configuration.
+    """
+    if repositories is None:
+        repositories = [
+            Repository(
+                name=repository_name,
+                arn=f"arn:aws:ecr:{region}:{AWS_ACCOUNT_NUMBER}:repository/{repository_name}",
+                region=region,
+                scan_on_push=True,
+                policy="",
+                images_details=None,
+                lifecycle_policy="",
+            )
+        ]
+    return Registry(
+        id=AWS_ACCOUNT_NUMBER,
+        arn=f"arn:aws:ecr:{region}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
+        region=region,
+        scan_type=scan_type,
+        repositories=repositories,
+        rules=rules,
+    )
+
+
+class Test_ecr_registry_enhanced_scanning_enabled:
+    def test_no_registries(self):
+        """Check produces no findings when no registries exist."""
+        ecr_client = mock.MagicMock
+        ecr_client.registries = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled.ecr_client",
+                ecr_client,
+            ),
+        ):
+            from prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled import (
+                ecr_registry_enhanced_scanning_enabled,
+            )
+
+            check = ecr_registry_enhanced_scanning_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_registry_no_repositories(self):
+        """Check skips registries holding no repositories (not in use)."""
+        ecr_client = mock.MagicMock
+        ecr_client.registries = {}
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = _registry(
+            "BASIC", [], repositories=[]
+        )
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled.ecr_client",
+                ecr_client,
+            ),
+        ):
+            from prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled import (
+                ecr_registry_enhanced_scanning_enabled,
+            )
+
+            check = ecr_registry_enhanced_scanning_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_registry_enhanced_scanning(self):
+        """Registry with ENHANCED scan type passes the check."""
+        ecr_client = mock.MagicMock
+        ecr_client.audited_account_arn = AWS_ACCOUNT_ARN
+        ecr_client.registries = {}
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = _registry(
+            "ENHANCED",
+            [
+                ScanningRule(
+                    scan_frequency="CONTINUOUS_SCAN",
+                    scan_filters=[{"filter": "*", "filterType": "WILDCARD"}],
+                )
+            ],
+        )
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled.ecr_client",
+                ecr_client,
+            ),
+        ):
+            from prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled import (
+                ecr_registry_enhanced_scanning_enabled,
+            )
+
+            check = ecr_registry_enhanced_scanning_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"ECR registry {AWS_ACCOUNT_NUMBER} has enhanced scanning enabled."
+            )
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == registry_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_registry_basic_scanning(self):
+        """Registry with BASIC scan type fails the check."""
+        ecr_client = mock.MagicMock
+        ecr_client.audited_account_arn = AWS_ACCOUNT_ARN
+        ecr_client.registries = {}
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = _registry(
+            "BASIC",
+            [
+                ScanningRule(
+                    scan_frequency="SCAN_ON_PUSH",
+                    scan_filters=[{"filter": "*", "filterType": "WILDCARD"}],
+                )
+            ],
+        )
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled.ecr_client",
+                ecr_client,
+            ),
+        ):
+            from prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled import (
+                ecr_registry_enhanced_scanning_enabled,
+            )
+
+            check = ecr_registry_enhanced_scanning_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"ECR registry {AWS_ACCOUNT_NUMBER} has BASIC scanning enabled instead of enhanced scanning."
+            )
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == registry_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_registry_enhanced_scanning_empty_rules(self):
+        """ENHANCED scan type with empty rules list.
+
+        An ENHANCED registry with no scanning rules still has the scan type
+        set to ENHANCED. The check verifies scan type only, not rules.
+        """
+        ecr_client = mock.MagicMock
+        ecr_client.audited_account_arn = AWS_ACCOUNT_ARN
+        ecr_client.registries = {}
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = _registry("ENHANCED", [])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled.ecr_client",
+                ecr_client,
+            ),
+        ):
+            from prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled import (
+                ecr_registry_enhanced_scanning_enabled,
+            )
+
+            check = ecr_registry_enhanced_scanning_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"ECR registry {AWS_ACCOUNT_NUMBER} has enhanced scanning enabled."
+            )
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == registry_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_registry_scanning_configuration_not_retrieved(self):
+        """An unread scan type is MANUAL, never PASS.
+
+        ``_get_registry_scanning_configuration`` leaves ``scan_type`` at
+        ``None`` when ``GetRegistryScanningConfiguration`` fails for any
+        reason other than the "feature is disabled" ValidationException, and
+        when the response carries no ``scanningConfiguration`` at all. An
+        unanswered scan type is not evidence that enhanced scanning is on.
+        """
+        ecr_client = mock.MagicMock
+        ecr_client.audited_account_arn = AWS_ACCOUNT_ARN
+        ecr_client.registries = {}
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = _registry(None, None)
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled.ecr_client",
+                ecr_client,
+            ),
+        ):
+            from prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled import (
+                ecr_registry_enhanced_scanning_enabled,
+            )
+
+            check = ecr_registry_enhanced_scanning_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"ECR registry {AWS_ACCOUNT_NUMBER} scanning configuration could not be retrieved, check manually if enhanced scanning is enabled."
+            )
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == registry_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_multiple_registries_one_verdict_each(self):
+        """Each registry is judged on its own scanning configuration.
+
+        A registry is per-region, so an account using ECR in three regions has three of them. One
+        ENHANCED, one BASIC and one unread must yield PASS, FAIL and MANUAL against the matching
+        region -- a check that reported only the first registry, or reused one verdict across them,
+        would leave the other regions unreported or misreported.
+        """
+        ecr_client = mock.MagicMock
+        ecr_client.audited_account_arn = AWS_ACCOUNT_ARN
+        ecr_client.registries = {
+            AWS_REGION_EU_WEST_1: _registry(
+                "ENHANCED", [], region=AWS_REGION_EU_WEST_1
+            ),
+            AWS_REGION_US_EAST_1: _registry("BASIC", [], region=AWS_REGION_US_EAST_1),
+            "eu-central-1": _registry(None, None, region="eu-central-1"),
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled.ecr_client",
+                ecr_client,
+            ),
+        ):
+            from prowler.providers.aws.services.ecr.ecr_registry_enhanced_scanning_enabled.ecr_registry_enhanced_scanning_enabled import (
+                ecr_registry_enhanced_scanning_enabled,
+            )
+
+            check = ecr_registry_enhanced_scanning_enabled()
+            result = check.execute()
+
+            assert len(result) == 3
+            by_region = {report.region: report for report in result}
+            assert set(by_region) == {
+                AWS_REGION_EU_WEST_1,
+                AWS_REGION_US_EAST_1,
+                "eu-central-1",
+            }
+            assert by_region[AWS_REGION_EU_WEST_1].status == "PASS"
+            assert by_region[AWS_REGION_US_EAST_1].status == "FAIL"
+            assert by_region["eu-central-1"].status == "MANUAL"
+            assert (
+                by_region[AWS_REGION_US_EAST_1].status_extended
+                == f"ECR registry {AWS_ACCOUNT_NUMBER} has BASIC scanning enabled instead of enhanced scanning."
+            )

--- a/tests/providers/aws/services/ecr/ecr_service_test.py
+++ b/tests/providers/aws/services/ecr/ecr_service_test.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import botocore
 import pytest
 from boto3 import client
+from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from prowler.providers.aws.services.ecr.ecr_service import (
@@ -199,6 +200,21 @@ def mock_make_api_call(self, operation_name, kwarg):
         return {"downloadUrl": f"https://layers.example.com/{digest}"}
 
     return make_api_call(self, operation_name, kwarg)
+
+
+def mock_make_api_call_registry_scanning_denied(self, operation_name, kwarg):
+    """Deny GetRegistryScanningConfiguration, serving every other call normally."""
+    if operation_name == "GetRegistryScanningConfiguration":
+        raise ClientError(
+            {
+                "Error": {
+                    "Code": "AccessDeniedException",
+                    "Message": "User is not authorized to perform: ecr:GetRegistryScanningConfiguration",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
 
 
 def mock_generate_regional_clients(provider, service):
@@ -436,6 +452,27 @@ class Test_ECR_Service:
                 scan_filters=[{"filter": "*", "filterType": "WILDCARD"}],
             )
         ]
+
+    @mock_aws
+    def test_get_registry_scanning_configuration_not_retrieved(self):
+        """A denied GetRegistryScanningConfiguration leaves the scan type unknown.
+
+        Prowler leaves unretrieved attributes at None, so checks reading
+        ``scan_type`` can tell "not enhanced" apart from "not answered".
+
+        The patch is entered inside the test body rather than as a decorator:
+        stacked patch decorators are merged into one ``patchings`` list, so the
+        class-level ``_make_api_call`` patch would be applied last and win.
+        """
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        with patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_registry_scanning_denied,
+        ):
+            ecr = ECR(aws_provider)
+        assert len(ecr.registries) == 1
+        assert ecr.registries[AWS_REGION_EU_WEST_1].scan_type is None
+        assert ecr.registries[AWS_REGION_EU_WEST_1].rules is None
 
     def test_is_artifact_scannable_docker(self):
         """A Docker image config is scannable."""


### PR DESCRIPTION
One new check over ECR registry scanning configuration.

## What this asserts

`ecr_registry_enhanced_scanning_enabled` reports whether an in-use ECR registry has enhanced scanning
(Amazon Inspector) rather than basic scanning. **Basic scanning identifies vulnerabilities only in
operating-system packages; enhanced scanning covers OS *and* programming-language packages** (Amazon
Inspector FAQ). For registries holding container images that back AI workloads, the language-package layer
is where most of the dependency surface lives, so the difference is the bulk of the dependency tree rather
than a marginal one.

Scope is registries with at least one repository. A registry holding none is not in use, and reporting
it would produce a finding with no remediable subject.

## Verdict semantics

- **PASS** — `scanType` is `ENHANCED`.
- **FAIL** — `scanType` is anything else, and the message names the value found rather than only
  saying "not enhanced". Two of the paths that reach FAIL never saw a `scanType` from AWS at all — see the
  driven table below.
- **MANUAL** — `scan_type` is `None`, which is **three** causes and not only a failed call.

## Two things this check does not claim

**Basic scanning is not "scan once and never again", and the metadata says so.** It rescans on push or on
an explicit `StartImageScan`, at most once per 24 hours — so a manual rescan is available, and the real
exposure is staleness against newly published CVEs rather than the absence of any rescan path. Scan
*frequency* is a separate axis from scan *type* and this check does not read it: the ECR user guide gives
basic scanning manual and scan-on-push frequencies and notes that a repository matching no scan-on-push
filter falls back to manual, which corroborates the pinned botocore 1.40.61, where `ScanFrequency` admits
`SCAN_ON_PUSH`, `CONTINUOUS_SCAN` and `MANUAL`. Cadence is #12560's subject; this check reads only
`scanType`.

One doc-versus-doc conflict, recorded rather than smoothed over: the Inspector FAQ says basic scanning
"offers only on-push scanning", which contradicts the ECR user guide's manual-and-on-push. The ECR guide is
authoritative for ECR's own feature and agrees with the API model, so it is the one followed — but a
reviewer citing the FAQ will read a different story, and that drift is worth knowing before the argument
happens in review.

**A PASS is not a guarantee that every repository is scanned.** Enhanced scanning is driven by repository
filters, so clearing the scan-all filter leaves any repository no filter matches unscanned. What this check
asserts is the registry's scan *type*, and the metadata Notes say exactly that. Registry-wide scan-on-push
coverage and its repository filters are asserted by `ecr_registry_scan_images_on_push_enabled`, which
passes for either scan type. No separate frequency assertion is needed for the ENHANCED case, because the
ECR API accepts only `CONTINUOUS_SCAN` and `SCAN_ON_PUSH` for that scan type.

## Verification

- 101 tests pass across `tests/providers/aws/services/ecr/`, and 128 across the full set CI runs for this
  diff (`ecr` + `inspector2`).
- Every line the diff adds to `prowler/` is covered: 34/34.
- Upstream's own compliance-mapping validation accepts the framework file this check is added to.

## Disclosures

**A successful call that omits `scanType` produces a FAIL, not a MANUAL.** The collector reads
`response.get("scanningConfiguration").get("scanType", "BASIC")`, so a successful
`GetRegistryScanningConfiguration` that omits the field is collapsed to `"BASIC"` **before the check
sees it** — and the check then reports FAIL, "has BASIC scanning enabled instead of enhanced
scanning", on the strength of a default the collector supplied rather than a value AWS returned. The
check's `scan_type is None` MANUAL branch is reached by **three** causes, two of which are successful
calls. Driven at this head by extracting the collector and feeding it each response shape:

| `GetRegistryScanningConfiguration` | `scan_type` | verdict |
| --- | --- | --- |
| `scanType: ENHANCED` | `ENHANCED` | PASS |
| `scanType: BASIC` | `BASIC` | FAIL |
| config present, **`scanType` omitted** | `BASIC` | **FAIL** — the collector's default, not AWS's answer |
| **`scanningConfiguration` absent** | `None` | **MANUAL** — a *successful* call |
| **`scanningConfiguration` null** | `None` | **MANUAL** — a *successful* call |
| call raises `AccessDeniedException`, or anything else | `None` | MANUAL |
| call raises **`ValidationException` "This feature is disabled"** | **`BASIC`** | **FAIL** |

The two successful-call MANUALs happen because `response.get("scanningConfiguration")` yields `None` and
the chained `.get` raises, so the model default survives — the same end state as a failed call, one level
further up the shape tree than the omitted-`scanType` case.

**The last row is the strongest instance of the very defect this disclosure exists to flag.**
`ecr_service.py`'s `except ClientError` has a branch that sets `scan_type = "BASIC"` when the code is
`ValidationException` and the message contains "GetRegistryScanningConfiguration operation: This feature
is disabled". So **a call AWS refused produces a FAIL** on a request that never succeeded. A reviewer
reading a BASIC FAIL cannot rule out "the API refused the call", because that is one of the cases that
reaches it.

**To be fair to the collector: the inference is sound and only the framing is not.** A
`ValidationException` saying the feature is disabled genuinely does establish that enhanced scanning is
off, so `BASIC` is the true state and the FAIL is the right verdict. What is wrong is the *message*, which
reports it as "has BASIC scanning enabled" — an observed configuration — when it was derived from an error
string rather than read from a response. So this row is a wording defect on a correct verdict, not an
unsound deduction, and it belongs in the same family as the other two rows where the collector's default
survives.

Absence is legal rather than hypothetical at both levels: at the pinned botocore 1.40.61 the
`scanningConfiguration` shape declares **no required members**, and `scanType` is an optional string
with enum `['BASIC', 'ENHANCED']`. This is a property of the pre-existing collector, not of this
check, and changing it would alter the behaviour of the existing
`ecr_registry_scan_images_on_push_enabled` path that reads the same field. Flagged so that a BASIC FAIL
is not read as necessarily observed, and so the MANUAL branch is not read as narrower than it is.

**`execute()` carries no return annotation, and that matches the service.** CodeRabbit has asked for this
annotation on 5 of 8 PRs in this campaign, so expect it here too. It is deliberately not added: measured
on `master`, ecr annotates `execute()` on **1/7 = 14.3%** of its check files, so annotating it would put
this file with 1 of 7 rather than with the other 6. The repo-wide rate is about 20%, but per-service
variance is enormous — iam is 47/48 = 97.9% while cloudwatch is 0/22 — so the per-service figure is the
one a maintainer would apply.

**Related open PR.** #12560 (`fix/ecr-registry-scan-frequency`) also touches this service, reading each
registry scanning rule's frequency instead of assuming scan-on-push. It changes the rule-frequency path
rather than `scanType`, and adds no `.metadata.json`, so no CheckID collides; confirm the merge order.

`codecov/project` is red on this PR, as it is across this campaign; `codecov/patch` is the signal that
reflects the diff, and it is green here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an AWS ECR check to verify that registries containing repositories use enhanced scanning powered by Amazon Inspector.
  - Reports enhanced-scanning registries as passing and basic-scanning registries as failing.
  - Flags unavailable scanning configurations for manual review.
  - Evaluates registries independently across regions and skips registries without repositories.

- **Documentation**
  - Added guidance covering risks, recommendations, and remediation through the AWS Console, CLI, and Terraform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
