### PR TITLE
feat(compliance): map Cyber Essentials 3.3 to GCP

### DIFF
--- a/prowler/changelog.d/cyber-essentials-gcp-mappings.added.md
+++ b/prowler/changelog.d/cyber-essentials-gcp-mappings.added.md
@@ -1,0 +1,1 @@
+GCP check mappings for the Cyber Essentials 3.3 compliance framework

--- a/prowler/compliance/cyber_essentials_3.3.json
+++ b/prowler/compliance/cyber_essentials_3.3.json
@@ -132,6 +132,10 @@
           "network_ssh_internet_access_restricted",
           "network_udp_internet_access_restricted",
           "network_http_internet_access_restricted"
+        ],
+        "gcp": [
+          "compute_firewall_rdp_access_from_the_internet_allowed",
+          "compute_firewall_ssh_access_from_the_internet_allowed"
         ]
       }
     },
@@ -147,7 +151,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     },
     {
@@ -168,6 +173,13 @@
           "keyvault_access_only_through_private_endpoints",
           "network_rdp_internet_access_restricted",
           "network_ssh_internet_access_restricted"
+        ],
+        "gcp": [
+          "cloudstorage_bucket_public_access",
+          "compute_firewall_rdp_access_from_the_internet_allowed",
+          "compute_firewall_ssh_access_from_the_internet_allowed",
+          "kms_key_not_publicly_accessible",
+          "secretmanager_secret_not_publicly_accessible"
         ]
       }
     },
@@ -189,6 +201,13 @@
           "network_udp_internet_access_restricted",
           "network_http_internet_access_restricted",
           "storage_account_public_network_access_disabled"
+        ],
+        "gcp": [
+          "cloudsql_instance_public_access",
+          "cloudstorage_bucket_public_access",
+          "compute_firewall_rdp_access_from_the_internet_allowed",
+          "compute_firewall_ssh_access_from_the_internet_allowed",
+          "compute_network_default_in_use"
         ]
       }
     },
@@ -204,7 +223,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     },
     {
@@ -219,7 +239,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     },
     {
@@ -234,7 +255,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     },
     {
@@ -252,6 +274,9 @@
         "azure": [
           "entra_policy_guest_users_access_restrictions",
           "entra_policy_guest_invite_only_for_admin_roles"
+        ],
+        "gcp": [
+          "iam_service_account_unused"
         ]
       }
     },
@@ -269,7 +294,8 @@
       "checks": {
         "azure": [
           "entra_security_defaults_enabled"
-        ]
+        ],
+        "gcp": []
       }
     },
     {
@@ -284,7 +310,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     },
     {
@@ -299,7 +326,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     },
     {
@@ -320,6 +348,14 @@
           "storage_account_public_network_access_disabled",
           "storage_ensure_minimum_tls_version_12",
           "keyvault_rbac_enabled"
+        ],
+        "gcp": [
+          "bigquery_dataset_public_access",
+          "cloudfunction_function_not_publicly_accessible",
+          "cloudsql_instance_ssl_connections",
+          "cloudstorage_bucket_public_access",
+          "kms_key_not_publicly_accessible",
+          "secretmanager_secret_not_publicly_accessible"
         ]
       }
     },
@@ -335,7 +371,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     },
     {
@@ -350,7 +387,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     },
     {
@@ -365,7 +403,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     },
     {
@@ -380,7 +419,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     },
     {
@@ -398,7 +438,8 @@
         "azure": [
           "defender_ensure_system_updates_are_applied",
           "defender_auto_provisioning_vulnerabilty_assessments_machines_on"
-        ]
+        ],
+        "gcp": []
       }
     },
     {
@@ -413,7 +454,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     },
     {
@@ -431,6 +473,10 @@
         "azure": [
           "entra_security_defaults_enabled",
           "storage_default_to_entra_authorization_enabled"
+        ],
+        "gcp": [
+          "compute_instance_block_project_wide_ssh_keys_disabled",
+          "compute_project_os_login_enabled"
         ]
       }
     },
@@ -446,7 +492,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     },
     {
@@ -467,6 +514,9 @@
           "entra_conditional_access_policy_require_mfa_for_admin_portals",
           "entra_conditional_access_policy_require_mfa_for_management_api",
           "entra_user_with_vm_access_has_mfa"
+        ],
+        "gcp": [
+          "compute_project_os_login_2fa_enabled"
         ]
       }
     },
@@ -486,6 +536,12 @@
           "entra_global_admin_in_less_than_five_users",
           "iam_role_user_access_admin_restricted",
           "iam_subscription_roles_owner_custom_not_created"
+        ],
+        "gcp": [
+          "compute_instance_default_service_account_in_use_with_full_api_access",
+          "iam_role_kms_enforce_separation_of_duties",
+          "iam_role_sa_enforce_separation_of_duties",
+          "iam_sa_no_administrative_privileges"
         ]
       }
     },
@@ -504,7 +560,8 @@
         "azure": [
           "entra_global_admin_in_less_than_five_users",
           "iam_role_user_access_admin_restricted"
-        ]
+        ],
+        "gcp": []
       }
     },
     {
@@ -522,6 +579,9 @@
         "azure": [
           "entra_security_defaults_enabled",
           "entra_privileged_user_has_mfa"
+        ],
+        "gcp": [
+          "compute_project_os_login_2fa_enabled"
         ]
       }
     },
@@ -541,6 +601,9 @@
           "entra_security_defaults_enabled",
           "entra_privileged_user_has_mfa",
           "entra_non_privileged_user_has_mfa"
+        ],
+        "gcp": [
+          "compute_project_os_login_2fa_enabled"
         ]
       }
     },
@@ -560,7 +623,8 @@
           "defender_assessments_vm_endpoint_protection_installed",
           "defender_ensure_wdatp_is_enabled",
           "defender_ensure_defender_for_server_is_on"
-        ]
+        ],
+        "gcp": []
       }
     },
     {
@@ -579,7 +643,8 @@
           "defender_ensure_wdatp_is_enabled",
           "defender_ensure_defender_for_server_is_on",
           "defender_ensure_defender_for_storage_is_on"
-        ]
+        ],
+        "gcp": []
       }
     },
     {
@@ -594,7 +659,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "gcp": []
       }
     }
   ]

--- a/tests/lib/check/universal_compliance_models_test.py
+++ b/tests/lib/check/universal_compliance_models_test.py
@@ -930,7 +930,12 @@ class TestCyberEssentialsFramework:
         for dirpath, _, filenames in os.walk(services_root):
             for filename in filenames:
                 if filename.endswith(".metadata.json"):
-                    registered_checks.add(filename.replace(".metadata.json", ""))
+                    with open(os.path.join(dirpath, filename)) as metadata_file:
+                        check_id = json.load(metadata_file)["CheckID"]
+                    # Runtime finding identity is metadata CheckID; it must
+                    # match the filename/folder name.
+                    assert check_id == filename.replace(".metadata.json", "")
+                    registered_checks.add(check_id)
         referenced_checks = {
             check_id
             for requirement in fw.requirements

--- a/tests/lib/check/universal_compliance_models_test.py
+++ b/tests/lib/check/universal_compliance_models_test.py
@@ -908,13 +908,36 @@ class TestCyberEssentialsFramework:
         )
         return os.path.normpath(base)
 
-    def test_loads_and_supports_azure(self):
+    def test_loads_and_supports_azure_and_gcp(self):
         fw = load_compliance_framework_universal(self._path())
         assert fw is not None
         assert fw.framework == "Cyber-Essentials"
         assert fw.version == "3.3"
-        assert fw.get_providers() == ["azure"]
+        assert fw.get_providers() == ["azure", "gcp"]
         assert fw.supports_provider("azure")
+        assert fw.supports_provider("gcp")
+        assert all("gcp" in requirement.checks for requirement in fw.requirements)
+
+    def test_gcp_check_mappings_reference_registered_checks(self):
+        fw = load_compliance_framework_universal(self._path())
+        repository_root = os.path.normpath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..")
+        )
+        services_root = os.path.join(
+            repository_root, "prowler", "providers", "gcp", "services"
+        )
+        registered_checks = set()
+        for dirpath, _, filenames in os.walk(services_root):
+            for filename in filenames:
+                if filename.endswith(".metadata.json"):
+                    registered_checks.add(filename.replace(".metadata.json", ""))
+        referenced_checks = {
+            check_id
+            for requirement in fw.requirements
+            for check_id in requirement.checks.get("gcp", [])
+        }
+        assert referenced_checks
+        assert referenced_checks <= registered_checks
 
     def test_covers_all_five_themes(self):
         fw = load_compliance_framework_universal(self._path())
@@ -941,8 +964,8 @@ class TestCyberEssentialsFramework:
                 "partial",
                 "non-applicable",
             }
-            # Requirements with no checks must not claim to be Automated.
-            if not req.checks.get("azure"):
+            # Requirements with no checks for any provider must not claim to be Automated.
+            if not any(req.checks.values()):
                 assert req.attributes["AssessmentStatus"] == "Manual"
 
 


### PR DESCRIPTION
### Context

Cyber Essentials 3.3 currently ships with Azure mappings only. This PR extends the universal compliance framework to GCP, so `cyber_essentials_3.3` works with `prowler gcp` in the CLI table, CSV, OCSF output and the Prowler App.

Fixes #12592

### Description

- Add an explicit `gcp` key to all 28 Cyber Essentials 3.3 requirements
- Map existing GCP checks where they directly evidence a requirement: firewall exposure (RDP/SSH from 0.0.0.0/0, default VPC network), public accessibility of data and management-plane services (Cloud Storage, BigQuery, Cloud SQL, Cloud Functions, KMS, Secret Manager), unique credentials (OS Login, block project-wide SSH keys), MFA (OS Login 2FA), and administrative privilege separation (service account admin privileges, KMS/SA separation-of-duties roles)
- Leave `"gcp": []` where no existing GCP check directly evidences the requirement — this includes the device-level/process controls and also automated requirements with no GCP control-plane check today (default passwords, patch compliance, malware protection, since the GCP catalog has no OS Config patch or malware-protection checks)
- Azure mappings and all shared `attributes` are unchanged
- Extend the framework test to cover GCP provider discovery, assert every requirement carries a `gcp` key, and validate every referenced GCP check ID against the registered check metadata
- Add the SDK changelog fragment

No new checks, permissions, dependencies, API changes, UI changes or docs changes.

### Steps to review

1. Inspect the `gcp` lists in `prowler/compliance/cyber_essentials_3.3.json` and confirm each mapped check directly evidences its requirement.
2. Confirm every requirement has a `gcp` key and that Azure mappings and shared attributes are unchanged.
3. Run the framework tests:

```bash
uv run pytest tests/lib/check/universal_compliance_models_test.py -q
```

4. Run the compliance output regression tests:

```bash
uv run pytest tests/lib/outputs/compliance/ -q
```

5. Verify discovery and check selection:

```bash
uv run python prowler-cli.py gcp --list-compliance
uv run python prowler-cli.py gcp --compliance cyber_essentials_3.3 --list-checks-json
```

All of the above pass locally (208 passed for the framework tests, 418 passed for the compliance output tests; the CLI resolves 18 distinct GCP checks).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GCP check mappings for the Cyber Essentials 3.3 compliance framework.

* **Tests**
  * Expanded framework validation to cover Azure and GCP providers.
  * Added checks to ensure all referenced GCP checks are properly registered.
  * Improved validation for requirements without automated checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->