### PR TITLE
feat(compliance): add Alibaba Cloud mappings to Cyber Essentials 3.3

### DIFF
--- a/prowler/changelog.d/add-alibabacloud-cyber-essentials.added.md
+++ b/prowler/changelog.d/add-alibabacloud-cyber-essentials.added.md
@@ -1,0 +1,1 @@
+Alibaba Cloud check mappings for the Cyber Essentials 3.3 universal compliance framework

--- a/prowler/compliance/cyber_essentials_3.3.json
+++ b/prowler/compliance/cyber_essentials_3.3.json
@@ -132,6 +132,10 @@
           "network_ssh_internet_access_restricted",
           "network_udp_internet_access_restricted",
           "network_http_internet_access_restricted"
+        ],
+        "alibabacloud": [
+          "ecs_securitygroup_restrict_rdp_internet",
+          "ecs_securitygroup_restrict_ssh_internet"
         ]
       }
     },
@@ -147,7 +151,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     },
     {
@@ -168,6 +173,12 @@
           "keyvault_access_only_through_private_endpoints",
           "network_rdp_internet_access_restricted",
           "network_ssh_internet_access_restricted"
+        ],
+        "alibabacloud": [
+          "oss_bucket_not_publicly_accessible",
+          "rds_instance_no_public_access_whitelist",
+          "ecs_securitygroup_restrict_rdp_internet",
+          "ecs_securitygroup_restrict_ssh_internet"
         ]
       }
     },
@@ -189,6 +200,12 @@
           "network_udp_internet_access_restricted",
           "network_http_internet_access_restricted",
           "storage_account_public_network_access_disabled"
+        ],
+        "alibabacloud": [
+          "ecs_securitygroup_restrict_rdp_internet",
+          "ecs_securitygroup_restrict_ssh_internet",
+          "oss_bucket_not_publicly_accessible",
+          "rds_instance_no_public_access_whitelist"
         ]
       }
     },
@@ -204,7 +221,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     },
     {
@@ -219,7 +237,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     },
     {
@@ -234,7 +253,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     },
     {
@@ -252,6 +272,9 @@
         "azure": [
           "entra_policy_guest_users_access_restrictions",
           "entra_policy_guest_invite_only_for_admin_roles"
+        ],
+        "alibabacloud": [
+          "ram_user_console_access_unused"
         ]
       }
     },
@@ -269,7 +292,8 @@
       "checks": {
         "azure": [
           "entra_security_defaults_enabled"
-        ]
+        ],
+        "alibabacloud": []
       }
     },
     {
@@ -284,7 +308,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     },
     {
@@ -299,7 +324,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     },
     {
@@ -320,6 +346,12 @@
           "storage_account_public_network_access_disabled",
           "storage_ensure_minimum_tls_version_12",
           "keyvault_rbac_enabled"
+        ],
+        "alibabacloud": [
+          "oss_bucket_secure_transport_enabled",
+          "oss_bucket_not_publicly_accessible",
+          "rds_instance_ssl_enabled",
+          "rds_instance_no_public_access_whitelist"
         ]
       }
     },
@@ -335,7 +367,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     },
     {
@@ -350,7 +383,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     },
     {
@@ -365,7 +399,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     },
     {
@@ -380,7 +415,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     },
     {
@@ -398,6 +434,10 @@
         "azure": [
           "defender_ensure_system_updates_are_applied",
           "defender_auto_provisioning_vulnerabilty_assessments_machines_on"
+        ],
+        "alibabacloud": [
+          "ecs_instance_latest_os_patches_applied",
+          "securitycenter_vulnerability_scan_enabled"
         ]
       }
     },
@@ -413,7 +453,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     },
     {
@@ -431,6 +472,9 @@
         "azure": [
           "entra_security_defaults_enabled",
           "storage_default_to_entra_authorization_enabled"
+        ],
+        "alibabacloud": [
+          "ram_no_root_access_key"
         ]
       }
     },
@@ -446,7 +490,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     },
     {
@@ -467,6 +512,9 @@
           "entra_conditional_access_policy_require_mfa_for_admin_portals",
           "entra_conditional_access_policy_require_mfa_for_management_api",
           "entra_user_with_vm_access_has_mfa"
+        ],
+        "alibabacloud": [
+          "ram_user_mfa_enabled_console_access"
         ]
       }
     },
@@ -486,6 +534,9 @@
           "entra_global_admin_in_less_than_five_users",
           "iam_role_user_access_admin_restricted",
           "iam_subscription_roles_owner_custom_not_created"
+        ],
+        "alibabacloud": [
+          "ram_policy_no_administrative_privileges"
         ]
       }
     },
@@ -504,6 +555,9 @@
         "azure": [
           "entra_global_admin_in_less_than_five_users",
           "iam_role_user_access_admin_restricted"
+        ],
+        "alibabacloud": [
+          "ram_policy_no_administrative_privileges"
         ]
       }
     },
@@ -522,6 +576,10 @@
         "azure": [
           "entra_security_defaults_enabled",
           "entra_privileged_user_has_mfa"
+        ],
+        "alibabacloud": [
+          "ram_password_policy_max_login_attempts",
+          "ram_user_mfa_enabled_console_access"
         ]
       }
     },
@@ -541,6 +599,10 @@
           "entra_security_defaults_enabled",
           "entra_privileged_user_has_mfa",
           "entra_non_privileged_user_has_mfa"
+        ],
+        "alibabacloud": [
+          "ram_password_policy_minimum_length",
+          "ram_user_mfa_enabled_console_access"
         ]
       }
     },
@@ -560,6 +622,11 @@
           "defender_assessments_vm_endpoint_protection_installed",
           "defender_ensure_wdatp_is_enabled",
           "defender_ensure_defender_for_server_is_on"
+        ],
+        "alibabacloud": [
+          "ecs_instance_endpoint_protection_installed",
+          "securitycenter_all_assets_agent_installed",
+          "securitycenter_advanced_or_enterprise_edition"
         ]
       }
     },
@@ -579,6 +646,10 @@
           "defender_ensure_wdatp_is_enabled",
           "defender_ensure_defender_for_server_is_on",
           "defender_ensure_defender_for_storage_is_on"
+        ],
+        "alibabacloud": [
+          "securitycenter_advanced_or_enterprise_edition",
+          "securitycenter_all_assets_agent_installed"
         ]
       }
     },
@@ -594,7 +665,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "alibabacloud": []
       }
     }
   ]

--- a/tests/lib/check/universal_compliance_models_test.py
+++ b/tests/lib/check/universal_compliance_models_test.py
@@ -917,6 +917,8 @@ class TestCyberEssentialsFramework:
         assert "alibabacloud" in fw.get_providers()
         assert fw.supports_provider("azure")
         assert fw.supports_provider("alibabacloud")
+        assert len(fw.requirements) == 28
+        assert all("alibabacloud" in req.checks for req in fw.requirements)
 
     def test_alibabacloud_check_ids_exist(self):
         # Nothing validates check IDs at load time, so a typo silently

--- a/tests/lib/check/universal_compliance_models_test.py
+++ b/tests/lib/check/universal_compliance_models_test.py
@@ -926,7 +926,11 @@ class TestCyberEssentialsFramework:
         fw = load_compliance_framework_universal(self._path())
         services_dir = os.path.normpath(
             os.path.join(
-                os.path.dirname(self._path()), "..", "providers", "alibabacloud", "services"
+                os.path.dirname(self._path()),
+                "..",
+                "providers",
+                "alibabacloud",
+                "services",
             )
         )
         real = {
@@ -935,7 +939,9 @@ class TestCyberEssentialsFramework:
             for f in files
             if f.endswith(".metadata.json")
         }
-        refs = {c for req in fw.requirements for c in req.checks.get("alibabacloud", [])}
+        refs = {
+            c for req in fw.requirements for c in req.checks.get("alibabacloud", [])
+        }
         assert refs, "expected alibabacloud mappings"
         assert refs <= real, f"unknown alibabacloud check IDs: {sorted(refs - real)}"
 

--- a/tests/lib/check/universal_compliance_models_test.py
+++ b/tests/lib/check/universal_compliance_models_test.py
@@ -908,13 +908,34 @@ class TestCyberEssentialsFramework:
         )
         return os.path.normpath(base)
 
-    def test_loads_and_supports_azure(self):
+    def test_loads_and_supports_providers(self):
         fw = load_compliance_framework_universal(self._path())
         assert fw is not None
         assert fw.framework == "Cyber-Essentials"
         assert fw.version == "3.3"
-        assert fw.get_providers() == ["azure"]
+        assert "azure" in fw.get_providers()
+        assert "alibabacloud" in fw.get_providers()
         assert fw.supports_provider("azure")
+        assert fw.supports_provider("alibabacloud")
+
+    def test_alibabacloud_check_ids_exist(self):
+        # Nothing validates check IDs at load time, so a typo silently
+        # produces a requirement that never matches any finding.
+        fw = load_compliance_framework_universal(self._path())
+        services_dir = os.path.normpath(
+            os.path.join(
+                os.path.dirname(self._path()), "..", "providers", "alibabacloud", "services"
+            )
+        )
+        real = {
+            f.replace(".metadata.json", "")
+            for _, _, files in os.walk(services_dir)
+            for f in files
+            if f.endswith(".metadata.json")
+        }
+        refs = {c for req in fw.requirements for c in req.checks.get("alibabacloud", [])}
+        assert refs, "expected alibabacloud mappings"
+        assert refs <= real, f"unknown alibabacloud check IDs: {sorted(refs - real)}"
 
     def test_covers_all_five_themes(self):
         fw = load_compliance_framework_universal(self._path())


### PR DESCRIPTION
### Context

Fixes #12594

Extends the Cyber Essentials 3.3 universal compliance framework to Alibaba Cloud, following the Azure precedent from #11588. JSON only, plus the framework's provider test.

### What changed

- `prowler/compliance/cyber_essentials_3.3.json`: every requirement's `checks` dict gains an `alibabacloud` key. 14 of 28 requirements map to 17 distinct Alibaba Cloud checks; the other 14 are device-level or process controls with no cloud control-plane equivalent and get an explicit `[]`. Azure lists and `attributes` untouched.
- `tests/lib/check/universal_compliance_models_test.py`: `test_loads_and_supports_azure` becomes `test_loads_and_supports_providers` (asserts both providers via membership, so a future provider addition doesn't conflict), and a new `test_alibabacloud_check_ids_exist` guards every mapped ID against the provider's `*.metadata.json` catalog, since nothing validates check IDs at load time.

### Mapping rationale (mirrors the Azure column)

| Requirement | Alibaba Cloud checks |
|---|---|
| CE-FW-01/03/04 (boundary firewall, admin interfaces, default-deny inbound) | `ecs_securitygroup_restrict_{rdp,ssh}_internet`, `oss_bucket_not_publicly_accessible`, `rds_instance_no_public_access_whitelist` |
| CE-SC-01 (remove unnecessary/unused accounts) | `ram_user_console_access_unused` |
| CE-SC-05 (authenticate before access, encrypted transport) | `oss_bucket_secure_transport_enabled`, `oss_bucket_not_publicly_accessible`, `rds_instance_ssl_enabled`, `rds_instance_no_public_access_whitelist` |
| CE-SUM-04 (critical updates within 14 days) | `ecs_instance_latest_os_patches_applied`, `securitycenter_vulnerability_scan_enabled` |
| CE-UAC-02 (unique credentials, no shared keys) | `ram_no_root_access_key` |
| CE-UAC-04 (MFA for cloud services) | `ram_user_mfa_enabled_console_access` |
| CE-UAC-05/06 (limit standing admin privilege) | `ram_policy_no_administrative_privileges` |
| CE-UAC-07 (brute-force protection) | `ram_password_policy_max_login_attempts` (blocks after 5 attempts, within the CE limit of 10), `ram_user_mfa_enabled_console_access` |
| CE-UAC-08 (password quality) | `ram_password_policy_minimum_length` (14 >= the CE 12-char bar), `ram_user_mfa_enabled_console_access` |
| CE-MP-01/02 (malware protection active and effective) | `ecs_instance_endpoint_protection_installed`, `securitycenter_all_assets_agent_installed`, `securitycenter_advanced_or_enterprise_edition` |

Deliberate gaps: CE-SC-02 stays empty for Alibaba Cloud — the RAM password-policy checks govern password quality (CE-UAC-08), and no check evidences that default/guessable passwords were changed. Complexity (`ram_password_policy_{upper,lower,number,symbol}`) and expiry (`ram_password_policy_max_password_age`) checks are intentionally unmapped: CE 3.3 says complexity and forced expiry should not be enforced. CE-UAC-03 stays empty because its attributes declare it Manual/non-applicable and attributes are shared across providers.

### Verification

- Issue's validation script: `OK: 17 check IDs, all exist`.
- `pytest tests/lib/check/universal_compliance_models_test.py tests/lib/check/compliance_config_requirements_data_test.py` — 3604 passed.

Note: PR prepared with Claude Code assistance; mappings reviewed against the check metadata titles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Alibaba Cloud support for the Cyber Essentials 3.3 universal compliance framework.
  - Added mappings for Alibaba Cloud compliance checks to improve coverage and reporting.

- **Tests**
  - Expanded provider coverage validation to include Azure and Alibaba Cloud.
  - Added checks to ensure all Alibaba Cloud compliance references map to valid service definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->