### PR TITLE
feat(bedrock): add bedrock_knowledge_base_ingestion_recently_completed check

### DIFF
--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -366,6 +366,12 @@ aws:
   # Whether to check RDS instance replicas or not
   check_rds_instance_replicas: False
 
+  # AWS Bedrock Configuration
+  # aws.bedrock_knowledge_base_ingestion_recently_completed
+  # Maximum age, in days, of the latest successful knowledge base data source
+  # ingestion job before it is considered stale. Defaults to 7 days.
+  bedrock_knowledge_base_ingestion_max_age_in_days: 7
+
   # AWS ACM Configuration
   # aws.acm_certificates_expiration_check
   days_to_expire_threshold: 7

--- a/prowler/providers/aws/services/bedrock/bedrock_knowledge_base_ingestion_recently_completed/bedrock_knowledge_base_ingestion_recently_completed.metadata.json
+++ b/prowler/providers/aws/services/bedrock/bedrock_knowledge_base_ingestion_recently_completed/bedrock_knowledge_base_ingestion_recently_completed.metadata.json
@@ -1,0 +1,39 @@
+{
+  "Provider": "aws",
+  "CheckID": "bedrock_knowledge_base_ingestion_recently_completed",
+  "CheckTitle": "Bedrock knowledge base data source has recently completed an ingestion job",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices"
+  ],
+  "ServiceName": "bedrock",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:partition:bedrock:region:account-id:knowledge-base/knowledge-base-id/data-source/data-source-id",
+  "Severity": "medium",
+  "ResourceType": "Other",
+  "ResourceGroup": "ai_ml",
+  "Description": "This check ensures that each Amazon Bedrock knowledge base data source has a successfully completed (COMPLETE) ingestion job within a configurable time window (bedrock_knowledge_base_ingestion_max_age_in_days, default 7 days). A data source with no successful ingestion job, or whose latest one is older than the threshold, is flagged.",
+  "Risk": "If a knowledge base data source has not completed a recent ingestion job, the knowledge base serves stale or incomplete data to retrieval-augmented generation (RAG) applications. This can silently degrade answer quality, hide newly added or corrected source documents, and mask ingestion pipeline failures, leading to incorrect or outdated model responses.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/bedrock/latest/userguide/kb-data-source-sync-ingest.html",
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_ListIngestionJobs.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws bedrock-agent start-ingestion-job --knowledge-base-id <knowledge_base_id> --data-source-id <data_source_id>",
+      "NativeIaC": "",
+      "Other": "1. In the AWS Console, go to Amazon Bedrock > Knowledge bases and select the knowledge base.\n2. In the Data source section, select the data source and choose 'Sync' to start an ingestion job.\n3. Wait for the ingestion job status to become 'COMPLETE'.\n4. To keep data fresh automatically, schedule regular syncs (for example, with an EventBridge rule invoking a Lambda that calls StartIngestionJob) and monitor ingestion job outcomes.",
+      "Terraform": "```hcl\n# Terraform: schedule regular ingestion of a Bedrock knowledge base data source.\n# There is no Terraform resource that runs an ingestion job directly; trigger it on a\n# schedule with EventBridge + Lambda calling bedrock-agent StartIngestionJob.\nresource \"aws_cloudwatch_event_rule\" \"<example_resource_name>\" {\n  name                = \"bedrock-kb-sync\"\n  schedule_expression = \"rate(1 day)\"\n}\n\nresource \"aws_cloudwatch_event_target\" \"<example_resource_name>\" {\n  rule = aws_cloudwatch_event_rule.<example_resource_name>.name\n  arn  = aws_lambda_function.<example_lambda_name>.arn\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Run knowledge base data source ingestion jobs on a regular schedule so the knowledge base reflects the current source documents, monitor ingestion job outcomes, and alert on failed or missing jobs. Tune the freshness window with the bedrock_knowledge_base_ingestion_max_age_in_days configuration value to match your data update cadence.",
+      "Url": "https://hub.prowler.com/check/bedrock_knowledge_base_ingestion_recently_completed"
+    }
+  },
+  "Categories": [
+    "gen-ai"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/bedrock/bedrock_knowledge_base_ingestion_recently_completed/bedrock_knowledge_base_ingestion_recently_completed.py
+++ b/prowler/providers/aws/services/bedrock/bedrock_knowledge_base_ingestion_recently_completed/bedrock_knowledge_base_ingestion_recently_completed.py
@@ -1,0 +1,86 @@
+from datetime import datetime, timezone
+
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.bedrock.bedrock_agent_client import (
+    bedrock_agent_client,
+)
+
+
+class bedrock_knowledge_base_ingestion_recently_completed(Check):
+    """Ensure Bedrock knowledge base data sources have recently ingested successfully.
+
+    One finding is reported per data source, because ingestion jobs run per data source.
+
+    - PASS: The latest successful (COMPLETE) ingestion job finished within the configured
+      window (``bedrock_knowledge_base_ingestion_max_age_in_days``, default 7 days).
+    - FAIL: The data source has no successfully completed ingestion job, or the latest one
+      is older than the configured window, so the knowledge base may be serving stale data.
+    - MANUAL: ListIngestionJobs failed for the data source, ListDataSources failed for the
+      knowledge base, or ListKnowledgeBases failed for the region, so ingestion state is
+      unknown.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        findings = []
+
+        max_age_in_days = bedrock_agent_client.audit_config.get(
+            "bedrock_knowledge_base_ingestion_max_age_in_days", 7
+        )
+
+        for region, error in sorted(
+            bedrock_agent_client.knowledge_bases_scan_errors.items()
+        ):
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource={"region": region}
+            )
+            report.region = region
+            report.resource_id = "knowledge-base/unknown"
+            report.resource_arn = f"arn:{bedrock_agent_client.audited_partition}:bedrock:{region}:{bedrock_agent_client.audited_account}:knowledge-base/unknown"
+            report.status = "MANUAL"
+            report.status_extended = f"Bedrock knowledge bases could not be listed in region {region} ({error}); verify manually that every knowledge base data source has recently completed an ingestion job."
+            findings.append(report)
+
+        for knowledge_base in bedrock_agent_client.knowledge_bases.values():
+            if knowledge_base.data_sources_listed:
+                continue
+            report = Check_Report_AWS(metadata=self.metadata(), resource=knowledge_base)
+            report.status = "MANUAL"
+            reason = (
+                f" ({knowledge_base.data_sources_error})"
+                if knowledge_base.data_sources_error
+                else ""
+            )
+            report.status_extended = f"Bedrock knowledge base {knowledge_base.name} data sources could not be listed in region {knowledge_base.region}{reason}; verify manually that each one has recently completed an ingestion job."
+            findings.append(report)
+
+        for data_source in bedrock_agent_client.data_sources.values():
+            report = Check_Report_AWS(metadata=self.metadata(), resource=data_source)
+            knowledge_base = (
+                data_source.knowledge_base_name or data_source.knowledge_base_id
+            )
+
+            if not data_source.ingestion_jobs_listed:
+                report.status = "MANUAL"
+                reason = (
+                    f" ({data_source.ingestion_jobs_error})"
+                    if data_source.ingestion_jobs_error
+                    else ""
+                )
+                report.status_extended = f"Bedrock knowledge base {knowledge_base} data source {data_source.name} ingestion jobs could not be listed in region {data_source.region}{reason}; verify manually that it has recently completed an ingestion job."
+            elif data_source.last_successful_ingestion_at is None:
+                report.status = "FAIL"
+                report.status_extended = f"Bedrock knowledge base {knowledge_base} data source {data_source.name} has no successfully completed ingestion job in region {data_source.region}."
+            else:
+                age_in_days = (
+                    datetime.now(timezone.utc)
+                    - data_source.last_successful_ingestion_at
+                ).days
+                if age_in_days <= max_age_in_days:
+                    report.status = "PASS"
+                    report.status_extended = f"Bedrock knowledge base {knowledge_base} data source {data_source.name} completed an ingestion job {age_in_days} day(s) ago in region {data_source.region}, within the {max_age_in_days} day(s) threshold."
+                else:
+                    report.status = "FAIL"
+                    report.status_extended = f"Bedrock knowledge base {knowledge_base} data source {data_source.name} last completed an ingestion job {age_in_days} day(s) ago in region {data_source.region}, exceeding the {max_age_in_days} day(s) threshold."
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/bedrock/bedrock_service.py
+++ b/prowler/providers/aws/services/bedrock/bedrock_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional
 
 from botocore.exceptions import ClientError
@@ -270,6 +271,7 @@ class BedrockAgent(AWSService):
         self.__threading_call__(self._list_knowledge_bases)
         self.__threading_call__(self._list_data_sources, self.knowledge_bases.values())
         self.__threading_call__(self._get_data_source, self.data_sources.values())
+        self.__threading_call__(self._list_ingestion_jobs, self.data_sources.values())
 
     def _list_agents(self, regional_client):
         logger.info("Bedrock Agent - Listing Agents...")
@@ -541,6 +543,47 @@ class BedrockAgent(AWSService):
                 f"{data_source.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
+    def _list_ingestion_jobs(self, data_source):
+        """Record the timestamp of a data source's most recent successful ingestion job.
+
+        Findings are per data source, so a failed ListIngestionJobs is recorded on the
+        data source itself rather than dropping it from the report.
+        """
+        logger.info("Bedrock Agent - Listing Ingestion Jobs...")
+        try:
+            paginator = self.regional_clients[data_source.region].get_paginator(
+                "list_ingestion_jobs"
+            )
+            latest_completed = None
+            for page in paginator.paginate(
+                knowledgeBaseId=data_source.knowledge_base_id,
+                dataSourceId=data_source.id,
+            ):
+                for ingestion_job in page.get("ingestionJobSummaries", []):
+                    if ingestion_job.get("status") != "COMPLETE":
+                        continue
+                    updated_at = ingestion_job.get("updatedAt") or ingestion_job.get(
+                        "startedAt"
+                    )
+                    if updated_at and (
+                        latest_completed is None or updated_at > latest_completed
+                    ):
+                        latest_completed = updated_at
+            data_source.last_successful_ingestion_at = latest_completed
+            data_source.ingestion_jobs_listed = True
+        except ClientError as error:
+            data_source.ingestion_jobs_error = error.response["Error"].get(
+                "Code", error.__class__.__name__
+            )
+            logger.error(
+                f"{data_source.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+        except Exception as error:
+            data_source.ingestion_jobs_error = error.__class__.__name__
+            logger.error(
+                f"{data_source.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
     def _list_tags_for_resource(self, resource):
         """List tags for a Bedrock Agent resource."""
         logger.info("Bedrock Agent - Listing Tags for Resource...")
@@ -616,3 +659,10 @@ class KnowledgeBaseDataSource(BaseModel):
     kms_key_arn: Optional[str] = None
     # False when GetDataSource failed: absent key is unknown, not unset.
     detail_retrieved: bool = False
+    # False when ListIngestionJobs failed: no successful job is unknown, not none.
+    ingestion_jobs_listed: bool = False
+    # The error code from a failed ListIngestionJobs, for the finding message.
+    ingestion_jobs_error: Optional[str] = None
+    # updatedAt of the most recent ingestion job with status COMPLETE, or None when the
+    # data source has no successfully completed ingestion job.
+    last_successful_ingestion_at: Optional[datetime] = None

--- a/tests/providers/aws/services/bedrock/bedrock_knowledge_base_ingestion_recently_completed/bedrock_knowledge_base_ingestion_recently_completed_test.py
+++ b/tests/providers/aws/services/bedrock/bedrock_knowledge_base_ingestion_recently_completed/bedrock_knowledge_base_ingestion_recently_completed_test.py
@@ -1,0 +1,247 @@
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+import botocore
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+make_api_call = botocore.client.BaseClient._make_api_call
+
+KB_ID = "test-kb-id"
+KB_NAME = "test-knowledge-base"
+KB_ARN = f"arn:aws:bedrock:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:knowledge-base/{KB_ID}"
+DS_ID = "test-ds-id"
+DS_NAME = "test-data-source"
+DS_ARN = f"{KB_ARN}/data-source/{DS_ID}"
+
+CHECK_PATH = "prowler.providers.aws.services.bedrock.bedrock_knowledge_base_ingestion_recently_completed.bedrock_knowledge_base_ingestion_recently_completed.bedrock_agent_client"
+
+# Operations the BedrockAgent constructor calls that these tests do not exercise.
+_UNUSED_OPERATIONS = (
+    "ListAgents",
+    "GetAgent",
+    "ListPrompts",
+    "GetPrompt",
+    "ListTagsForResource",
+)
+
+
+def _base(operation_name):
+    if operation_name in _UNUSED_OPERATIONS:
+        return {}
+    if operation_name == "ListKnowledgeBases":
+        return {
+            "knowledgeBaseSummaries": [
+                {"knowledgeBaseId": KB_ID, "name": KB_NAME, "status": "ACTIVE"}
+            ]
+        }
+    if operation_name == "ListDataSources":
+        return {
+            "dataSourceSummaries": [
+                {
+                    "knowledgeBaseId": KB_ID,
+                    "dataSourceId": DS_ID,
+                    "name": DS_NAME,
+                    "status": "AVAILABLE",
+                }
+            ]
+        }
+    if operation_name == "GetDataSource":
+        return {
+            "dataSource": {
+                "knowledgeBaseId": KB_ID,
+                "dataSourceId": DS_ID,
+                "name": DS_NAME,
+                "status": "AVAILABLE",
+            }
+        }
+    return None
+
+
+def _make_mock(ingestion_summaries=None, fail_ingestion=False):
+    def _mock(self, operation_name, kwarg):
+        base = _base(operation_name)
+        if base is not None:
+            return base
+        if operation_name == "ListIngestionJobs":
+            if fail_ingestion:
+                raise ClientError(
+                    {"Error": {"Code": "AccessDeniedException", "Message": "denied"}},
+                    operation_name,
+                )
+            return {"ingestionJobSummaries": ingestion_summaries or []}
+        return make_api_call(self, operation_name, kwarg)
+
+    return _mock
+
+
+def _mock_empty(self, operation_name, kwarg):
+    if operation_name in _UNUSED_OPERATIONS:
+        return {}
+    if operation_name == "ListKnowledgeBases":
+        return {"knowledgeBaseSummaries": []}
+    return make_api_call(self, operation_name, kwarg)
+
+
+def _mock_list_kb_denied(self, operation_name, kwarg):
+    if operation_name in _UNUSED_OPERATIONS:
+        return {}
+    if operation_name == "ListKnowledgeBases":
+        raise ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "denied"}},
+            operation_name,
+        )
+    return make_api_call(self, operation_name, kwarg)
+
+
+class Test_bedrock_knowledge_base_ingestion_recently_completed:
+    def _run(self):
+        from prowler.providers.aws.services.bedrock.bedrock_service import BedrockAgent
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(CHECK_PATH, new=BedrockAgent(aws_provider)),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_knowledge_base_ingestion_recently_completed.bedrock_knowledge_base_ingestion_recently_completed import (
+                bedrock_knowledge_base_ingestion_recently_completed,
+            )
+
+            return bedrock_knowledge_base_ingestion_recently_completed().execute()
+
+    @mock.patch("botocore.client.BaseClient._make_api_call", new=_mock_empty)
+    @mock_aws
+    def test_no_resources(self):
+        assert self._run() == []
+
+    @mock_aws
+    def test_recent_ingestion_passes(self):
+        recent = datetime.now(timezone.utc) - timedelta(days=2)
+        summaries = [
+            {"ingestionJobId": "job1", "status": "COMPLETE", "updatedAt": recent}
+        ]
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=_make_mock(ingestion_summaries=summaries),
+        ):
+            result = self._run()
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert result[0].resource_id == DS_ID
+        assert result[0].resource_arn == DS_ARN
+        assert result[0].region == AWS_REGION_US_EAST_1
+        assert "within the 7 day(s) threshold" in result[0].status_extended
+
+    @mock_aws
+    def test_stale_ingestion_fails(self):
+        stale = datetime.now(timezone.utc) - timedelta(days=30)
+        summaries = [
+            {"ingestionJobId": "job1", "status": "COMPLETE", "updatedAt": stale}
+        ]
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=_make_mock(ingestion_summaries=summaries),
+        ):
+            result = self._run()
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert "exceeding the 7 day(s) threshold" in result[0].status_extended
+
+    @mock_aws
+    def test_latest_complete_job_is_used(self):
+        # A recent FAILED job and an older COMPLETE job: the latest *successful* one drives
+        # the verdict, so this is stale -> FAIL.
+        recent_failed = datetime.now(timezone.utc) - timedelta(days=1)
+        old_complete = datetime.now(timezone.utc) - timedelta(days=20)
+        summaries = [
+            {"ingestionJobId": "job2", "status": "FAILED", "updatedAt": recent_failed},
+            {"ingestionJobId": "job1", "status": "COMPLETE", "updatedAt": old_complete},
+        ]
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=_make_mock(ingestion_summaries=summaries),
+        ):
+            result = self._run()
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+
+    @mock_aws
+    def test_no_successful_ingestion_fails(self):
+        recent_failed = datetime.now(timezone.utc) - timedelta(days=1)
+        summaries = [
+            {"ingestionJobId": "job1", "status": "FAILED", "updatedAt": recent_failed}
+        ]
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=_make_mock(ingestion_summaries=summaries),
+        ):
+            result = self._run()
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert "no successfully completed ingestion job" in result[0].status_extended
+
+    @mock_aws
+    def test_configurable_threshold(self):
+        # 10-day-old job is stale with the default 7 but passes with a configured 30.
+        job_time = datetime.now(timezone.utc) - timedelta(days=10)
+        summaries = [
+            {"ingestionJobId": "job1", "status": "COMPLETE", "updatedAt": job_time}
+        ]
+        from prowler.providers.aws.services.bedrock.bedrock_service import BedrockAgent
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1],
+            audit_config={"bedrock_knowledge_base_ingestion_max_age_in_days": 30},
+        )
+        with (
+            mock.patch(
+                "botocore.client.BaseClient._make_api_call",
+                new=_make_mock(ingestion_summaries=summaries),
+            ),
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(CHECK_PATH, new=BedrockAgent(aws_provider)),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_knowledge_base_ingestion_recently_completed.bedrock_knowledge_base_ingestion_recently_completed import (
+                bedrock_knowledge_base_ingestion_recently_completed,
+            )
+
+            result = bedrock_knowledge_base_ingestion_recently_completed().execute()
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert "within the 30 day(s) threshold" in result[0].status_extended
+
+    @mock_aws
+    def test_ingestion_jobs_listing_failed_is_manual(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=_make_mock(fail_ingestion=True),
+        ):
+            result = self._run()
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+
+    @mock.patch("botocore.client.BaseClient._make_api_call", new=_mock_list_kb_denied)
+    @mock_aws
+    def test_list_knowledge_bases_denied_is_manual(self):
+        result = self._run()
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+        assert result[0].resource_id == "knowledge-base/unknown"


### PR DESCRIPTION
Implements #12634 (FS-31). PASS when the latest KB ingestion completed within a configurable window (default 7d). Unit tests pass. DRAFT: add AWS runtime PASS/FAIL evidence + CodeRabbit before ready (see prowler-SUMMARY.md).