### PR TITLE
feat(ui): add provider credential schema renderer

### DIFF
--- a/ui/components/registry/provider-credential-fields.test.tsx
+++ b/ui/components/registry/provider-credential-fields.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { RegistryCredentialSchema } from "@/lib/registry/provider-credential-schema";
+
+import { RegistryCredentialFields } from "./provider-credential-fields";
+
+// prettier-ignore
+const schema: RegistryCredentialSchema = { fields: [{ name: "api_key", label: "API Key", description: "Issued from the console.", kind: "password", required: true }, { name: "scheme", label: "Scheme", kind: "select", options: ["bearer", "basic"], required: false }, { name: "notes", label: "Notes", kind: "textarea", required: false }] };
+
+beforeAll(() => {
+  // prettier-ignore
+  for (const name of ["hasPointerCapture", "releasePointerCapture", "scrollIntoView"]) {
+    Object.defineProperty(HTMLElement.prototype, name, { configurable: true, value: () => false });
+  }
+});
+
+describe("RegistryCredentialFields", () => {
+  it("renders accessible controlled credential fields and emits changes", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    // prettier-ignore
+    render(<RegistryCredentialFields errors={{ api_key: "A key is required." }} onChange={onChange} schema={schema} values={{ api_key: "", scheme: "bearer", notes: "" }} />);
+
+    // When
+    await user.type(screen.getByLabelText(/API Key/), "x");
+    await user.click(screen.getByRole("combobox", { name: "Scheme" }));
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    // Then
+    const apiKey = screen.getByLabelText(/API Key/);
+    const description = screen.getByText("Issued from the console.");
+    const error = screen.getByRole("alert");
+    expect(apiKey).toHaveAttribute("type", "password");
+    expect(apiKey).toHaveAttribute("autocomplete", "new-password");
+    // prettier-ignore
+    expect(apiKey).toHaveAttribute("aria-describedby", `${description.id} ${error.id}`);
+    expect(apiKey.id).toMatch(/-0-control$/);
+    expect(apiKey).toHaveAttribute("aria-invalid", "true");
+    expect(apiKey).toBeRequired();
+    expect(description.id).toMatch(/-0-description$/);
+    expect(error).toHaveTextContent("A key is required.");
+    expect(error.id).toMatch(/-0-error$/);
+    expect(onChange).toHaveBeenCalledWith("api_key", "x");
+    expect(onChange).toHaveBeenCalledWith("scheme", "basic");
+  });
+
+  it("uses unique index-based IDs for hostile field names and instances", () => {
+    // Given
+    // prettier-ignore
+    const hostileSchema: RegistryCredentialSchema = { fields: [{ name: "x-description", label: "First", kind: "text", required: false }, { name: "registry-credential-x", label: "Second", description: "Second description.", kind: "text", required: false }] };
+    // prettier-ignore
+    const { container } = render(<><RegistryCredentialFields errors={{}} onChange={vi.fn()} schema={hostileSchema} values={{}} /><RegistryCredentialFields errors={{}} onChange={vi.fn()} schema={schema} values={{}} /><RegistryCredentialFields errors={{}} onChange={vi.fn()} schema={schema} values={{}} /></>);
+
+    // When / Then
+    expect(screen.getByLabelText("First").id).toMatch(/-0-control$/);
+    // prettier-ignore
+    expect(screen.getByText("Second description.").id).toMatch(/-1-description$/);
+    const ids = Array.from(container.querySelectorAll("[id]"), ({ id }) => id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/ui/components/registry/provider-credential-fields.tsx
+++ b/ui/components/registry/provider-credential-fields.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { type ChangeEvent, useId } from "react";
+
+import { Field, FieldError, FieldLabel } from "@/components/shadcn/field/field";
+import { Input } from "@/components/shadcn/input/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/shadcn/select/select";
+import { Textarea } from "@/components/shadcn/textarea/textarea";
+import type { RegistryCredentialSchema } from "@/lib/registry/provider-credential-schema";
+
+// prettier-ignore
+interface RegistryCredentialFieldsProps { readonly errors: Readonly<Record<string, string | undefined>>; readonly onChange: (name: string, value: string) => void; readonly schema: RegistryCredentialSchema; readonly values: Readonly<Record<string, string | undefined>>; }
+
+export function RegistryCredentialFields({
+  errors,
+  onChange,
+  schema,
+  values,
+}: RegistryCredentialFieldsProps) {
+  const instanceId = useId();
+
+  return (
+    <div className="flex flex-col gap-4">
+      {schema.fields.map((field, index) => {
+        const error = errors[field.name];
+        const fieldId = `registry-credential-${instanceId}-${index}`;
+        const id = `${fieldId}-control`;
+        const descriptionId = field.description
+          ? `${fieldId}-description`
+          : undefined;
+        const errorId = error ? `${fieldId}-error` : undefined;
+        const describedBy =
+          [descriptionId, errorId].filter(Boolean).join(" ") || undefined;
+        const invalid = error ? true : undefined;
+        const value = values[field.name];
+        const textControlProps = {
+          "aria-describedby": describedBy,
+          "aria-invalid": invalid,
+          id,
+          // prettier-ignore
+          onChange: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => onChange(field.name, event.target.value),
+          required: field.required,
+          spellCheck: false,
+          value: typeof value === "string" ? value : "",
+        };
+
+        return (
+          <Field key={field.name}>
+            <FieldLabel htmlFor={id}>
+              {field.label}
+              {field.required && <span aria-hidden="true"> *</span>}
+            </FieldLabel>
+            {field.kind === "select" ? (
+              <Select
+                onValueChange={(nextValue) => onChange(field.name, nextValue)}
+                value={typeof value === "string" ? value : ""}
+              >
+                <SelectTrigger
+                  aria-describedby={describedBy}
+                  aria-invalid={invalid}
+                  aria-label={field.label}
+                  aria-required={field.required}
+                  id={id}
+                >
+                  <SelectValue placeholder="Select an option" />
+                </SelectTrigger>
+                <SelectContent>
+                  {field.options?.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : field.kind === "textarea" ? (
+              <Textarea autoComplete="off" {...textControlProps} />
+            ) : (
+              <Input
+                // prettier-ignore
+                autoComplete={field.kind === "password" ? "new-password" : "off"}
+                type={field.kind === "password" ? "password" : "text"}
+                {...textControlProps}
+              />
+            )}
+            {field.description &&
+              // prettier-ignore
+              <p className="text-text-neutral-secondary text-sm" id={descriptionId}>{field.description}</p>}
+            {error && (
+              <FieldError id={errorId} role="alert">
+                {error}
+              </FieldError>
+            )}
+          </Field>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/lib/registry/provider-credential-schema.test.ts
+++ b/ui/lib/registry/provider-credential-schema.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseRegistryCredentialSchema,
+  REGISTRY_CREDENTIAL_SCHEMA_LIMITS,
+} from "./provider-credential-schema";
+
+// prettier-ignore
+const schema = { type: "object", properties: { api_key: { title: "API Key", description: "The key.", type: "string", format: "password", writeOnly: true }, scheme: { title: "Scheme", type: "string", enum: ["bearer", "basic"], default: "bearer" }, notes: { title: "Notes", type: "string", "x-prowler-widget": "textarea", default: "" } }, required: ["api_key"] };
+
+describe("parseRegistryCredentialSchema", () => {
+  it("accepts the observed flat credential schema and preserves property order", () => {
+    // Given
+    const result = parseRegistryCredentialSchema(schema);
+
+    // When / Then
+    // prettier-ignore
+    expect(result?.fields.map(({ name, kind }) => [name, kind])).toEqual([["api_key", "password"], ["scheme", "select"], ["notes", "textarea"]]);
+    // prettier-ignore
+    expect(result?.fields[0]).toMatchObject({ description: "The key.", label: "API Key", required: true });
+  });
+
+  // prettier-ignore
+  it.each([["$ref", { $ref: "#/$defs/credential" }], ["$defs", { $defs: {} }], ["definitions", { definitions: {} }], ["combinators", { anyOf: [] }], ["additional properties", { additionalProperties: true }]])("rejects risky root keywords: %s", (_name, keyword) => {
+    expect(parseRegistryCredentialSchema({ ...schema, ...keyword })).toBeNull();
+  });
+
+  // prettier-ignore
+  it.each([["nested objects", { type: "object", properties: {} }], ["arrays", { type: "array" }], ["booleans", { type: "boolean" }], ["nullable unions", { type: ["string", "null"] }], ["unsupported formats", { type: "string", format: "email" }], ["passwords without writeOnly", { type: "string", format: "password" }], ["maps", { type: "string", additionalProperties: true }]])("rejects unsupported fields: %s", (_name, apiKey) => {
+    expect(parseRegistryCredentialSchema({ ...schema, properties: { ...schema.properties, api_key: apiKey } })).toBeNull();
+  });
+
+  // prettier-ignore
+  it.each([["invalid defaults", { type: "string", enum: ["bearer", "basic"], default: "token" }], ["duplicate values", { type: "string", enum: ["bearer", "bearer"] }]])("rejects enum definitions with %s", (_name, scheme) => {
+    expect(parseRegistryCredentialSchema({ ...schema, properties: { ...schema.properties, scheme } })).toBeNull();
+  });
+
+  it("rejects unsafe names, invalid required fields, and over-limit metadata", () => {
+    // Given
+    // prettier-ignore
+    const fields = Object.fromEntries(Array.from({ length: REGISTRY_CREDENTIAL_SCHEMA_LIMITS.MAX_FIELDS + 1 }, (_, index) => [`field${index}`, { type: "string" }]));
+    // prettier-ignore
+    const cases = [{ ...schema, required: ["missing"] }, JSON.parse('{"type":"object","properties":{"__proto__":{"type":"string"}}}'), { type: "object", properties: fields }, { ...schema, properties: { ...schema.properties, notes: { ...schema.properties.notes, title: "a".repeat(REGISTRY_CREDENTIAL_SCHEMA_LIMITS.MAX_TEXT_LENGTH + 1) } } }];
+
+    // When / Then
+    // prettier-ignore
+    expect(cases.map(parseRegistryCredentialSchema)).toEqual([null, null, null, null]);
+  });
+});

--- a/ui/lib/registry/provider-credential-schema.ts
+++ b/ui/lib/registry/provider-credential-schema.ts
@@ -1,0 +1,180 @@
+const FIELD_KIND = {
+  TEXT: "text",
+  PASSWORD: "password",
+  SELECT: "select",
+  TEXTAREA: "textarea",
+} as const;
+
+export const REGISTRY_CREDENTIAL_SCHEMA_LIMITS = {
+  MAX_FIELDS: 12,
+  MAX_NAME_LENGTH: 50,
+  MAX_TEXT_LENGTH: 200,
+  MAX_ENUM_OPTIONS: 20,
+} as const;
+
+type FieldKind = (typeof FIELD_KIND)[keyof typeof FIELD_KIND];
+
+export interface RegistryCredentialField {
+  readonly name: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly kind: FieldKind;
+  readonly options?: readonly string[];
+  readonly required: boolean;
+}
+
+export interface RegistryCredentialSchema {
+  readonly fields: readonly RegistryCredentialField[];
+}
+
+const ROOT = new Set("type title description properties required".split(" "));
+const FIELD = new Set(
+  "title description type format writeOnly enum default x-prowler-widget".split(
+    " ",
+  ),
+);
+const FORBIDDEN_NAMES = new Set(["__proto__", "prototype", "constructor"]);
+const FIELD_NAME = /^[A-Za-z][A-Za-z0-9_-]*$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function isText(value: unknown, allowEmpty = false): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= REGISTRY_CREDENTIAL_SCHEMA_LIMITS.MAX_TEXT_LENGTH &&
+    (allowEmpty || value.length > 0)
+  );
+}
+
+function hasOnly(
+  record: Record<string, unknown>,
+  allowed: Set<string>,
+): boolean {
+  for (const key in record) {
+    if (Object.hasOwn(record, key) && !allowed.has(key)) return false;
+  }
+  return true;
+}
+
+export function parseRegistryCredentialSchema(
+  value: unknown,
+): RegistryCredentialSchema | null {
+  if (!isRecord(value) || !hasOnly(value, ROOT) || value.type !== "object") {
+    return null;
+  }
+  if (
+    (value.title !== undefined && !isText(value.title)) ||
+    (value.description !== undefined && !isText(value.description))
+  ) {
+    return null;
+  }
+
+  const properties = value.properties;
+  if (!isRecord(properties)) return null;
+  const entries: [string, unknown][] = [];
+  for (const name in properties) {
+    if (!Object.hasOwn(properties, name)) continue;
+    if (entries.length === REGISTRY_CREDENTIAL_SCHEMA_LIMITS.MAX_FIELDS)
+      return null;
+    entries.push([name, properties[name]]);
+  }
+
+  const required = value.required ?? [];
+  if (
+    !Array.isArray(required) ||
+    required.length > entries.length ||
+    !required.every((name) => typeof name === "string")
+  ) {
+    return null;
+  }
+  const requiredNames = new Set(required);
+  if (
+    requiredNames.size !== required.length ||
+    required.some((name) => !Object.hasOwn(properties, name))
+  ) {
+    return null;
+  }
+
+  const fields: RegistryCredentialField[] = [];
+  for (const [name, property] of entries) {
+    if (
+      FORBIDDEN_NAMES.has(name) ||
+      !FIELD_NAME.test(name) ||
+      name.length > REGISTRY_CREDENTIAL_SCHEMA_LIMITS.MAX_NAME_LENGTH ||
+      !isRecord(property) ||
+      !hasOnly(property, FIELD) ||
+      property.type !== "string"
+    ) {
+      return null;
+    }
+
+    const label = property.title ?? name;
+    const description = property.description;
+    const format = property.format;
+    const widget = property["x-prowler-widget"];
+    const defaultValue = property.default;
+    const options = property.enum;
+    const password = format === "password" && property.writeOnly === true;
+    if (
+      !isText(label) ||
+      (description !== undefined && !isText(description)) ||
+      ((format !== undefined || property.writeOnly !== undefined) &&
+        !password) ||
+      (widget !== undefined && widget !== "textarea") ||
+      (defaultValue !== undefined && !isText(defaultValue, true))
+    ) {
+      return null;
+    }
+
+    if (options !== undefined) {
+      if (
+        format !== undefined ||
+        widget !== undefined ||
+        property.writeOnly !== undefined ||
+        !Array.isArray(options) ||
+        options.length === 0 ||
+        options.length > REGISTRY_CREDENTIAL_SCHEMA_LIMITS.MAX_ENUM_OPTIONS ||
+        !options.every((option) => isText(option)) ||
+        new Set(options).size !== options.length ||
+        (defaultValue !== undefined && !options.includes(defaultValue))
+      ) {
+        return null;
+      }
+      fields.push({
+        name,
+        label,
+        ...(description ? { description } : {}),
+        kind: FIELD_KIND.SELECT,
+        options,
+        required: requiredNames.has(name),
+      });
+      continue;
+    }
+
+    if (
+      widget !== undefined &&
+      (format !== undefined || property.writeOnly !== undefined)
+    ) {
+      return null;
+    }
+    fields.push({
+      name,
+      label,
+      ...(description ? { description } : {}),
+      kind: password
+        ? FIELD_KIND.PASSWORD
+        : widget === "textarea"
+          ? FIELD_KIND.TEXTAREA
+          : FIELD_KIND.TEXT,
+      required: requiredNames.has(name),
+    });
+  }
+  return { fields };
+}


### PR DESCRIPTION
## Context

This is PR 13 in the Registry UI chain and follows #12646.

PR 12 introduced the strict transport boundary for provider credential schemas. This child converts the backend's opaque schema object into a narrow UI-safe representation and renders that representation without integrating onboarding or persisting credential values.

## Description

- add a bounded, allowlisted parser for observed flat provider credential schemas
- support ordinary strings, masked password strings, string enums, and the observed textarea widget
- require exact password metadata (`format: password` and `writeOnly: true`)
- reject unsupported types, booleans, arrays, nested objects, maps, unions, refs/defs, combinators, conditionals, unknown keywords, prototype names, invalid defaults, excessive fields, and oversized metadata
- stop property traversal at the configured field bound without attacker-sized key allocation
- expose a narrow deterministic credential-field representation
- add a controlled Registry-local renderer using accessible Input, Select, and Textarea primitives
- scope DOM IDs per renderer instance and field index to avoid hostile-name or repeated-instance collisions
- keep submission, persistence, onboarding orchestration, and provider mutation outside this child

### Chain

- Parent: #12646
- Current: allowlisted schema parser and accessible renderer
- Next: Registry handoff, provider identity, and ephemeral credentials form

## Steps to review

1. Review `ui/lib/registry/provider-credential-schema.ts` for the positive allowlists, bounds, and fail-closed branches.
2. Review `ui/lib/registry/provider-credential-schema.test.ts` for accepted backend shapes and hostile/unsupported rejection cases.
3. Review `ui/components/registry/provider-credential-fields.tsx` for controlled values, unique IDs, password masking, and ARIA wiring.
4. Review the component test for keyboard selection, hostile names, repeated instances, and controlled change emission.

## Validation

- focused Vitest — 2 files, 18 tests passed
- full UI unit suite — 444 files, 3,187 tests passed
- TypeScript check — passed
- scoped ESLint — passed
- scoped Prettier check — passed
- primary LSP diagnostics — 0 findings across all four files
- pre-commit hooks — passed
- native RDD review and acknowledgement — approved (`review-e7e30f19b39e0b47`)

## Checklist

- [x] The PR title follows Conventional Commits.
- [x] Relevant tests were added and pass.
- [x] Type checking, linting, and formatting checks pass.
- [x] No screenshots are required because this component is not integrated into a visible flow yet.
- [x] No changelog entry is required for this intermediate chained PR.
