### PR TITLE
feat(cloudwatch): add cloudwatch_bedrock_runtime_alarms_configured check

### DIFF
--- a/prowler/changelog.d/cloudwatch-bedrock-runtime-alarms.added.md
+++ b/prowler/changelog.d/cloudwatch-bedrock-runtime-alarms.added.md
@@ -1,0 +1,1 @@
+`cloudwatch_bedrock_runtime_alarms_configured` check for CloudWatch alarms covering Amazon Bedrock runtime metrics

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_bedrock_runtime_alarms_configured/cloudwatch_bedrock_runtime_alarms_configured.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_bedrock_runtime_alarms_configured/cloudwatch_bedrock_runtime_alarms_configured.metadata.json
@@ -1,0 +1,42 @@
+{
+  "Provider": "aws",
+  "CheckID": "cloudwatch_bedrock_runtime_alarms_configured",
+  "CheckTitle": "CloudWatch alarms cover Amazon Bedrock runtime metrics",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices/Runtime Behavior Analysis"
+  ],
+  "ServiceName": "cloudwatch",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "AwsCloudWatchAlarm",
+  "ResourceGroup": "monitoring",
+  "Description": "**CloudWatch alarms** should exist on the **AWS/Bedrock** metric namespace in every region where Amazon Bedrock is in use, so abuse, denial-of-wallet, sustained throttling, or content-filter spikes are detected.",
+  "Risk": "Without an alarm on Bedrock runtime metrics, unusually high invocation volume, sustained throttling, or a spike in content-filter blocks can go unnoticed, allowing cost abuse (A), runaway spend, or an ongoing attack against deployed models to continue undetected.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring-cw.html",
+    "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws cloudwatch put-metric-alarm --alarm-name bedrock-runtime-invocation-throttles --namespace AWS/Bedrock --metric-name InvocationThrottles --statistic Sum --period 300 --evaluation-periods 1 --threshold 1 --comparison-operator GreaterThanOrEqualToThreshold --alarm-actions <sns-topic-arn>",
+      "NativeIaC": "```yaml\n# CloudFormation: Alarm on Bedrock runtime throttling\nResources:\n  BedrockRuntimeThrottleAlarm:\n    Type: AWS::CloudWatch::Alarm\n    Properties:\n      AlarmName: bedrock-runtime-invocation-throttles\n      Namespace: AWS/Bedrock  # Critical: targets the Bedrock runtime namespace\n      MetricName: InvocationThrottles\n      Statistic: Sum\n      Period: 300\n      EvaluationPeriods: 1\n      Threshold: 1\n      ComparisonOperator: GreaterThanOrEqualToThreshold\n      AlarmActions:\n        - <sns_topic_arn>  # Critical: alarm must have an enabled action\n```",
+      "Other": "1. In the AWS Console, go to CloudWatch > Alarms > Create alarm\n2. Select a metric under the AWS/Bedrock namespace (e.g. Invocations, InvocationThrottles, or a content-filter metric)\n3. Configure a threshold appropriate for the workload (e.g. sustained throttling or an abnormal invocation spike)\n4. Under Actions, attach an SNS topic or other action, and ensure the alarm actions are enabled\n5. Create the alarm; repeat in every region where Bedrock models are invoked\n",
+      "Terraform": "```hcl\n# Alarm on Bedrock runtime throttling\nresource \"aws_cloudwatch_metric_alarm\" \"bedrock_runtime_throttles\" {\n  alarm_name          = \"bedrock-runtime-invocation-throttles\"\n  namespace           = \"AWS/Bedrock\"\n  metric_name         = \"InvocationThrottles\"\n  statistic           = \"Sum\"\n  period              = 300\n  evaluation_periods  = 1\n  threshold           = 1\n  comparison_operator = \"GreaterThanOrEqualToThreshold\"\n  alarm_actions       = [<sns_topic_arn>]\n  actions_enabled     = true\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Create an enabled CloudWatch alarm on the AWS/Bedrock namespace in every region where Bedrock models are invoked, and route it to a responder so abuse, throttling, or content-filter spikes are detected promptly.",
+      "Url": "https://hub.prowler.com/check/cloudwatch_bedrock_runtime_alarms_configured"
+    }
+  },
+  "Categories": [
+    "gen-ai",
+    "threat-detection"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [
+    "bedrock_guardrails_configured"
+  ],
+  "Notes": "Evaluated as one regional posture result, only in regions with existing Bedrock resources (guardrails, custom models, agents, knowledge bases, prompts, or model invocation logging), since AWS/Bedrock runtime metrics have no listable resource of their own. Matches alarms that reference the AWS/Bedrock namespace either directly or through a metric-math component metric; alarms whose actions are disabled do not count as coverage."
+}

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_bedrock_runtime_alarms_configured/cloudwatch_bedrock_runtime_alarms_configured.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_bedrock_runtime_alarms_configured/cloudwatch_bedrock_runtime_alarms_configured.py
@@ -1,0 +1,110 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.bedrock.bedrock_agent_client import (
+    bedrock_agent_client,
+)
+from prowler.providers.aws.services.bedrock.bedrock_client import bedrock_client
+from prowler.providers.aws.services.cloudwatch.cloudwatch_client import (
+    cloudwatch_client,
+)
+
+BEDROCK_RUNTIME_NAMESPACE = "AWS/Bedrock"
+
+
+class cloudwatch_bedrock_runtime_alarms_configured(Check):
+    """Ensure CloudWatch alarms cover Amazon Bedrock runtime metrics.
+
+    Evaluated as one regional posture result per region that has Bedrock
+    resources (guardrails, custom models, agents, knowledge bases, prompts, or
+    model invocation logging), since AWS/Bedrock runtime metrics are only
+    meaningful where Bedrock is actually in use:
+    - PASS: at least one enabled alarm references the AWS/Bedrock namespace,
+      directly or through a metric-math expression.
+    - FAIL: the region has Bedrock resources but no such alarm exists.
+    - MANUAL: CloudWatch alarms could not be listed, so coverage is unknown.
+    - No finding: the region has no Bedrock resources.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the check logic.
+
+        Returns:
+            A list of reports containing the result of the check.
+        """
+        findings = []
+
+        regions_with_bedrock_resources = self._regions_with_bedrock_resources()
+        if not regions_with_bedrock_resources:
+            return findings
+
+        if cloudwatch_client.metric_alarms is None:
+            for region in sorted(regions_with_bedrock_resources):
+                report = self._report_for_region(region)
+                report.status = "MANUAL"
+                report.status_extended = (
+                    f"CloudWatch alarms could not be listed in region {region}; "
+                    "verify manually that an enabled alarm covers Amazon Bedrock "
+                    f"runtime metrics ({BEDROCK_RUNTIME_NAMESPACE})."
+                )
+                findings.append(report)
+            return findings
+
+        covered_regions = {
+            alarm.region
+            for alarm in cloudwatch_client.metric_alarms
+            if alarm.actions_enabled and BEDROCK_RUNTIME_NAMESPACE in alarm.namespaces
+        }
+
+        for region in sorted(regions_with_bedrock_resources):
+            report = self._report_for_region(region)
+            if region in covered_regions:
+                report.status = "PASS"
+                report.status_extended = (
+                    "At least one enabled CloudWatch alarm covers Amazon Bedrock "
+                    f"runtime metrics ({BEDROCK_RUNTIME_NAMESPACE}) in region {region}."
+                )
+            else:
+                report.status = "FAIL"
+                report.status_extended = (
+                    "No enabled CloudWatch alarm covers Amazon Bedrock runtime "
+                    f"metrics ({BEDROCK_RUNTIME_NAMESPACE}) in region {region}."
+                )
+            findings.append(report)
+
+        return findings
+
+    def _report_for_region(self, region: str) -> Check_Report_AWS:
+        report = Check_Report_AWS(metadata=self.metadata(), resource={})
+        report.region = region
+        report.resource_id = "bedrock-runtime-alarms"
+        report.resource_arn = (
+            f"arn:{cloudwatch_client.audited_partition}:cloudwatch:{region}:"
+            f"{cloudwatch_client.audited_account}:alarm"
+        )
+        return report
+
+    @staticmethod
+    def _regions_with_bedrock_resources() -> set[str]:
+        """Regions where Bedrock is actually in use.
+
+        AWS/Bedrock runtime metrics have no independent inventory of their own
+        (they are emitted on invocation, not on a listable resource), so
+        presence of any existing Bedrock resource is used as the signal that
+        the region is in scope for this check.
+        """
+        regions = set()
+        for guardrail in bedrock_client.guardrails.values():
+            regions.add(guardrail.region)
+        for model in bedrock_client.custom_models.values():
+            regions.add(model.region)
+        for region, logging_configuration in (
+            bedrock_client.logging_configurations or {}
+        ).items():
+            if logging_configuration.enabled:
+                regions.add(region)
+        for agent in bedrock_agent_client.agents.values():
+            regions.add(agent.region)
+        for knowledge_base in bedrock_agent_client.knowledge_bases.values():
+            regions.add(knowledge_base.region)
+        for prompt in bedrock_agent_client.prompts.values():
+            regions.add(prompt.region)
+        return regions

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -38,6 +38,20 @@ class CloudWatch(AWSService):
                         namespace = None
                         if "Namespace" in alarm:
                             namespace = alarm["Namespace"]
+                        # Metric-math alarms carry no top-level Namespace: each
+                        # component metric is listed under Metrics[].MetricStat
+                        # instead, so a namespace-based check must inspect both.
+                        namespaces = set()
+                        if namespace:
+                            namespaces.add(namespace)
+                        for metric in alarm.get("Metrics", []):
+                            component_namespace = (
+                                metric.get("MetricStat", {})
+                                .get("Metric", {})
+                                .get("Namespace")
+                            )
+                            if component_namespace:
+                                namespaces.add(component_namespace)
                         if self.metric_alarms is None:
                             self.metric_alarms = []
                         self.metric_alarms.append(
@@ -46,6 +60,7 @@ class CloudWatch(AWSService):
                                 name=alarm["AlarmName"],
                                 metric=metric_name,
                                 name_space=namespace,
+                                namespaces=sorted(namespaces),
                                 region=regional_client.region,
                                 alarm_actions=alarm.get("AlarmActions", []),
                                 actions_enabled=alarm.get("ActionsEnabled", False),
@@ -324,6 +339,9 @@ class MetricAlarm(BaseModel):
     name: str
     metric: Optional[str] = None
     name_space: Optional[str] = None
+    # Every namespace the alarm reads from: name_space for a plain alarm, plus
+    # one entry per Metrics[].MetricStat.Metric.Namespace for a metric-math one.
+    namespaces: list[str] = []
     region: str
     tags: Optional[list] = []
     alarm_actions: list

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_bedrock_runtime_alarms_configured/cloudwatch_bedrock_runtime_alarms_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_bedrock_runtime_alarms_configured/cloudwatch_bedrock_runtime_alarms_configured_test.py
@@ -1,0 +1,398 @@
+from unittest import mock
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+CHECK_MODULE = "prowler.providers.aws.services.cloudwatch.cloudwatch_bedrock_runtime_alarms_configured.cloudwatch_bedrock_runtime_alarms_configured"
+
+# The check module instantiates the bedrock_client/bedrock_agent_client/cloudwatch_client
+# singletons at import time, so a provider must exist in the global slot for that first
+# import. Every test below then overrides those singletons with its own MagicMocks.
+with mock.patch(
+    "prowler.providers.common.provider.Provider.get_global_provider",
+    return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+):
+    from prowler.providers.aws.services.cloudwatch.cloudwatch_bedrock_runtime_alarms_configured.cloudwatch_bedrock_runtime_alarms_configured import (
+        cloudwatch_bedrock_runtime_alarms_configured,
+    )
+
+
+def _bedrock_client(guardrails=None, custom_models=None, logging_configurations=None):
+    client = mock.MagicMock()
+    client.guardrails = guardrails or {}
+    client.custom_models = custom_models or {}
+    client.logging_configurations = logging_configurations or {}
+    return client
+
+
+def _bedrock_agent_client(agents=None, knowledge_bases=None, prompts=None):
+    client = mock.MagicMock()
+    client.agents = agents or {}
+    client.knowledge_bases = knowledge_bases or {}
+    client.prompts = prompts or {}
+    return client
+
+
+def _cloudwatch_client(metric_alarms):
+    client = mock.MagicMock()
+    client.metric_alarms = metric_alarms
+    client.audited_partition = "aws"
+    client.audited_account = AWS_ACCOUNT_NUMBER
+    return client
+
+
+class Test_cloudwatch_bedrock_runtime_alarms_configured:
+    def test_no_bedrock_resources_no_findings(self):
+        """No Bedrock resources anywhere: the check has nothing in scope."""
+        with (
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_client",
+                new=_bedrock_client(),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_agent_client",
+                new=_bedrock_agent_client(),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.cloudwatch_client",
+                new=_cloudwatch_client([]),
+            ),
+        ):
+
+            check = cloudwatch_bedrock_runtime_alarms_configured()
+            result = check.execute()
+
+            assert result == []
+
+    def test_bedrock_resources_no_alarm_fails(self):
+        """A guardrail exists in-region but no CloudWatch alarm covers Bedrock."""
+        from prowler.providers.aws.services.bedrock.bedrock_service import Guardrail
+
+        guardrail = Guardrail(
+            id="test-id",
+            name="test-guardrail",
+            arn=f"arn:aws:bedrock:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:guardrail/test-id",
+            region=AWS_REGION_US_EAST_1,
+        )
+
+        with (
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_client",
+                new=_bedrock_client(guardrails={guardrail.arn: guardrail}),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_agent_client",
+                new=_bedrock_agent_client(),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.cloudwatch_client",
+                new=_cloudwatch_client([]),
+            ),
+        ):
+
+            check = cloudwatch_bedrock_runtime_alarms_configured()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_id == "bedrock-runtime-alarms"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:cloudwatch:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:alarm"
+            )
+            assert "No enabled CloudWatch alarm" in result[0].status_extended
+
+    def test_direct_namespace_alarm_passes(self):
+        """A single-metric alarm on the AWS/Bedrock namespace covers the region."""
+        from prowler.providers.aws.services.bedrock.bedrock_service import Guardrail
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_service import (
+            MetricAlarm,
+        )
+
+        guardrail = Guardrail(
+            id="test-id",
+            name="test-guardrail",
+            arn=f"arn:aws:bedrock:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:guardrail/test-id",
+            region=AWS_REGION_US_EAST_1,
+        )
+        alarm = MetricAlarm(
+            arn=f"arn:aws:cloudwatch:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:alarm:test",
+            name="test",
+            metric="Invocations",
+            name_space="AWS/Bedrock",
+            namespaces=["AWS/Bedrock"],
+            region=AWS_REGION_US_EAST_1,
+            alarm_actions=["arn:aws:sns:us-east-1:123456789012:topic"],
+            actions_enabled=True,
+        )
+
+        with (
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_client",
+                new=_bedrock_client(guardrails={guardrail.arn: guardrail}),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_agent_client",
+                new=_bedrock_agent_client(),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.cloudwatch_client",
+                new=_cloudwatch_client([alarm]),
+            ),
+        ):
+
+            check = cloudwatch_bedrock_runtime_alarms_configured()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert "At least one enabled CloudWatch alarm" in result[0].status_extended
+
+    def test_metric_math_alarm_passes(self):
+        """A metric-math alarm whose component metric is AWS/Bedrock also counts."""
+        from prowler.providers.aws.services.bedrock.bedrock_service import (
+            LoggingConfiguration,
+        )
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_service import (
+            MetricAlarm,
+        )
+
+        alarm = MetricAlarm(
+            arn=f"arn:aws:cloudwatch:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:alarm:math-alarm",
+            name="math-alarm",
+            metric=None,
+            name_space=None,
+            namespaces=["AWS/Bedrock"],
+            region=AWS_REGION_US_EAST_1,
+            alarm_actions=["arn:aws:sns:us-east-1:123456789012:topic"],
+            actions_enabled=True,
+        )
+
+        with (
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_client",
+                new=_bedrock_client(
+                    logging_configurations={
+                        AWS_REGION_US_EAST_1: LoggingConfiguration(enabled=True)
+                    }
+                ),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_agent_client",
+                new=_bedrock_agent_client(),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.cloudwatch_client",
+                new=_cloudwatch_client([alarm]),
+            ),
+        ):
+
+            check = cloudwatch_bedrock_runtime_alarms_configured()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+
+    def test_disabled_alarm_actions_do_not_count(self):
+        """An alarm on AWS/Bedrock whose actions are disabled is not coverage."""
+        from prowler.providers.aws.services.bedrock.bedrock_service import Agent
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_service import (
+            MetricAlarm,
+        )
+
+        agent = Agent(
+            id="agent-id",
+            name="test-agent",
+            arn=f"arn:aws:bedrock:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:agent/agent-id",
+            region=AWS_REGION_US_EAST_1,
+        )
+        alarm = MetricAlarm(
+            arn=f"arn:aws:cloudwatch:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:alarm:test",
+            name="test",
+            metric="Invocations",
+            name_space="AWS/Bedrock",
+            namespaces=["AWS/Bedrock"],
+            region=AWS_REGION_US_EAST_1,
+            alarm_actions=[],
+            actions_enabled=False,
+        )
+
+        with (
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_client",
+                new=_bedrock_client(),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_agent_client",
+                new=_bedrock_agent_client(agents={agent.arn: agent}),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.cloudwatch_client",
+                new=_cloudwatch_client([alarm]),
+            ),
+        ):
+
+            check = cloudwatch_bedrock_runtime_alarms_configured()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+
+    def test_alarm_on_unrelated_namespace_fails(self):
+        """An enabled alarm that does not reference AWS/Bedrock is not coverage."""
+        from prowler.providers.aws.services.bedrock.bedrock_service import (
+            CustomModel,
+        )
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_service import (
+            MetricAlarm,
+        )
+
+        model = CustomModel(
+            name="test-model",
+            arn=f"arn:aws:bedrock:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:custom-model/test-model",
+            region=AWS_REGION_US_EAST_1,
+        )
+        alarm = MetricAlarm(
+            arn=f"arn:aws:cloudwatch:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:alarm:test",
+            name="test",
+            metric="CPUUtilization",
+            name_space="AWS/EC2",
+            namespaces=["AWS/EC2"],
+            region=AWS_REGION_US_EAST_1,
+            alarm_actions=["arn:aws:sns:us-east-1:123456789012:topic"],
+            actions_enabled=True,
+        )
+
+        with (
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_client",
+                new=_bedrock_client(custom_models={model.arn: model}),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_agent_client",
+                new=_bedrock_agent_client(),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.cloudwatch_client",
+                new=_cloudwatch_client([alarm]),
+            ),
+        ):
+
+            check = cloudwatch_bedrock_runtime_alarms_configured()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+
+    def test_alarms_could_not_be_listed_is_manual(self):
+        """cloudwatch_client.metric_alarms is None when DescribeAlarms failed."""
+        from prowler.providers.aws.services.bedrock.bedrock_service import (
+            KnowledgeBase,
+        )
+
+        knowledge_base = KnowledgeBase(
+            id="kb-id",
+            name="test-kb",
+            arn=f"arn:aws:bedrock:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:knowledge-base/kb-id",
+            region=AWS_REGION_US_EAST_1,
+        )
+
+        with (
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_client",
+                new=_bedrock_client(),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_agent_client",
+                new=_bedrock_agent_client(
+                    knowledge_bases={knowledge_base.arn: knowledge_base}
+                ),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.cloudwatch_client",
+                new=_cloudwatch_client(None),
+            ),
+        ):
+
+            check = cloudwatch_bedrock_runtime_alarms_configured()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert "could not be listed" in result[0].status_extended
+
+    def test_multi_region_mixed_results(self):
+        """One region passes, one fails, and a Bedrock-free region is absent."""
+        from prowler.providers.aws.services.bedrock.bedrock_service import Guardrail
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_service import (
+            MetricAlarm,
+        )
+
+        guardrail_us = Guardrail(
+            id="test-id-us",
+            name="us-guardrail",
+            arn=f"arn:aws:bedrock:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:guardrail/test-id-us",
+            region=AWS_REGION_US_EAST_1,
+        )
+        guardrail_eu = Guardrail(
+            id="test-id-eu",
+            name="eu-guardrail",
+            arn=f"arn:aws:bedrock:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:guardrail/test-id-eu",
+            region=AWS_REGION_EU_WEST_1,
+        )
+        covering_alarm = MetricAlarm(
+            arn=f"arn:aws:cloudwatch:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:alarm:test",
+            name="test",
+            metric="Invocations",
+            name_space="AWS/Bedrock",
+            namespaces=["AWS/Bedrock"],
+            region=AWS_REGION_US_EAST_1,
+            alarm_actions=["arn:aws:sns:us-east-1:123456789012:topic"],
+            actions_enabled=True,
+        )
+        # An alarm in a third region with no Bedrock resources: must not appear.
+        unrelated_region_alarm = MetricAlarm(
+            arn="arn:aws:cloudwatch:ap-southeast-1:123456789012:alarm:unrelated",
+            name="unrelated",
+            metric="Invocations",
+            name_space="AWS/Bedrock",
+            namespaces=["AWS/Bedrock"],
+            region="ap-southeast-1",
+            alarm_actions=["arn:aws:sns:ap-southeast-1:123456789012:topic"],
+            actions_enabled=True,
+        )
+
+        with (
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_client",
+                new=_bedrock_client(
+                    guardrails={
+                        guardrail_us.arn: guardrail_us,
+                        guardrail_eu.arn: guardrail_eu,
+                    }
+                ),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.bedrock_agent_client",
+                new=_bedrock_agent_client(),
+            ),
+            mock.patch(
+                f"{CHECK_MODULE}.cloudwatch_client",
+                new=_cloudwatch_client([covering_alarm, unrelated_region_alarm]),
+            ),
+        ):
+
+            check = cloudwatch_bedrock_runtime_alarms_configured()
+            result = check.execute()
+
+            assert len(result) == 2
+            results_by_region = {r.region: r for r in result}
+            assert results_by_region[AWS_REGION_US_EAST_1].status == "PASS"
+            assert results_by_region[AWS_REGION_EU_WEST_1].status == "FAIL"
+            assert "ap-southeast-1" not in results_by_region

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py
@@ -141,6 +141,43 @@ class Test_CloudWatch_Service:
         ]
         assert cloudwatch.metric_alarms[0].alarm_actions == ["arn:alarm"]
         assert cloudwatch.metric_alarms[0].actions_enabled
+        assert cloudwatch.metric_alarms[0].namespaces == ["test_namespace"]
+
+    # Test CloudWatch metric-math alarms: no top-level Namespace, so the
+    # namespace has to be read from each component metric instead.
+    @mock_aws
+    def test_describe_alarms_metric_math(self):
+        cw_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        cw_client.put_metric_alarm(
+            AlarmName="math-alarm",
+            AlarmActions=["arn:alarm"],
+            ComparisonOperator="GreaterThanOrEqualToThreshold",
+            EvaluationPeriods=1,
+            Threshold=1,
+            ActionsEnabled=True,
+            Metrics=[
+                {
+                    "Id": "m1",
+                    "MetricStat": {
+                        "Metric": {
+                            "Namespace": "AWS/Bedrock",
+                            "MetricName": "Invocations",
+                        },
+                        "Period": 60,
+                        "Stat": "Sum",
+                    },
+                    "ReturnData": True,
+                }
+            ],
+        )
+        aws_provider = set_mocked_aws_provider(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
+        cloudwatch = CloudWatch(aws_provider)
+        assert len(cloudwatch.metric_alarms) == 1
+        assert cloudwatch.metric_alarms[0].name == "math-alarm"
+        assert cloudwatch.metric_alarms[0].name_space is None
+        assert cloudwatch.metric_alarms[0].namespaces == ["AWS/Bedrock"]
 
     # Test Logs Filters
     @mock_aws


### PR DESCRIPTION
### Context

Closes #12614. Amazon Bedrock runtime metrics (the `AWS/Bedrock` CloudWatch
namespace) had no check verifying an alarm exists to catch abuse,
denial-of-wallet, sustained throttling, or content-filter spikes.

### Description

- Extends `CloudWatch._describe_alarms` to also collect every namespace an
  alarm references through a metric-math component metric
  (`Metrics[].MetricStat.Metric.Namespace`), not just the top-level
  `Namespace` field. Adds a new `MetricAlarm.namespaces` field; the existing
  `name_space`/`metric` fields are untouched so no existing check changes
  behavior.
- Adds `cloudwatch_bedrock_runtime_alarms_configured`: a regional posture
  check, evaluated only in regions that already have some Bedrock resource
  (guardrail, custom model, agent, knowledge base, prompt, or model
  invocation logging enabled) — `AWS/Bedrock` metrics have no listable
  resource of their own, so an existing-resource signal is used to scope
  the check to regions where Bedrock is actually in use.
  - PASS: at least one *enabled* alarm covers `AWS/Bedrock`, directly or via
    metric math.
  - FAIL: the region has Bedrock resources but no such alarm.
  - MANUAL: CloudWatch alarms could not be listed.
  - No finding: the region has no Bedrock resources.

### Steps to review

1. `cloudwatch_service.py` — the metric-math namespace parsing added to
   `_describe_alarms`, and the new `namespaces` field on `MetricAlarm`.
2. `cloudwatch_bedrock_runtime_alarms_configured.py` — in particular
   `_regions_with_bedrock_resources`, since that's the judgment call this
   check makes: there's no `ListBedrockUsage`-type API, so region scope is
   inferred from existing Bedrock resource inventory already collected by
   `bedrock_client` / `bedrock_agent_client`. Flagging this explicitly for
   review in case a different scoping signal is preferred.

### Verification

- New tests: 8 check tests (`cloudwatch_bedrock_runtime_alarms_configured_test.py`)
  covering no-resources/no-finding, FAIL, direct-namespace PASS,
  metric-math PASS, disabled-alarm-actions FAIL, unrelated-namespace FAIL,
  MANUAL on listing failure, and multi-region mixed results; plus 1 new
  service test for metric-math namespace parsing.
- Full `tests/providers/aws/services/cloudwatch/` and
  `tests/providers/aws/services/bedrock/` suites: 361 passed, 0 regressions.
- `black`, `flake8` (project ignore list), `pylint`, `bandit`, `isort`,
  `vulture` all pass clean on the changed files.
- `prowler-cli.py aws --list-checks --service cloudwatch` confirms the check
  metadata loads and the check is discovered.

**Real-AWS PASS/FAIL execution evidence is still outstanding** — I don't
have an AWS account with Bedrock resources handy. Will follow up with
redacted evidence per the issue's validation requirements before this is
ready for full review; opening as draft in the meantime.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following the Google Python style guide.
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the README.md
- [x] Ensure a changelog fragment is added under `prowler/changelog.d/`.

#### SDK/CLI

- Are there new checks included in this PR? **Yes** —
  `cloudwatch_bedrock_runtime_alarms_configured`.
  - No new AWS API calls or permissions: `cloudwatch:DescribeAlarms` and the
    Bedrock list/get calls it reads from were already called by existing
    collectors.

### License

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.