### PR TITLE
feat(bedrock): add imported model CMK check

### DIFF
--- a/prowler/changelog.d/bedrock-imported-model-cmk.added.md
+++ b/prowler/changelog.d/bedrock-imported-model-cmk.added.md
@@ -1,0 +1,1 @@
+`bedrock_imported_model_encrypted_with_cmk` check for AWS Bedrock imported models using customer-managed KMS keys

--- a/prowler/providers/aws/services/bedrock/bedrock_imported_model_encrypted_with_cmk/bedrock_imported_model_encrypted_with_cmk.metadata.json
+++ b/prowler/providers/aws/services/bedrock/bedrock_imported_model_encrypted_with_cmk/bedrock_imported_model_encrypted_with_cmk.metadata.json
@@ -1,0 +1,43 @@
+{
+  "Provider": "aws",
+  "CheckID": "bedrock_imported_model_encrypted_with_cmk",
+  "CheckTitle": "Bedrock imported model is encrypted with a customer-managed KMS key",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/AWS Security Best Practices/Data Encryption"
+  ],
+  "ServiceName": "bedrock",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "Other",
+  "ResourceGroup": "ai_ml",
+  "Description": "**Bedrock imported models** can be encrypted at rest with a customer-managed KMS key instead of an AWS-owned key.",
+  "Risk": "An imported model can contain proprietary weights or information derived from sensitive training data. Under an **AWS-owned key**, the organization cannot define the key policy, independently rotate or disable the key, or audit key usage in its own account.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_GetImportedModel.html",
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateModelImportJob.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws bedrock create-model-import-job --job-name <job-name> --imported-model-name <model-name> --role-arn <role-arn> --model-data-source '{\"s3DataSource\":{\"s3Uri\":\"s3://<bucket>/<model-artifacts>\"}}' --imported-model-kms-key-id <kms-key-arn>",
+      "NativeIaC": "",
+      "Other": "1. Open the AWS Console and go to Amazon Bedrock\n2. Select **Imported models**, then start a new model import\n3. Under encryption, select a customer-managed KMS key\n4. Complete the import using a service role that can use the selected key\n5. Replace workloads that use an imported model without a customer-managed key",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Specify a customer-managed KMS key when importing each model so access to the model artifacts is governed by an auditable key policy that the organization can rotate or disable.",
+      "Url": "https://hub.prowler.com/check/bedrock_imported_model_encrypted_with_cmk"
+    }
+  },
+  "Categories": [
+    "gen-ai",
+    "encryption"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [
+    "bedrock_custom_model_encrypted_with_cmk"
+  ],
+  "Notes": "Reports one finding per imported model. The KMS key is read from GetImportedModel because ListImportedModels summaries do not include modelKmsKeyArn. If model details cannot be retrieved, the result is MANUAL rather than PASS."
+}

--- a/prowler/providers/aws/services/bedrock/bedrock_imported_model_encrypted_with_cmk/bedrock_imported_model_encrypted_with_cmk.py
+++ b/prowler/providers/aws/services/bedrock/bedrock_imported_model_encrypted_with_cmk/bedrock_imported_model_encrypted_with_cmk.py
@@ -1,0 +1,40 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.bedrock.bedrock_client import bedrock_client
+
+
+class bedrock_imported_model_encrypted_with_cmk(Check):
+    """Ensure Bedrock imported models use a customer-managed KMS key."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check logic.
+
+        Returns:
+            A list of reports containing the result of the check.
+        """
+        findings = []
+
+        for region, error in sorted(bedrock_client.imported_models_scan_errors.items()):
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource={"region": region}
+            )
+            report.region = region
+            report.resource_id = "imported-model/unknown"
+            report.resource_arn = f"arn:{bedrock_client.audited_partition}:bedrock:{region}:{bedrock_client.audited_account}:imported-model/unknown"
+            report.status = "MANUAL"
+            report.status_extended = f"Bedrock imported models could not be listed in region {region} ({error}); verify manually that every imported model uses a customer-managed KMS key."
+            findings.append(report)
+
+        for model in bedrock_client.imported_models.values():
+            report = Check_Report_AWS(metadata=self.metadata(), resource=model)
+            if not model.detail_retrieved:
+                report.status = "MANUAL"
+                report.status_extended = f"Bedrock imported model {model.name} encryption configuration could not be retrieved in region {model.region}; verify manually that it uses a customer-managed KMS key."
+            elif model.kms_key_arn:
+                report.status = "PASS"
+                report.status_extended = f"Bedrock imported model {model.name} is encrypted with a customer-managed KMS key in region {model.region}."
+            else:
+                report.status = "FAIL"
+                report.status_extended = f"Bedrock imported model {model.name} is not encrypted with a customer-managed KMS key in region {model.region}."
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/bedrock/bedrock_service.py
+++ b/prowler/providers/aws/services/bedrock/bedrock_service.py
@@ -18,12 +18,16 @@ class Bedrock(AWSService):
         self.guardrails_scan_errors = {}
         self.custom_models = {}
         self.custom_models_scan_errors = {}
+        self.imported_models = {}
+        self.imported_models_scan_errors = {}
         self.__threading_call__(self._get_model_invocation_logging_configuration)
         self.__threading_call__(self._list_guardrails)
         self.__threading_call__(self._get_guardrail, self.guardrails.values())
         self.__threading_call__(self._list_tags_for_resource, self.guardrails.values())
         self.__threading_call__(self._list_custom_models)
         self.__threading_call__(self._get_custom_model, self.custom_models.values())
+        self.__threading_call__(self._list_imported_models)
+        self.__threading_call__(self._get_imported_model, self.imported_models.values())
 
     def _get_model_invocation_logging_arn_template(self, region):
         return (
@@ -196,6 +200,52 @@ class Bedrock(AWSService):
                 f"{model.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
+    def _list_imported_models(self, regional_client):
+        """List models imported into the audited account."""
+        logger.info("Bedrock - Listing Imported Models...")
+        try:
+            paginator = regional_client.get_paginator("list_imported_models")
+            for page in paginator.paginate():
+                for model in page.get("modelSummaries", []):
+                    model_arn = model.get("modelArn", "")
+                    if model_arn and (
+                        not self.audit_resources
+                        or is_resource_filtered(model_arn, self.audit_resources)
+                    ):
+                        self.imported_models[model_arn] = ImportedModel(
+                            name=model.get("modelName", ""),
+                            arn=model_arn,
+                            region=regional_client.region,
+                        )
+        except ClientError as error:
+            code = error.response["Error"].get("Code", error.__class__.__name__)
+            if code != "ValidationException":
+                self.imported_models_scan_errors[regional_client.region] = code
+            logger.error(
+                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+        except Exception as error:
+            self.imported_models_scan_errors[regional_client.region] = (
+                error.__class__.__name__
+            )
+            logger.error(
+                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _get_imported_model(self, model):
+        """Fetch the KMS key used to encrypt an imported model at rest."""
+        logger.info("Bedrock - Getting Imported Model...")
+        try:
+            model_info = self.regional_clients[model.region].get_imported_model(
+                modelIdentifier=model.arn
+            )
+            model.kms_key_arn = model_info.get("modelKmsKeyArn")
+            model.detail_retrieved = True
+        except Exception as error:
+            logger.error(
+                f"{model.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
 
 class LoggingConfiguration(BaseModel):
     enabled: bool = False
@@ -237,6 +287,17 @@ class CustomModel(BaseModel):
     region: str
     kms_key_arn: Optional[str] = None
     # False when GetCustomModel failed: absent key is unknown, not unset.
+    detail_retrieved: bool = False
+
+
+class ImportedModel(BaseModel):
+    """Model representing a model imported into Amazon Bedrock."""
+
+    name: str
+    arn: str
+    region: str
+    kms_key_arn: Optional[str] = None
+    # False when GetImportedModel failed: absent key is unknown, not unset.
     detail_retrieved: bool = False
 
 

--- a/tests/providers/aws/services/bedrock/bedrock_imported_model_encrypted_with_cmk/bedrock_imported_model_encrypted_with_cmk_test.py
+++ b/tests/providers/aws/services/bedrock/bedrock_imported_model_encrypted_with_cmk/bedrock_imported_model_encrypted_with_cmk_test.py
@@ -1,0 +1,271 @@
+from unittest import mock
+
+import botocore
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+make_api_call = botocore.client.BaseClient._make_api_call
+
+MODEL_NAME = "test-imported-model"
+MODEL_ID = "a1b2c3d4e5f6"
+MODEL_ARN = f"arn:aws:bedrock:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:imported-model/{MODEL_ID}"
+KMS_KEY_ARN = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/11111111-2222-3333-4444-555555555555"
+
+
+def _mock_empty(self, operation_name, kwarg):
+    """Return no resources from the Bedrock APIs used during construction."""
+    if operation_name in (
+        "GetModelInvocationLoggingConfiguration",
+        "ListGuardrails",
+        "GetGuardrail",
+        "ListTagsForResource",
+        "ListCustomModels",
+    ):
+        return {}
+    if operation_name == "ListImportedModels":
+        return {"modelSummaries": []}
+    return make_api_call(self, operation_name, kwarg)
+
+
+def _imported_model_mock(kms_key_arn=None, fail_get=False):
+    """Build a Bedrock API stub returning one imported model."""
+
+    def _mock(self, operation_name, kwarg):
+        if operation_name in (
+            "GetModelInvocationLoggingConfiguration",
+            "ListGuardrails",
+            "GetGuardrail",
+            "ListTagsForResource",
+            "ListCustomModels",
+        ):
+            return {}
+        if operation_name == "ListImportedModels":
+            return {
+                "modelSummaries": [
+                    {"modelArn": MODEL_ARN, "modelName": MODEL_NAME},
+                ]
+            }
+        if operation_name == "GetImportedModel":
+            if fail_get:
+                raise ClientError(
+                    {"Error": {"Code": "AccessDeniedException", "Message": "denied"}},
+                    operation_name,
+                )
+            response = {"modelArn": MODEL_ARN, "modelName": MODEL_NAME}
+            if kms_key_arn is not None:
+                response["modelKmsKeyArn"] = kms_key_arn
+            return response
+        return make_api_call(self, operation_name, kwarg)
+
+    return _mock
+
+
+_mock_with_cmk = _imported_model_mock(KMS_KEY_ARN)
+_mock_without_cmk = _imported_model_mock()
+_mock_empty_cmk = _imported_model_mock("")
+_mock_unreadable = _imported_model_mock(fail_get=True)
+
+
+def _mock_list_denied(self, operation_name, kwarg):
+    """Deny ListImportedModels while allowing unrelated Bedrock calls."""
+    if operation_name in (
+        "GetModelInvocationLoggingConfiguration",
+        "ListGuardrails",
+        "GetGuardrail",
+        "ListTagsForResource",
+        "ListCustomModels",
+    ):
+        return {}
+    if operation_name == "ListImportedModels":
+        raise ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "denied"}},
+            operation_name,
+        )
+    return make_api_call(self, operation_name, kwarg)
+
+
+def _mock_unsupported_region(self, operation_name, kwarg):
+    """Report that the imported-model API is unavailable in this region."""
+    if operation_name in (
+        "GetModelInvocationLoggingConfiguration",
+        "ListGuardrails",
+        "GetGuardrail",
+        "ListTagsForResource",
+        "ListCustomModels",
+    ):
+        return {}
+    if operation_name == "ListImportedModels":
+        raise ClientError(
+            {
+                "Error": {
+                    "Code": "ValidationException",
+                    "Message": "Bedrock is not supported in this region.",
+                }
+            },
+            operation_name,
+        )
+    return make_api_call(self, operation_name, kwarg)
+
+
+def _mock_two_models(self, operation_name, kwarg):
+    """Return two imported models with different encryption states."""
+    second_name = "model-without-cmk"
+    second_arn = f"arn:aws:bedrock:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:imported-model/f6e5d4c3b2a1"
+    if operation_name in (
+        "GetModelInvocationLoggingConfiguration",
+        "ListGuardrails",
+        "GetGuardrail",
+        "ListTagsForResource",
+        "ListCustomModels",
+    ):
+        return {}
+    if operation_name == "ListImportedModels":
+        return {
+            "modelSummaries": [
+                {"modelArn": MODEL_ARN, "modelName": MODEL_NAME},
+                {"modelArn": second_arn, "modelName": second_name},
+            ]
+        }
+    if operation_name == "GetImportedModel":
+        if kwarg["modelIdentifier"] == MODEL_ARN:
+            return {
+                "modelArn": MODEL_ARN,
+                "modelName": MODEL_NAME,
+                "modelKmsKeyArn": KMS_KEY_ARN,
+            }
+        return {"modelArn": second_arn, "modelName": second_name}
+    return make_api_call(self, operation_name, kwarg)
+
+
+class Test_bedrock_imported_model_encrypted_with_cmk:
+    """Unit tests for the imported-model CMK check."""
+
+    def _run(self, audit_resources=None):
+        """Import the service and check under active mocks, then execute."""
+        from prowler.providers.aws.services.bedrock.bedrock_service import Bedrock
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        if audit_resources is not None:
+            aws_provider._audit_resources = audit_resources
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.bedrock.bedrock_imported_model_encrypted_with_cmk.bedrock_imported_model_encrypted_with_cmk.bedrock_client",
+                new=Bedrock(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_imported_model_encrypted_with_cmk.bedrock_imported_model_encrypted_with_cmk import (
+                bedrock_imported_model_encrypted_with_cmk,
+            )
+
+            return bedrock_imported_model_encrypted_with_cmk().execute()
+
+    @mock.patch("botocore.client.BaseClient._make_api_call", new=_mock_empty)
+    @mock_aws
+    def test_no_resources(self):
+        """No imported models means no findings."""
+        assert self._run() == []
+
+    @mock.patch(
+        "botocore.client.BaseClient._make_api_call", new=_mock_unsupported_region
+    )
+    @mock_aws
+    def test_region_not_supported(self):
+        """An unsupported region produces no false finding."""
+        assert self._run() == []
+
+    @mock.patch("botocore.client.BaseClient._make_api_call", new=_mock_with_cmk)
+    @mock_aws
+    def test_cmk_present_passes(self):
+        """An imported model with modelKmsKeyArn is compliant."""
+        result = self._run()
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert result[0].resource_id == MODEL_NAME
+        assert result[0].resource_arn == MODEL_ARN
+        assert result[0].region == AWS_REGION_US_EAST_1
+        assert (
+            result[0].status_extended
+            == f"Bedrock imported model {MODEL_NAME} is encrypted with a customer-managed KMS key in region {AWS_REGION_US_EAST_1}."
+        )
+
+    @mock.patch("botocore.client.BaseClient._make_api_call", new=_mock_with_cmk)
+    @mock_aws
+    def test_out_of_scope_model_is_not_reported(self):
+        """Resource scoping excludes imported models outside the requested ARNs."""
+        other_model_arn = f"arn:aws:bedrock:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:imported-model/ffffffffffff"
+
+        assert self._run(audit_resources=[other_model_arn]) == []
+
+    @mock.patch("botocore.client.BaseClient._make_api_call", new=_mock_two_models)
+    @mock_aws
+    def test_each_model_is_evaluated_independently(self):
+        """Mixed imported-model inventory produces one verdict per resource."""
+        result = self._run()
+
+        assert len(result) == 2
+        assert {report.resource_id: report.status for report in result} == {
+            MODEL_NAME: "PASS",
+            "model-without-cmk": "FAIL",
+        }
+
+    @mock.patch("botocore.client.BaseClient._make_api_call", new=_mock_without_cmk)
+    @mock_aws
+    def test_no_cmk_fails(self):
+        """An absent modelKmsKeyArn means an AWS-owned key is in use."""
+        result = self._run()
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert (
+            result[0].status_extended
+            == f"Bedrock imported model {MODEL_NAME} is not encrypted with a customer-managed KMS key in region {AWS_REGION_US_EAST_1}."
+        )
+
+    @mock.patch("botocore.client.BaseClient._make_api_call", new=_mock_empty_cmk)
+    @mock_aws
+    def test_empty_cmk_fails(self):
+        """An empty modelKmsKeyArn is not a configured key."""
+        result = self._run()
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+
+    @mock.patch("botocore.client.BaseClient._make_api_call", new=_mock_unreadable)
+    @mock_aws
+    def test_detail_unreadable_is_manual(self):
+        """A failed GetImportedModel call must not become a false FAIL."""
+        result = self._run()
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+        assert (
+            result[0].status_extended
+            == f"Bedrock imported model {MODEL_NAME} encryption configuration could not be retrieved in region {AWS_REGION_US_EAST_1}; verify manually that it uses a customer-managed KMS key."
+        )
+
+    @mock.patch("botocore.client.BaseClient._make_api_call", new=_mock_list_denied)
+    @mock_aws
+    def test_list_denied_is_manual(self):
+        """A denied imported-model inventory must produce a regional finding."""
+        result = self._run()
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+        assert result[0].region == AWS_REGION_US_EAST_1
+        assert result[0].resource_id == "imported-model/unknown"
+        assert (
+            result[0].resource_arn
+            == f"arn:aws:bedrock:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:imported-model/unknown"
+        )
+        assert "AccessDeniedException" in result[0].status_extended


### PR DESCRIPTION
### Context

Adds coverage for AWS Bedrock imported models that are not encrypted with a customer-managed KMS key.

Fix #12612

The representative AWS PASS/FAIL execution evidence requested in the issue will be added before merge.

### Description

- Collect imported models with `ListImportedModels` and retrieve `modelKmsKeyArn` with `GetImportedModel`
- Emit one PASS or FAIL result per imported model and MANUAL results when inventory or model details cannot be read
- Add high-severity check metadata, a changelog fragment, and coverage for empty inventory, unsupported regions, API failures, resource filtering, and mixed model states
- Reuse the existing `bedrock:List*` and `bedrock:Get*` provider permissions; no permission update or new dependency is required

### Steps to review

1. Review the imported-model collection and error handling in `bedrock_service.py`.
2. Review PASS, FAIL, and MANUAL reporting in `bedrock_imported_model_encrypted_with_cmk.py`.
3. Run:

   ```bash
   uv run pytest tests/providers/aws/services/bedrock/ -q
   ```

   Local result: `184 passed`.

4. Confirm the metadata describes a high-severity AWS Bedrock encryption check and references the official Bedrock APIs.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature is listed in the open issues.
- [x] The issue is assigned to me (#12612).
- [x] I reviewed the open pull requests and found no existing PR implementing the same outcome.

</details>

- [x] The code is covered by tests.
- [x] Code and docstrings follow the Python documentation guidelines.
- [x] No backport is needed.
- [x] No README change is needed.
- [x] A changelog fragment is included under `prowler/changelog.d/`.

#### SDK/CLI

- Are there new checks included in this PR? Yes
- Do provider permissions need to be updated? No. Existing `bedrock:List*` and `bedrock:Get*` permissions cover the required APIs.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a security check for AWS Bedrock imported models that verifies encryption with a customer-managed KMS key.
  * Imported models are now included in Bedrock resource inventory and evaluated individually.
  * Findings identify models that pass, fail, or require manual review when encryption details are unavailable.

* **Documentation**
  * Added guidance for remediating models that are not encrypted with a customer-managed KMS key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
