### PR TITLE
feat(cloudwatch): add cloudwatch_log_group_data_protection_policy_configured check

### DIFF
--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_data_protection_policy_configured/cloudwatch_log_group_data_protection_policy_configured.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_data_protection_policy_configured/cloudwatch_log_group_data_protection_policy_configured.metadata.json
@@ -1,0 +1,41 @@
+{
+  "Provider": "aws",
+  "CheckID": "cloudwatch_log_group_data_protection_policy_configured",
+  "CheckTitle": "CloudWatch Log Group has a data protection policy configured",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices",
+    "Effects/Data Exposure"
+  ],
+  "ServiceName": "cloudwatch",
+  "SubServiceName": "logs",
+  "ResourceIdTemplate": "arn:partition:logs:region:account-id:log-group:log-group-name",
+  "Severity": "high",
+  "ResourceType": "AwsCloudWatchLogGroup",
+  "ResourceGroup": "monitoring",
+  "Description": "This check ensures that Amazon CloudWatch log groups have an active data protection policy that audits and/or de-identifies sensitive data identifiers (such as email addresses, credentials, and PII) found in log events.",
+  "Risk": "Application and infrastructure logs frequently capture sensitive data such as credentials, personal information, and financial data. Without a data protection policy that audits and de-identifies sensitive data identifiers, this data is stored in plaintext and can be exposed to anyone with read access to the log group, leading to privacy violations and compliance failures.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html",
+    "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data-types.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws logs put-data-protection-policy --log-group-identifier <log_group_name> --policy-document '{\"Name\":\"data-protection-policy\",\"Version\":\"2021-06-01\",\"Statement\":[{\"Sid\":\"audit\",\"DataIdentifier\":[\"arn:aws:dataprotection::aws:data-identifier/EmailAddress\"],\"Operation\":{\"Audit\":{\"FindingsDestination\":{}}}},{\"Sid\":\"redact\",\"DataIdentifier\":[\"arn:aws:dataprotection::aws:data-identifier/EmailAddress\"],\"Operation\":{\"Deidentify\":{\"MaskConfig\":{}}}}]}'",
+      "NativeIaC": "```yaml\n# CloudFormation: attach a data protection policy to a CloudWatch log group\nResources:\n  <example_resource_name>:\n    Type: AWS::Logs::LogGroup\n    Properties:\n      LogGroupName: <example_resource_name>\n      DataProtectionPolicy:\n        Name: data-protection-policy\n        Version: \"2021-06-01\"\n        Statement:\n          - Sid: audit\n            DataIdentifier:\n              - arn:aws:dataprotection::aws:data-identifier/EmailAddress\n            Operation:\n              Audit:\n                FindingsDestination: {}\n          - Sid: redact\n            DataIdentifier:\n              - arn:aws:dataprotection::aws:data-identifier/EmailAddress\n            Operation:\n              Deidentify:\n                MaskConfig: {}\n```",
+      "Other": "1. In the AWS Console, go to CloudWatch > Log groups and select the log group.\n2. On the log group page, open the 'Data protection' tab and choose 'Create/Edit policy'.\n3. Select the managed and/or custom data identifiers to detect (e.g. Email address, AWS secret key), and enable both Audit and Masking (de-identification).\n4. Optionally configure an audit findings destination (S3, Firehose, or another log group), then Save.",
+      "Terraform": "```hcl\n# Terraform: attach a data protection policy to a CloudWatch log group\nresource \"aws_cloudwatch_log_data_protection_policy\" \"<example_resource_name>\" {\n  log_group_name = aws_cloudwatch_log_group.<example_resource_name>.name\n\n  policy_document = jsonencode({\n    Name    = \"data-protection-policy\"\n    Version = \"2021-06-01\"\n    Statement = [\n      {\n        Sid            = \"audit\"\n        DataIdentifier = [\"arn:aws:dataprotection::aws:data-identifier/EmailAddress\"]\n        Operation      = { Audit = { FindingsDestination = {} } }\n      },\n      {\n        Sid            = \"redact\"\n        DataIdentifier = [\"arn:aws:dataprotection::aws:data-identifier/EmailAddress\"]\n        Operation      = { Deidentify = { MaskConfig = {} } }\n      }\n    ]\n  })\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Attach a data protection policy to log groups that may contain sensitive data. Configure both an Audit statement (to detect and report sensitive-data findings) and a Deidentify statement (to mask the data at rest) covering the relevant managed and custom data identifiers.",
+      "Url": "https://hub.prowler.com/check/cloudwatch_log_group_data_protection_policy_configured"
+    }
+  },
+  "Categories": [
+    "logging"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_data_protection_policy_configured/cloudwatch_log_group_data_protection_policy_configured.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_data_protection_policy_configured/cloudwatch_log_group_data_protection_policy_configured.py
@@ -1,0 +1,44 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.cloudwatch.logs_client import logs_client
+
+# Operations that make a data protection policy statement actively protect sensitive data.
+PROTECTIVE_OPERATIONS = {"Audit", "Deidentify"}
+
+
+def _has_active_data_protection(policy: dict) -> bool:
+    """Return True when the policy has at least one statement that audits or de-identifies
+    one or more sensitive-data identifiers."""
+    if not isinstance(policy, dict):
+        return False
+    for statement in policy.get("Statement", []):
+        if not isinstance(statement, dict):
+            continue
+        data_identifiers = statement.get("DataIdentifier", [])
+        operation = statement.get("Operation", {})
+        if data_identifiers and any(
+            op in operation for op in PROTECTIVE_OPERATIONS
+        ):
+            return True
+    return False
+
+
+class cloudwatch_log_group_data_protection_policy_configured(Check):
+    def execute(self):
+        findings = []
+        if logs_client.log_groups:
+            for log_group in logs_client.log_groups.values():
+                report = Check_Report_AWS(metadata=self.metadata(), resource=log_group)
+                if _has_active_data_protection(log_group.data_protection_policy):
+                    report.status = "PASS"
+                    report.status_extended = (
+                        f"Log Group {log_group.name} has a data protection policy that "
+                        "audits or de-identifies sensitive data identifiers."
+                    )
+                else:
+                    report.status = "FAIL"
+                    report.status_extended = (
+                        f"Log Group {log_group.name} does not have a data protection policy "
+                        "configured to audit or de-identify sensitive data identifiers."
+                    )
+                findings.append(report)
+        return findings

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -111,6 +111,9 @@ class Logs(AWSService):
             ):
                 self.__threading_call__(self._get_log_events, self.log_groups.values())
             self.__threading_call__(
+                self._get_data_protection_policy, self.log_groups.values()
+            )
+            self.__threading_call__(
                 self._list_tags_for_resource, self.log_groups.values()
             )
 
@@ -260,6 +263,37 @@ class Logs(AWSService):
                 f"{log_group.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
+    def _get_data_protection_policy(self, log_group):
+        """Retrieve the data protection policy for a selected log group.
+
+        Args:
+            log_group: Log group selected for bounded analysis.
+        """
+        logger.info(
+            f"CloudWatch Logs - Getting data protection policy for log group {log_group.name}..."
+        )
+        try:
+            regional_client = self.regional_clients[log_group.region]
+            policy_document = regional_client.get_data_protection_policy(
+                logGroupIdentifier=log_group.arn
+            ).get("policyDocument")
+            if policy_document:
+                log_group.data_protection_policy = json.loads(policy_document)
+        except ClientError as error:
+            # A log group without a data protection policy returns ResourceNotFoundException.
+            if error.response["Error"]["Code"] == "ResourceNotFoundException":
+                logger.info(
+                    f"{log_group.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
+            else:
+                logger.error(
+                    f"{log_group.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
+        except Exception as error:
+            logger.error(
+                f"{log_group.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
     def _describe_resource_policies(self, regional_client):
         logger.info("CloudWatch Logs - Describing resource policies...")
         try:
@@ -341,6 +375,9 @@ class LogGroup(BaseModel):
     log_streams: dict[str, list[str]] = (
         {}
     )  # Log stream name as the key, array of events as the value
+    # Parsed data protection policy document (from GetDataProtectionPolicy) or None when
+    # the log group has no data protection policy configured.
+    data_protection_policy: Optional[dict] = None
     tags: Optional[list] = []
 
 

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_data_protection_policy_configured/cloudwatch_log_group_data_protection_policy_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_data_protection_policy_configured/cloudwatch_log_group_data_protection_policy_configured_test.py
@@ -1,0 +1,129 @@
+from unittest import mock
+
+from prowler.providers.aws.services.cloudwatch.cloudwatch_service import LogGroup
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+CHECK_PATH = "prowler.providers.aws.services.cloudwatch.cloudwatch_log_group_data_protection_policy_configured.cloudwatch_log_group_data_protection_policy_configured"
+
+log_group_name = "test-log-group"
+log_group_arn = (
+    f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:{log_group_name}"
+)
+
+EMAIL_IDENTIFIER = "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+
+ACTIVE_POLICY = {
+    "Name": "data-protection-policy",
+    "Version": "2021-06-01",
+    "Statement": [
+        {
+            "Sid": "audit",
+            "DataIdentifier": [EMAIL_IDENTIFIER],
+            "Operation": {"Audit": {"FindingsDestination": {}}},
+        },
+        {
+            "Sid": "redact",
+            "DataIdentifier": [EMAIL_IDENTIFIER],
+            "Operation": {"Deidentify": {"MaskConfig": {}}},
+        },
+    ],
+}
+
+
+def _log_group(data_protection_policy=None):
+    return LogGroup(
+        arn=log_group_arn,
+        name=log_group_name,
+        retention_days=9999,
+        never_expire=True,
+        kms_id=None,
+        region=AWS_REGION_US_EAST_1,
+        data_protection_policy=data_protection_policy,
+    )
+
+
+def _run_check(log_groups):
+    logs_client = mock.MagicMock
+    logs_client.log_groups = log_groups
+
+    aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+    with (
+        mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ),
+        mock.patch(f"{CHECK_PATH}.logs_client", logs_client),
+    ):
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_log_group_data_protection_policy_configured.cloudwatch_log_group_data_protection_policy_configured import (
+            cloudwatch_log_group_data_protection_policy_configured,
+        )
+
+        return cloudwatch_log_group_data_protection_policy_configured().execute()
+
+
+class Test_cloudwatch_log_group_data_protection_policy_configured:
+    def test_no_log_groups(self):
+        result = _run_check({})
+        assert len(result) == 0
+
+    def test_log_group_with_active_policy(self):
+        result = _run_check({log_group_arn: _log_group(ACTIVE_POLICY)})
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert (
+            result[0].status_extended
+            == f"Log Group {log_group_name} has a data protection policy that audits or "
+            "de-identifies sensitive data identifiers."
+        )
+        assert result[0].resource_id == log_group_name
+        assert result[0].resource_arn == log_group_arn
+        assert result[0].region == AWS_REGION_US_EAST_1
+
+    def test_log_group_without_policy(self):
+        result = _run_check({log_group_arn: _log_group(None)})
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert (
+            result[0].status_extended
+            == f"Log Group {log_group_name} does not have a data protection policy "
+            "configured to audit or de-identify sensitive data identifiers."
+        )
+
+    def test_log_group_policy_without_protective_operations(self):
+        # A policy with statements that reference no data identifiers is not effective
+        # protection.
+        policy = {
+            "Name": "empty-policy",
+            "Version": "2021-06-01",
+            "Statement": [
+                {"Sid": "s1", "DataIdentifier": [], "Operation": {"Audit": {}}}
+            ],
+        }
+        result = _run_check({log_group_arn: _log_group(policy)})
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+
+    def test_log_group_audit_only_policy(self):
+        policy = {
+            "Name": "audit-only",
+            "Version": "2021-06-01",
+            "Statement": [
+                {
+                    "Sid": "audit",
+                    "DataIdentifier": [EMAIL_IDENTIFIER],
+                    "Operation": {"Audit": {"FindingsDestination": {}}},
+                }
+            ],
+        }
+        result = _run_check({log_group_arn: _log_group(policy)})
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py
@@ -1,3 +1,7 @@
+import json
+from unittest import mock
+
+import botocore
 import pytest
 from boto3 import client
 from moto import mock_aws
@@ -225,6 +229,81 @@ class Test_CloudWatch_Service:
         assert logs.log_groups[arn].kms_id == "test_kms_id"
         assert logs.log_groups[arn].region == AWS_REGION_US_EAST_1
         assert logs.log_groups[arn].tags == [{}]
+
+    @mock_aws
+    def test_get_data_protection_policy(self):
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        logs_client.create_log_group(logGroupName="/log-group/test")
+
+        aws_provider = set_mocked_aws_provider(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
+        arn = f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*"
+
+        policy = {
+            "Name": "data-protection-policy",
+            "Version": "2021-06-01",
+            "Statement": [
+                {
+                    "Sid": "audit",
+                    "DataIdentifier": [
+                        "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+                    ],
+                    "Operation": {"Audit": {"FindingsDestination": {}}},
+                }
+            ],
+        }
+
+        # moto does not implement GetDataProtectionPolicy, so intercept just that call and
+        # delegate the rest to moto's patched client.
+        orig_make_api_call = botocore.client.BaseClient._make_api_call
+
+        def mock_make_api_call(self, operation_name, kwarg):
+            if operation_name == "GetDataProtectionPolicy":
+                return {
+                    "logGroupIdentifier": kwarg.get("logGroupIdentifier"),
+                    "policyDocument": json.dumps(policy),
+                }
+            return orig_make_api_call(self, operation_name, kwarg)
+
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call
+        ):
+            logs = Logs(aws_provider)
+
+        assert logs.log_groups[arn].data_protection_policy == policy
+
+    @mock_aws
+    def test_get_data_protection_policy_none_when_absent(self):
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        logs_client.create_log_group(logGroupName="/log-group/test")
+
+        aws_provider = set_mocked_aws_provider(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
+        arn = f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*"
+
+        orig_make_api_call = botocore.client.BaseClient._make_api_call
+
+        def mock_make_api_call(self, operation_name, kwarg):
+            if operation_name == "GetDataProtectionPolicy":
+                raise botocore.exceptions.ClientError(
+                    {
+                        "Error": {
+                            "Code": "ResourceNotFoundException",
+                            "Message": "No data protection policy",
+                        }
+                    },
+                    operation_name,
+                )
+            return orig_make_api_call(self, operation_name, kwarg)
+
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call
+        ):
+            logs = Logs(aws_provider)
+
+        assert logs.log_groups[arn].data_protection_policy is None
 
     def test_log_group_limit_exposes_only_selected_resources(self):
         class FakeLogsClient:


### PR DESCRIPTION
Implements #12635 (FS-43). PASS when a log group has an active data-protection policy masking sensitive-data identifiers. Unit tests pass. DRAFT: add AWS runtime PASS/FAIL evidence + CodeRabbit before ready (see prowler-SUMMARY.md).