### PR TITLE
feat(sagemaker): add sagemaker_feature_group_offline_store_encrypted_with_cmk check

### DIFF
--- a/prowler/providers/aws/services/sagemaker/sagemaker_feature_group_offline_store_encrypted_with_cmk/sagemaker_feature_group_offline_store_encrypted_with_cmk.metadata.json
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_feature_group_offline_store_encrypted_with_cmk/sagemaker_feature_group_offline_store_encrypted_with_cmk.metadata.json
@@ -1,0 +1,42 @@
+{
+  "Provider": "aws",
+  "CheckID": "sagemaker_feature_group_offline_store_encrypted_with_cmk",
+  "CheckTitle": "SageMaker Feature Group offline store is encrypted with a KMS Customer Managed Key",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices",
+    "Effects/Data Exposure"
+  ],
+  "ServiceName": "sagemaker",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "AwsSageMakerFeatureGroup",
+  "ResourceGroup": "ai_ml",
+  "Description": "This check ensures that Amazon SageMaker Feature Groups that have an offline store configured encrypt the offline store S3 data with a KMS key (OfflineStoreConfig.S3StorageConfig.KmsKeyId). Feature groups without an offline store are not in scope.",
+  "Risk": "The offline store persists feature data in Amazon S3 for training and batch inference. Without encryption using a KMS Customer Managed Key, that data can be exposed through misconfigured bucket access, copied backups, or account compromise, and the organization loses fine-grained key access control, rotation, and revocation over its ML feature data.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-security.html",
+    "https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_S3StorageConfig.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws sagemaker create-feature-group --feature-group-name <feature_group_name> --record-identifier-feature-name <id_feature> --event-time-feature-name <event_time_feature> --feature-definitions <definitions> --role-arn <role_arn> --offline-store-config 'S3StorageConfig={S3Uri=s3://<bucket>/<prefix>,KmsKeyId=<kms_key_arn>}'",
+      "NativeIaC": "```yaml\n# CloudFormation: SageMaker Feature Group offline store encrypted with a KMS key\nResources:\n  <example_resource_name>:\n    Type: AWS::SageMaker::FeatureGroup\n    Properties:\n      FeatureGroupName: <example_resource_name>\n      RecordIdentifierFeatureName: <id_feature>\n      EventTimeFeatureName: <event_time_feature>\n      RoleArn: <example_resource_arn>\n      FeatureDefinitions:\n        - FeatureName: <id_feature>\n          FeatureType: Integral\n        - FeatureName: <event_time_feature>\n          FeatureType: String\n      OfflineStoreConfig:\n        S3StorageConfig:\n          S3Uri: s3://<bucket>/<prefix>\n          KmsKeyId: <kms_key_arn>  # Critical: encrypts the offline store S3 data with the KMS key\n```",
+      "Other": "1. Open the AWS Console > Amazon SageMaker > Feature Store > Feature Groups.\n2. Because the offline store KMS key cannot be changed after creation, create a new feature group with the same schema, choosing a KMS Customer Managed Key for the offline store S3 encryption.\n3. Backfill/ingest the records into the new feature group.\n4. Repoint consumers to the new feature group and delete the unencrypted one.",
+      "Terraform": "```hcl\n# Terraform: SageMaker Feature Group offline store encrypted with a KMS key\nresource \"aws_sagemaker_feature_group\" \"<example_resource_name>\" {\n  feature_group_name             = \"<example_resource_name>\"\n  record_identifier_feature_name = \"<id_feature>\"\n  event_time_feature_name        = \"<event_time_feature>\"\n  role_arn                       = \"<example_resource_arn>\"\n\n  feature_definition {\n    feature_name = \"<id_feature>\"\n    feature_type = \"Integral\"\n  }\n  feature_definition {\n    feature_name = \"<event_time_feature>\"\n    feature_type = \"String\"\n  }\n\n  offline_store_config {\n    s3_storage_config {\n      s3_uri     = \"s3://<bucket>/<prefix>\"\n      kms_key_id = \"<kms_key_arn>\"  # Critical: encrypts the offline store S3 data with the KMS key\n    }\n  }\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Configure the offline store of every SageMaker Feature Group with a KMS Customer Managed Key by setting OfflineStoreConfig.S3StorageConfig.KmsKeyId at creation time. Enforce least-privilege key policies, enable key rotation, and align key access with your data classification and defense-in-depth strategy.",
+      "Url": "https://hub.prowler.com/check/sagemaker_feature_group_offline_store_encrypted_with_cmk"
+    }
+  },
+  "Categories": [
+    "encryption",
+    "gen-ai"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/sagemaker/sagemaker_feature_group_offline_store_encrypted_with_cmk/sagemaker_feature_group_offline_store_encrypted_with_cmk.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_feature_group_offline_store_encrypted_with_cmk/sagemaker_feature_group_offline_store_encrypted_with_cmk.py
@@ -1,0 +1,31 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.sagemaker.sagemaker_client import sagemaker_client
+
+
+class sagemaker_feature_group_offline_store_encrypted_with_cmk(Check):
+    def execute(self):
+        findings = []
+        for feature_group in sagemaker_client.sagemaker_feature_groups:
+            # Only feature groups with an offline store are in scope; the online store is
+            # always encrypted and covered elsewhere.
+            if not feature_group.offline_store_enabled:
+                continue
+
+            report = Check_Report_AWS(metadata=self.metadata(), resource=feature_group)
+
+            if feature_group.offline_store_kms_key_id:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"SageMaker Feature Group {feature_group.name} has its offline store "
+                    "encrypted with a KMS Customer Managed Key."
+                )
+            else:
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"SageMaker Feature Group {feature_group.name} has an offline store that "
+                    "is not encrypted with a KMS Customer Managed Key."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/sagemaker/sagemaker_service.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_service.py
@@ -22,6 +22,7 @@ class SageMaker(AWSService):
         self.endpoint_configs = {}
         self.sagemaker_model_registries = []
         self.sagemaker_monitoring_schedules = []
+        self.sagemaker_feature_groups = []
 
         # Retrieve resources concurrently
         self.__threading_call__(self._list_notebook_instances)
@@ -32,6 +33,7 @@ class SageMaker(AWSService):
         self.__threading_call__(self._list_domains)
         self.__threading_call__(self._list_model_package_groups)
         self.__threading_call__(self._list_monitoring_schedules)
+        self.__threading_call__(self._list_feature_groups)
 
         # Describe resources concurrently
         self.__threading_call__(self._describe_model, self.sagemaker_models)
@@ -53,6 +55,9 @@ class SageMaker(AWSService):
             self._describe_endpoint_config, list(self.endpoint_configs.values())
         )
         self.__threading_call__(self._describe_domain, self.sagemaker_domains)
+        self.__threading_call__(
+            self._describe_feature_group, self.sagemaker_feature_groups
+        )
 
         # List tags concurrently for each resource collection
         # This replaces the previous sequential sequential execution to improve performance
@@ -70,6 +75,9 @@ class SageMaker(AWSService):
             self._list_tags_for_resource, list(self.endpoint_configs.values())
         )
         self.__threading_call__(self._list_tags_for_resource, self.sagemaker_domains)
+        self.__threading_call__(
+            self._list_tags_for_resource, self.sagemaker_feature_groups
+        )
 
     def _list_notebook_instances(self, regional_client):
         logger.info("SageMaker - listing notebook instances...")
@@ -300,6 +308,49 @@ class SageMaker(AWSService):
         except Exception as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _list_feature_groups(self, regional_client):
+        logger.info("SageMaker - listing feature groups...")
+        try:
+            list_feature_groups_paginator = regional_client.get_paginator(
+                "list_feature_groups"
+            )
+            for page in list_feature_groups_paginator.paginate():
+                for feature_group in page["FeatureGroupSummaries"]:
+                    if not self.audit_resources or (
+                        is_resource_filtered(
+                            feature_group["FeatureGroupArn"], self.audit_resources
+                        )
+                    ):
+                        self.sagemaker_feature_groups.append(
+                            FeatureGroup(
+                                name=feature_group["FeatureGroupName"],
+                                region=regional_client.region,
+                                arn=feature_group["FeatureGroupArn"],
+                            )
+                        )
+        except Exception as error:
+            logger.error(
+                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _describe_feature_group(self, feature_group):
+        logger.info("SageMaker - describing feature groups...")
+        try:
+            regional_client = self.regional_clients[feature_group.region]
+            describe_feature_group = regional_client.describe_feature_group(
+                FeatureGroupName=feature_group.name
+            )
+            offline_store_config = describe_feature_group.get("OfflineStoreConfig")
+            if offline_store_config:
+                feature_group.offline_store_enabled = True
+                feature_group.offline_store_kms_key_id = offline_store_config.get(
+                    "S3StorageConfig", {}
+                ).get("KmsKeyId")
+        except Exception as error:
+            logger.error(
+                f"{feature_group.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
     def _describe_training_job(self, training_job):
@@ -582,6 +633,30 @@ class TrainingJob(BaseModel):
     volume_kms_key_id: str = None
     network_isolation: bool = None
     vpc_config_subnets: list[str] = []
+    tags: Optional[list] = []
+
+
+class FeatureGroup(BaseModel):
+    """Represents a SageMaker Feature Store feature group.
+
+    Attributes:
+        name: Feature group name.
+        region: AWS region where the feature group lives.
+        arn: Feature group ARN.
+        offline_store_enabled: True when the feature group has an offline store
+            configured (``OfflineStoreConfig`` present), populated by
+            `_describe_feature_group`.
+        offline_store_kms_key_id: The KMS key id used to encrypt the offline
+            store S3 data (``OfflineStoreConfig.S3StorageConfig.KmsKeyId``),
+            populated by `_describe_feature_group`.
+        tags: Resource tags, populated by `_list_tags_for_resource`.
+    """
+
+    name: str
+    region: str
+    arn: str
+    offline_store_enabled: bool = False
+    offline_store_kms_key_id: Optional[str] = None
     tags: Optional[list] = []
 
 

--- a/tests/providers/aws/services/sagemaker/sagemaker_feature_group_offline_store_encrypted_with_cmk/sagemaker_feature_group_offline_store_encrypted_with_cmk_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_feature_group_offline_store_encrypted_with_cmk/sagemaker_feature_group_offline_store_encrypted_with_cmk_test.py
@@ -1,0 +1,108 @@
+from unittest import mock
+
+from prowler.providers.aws.services.sagemaker.sagemaker_service import FeatureGroup
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_provider,
+)
+
+CHECK_PATH = "prowler.providers.aws.services.sagemaker.sagemaker_feature_group_offline_store_encrypted_with_cmk.sagemaker_feature_group_offline_store_encrypted_with_cmk"
+
+feature_group_arn = f"arn:aws:sagemaker:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:feature-group/fg-test"
+kms_key = f"arn:aws:kms:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:key/abcd-1234"
+
+
+def _run_check(sagemaker_client, aws_provider):
+    with (
+        mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ),
+        mock.patch(f"{CHECK_PATH}.sagemaker_client", sagemaker_client),
+    ):
+        from prowler.providers.aws.services.sagemaker.sagemaker_feature_group_offline_store_encrypted_with_cmk.sagemaker_feature_group_offline_store_encrypted_with_cmk import (
+            sagemaker_feature_group_offline_store_encrypted_with_cmk,
+        )
+
+        return sagemaker_feature_group_offline_store_encrypted_with_cmk().execute()
+
+
+class Test_sagemaker_feature_group_offline_store_encrypted_with_cmk:
+    def test_no_feature_groups(self):
+        sagemaker_client = mock.MagicMock
+        sagemaker_client.sagemaker_feature_groups = []
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        result = _run_check(sagemaker_client, aws_provider)
+
+        assert len(result) == 0
+
+    def test_offline_store_encrypted_with_cmk(self):
+        sagemaker_client = mock.MagicMock
+        sagemaker_client.sagemaker_feature_groups = [
+            FeatureGroup(
+                name="fg-test",
+                region=AWS_REGION_EU_WEST_1,
+                arn=feature_group_arn,
+                offline_store_enabled=True,
+                offline_store_kms_key_id=kms_key,
+            )
+        ]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        result = _run_check(sagemaker_client, aws_provider)
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert (
+            result[0].status_extended
+            == "SageMaker Feature Group fg-test has its offline store encrypted with a "
+            "KMS Customer Managed Key."
+        )
+        assert result[0].resource_id == "fg-test"
+        assert result[0].resource_arn == feature_group_arn
+        assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_offline_store_not_encrypted_with_cmk(self):
+        sagemaker_client = mock.MagicMock
+        sagemaker_client.sagemaker_feature_groups = [
+            FeatureGroup(
+                name="fg-test",
+                region=AWS_REGION_EU_WEST_1,
+                arn=feature_group_arn,
+                offline_store_enabled=True,
+                offline_store_kms_key_id=None,
+            )
+        ]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        result = _run_check(sagemaker_client, aws_provider)
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert (
+            result[0].status_extended
+            == "SageMaker Feature Group fg-test has an offline store that is not encrypted "
+            "with a KMS Customer Managed Key."
+        )
+        assert result[0].resource_id == "fg-test"
+        assert result[0].resource_arn == feature_group_arn
+
+    def test_feature_group_without_offline_store_skipped(self):
+        sagemaker_client = mock.MagicMock
+        sagemaker_client.sagemaker_feature_groups = [
+            FeatureGroup(
+                name="fg-online-only",
+                region=AWS_REGION_EU_WEST_1,
+                arn=feature_group_arn,
+                offline_store_enabled=False,
+                offline_store_kms_key_id=None,
+            )
+        ]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        result = _run_check(sagemaker_client, aws_provider)
+
+        # Feature groups without an offline store are out of scope -> no findings.
+        assert len(result) == 0

--- a/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
@@ -42,6 +42,11 @@ test_sso_instance_id = "app-test-instance-id"
 test_sso_application_arn = (
     f"arn:aws:sso::{AWS_ACCOUNT_NUMBER}:application/sagemaker/apl-test"
 )
+test_feature_group_name = "test-feature-group"
+test_feature_group_arn = f"arn:aws:sagemaker:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:feature-group/{test_feature_group_name}"
+test_feature_group_kms_key_id = (
+    f"arn:aws:kms:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:key/feature-group-key"
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -174,6 +179,26 @@ def mock_make_api_call(self, operation_name, kwarg):
             "AuthMode": "SSO",
             "SingleSignOnManagedApplicationInstanceId": test_sso_instance_id,
             "SingleSignOnApplicationArn": test_sso_application_arn,
+        }
+    if operation_name == "ListFeatureGroups":
+        return {
+            "FeatureGroupSummaries": [
+                {
+                    "FeatureGroupName": test_feature_group_name,
+                    "FeatureGroupArn": test_feature_group_arn,
+                },
+            ],
+        }
+    if operation_name == "DescribeFeatureGroup":
+        return {
+            "FeatureGroupName": test_feature_group_name,
+            "FeatureGroupArn": test_feature_group_arn,
+            "OfflineStoreConfig": {
+                "S3StorageConfig": {
+                    "S3Uri": "s3://test-bucket/prefix",
+                    "KmsKeyId": test_feature_group_kms_key_id,
+                }
+            },
         }
 
     return make_api_call(self, operation_name, kwarg)
@@ -351,6 +376,23 @@ class Test_SageMaker_Service:
             == test_sso_application_arn
         )
 
+    # Test SageMaker _list_feature_groups
+    def test_list_feature_groups(self):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        sagemaker = SageMaker(aws_provider)
+        assert len(sagemaker.sagemaker_feature_groups) == 1
+        assert sagemaker.sagemaker_feature_groups[0].name == test_feature_group_name
+        assert sagemaker.sagemaker_feature_groups[0].arn == test_feature_group_arn
+        assert sagemaker.sagemaker_feature_groups[0].region == AWS_REGION_EU_WEST_1
+
+    # Test SageMaker _describe_feature_group
+    def test_describe_feature_group(self):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        sagemaker = SageMaker(aws_provider)
+        feature_group = sagemaker.sagemaker_feature_groups[0]
+        assert feature_group.offline_store_enabled is True
+        assert feature_group.offline_store_kms_key_id == test_feature_group_kms_key_id
+
     # Test SageMaker _list_tags_for_resource
     def test_list_tags_for_resource_calls_client(self):
         """Test that _list_tags_for_resource calls the correct AWS client and updates the resource."""
@@ -421,13 +463,13 @@ class Test_SageMaker_Service:
                 sagemaker_service = SageMaker(audit_info)
 
                 # Check that __threading_call__ was called for _list_tags_for_resource
-                # (one for each resource type: models, notebooks, training jobs, processing jobs, endpoint configs, domains)
+                # (one for each resource type: models, notebooks, training jobs, processing jobs, endpoint configs, domains, feature groups)
                 tag_calls = [
                     c
                     for c in mock_threading_call.call_args_list
                     if c[0][0] == sagemaker_service._list_tags_for_resource
                 ]
-                assert len(tag_calls) == 6
+                assert len(tag_calls) == 7
 
     # Test SageMaker list model package groups
     def test_list_model_package_groups(self):


### PR DESCRIPTION
Implements #12599 (SM-15). PASS when a Feature Group offline store sets KmsKeyId, FAIL otherwise. Unit tests pass. DRAFT: still needs one PASS + one FAIL runtime evidence from a real AWS account (see prowler-SUMMARY.md) and a CodeRabbit pass before ready.