### PR TITLE
feat(sdk): AWS partition selection via PROWLER_AWS_PARTITION

### DIFF
--- a/prowler/changelog.d/aws-partition-env-var.added.md
+++ b/prowler/changelog.d/aws-partition-env-var.added.md
@@ -1,0 +1,1 @@
+`PROWLER_AWS_PARTITION` environment variable to select the AWS partition used for STS credential validation and scan bootstrap, with a clear error when the account belongs to a different partition

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -1645,7 +1645,7 @@ class AwsProvider(Provider):
         try:
             # Botocore resolves the regional STS endpoint for every partition
             # (China, EUSC, GovCloud, ISO); AWS_ENDPOINT_URL overrides it
-            sts_endpoint_url = os.environ.get("AWS_ENDPOINT_URL")
+            sts_endpoint_url = os.environ.get("AWS_ENDPOINT_URL") or None
             return session.client("sts", aws_region, endpoint_url=sts_endpoint_url)
         except Exception as error:
             logger.critical(

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -672,7 +672,12 @@ class AwsProvider(Provider):
             if mfa:
                 session = Session(**session_arguments)
                 session._session.set_default_client_config(session_config)
-                sts_client = session.client("sts")
+                sts_region = (
+                    get_env_partition_bootstrap_region()
+                    or session.region_name
+                    or AWS_STS_GLOBAL_ENDPOINT_REGION
+                )
+                sts_client = AwsProvider.create_sts_session(session, sts_region)
 
                 # TODO: pass values from the input
                 mfa_info = AwsProvider.input_role_mfa_token_and_code()
@@ -1725,26 +1730,44 @@ def read_aws_regions_file() -> dict:
 @lru_cache(maxsize=1)
 def get_botocore_partition_regions() -> dict:
     """
-    Get the AWS partitions and their regions from the botocore endpoints data.
+    Get the AWS partitions and their bootstrap region candidates from the
+    botocore endpoints data.
+
+    The region of the partition's global STS endpoint, when declared, is moved
+    to the front since it is never an opt-in region; the rest are sorted
+    alphabetically.
 
     Returns:
-        dict: A dictionary mapping each partition name to its sorted list of regions.
+        dict: A dictionary mapping each partition name to its list of regions.
     """
     endpoints_data = BotocoreSession().get_data("endpoints")
-    return {
-        partition["partition"]: sorted(partition.get("regions", {}))
-        for partition in endpoints_data["partitions"]
-    }
+    partition_regions = {}
+    for partition in endpoints_data["partitions"]:
+        regions = sorted(partition.get("regions", {}))
+        sts_service = partition.get("services", {}).get("sts", {})
+        global_endpoint = sts_service.get("partitionEndpoint")
+        global_region = (
+            sts_service.get("endpoints", {})
+            .get(global_endpoint, {})
+            .get("credentialScope", {})
+            .get("region")
+        )
+        if global_region in regions:
+            regions.remove(global_region)
+            regions.insert(0, global_region)
+        partition_regions[partition["partition"]] = regions
+    return partition_regions
 
 
-def get_env_partition_bootstrap_region() -> Optional[str]:
+def get_env_partition_regions() -> Optional[list]:
     """
-    Get the STS bootstrap region for the partition set in the
+    Get the bootstrap region candidates for the partition set in the
     PROWLER_AWS_PARTITION environment variable.
 
     Returns:
-        Optional[str]: The first region of the configured partition, or None
-            when the environment variable is not set.
+        Optional[list]: The regions of the configured partition, preferred
+            bootstrap region first, or None when the environment variable is
+            not set.
 
     Raises:
         AWSInvalidPartitionError: If the value is not a partition known to botocore.
@@ -1759,7 +1782,23 @@ def get_env_partition_bootstrap_region() -> Optional[str]:
         raise AWSInvalidPartitionError(
             message=f"Invalid partition: {raw_partition} set in PROWLER_AWS_PARTITION. Valid partitions: {', '.join(sorted(partition_regions))}"
         )
-    return regions[0]
+    return regions
+
+
+def get_env_partition_bootstrap_region() -> Optional[str]:
+    """
+    Get the STS bootstrap region for the partition set in the
+    PROWLER_AWS_PARTITION environment variable.
+
+    Returns:
+        Optional[str]: The preferred bootstrap region of the configured
+            partition, or None when the environment variable is not set.
+
+    Raises:
+        AWSInvalidPartitionError: If the value is not a partition known to botocore.
+    """
+    regions = get_env_partition_regions()
+    return regions[0] if regions else None
 
 
 # TODO: This can be moved to another class since it doesn't need self
@@ -1794,9 +1833,14 @@ def get_aws_region_for_sts(
             if region not in excluded_regions:
                 return region
 
-    env_partition_region = get_env_partition_bootstrap_region()
-    if env_partition_region and env_partition_region not in excluded_regions:
-        return env_partition_region
+    env_partition_regions = get_env_partition_regions()
+    if env_partition_regions:
+        # The configured partition constrains the whole fallback chain: prefer
+        # a non-excluded region, but never leave the partition
+        for region in env_partition_regions:
+            if region not in excluded_regions:
+                return region
+        return env_partition_regions[0]
 
     if session_region and session_region not in excluded_regions:
         return session_region

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -1643,14 +1643,9 @@ class AwsProvider(Provider):
             sts_client = create_sts_session(session, 'us-west-2')
         """
         try:
-            if os.environ.get("AWS_ENDPOINT_URL"):
-                sts_endpoint_url = os.environ["AWS_ENDPOINT_URL"]
-            elif aws_region.startswith("cn-"):
-                sts_endpoint_url = f"https://sts.{aws_region}.amazonaws.com.cn"
-            elif aws_region.startswith("eusc-"):
-                sts_endpoint_url = f"https://sts.{aws_region}.amazonaws.eu"
-            else:
-                sts_endpoint_url = f"https://sts.{aws_region}.amazonaws.com"
+            # Botocore resolves the regional STS endpoint for every partition
+            # (China, EUSC, GovCloud, ISO); AWS_ENDPOINT_URL overrides it
+            sts_endpoint_url = os.environ.get("AWS_ENDPOINT_URL")
             return session.client("sts", aws_region, endpoint_url=sts_endpoint_url)
         except Exception as error:
             logger.critical(

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 from datetime import datetime
+from functools import lru_cache
 from re import fullmatch
 from typing import Optional
 
@@ -1352,7 +1353,7 @@ class AwsProvider(Provider):
     @staticmethod
     def test_connection(
         profile: str = None,
-        aws_region: str = AWS_STS_GLOBAL_ENDPOINT_REGION,
+        aws_region: str = None,
         role_arn: str = None,
         role_session_name: str = ROLE_SESSION_NAME,
         session_duration: int = 3600,
@@ -1369,7 +1370,9 @@ class AwsProvider(Provider):
 
         Args:
             profile (str): The AWS profile to use for the session.
-            aws_region (str): The AWS region to validate the credentials in.
+            aws_region (str): The AWS region to validate the credentials in. When not
+                provided, it defaults to the bootstrap region of the partition set in
+                the PROWLER_AWS_PARTITION environment variable or, if unset, to us-east-1.
             role_arn (str): The ARN of the IAM role to assume.
             role_session_name (str): The name of the role session.
             session_duration (int): The duration of the assumed role session in seconds.
@@ -1412,6 +1415,12 @@ class AwsProvider(Provider):
             Connection(is_connected=True, Error=None))
         """
         try:
+            if aws_region is None:
+                aws_region = (
+                    get_env_partition_bootstrap_region()
+                    or AWS_STS_GLOBAL_ENDPOINT_REGION
+                )
+
             session = AwsProvider.setup_session(
                 mfa=mfa_enabled,
                 profile=profile,
@@ -1430,6 +1439,7 @@ class AwsProvider(Provider):
                     external_id=external_id,
                     mfa_enabled=mfa_enabled,
                     role_session_name=role_session_name,
+                    sts_region=aws_region,
                 )
                 assumed_role_credentials = AwsProvider.assume_role(
                     session,
@@ -1450,6 +1460,13 @@ class AwsProvider(Provider):
             # Do an extra validation if the AWS account ID is provided
             if provider_id and caller_identity.account != provider_id:
                 raise AWSInvalidProviderIdError(file=pathlib.Path(__file__).name)
+
+            # Validate that the account belongs to the configured partition, if any
+            env_partition = os.environ.get("PROWLER_AWS_PARTITION", "").strip()
+            if env_partition and caller_identity.arn.partition != env_partition:
+                raise AWSInvalidPartitionError(
+                    message=f"The AWS account is in the {caller_identity.arn.partition} partition, but this deployment is configured for the {env_partition} partition via PROWLER_AWS_PARTITION"
+                )
 
             return Connection(
                 is_connected=True,
@@ -1591,6 +1608,14 @@ class AwsProvider(Provider):
                 raise session_token_expired
             return Connection(error=session_token_expired)
 
+        except AWSInvalidPartitionError as invalid_partition_error:
+            logger.error(
+                f"{invalid_partition_error.__class__.__name__}[{invalid_partition_error.__traceback__.tb_lineno}]: {invalid_partition_error}"
+            )
+            if raise_on_exception:
+                raise invalid_partition_error
+            return Connection(error=invalid_partition_error)
+
         except Exception as error:
             logger.critical(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -1702,6 +1727,46 @@ def read_aws_regions_file() -> dict:
     return data
 
 
+@lru_cache(maxsize=1)
+def get_botocore_partition_regions() -> dict:
+    """
+    Get the AWS partitions and their regions from the botocore endpoints data.
+
+    Returns:
+        dict: A dictionary mapping each partition name to its sorted list of regions.
+    """
+    endpoints_data = BotocoreSession().get_data("endpoints")
+    return {
+        partition["partition"]: sorted(partition.get("regions", {}))
+        for partition in endpoints_data["partitions"]
+    }
+
+
+def get_env_partition_bootstrap_region() -> Optional[str]:
+    """
+    Get the STS bootstrap region for the partition set in the
+    PROWLER_AWS_PARTITION environment variable.
+
+    Returns:
+        Optional[str]: The first region of the configured partition, or None
+            when the environment variable is not set.
+
+    Raises:
+        AWSInvalidPartitionError: If the value is not a partition known to botocore.
+    """
+    raw_partition = os.environ.get("PROWLER_AWS_PARTITION", "").strip()
+    if not raw_partition:
+        return None
+
+    partition_regions = get_botocore_partition_regions()
+    regions = partition_regions.get(raw_partition)
+    if not regions:
+        raise AWSInvalidPartitionError(
+            message=f"Invalid partition: {raw_partition} set in PROWLER_AWS_PARTITION. Valid partitions: {', '.join(sorted(partition_regions))}"
+        )
+    return regions[0]
+
+
 # TODO: This can be moved to another class since it doesn't need self
 def get_aws_region_for_sts(
     session_region: str,
@@ -1710,6 +1775,10 @@ def get_aws_region_for_sts(
 ) -> str:
     """
     Get the AWS region for the STS Assume Role operation.
+
+    The precedence is: explicit regions, the partition set in the
+    PROWLER_AWS_PARTITION environment variable, the session region and,
+    finally, the bootstrap region candidates.
 
     Args:
         - session_region (str): The region configured in the AWS session.
@@ -1729,6 +1798,10 @@ def get_aws_region_for_sts(
         for region in regions:
             if region not in excluded_regions:
                 return region
+
+    env_partition_region = get_env_partition_bootstrap_region()
+    if env_partition_region and env_partition_region not in excluded_regions:
+        return env_partition_region
 
     if session_region and session_region not in excluded_regions:
         return session_region

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -1784,6 +1784,17 @@ aws:
         assert sts_session._endpoint.host == f"https://sts.{aws_region}.amazonaws.eu"
 
     @mock_aws
+    def test_create_sts_session_iso(self):
+        current_session = session.Session()
+        aws_region = "us-iso-east-1"
+        sts_session = AwsProvider.create_sts_session(current_session, aws_region)
+
+        assert sts_session._service_model.service_name == "sts"
+        assert sts_session._client_config.region_name == aws_region
+        assert sts_session._endpoint._endpoint_prefix == "sts"
+        assert sts_session._endpoint.host == f"https://sts.{aws_region}.c2s.ic.gov"
+
+    @mock_aws
     @patch(
         "prowler.lib.check.utils.recover_checks_from_provider",
         new=mock_recover_checks_from_aws_provider_elb_service,

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -1784,6 +1784,18 @@ aws:
         assert sts_session._endpoint.host == f"https://sts.{aws_region}.amazonaws.eu"
 
     @mock_aws
+    def test_create_sts_session_empty_endpoint_url(self):
+        current_session = session.Session()
+        aws_region = AWS_REGION_US_EAST_1
+        with mock.patch.dict(os.environ, {"AWS_ENDPOINT_URL": ""}):
+            sts_session = AwsProvider.create_sts_session(current_session, aws_region)
+
+        assert sts_session._service_model.service_name == "sts"
+        assert sts_session._client_config.region_name == aws_region
+        assert sts_session._endpoint._endpoint_prefix == "sts"
+        assert sts_session._endpoint.host == f"https://sts.{aws_region}.amazonaws.com"
+
+    @mock_aws
     def test_create_sts_session_iso(self):
         current_session = session.Session()
         aws_region = "us-iso-east-1"

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -2219,6 +2219,170 @@ aws:
             == AWS_REGION_US_EAST_1
         )
 
+    def test_get_aws_region_for_sts_env_partition_gov_cloud(self):
+        with mock.patch.dict(
+            os.environ,
+            {"PROWLER_AWS_PARTITION": AWS_GOV_CLOUD_PARTITION},
+            clear=False,
+        ):
+            assert get_aws_region_for_sts(None, None) == AWS_REGION_GOV_CLOUD_US_EAST_1
+
+    def test_get_aws_region_for_sts_env_partition_china(self):
+        with mock.patch.dict(
+            os.environ,
+            {"PROWLER_AWS_PARTITION": AWS_CHINA_PARTITION},
+            clear=False,
+        ):
+            assert get_aws_region_for_sts(None, None) == AWS_REGION_CN_NORTH_1
+
+    def test_get_aws_region_for_sts_env_partition_eusc(self):
+        with mock.patch.dict(
+            os.environ,
+            {"PROWLER_AWS_PARTITION": AWS_EUSC_PARTITION},
+            clear=False,
+        ):
+            assert get_aws_region_for_sts(None, None) == AWS_REGION_EUSC_DE_EAST_1
+
+    def test_get_aws_region_for_sts_env_partition_iso(self):
+        with mock.patch.dict(
+            os.environ,
+            {"PROWLER_AWS_PARTITION": AWS_ISO_PARTITION},
+            clear=False,
+        ):
+            assert get_aws_region_for_sts(None, None) == "us-iso-east-1"
+
+    def test_get_aws_region_for_sts_env_partition_overrides_session_region(self):
+        with mock.patch.dict(
+            os.environ,
+            {"PROWLER_AWS_PARTITION": AWS_GOV_CLOUD_PARTITION},
+            clear=False,
+        ):
+            assert (
+                get_aws_region_for_sts(AWS_REGION_EU_WEST_1, None)
+                == AWS_REGION_GOV_CLOUD_US_EAST_1
+            )
+
+    def test_get_aws_region_for_sts_input_regions_take_precedence_over_env_partition(
+        self,
+    ):
+        with mock.patch.dict(
+            os.environ,
+            {"PROWLER_AWS_PARTITION": AWS_GOV_CLOUD_PARTITION},
+            clear=False,
+        ):
+            assert (
+                get_aws_region_for_sts(None, {AWS_REGION_EU_WEST_1})
+                == AWS_REGION_EU_WEST_1
+            )
+
+    def test_get_aws_region_for_sts_env_partition_invalid_raises(self):
+        with mock.patch.dict(
+            os.environ,
+            {"PROWLER_AWS_PARTITION": "aws-invalid"},
+            clear=False,
+        ):
+            with pytest.raises(AWSInvalidPartitionError):
+                get_aws_region_for_sts(None, None)
+
+    @mock_aws
+    def test_test_connection_uses_env_partition_sts_region(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"PROWLER_AWS_PARTITION": AWS_GOV_CLOUD_PARTITION},
+                clear=False,
+            ),
+            mock.patch.object(
+                AwsProvider,
+                "validate_credentials",
+                return_value=AWSCallerIdentity(
+                    user_id="test-user-id",
+                    account=AWS_ACCOUNT_NUMBER,
+                    arn=ARN(AWS_GOV_CLOUD_ACCOUNT_ARN),
+                    region=AWS_REGION_GOV_CLOUD_US_EAST_1,
+                ),
+            ) as mock_validate_credentials,
+        ):
+            connection = AwsProvider.test_connection(
+                aws_access_key_id="test-access-key",
+                aws_secret_access_key="test-secret-key",
+                raise_on_exception=False,
+            )
+
+            assert connection.is_connected
+            assert (
+                mock_validate_credentials.call_args.args[1]
+                == AWS_REGION_GOV_CLOUD_US_EAST_1
+            )
+
+    @mock_aws
+    def test_test_connection_role_uses_env_partition_sts_region(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"PROWLER_AWS_PARTITION": AWS_GOV_CLOUD_PARTITION},
+                clear=False,
+            ),
+            mock.patch.object(
+                AwsProvider,
+                "assume_role",
+                return_value=AWSCredentials(
+                    aws_access_key_id="assumed-access-key",
+                    aws_secret_access_key="assumed-secret-key",
+                    aws_session_token="assumed-session-token",
+                    expiration=datetime.now(),
+                ),
+            ) as mock_assume_role,
+            mock.patch.object(
+                AwsProvider,
+                "validate_credentials",
+                return_value=AWSCallerIdentity(
+                    user_id="test-user-id",
+                    account=AWS_ACCOUNT_NUMBER,
+                    arn=ARN(AWS_GOV_CLOUD_ACCOUNT_ARN),
+                    region=AWS_REGION_GOV_CLOUD_US_EAST_1,
+                ),
+            ),
+        ):
+            connection = AwsProvider.test_connection(
+                role_arn=f"arn:{AWS_GOV_CLOUD_PARTITION}:iam::{AWS_ACCOUNT_NUMBER}:role/test-role",
+                aws_access_key_id="test-access-key",
+                aws_secret_access_key="test-secret-key",
+                raise_on_exception=False,
+            )
+
+            assert connection.is_connected
+            assumed_role_info = mock_assume_role.call_args.args[1]
+            assert assumed_role_info.sts_region == AWS_REGION_GOV_CLOUD_US_EAST_1
+
+    @mock_aws
+    def test_test_connection_env_partition_mismatch(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"PROWLER_AWS_PARTITION": AWS_GOV_CLOUD_PARTITION},
+                clear=False,
+            ),
+            mock.patch.object(
+                AwsProvider,
+                "validate_credentials",
+                return_value=AWSCallerIdentity(
+                    user_id="test-user-id",
+                    account=AWS_ACCOUNT_NUMBER,
+                    arn=ARN(AWS_ACCOUNT_ARN),
+                    region=AWS_REGION_US_EAST_1,
+                ),
+            ),
+        ):
+            connection = AwsProvider.test_connection(
+                aws_access_key_id="test-access-key",
+                aws_secret_access_key="test-secret-key",
+                raise_on_exception=False,
+            )
+
+            assert not connection.is_connected
+            assert isinstance(connection.error, AWSInvalidPartitionError)
+
     def test_get_profile_region_avoids_excluded_session_region(self):
         mocked_session = mock.Mock(region_name=AWS_REGION_EU_WEST_1)
 

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -2378,6 +2378,75 @@ aws:
             assumed_role_info = mock_assume_role.call_args.args[1]
             assert assumed_role_info.sts_region == AWS_REGION_GOV_CLOUD_US_EAST_1
 
+    def test_get_aws_region_for_sts_env_partition_commercial(self):
+        with mock.patch.dict(
+            os.environ,
+            {"PROWLER_AWS_PARTITION": AWS_COMMERCIAL_PARTITION},
+            clear=False,
+        ):
+            assert get_aws_region_for_sts(None, None) == AWS_REGION_US_EAST_1
+
+    def test_get_aws_region_for_sts_env_partition_excluded_region_stays_in_partition(
+        self,
+    ):
+        with mock.patch.dict(
+            os.environ,
+            {"PROWLER_AWS_PARTITION": AWS_GOV_CLOUD_PARTITION},
+            clear=False,
+        ):
+            assert (
+                get_aws_region_for_sts(None, None, {AWS_REGION_GOV_CLOUD_US_EAST_1})
+                == "us-gov-west-1"
+            )
+
+    def test_get_aws_region_for_sts_env_partition_all_regions_excluded_stays_in_partition(
+        self,
+    ):
+        with mock.patch.dict(
+            os.environ,
+            {"PROWLER_AWS_PARTITION": AWS_GOV_CLOUD_PARTITION},
+            clear=False,
+        ):
+            assert (
+                get_aws_region_for_sts(
+                    None, None, {AWS_REGION_GOV_CLOUD_US_EAST_1, "us-gov-west-1"}
+                )
+                == AWS_REGION_GOV_CLOUD_US_EAST_1
+            )
+
+    @mock_aws
+    def test_setup_session_mfa_uses_env_partition_sts_region(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"PROWLER_AWS_PARTITION": AWS_GOV_CLOUD_PARTITION},
+                clear=False,
+            ),
+            mock.patch.object(
+                AwsProvider,
+                "input_role_mfa_token_and_code",
+                return_value=AWSMFAInfo(
+                    arn=f"arn:{AWS_GOV_CLOUD_PARTITION}:iam::{AWS_ACCOUNT_NUMBER}:mfa/test",
+                    totp="123456",
+                ),
+            ),
+            mock.patch.object(
+                AwsProvider,
+                "create_sts_session",
+                side_effect=AwsProvider.create_sts_session,
+            ) as mock_create_sts_session,
+        ):
+            AwsProvider.setup_session(
+                mfa=True,
+                aws_access_key_id="test-access-key",
+                aws_secret_access_key="test-secret-key",
+            )
+
+            assert (
+                mock_create_sts_session.call_args.args[1]
+                == AWS_REGION_GOV_CLOUD_US_EAST_1
+            )
+
     @mock_aws
     def test_test_connection_env_partition_mismatch(self):
         with (


### PR DESCRIPTION
### Context

Prowler hardcodes `us-east-1` as the STS bootstrap region when it validates credentials and when it resolves the region for `AssumeRole`. That endpoint does not exist outside the commercial partition, so a deployment pointed at GovCloud, China, EUSC or any of the ISO partitions fails at credential validation before it can scan anything.

There was also nothing stopping a deployment meant for one partition from validating an account that lives in another one, which silently produces a scan against the wrong estate.

### Description

Adds the `PROWLER_AWS_PARTITION` environment variable to select the partition a deployment targets.

- `get_botocore_partition_regions()` reads the partition-to-region map straight from botocore's `endpoints` data, so the list of valid partitions follows the installed botocore instead of a hardcoded table. Cached with `lru_cache(maxsize=1)` since it never changes within a process.
- `get_env_partition_bootstrap_region()` resolves the variable to that partition's first region, and raises `AWSInvalidPartitionError` listing the valid partitions when the value is not one botocore knows.
- `test_connection()` now defaults `aws_region` to `None` and resolves it at call time to the configured partition's bootstrap region, falling back to `us-east-1`. It also forwards that region as `sts_region` when assuming a role.
- After resolving the caller identity, `test_connection()` compares `caller_identity.arn.partition` with the configured partition and raises `AWSInvalidPartitionError` on a mismatch, honouring `raise_on_exception` like the other error paths.
- `get_aws_region_for_sts()` gains the partition as a precedence step: explicit `--region` values first, then the configured partition, then the session region, then the existing bootstrap candidates.

`AWSInvalidPartitionError` (code 1917) already existed; this PR is the first thing to raise it.

Behaviour is unchanged when `PROWLER_AWS_PARTITION` is unset, which stays the default.

### Steps to review

Resolution of the bootstrap region per partition:

```bash
PROWLER_AWS_PARTITION=aws-us-gov python -c "from prowler.providers.aws.aws_provider import get_env_partition_bootstrap_region as r; print(r())"
# us-gov-east-1

PROWLER_AWS_PARTITION=aws-cn python -c "from prowler.providers.aws.aws_provider import get_env_partition_bootstrap_region as r; print(r())"
# cn-north-1

PROWLER_AWS_PARTITION=not-a-partition python -c "from prowler.providers.aws.aws_provider import get_env_partition_bootstrap_region as r; r()"
# AWSInvalidPartitionError, listing the valid partitions
```

Unset the variable and confirm nothing changes: `test_connection()` still bootstraps on `us-east-1` and `get_aws_region_for_sts()` keeps its previous precedence.

Tests:

```bash
uv run pytest tests/providers/aws/aws_provider_test.py -q -k "partition"
# 21 passed (10 added here, the rest pre-existing partition coverage)
```

The ten new cases cover the four non-commercial partitions, the precedence rules (explicit regions win over the partition, the partition wins over the session region), the invalid-value error, the STS region used by `test_connection()` with and without a role, and the account/partition mismatch.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the AWS partition used during credential validation and scan startup through the `PROWLER_AWS_PARTITION` environment variable.
  * Automatically selects suitable STS regions for supported partitions, including GovCloud, China, European Sovereign Cloud, and isolated regions.
  * Provides a clear connection error when the configured partition does not match the AWS account.

* **Bug Fixes**
  * Improved STS region selection while preserving explicitly provided regions and endpoint overrides.
  * Enhanced partition-specific STS support for static and role-based connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->