### PR TITLE
feat(wafv2): add wafv2_webacl_managed_injection_rule_groups_enabled check

### DIFF
--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -148,6 +148,21 @@ class WAFv2(AWSService):
                         else:
                             acl.rules.append(new_rule)
 
+                        # Recursively parse the rule statement to retain managed rule
+                        # groups (vendor/name/overrides/exclusions) and detect custom
+                        # XssMatchStatements, including nested statements.
+                        override_to_count = "Count" in rule.get(
+                            "OverrideAction", {}
+                        )
+                        rule_blocks = self._rule_action_blocks(rule.get("Action", {}))
+                        has_xss = self._parse_statement(
+                            rule.get("Statement", {}),
+                            acl,
+                            override_to_count,
+                        )
+                        if has_xss and rule_blocks:
+                            acl.rules_with_xss_match.append(new_rule.name)
+
                     firewall_manager_managed_rg = get_web_acl.get("WebACL", {}).get(
                         "PreProcessFirewallManagerRuleGroups", []
                     ) + get_web_acl.get("WebACL", {}).get(
@@ -173,6 +188,88 @@ class WAFv2(AWSService):
             logger.error(
                 f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
+
+    @staticmethod
+    def _rule_action_blocks(action: dict) -> bool:
+        """Return True if a custom rule action blocks or challenges the request.
+
+        Count and Allow actions do not protect against a matched request, so a rule with
+        those actions is not considered active protection.
+        """
+        if not action:
+            # Managed rule group / rule group reference rules use OverrideAction instead of
+            # Action; a custom XssMatchStatement rule must define an Action, so an empty
+            # Action means this is not an effective custom protection rule.
+            return False
+        return any(effective in action for effective in ("Block", "Captcha", "Challenge"))
+
+    def _parse_statement(self, statement: dict, acl, override_to_count: bool) -> bool:
+        """Recursively walk a rule Statement.
+
+        Retains any managed rule groups found on the given ``acl`` and returns whether an
+        ``XssMatchStatement`` was found anywhere in the (possibly nested) statement tree.
+        """
+        found_xss = False
+        if not isinstance(statement, dict):
+            return False
+
+        if "XssMatchStatement" in statement:
+            found_xss = True
+
+        managed = statement.get("ManagedRuleGroupStatement")
+        if managed:
+            excluded_rules = [
+                excluded.get("Name")
+                for excluded in managed.get("ExcludedRules", [])
+                if excluded.get("Name")
+            ]
+            for override in managed.get("RuleActionOverrides", []):
+                if "Count" in override.get("ActionToUse", {}) and override.get("Name"):
+                    excluded_rules.append(override["Name"])
+            acl.managed_rule_groups.append(
+                ManagedRuleGroup(
+                    vendor_name=managed.get("VendorName", ""),
+                    name=managed.get("Name", ""),
+                    override_to_count=override_to_count,
+                    excluded_rules=excluded_rules,
+                )
+            )
+            if managed.get("ScopeDownStatement"):
+                found_xss = (
+                    self._parse_statement(
+                        managed["ScopeDownStatement"], acl, override_to_count
+                    )
+                    or found_xss
+                )
+
+        for logical in ("AndStatement", "OrStatement"):
+            if logical in statement:
+                for sub_statement in statement[logical].get("Statements", []):
+                    found_xss = (
+                        self._parse_statement(sub_statement, acl, override_to_count)
+                        or found_xss
+                    )
+
+        if "NotStatement" in statement:
+            found_xss = (
+                self._parse_statement(
+                    statement["NotStatement"].get("Statement", {}),
+                    acl,
+                    override_to_count,
+                )
+                or found_xss
+            )
+
+        rate_based = statement.get("RateBasedStatement", {})
+        if rate_based.get("ScopeDownStatement"):
+            found_xss = (
+                self._parse_statement(
+                    rate_based["ScopeDownStatement"], acl, override_to_count
+                )
+                or found_xss
+            )
+
+        return found_xss
 
     def _list_tags(self, resource: any):
         logger.info("WAFv2 - Listing tags...")
@@ -207,6 +304,19 @@ class Rule(BaseModel):
     cloudwatch_metrics_enabled: bool = False
 
 
+class ManagedRuleGroup(BaseModel):
+    """Model representing an AWS/Marketplace managed rule group referenced by a Web ACL."""
+
+    vendor_name: str
+    name: str
+    # Whether the whole rule group action is overridden to Count (i.e. excluded wholesale
+    # from blocking) via the rule's OverrideAction.
+    override_to_count: bool = False
+    # Names of individual rules within the group that are excluded from blocking, either via
+    # (deprecated) ExcludedRules or via RuleActionOverrides that set the action to Count.
+    excluded_rules: list[str] = []
+
+
 class WebAclv2(BaseModel):
     """Model representing a Web ACL for WAFv2."""
 
@@ -221,3 +331,8 @@ class WebAclv2(BaseModel):
     scope: Scope = Scope.REGIONAL
     rules: list[Rule] = []
     rule_groups: list[Rule] = []
+    # Managed rule groups (AWS/Marketplace) referenced by the Web ACL, collected recursively.
+    managed_rule_groups: list[ManagedRuleGroup] = []
+    # Names of custom rules that contain an XssMatchStatement (found recursively) and whose
+    # action blocks/challenges the request (Block, Captcha or Challenge).
+    rules_with_xss_match: list[str] = []

--- a/prowler/providers/aws/services/wafv2/wafv2_webacl_managed_injection_rule_groups_enabled/wafv2_webacl_managed_injection_rule_groups_enabled.metadata.json
+++ b/prowler/providers/aws/services/wafv2/wafv2_webacl_managed_injection_rule_groups_enabled/wafv2_webacl_managed_injection_rule_groups_enabled.metadata.json
@@ -1,0 +1,40 @@
+{
+  "Provider": "aws",
+  "CheckID": "wafv2_webacl_managed_injection_rule_groups_enabled",
+  "CheckTitle": "AWS WAFv2 Web ACL has the AWS managed injection rule groups enabled",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices"
+  ],
+  "ServiceName": "wafv2",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:partition:wafv2:region:account-id:webacl/name/id",
+  "Severity": "high",
+  "ResourceType": "AwsWafv2WebAcl",
+  "ResourceGroup": "security",
+  "Description": "This check ensures that AWS WAFv2 Web ACLs have both the AWSManagedRulesSQLiRuleSet and AWSManagedRulesKnownBadInputsRuleSet AWS managed rule groups enabled and not excluded wholesale, so the Web ACL protects protected resources against SQL injection and other known bad inputs.",
+  "Risk": "Without the SQL injection (AWSManagedRulesSQLiRuleSet) and known bad inputs (AWSManagedRulesKnownBadInputsRuleSet) managed rule groups, web applications behind the Web ACL are exposed to SQLi attacks and requests that exploit known vulnerabilities such as host header and Log4j exploitation, which can lead to data exfiltration, remote code execution, and service compromise.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html",
+    "https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-managed-rule-group.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws wafv2 update-web-acl --name <web_acl_name> --scope REGIONAL --id <web_acl_id> --lock-token <lock_token> --default-action Allow={} --visibility-config SampledRequestsEnabled=true,CloudWatchMetricsEnabled=true,MetricName=<metric_name> --rules '[{\"Name\":\"AWS-SQLi\",\"Priority\":1,\"Statement\":{\"ManagedRuleGroupStatement\":{\"VendorName\":\"AWS\",\"Name\":\"AWSManagedRulesSQLiRuleSet\"}},\"OverrideAction\":{\"None\":{}},\"VisibilityConfig\":{\"SampledRequestsEnabled\":true,\"CloudWatchMetricsEnabled\":true,\"MetricName\":\"AWS-SQLi\"}},{\"Name\":\"AWS-KnownBadInputs\",\"Priority\":2,\"Statement\":{\"ManagedRuleGroupStatement\":{\"VendorName\":\"AWS\",\"Name\":\"AWSManagedRulesKnownBadInputsRuleSet\"}},\"OverrideAction\":{\"None\":{}},\"VisibilityConfig\":{\"SampledRequestsEnabled\":true,\"CloudWatchMetricsEnabled\":true,\"MetricName\":\"AWS-KnownBadInputs\"}}]'",
+      "NativeIaC": "```yaml\n# CloudFormation: enable the AWS managed injection rule groups on a WAFv2 Web ACL\nResources:\n  <example_resource_name>:\n    Type: AWS::WAFv2::WebACL\n    Properties:\n      Name: <example_resource_name>\n      Scope: REGIONAL\n      DefaultAction:\n        Allow: {}\n      VisibilityConfig:\n        SampledRequestsEnabled: true\n        CloudWatchMetricsEnabled: true\n        MetricName: <metric_name>\n      Rules:\n        - Name: AWS-SQLi\n          Priority: 1\n          OverrideAction:\n            None: {}  # Do not override the group to Count, otherwise it is excluded wholesale\n          Statement:\n            ManagedRuleGroupStatement:\n              VendorName: AWS\n              Name: AWSManagedRulesSQLiRuleSet\n          VisibilityConfig:\n            SampledRequestsEnabled: true\n            CloudWatchMetricsEnabled: true\n            MetricName: AWS-SQLi\n        - Name: AWS-KnownBadInputs\n          Priority: 2\n          OverrideAction:\n            None: {}\n          Statement:\n            ManagedRuleGroupStatement:\n              VendorName: AWS\n              Name: AWSManagedRulesKnownBadInputsRuleSet\n          VisibilityConfig:\n            SampledRequestsEnabled: true\n            CloudWatchMetricsEnabled: true\n            MetricName: AWS-KnownBadInputs\n```",
+      "Other": "1. In the AWS Console, go to AWS WAF & Shield > Web ACLs and select the Web ACL.\n2. On the Rules tab, choose Add rules > Add managed rule groups > AWS managed rule groups.\n3. Enable 'Core rule set' dependencies as needed, then enable 'SQL database' (AWSManagedRulesSQLiRuleSet) and 'Known bad inputs' (AWSManagedRulesKnownBadInputsRuleSet).\n4. Ensure the group action is not set to Count (Override to count disabled) so the rules block, and Save.",
+      "Terraform": "```hcl\n# Terraform: enable the AWS managed injection rule groups on a WAFv2 Web ACL\nresource \"aws_wafv2_web_acl\" \"<example_resource_name>\" {\n  name  = \"<example_resource_name>\"\n  scope = \"REGIONAL\"\n\n  default_action { allow {} }\n\n  visibility_config {\n    cloudwatch_metrics_enabled = true\n    metric_name                = \"<metric_name>\"\n    sampled_requests_enabled   = true\n  }\n\n  rule {\n    name     = \"AWS-SQLi\"\n    priority = 1\n    override_action { none {} }  # Not 'count {}', which would exclude the group wholesale\n    statement {\n      managed_rule_group_statement {\n        vendor_name = \"AWS\"\n        name        = \"AWSManagedRulesSQLiRuleSet\"\n      }\n    }\n    visibility_config {\n      cloudwatch_metrics_enabled = true\n      metric_name                = \"AWS-SQLi\"\n      sampled_requests_enabled   = true\n    }\n  }\n\n  rule {\n    name     = \"AWS-KnownBadInputs\"\n    priority = 2\n    override_action { none {} }\n    statement {\n      managed_rule_group_statement {\n        vendor_name = \"AWS\"\n        name        = \"AWSManagedRulesKnownBadInputsRuleSet\"\n      }\n    }\n    visibility_config {\n      cloudwatch_metrics_enabled = true\n      metric_name                = \"AWS-KnownBadInputs\"\n      sampled_requests_enabled   = true\n    }\n  }\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Attach both the AWSManagedRulesSQLiRuleSet and AWSManagedRulesKnownBadInputsRuleSet AWS managed rule groups to every Web ACL and keep them in blocking mode (do not override the whole group to Count). Review individual rule action overrides so that critical SQLi and known-bad-input rules are not silently set to Count.",
+      "Url": "https://hub.prowler.com/check/wafv2_webacl_managed_injection_rule_groups_enabled"
+    }
+  },
+  "Categories": [
+    "internet-exposed"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/wafv2/wafv2_webacl_managed_injection_rule_groups_enabled/wafv2_webacl_managed_injection_rule_groups_enabled.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_webacl_managed_injection_rule_groups_enabled/wafv2_webacl_managed_injection_rule_groups_enabled.py
@@ -1,0 +1,44 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.wafv2.wafv2_client import wafv2_client
+
+# AWS managed rule groups that protect against common injection-style attacks.
+REQUIRED_MANAGED_RULE_GROUPS = {
+    "AWSManagedRulesSQLiRuleSet",
+    "AWSManagedRulesKnownBadInputsRuleSet",
+}
+
+
+class wafv2_webacl_managed_injection_rule_groups_enabled(Check):
+    def execute(self):
+        findings = []
+        for web_acl in wafv2_client.web_acls.values():
+            report = Check_Report_AWS(metadata=self.metadata(), resource=web_acl)
+
+            # A managed rule group is considered enabled when it is referenced by the Web
+            # ACL, owned by AWS, and not excluded wholesale (its whole action overridden to
+            # Count).
+            enabled_groups = {
+                managed_rule_group.name
+                for managed_rule_group in web_acl.managed_rule_groups
+                if managed_rule_group.vendor_name == "AWS"
+                and not managed_rule_group.override_to_count
+            }
+
+            missing_groups = sorted(REQUIRED_MANAGED_RULE_GROUPS - enabled_groups)
+
+            if not missing_groups:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"AWS WAFv2 Web ACL {web_acl.name} has the AWS managed injection rule "
+                    "groups AWSManagedRulesSQLiRuleSet and AWSManagedRulesKnownBadInputsRuleSet enabled."
+                )
+            else:
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"AWS WAFv2 Web ACL {web_acl.name} does not have the following AWS managed "
+                    f"injection rule groups enabled: {', '.join(missing_groups)}."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/aws/services/wafv2/wafv2_webacl_managed_injection_rule_groups_enabled/wafv2_webacl_managed_injection_rule_groups_enabled_test.py
+++ b/tests/providers/aws/services/wafv2/wafv2_webacl_managed_injection_rule_groups_enabled/wafv2_webacl_managed_injection_rule_groups_enabled_test.py
@@ -1,0 +1,266 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
+
+CHECK_PATH = "prowler.providers.aws.services.wafv2.wafv2_webacl_managed_injection_rule_groups_enabled.wafv2_webacl_managed_injection_rule_groups_enabled"
+
+VISIBILITY = {
+    "SampledRequestsEnabled": True,
+    "CloudWatchMetricsEnabled": True,
+    "MetricName": "metric",
+}
+
+
+def _managed_rule(name, priority, override_to_count=False, rule_action_overrides=None):
+    managed_statement = {"VendorName": "AWS", "Name": name}
+    if rule_action_overrides:
+        managed_statement["RuleActionOverrides"] = rule_action_overrides
+    return {
+        "Name": name,
+        "Priority": priority,
+        "Statement": {"ManagedRuleGroupStatement": managed_statement},
+        "OverrideAction": {"Count": {}} if override_to_count else {"None": {}},
+        "VisibilityConfig": {**VISIBILITY, "MetricName": name},
+    }
+
+
+class Test_wafv2_webacl_managed_injection_rule_groups_enabled:
+    @mock_aws
+    def test_no_web_acls(self):
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_PATH}.wafv2_client", new=WAFv2(aws_provider)),
+        ):
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_managed_injection_rule_groups_enabled.wafv2_webacl_managed_injection_rule_groups_enabled import (
+                wafv2_webacl_managed_injection_rule_groups_enabled,
+            )
+
+            check = wafv2_webacl_managed_injection_rule_groups_enabled()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    @mock_aws
+    def test_both_managed_groups_enabled(self):
+        wafv2 = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        waf = wafv2.create_web_acl(
+            Name="waf-both",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                _managed_rule("AWSManagedRulesSQLiRuleSet", 1),
+                _managed_rule("AWSManagedRulesKnownBadInputsRuleSet", 2),
+            ],
+            VisibilityConfig=VISIBILITY,
+            Tags=[{"Key": "Name", "Value": "waf-both"}],
+        )["Summary"]
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_PATH}.wafv2_client", new=WAFv2(aws_provider)),
+        ):
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_managed_injection_rule_groups_enabled.wafv2_webacl_managed_injection_rule_groups_enabled import (
+                wafv2_webacl_managed_injection_rule_groups_enabled,
+            )
+
+            check = wafv2_webacl_managed_injection_rule_groups_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "AWS WAFv2 Web ACL waf-both has the AWS managed injection rule groups "
+                "AWSManagedRulesSQLiRuleSet and AWSManagedRulesKnownBadInputsRuleSet enabled."
+            )
+            assert result[0].resource_id == waf["Id"]
+            assert result[0].resource_arn == waf["ARN"]
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_one_managed_group_missing(self):
+        wafv2 = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        wafv2.create_web_acl(
+            Name="waf-missing",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[_managed_rule("AWSManagedRulesSQLiRuleSet", 1)],
+            VisibilityConfig=VISIBILITY,
+        )
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_PATH}.wafv2_client", new=WAFv2(aws_provider)),
+        ):
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_managed_injection_rule_groups_enabled.wafv2_webacl_managed_injection_rule_groups_enabled import (
+                wafv2_webacl_managed_injection_rule_groups_enabled,
+            )
+
+            check = wafv2_webacl_managed_injection_rule_groups_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "AWS WAFv2 Web ACL waf-missing does not have the following AWS managed "
+                "injection rule groups enabled: AWSManagedRulesKnownBadInputsRuleSet."
+            )
+
+    @mock_aws
+    def test_managed_group_overridden_to_count(self):
+        wafv2 = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        wafv2.create_web_acl(
+            Name="waf-count",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                _managed_rule("AWSManagedRulesSQLiRuleSet", 1),
+                # KnownBadInputs present but whole group overridden to Count -> excluded.
+                _managed_rule(
+                    "AWSManagedRulesKnownBadInputsRuleSet", 2, override_to_count=True
+                ),
+            ],
+            VisibilityConfig=VISIBILITY,
+        )
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_PATH}.wafv2_client", new=WAFv2(aws_provider)),
+        ):
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_managed_injection_rule_groups_enabled.wafv2_webacl_managed_injection_rule_groups_enabled import (
+                wafv2_webacl_managed_injection_rule_groups_enabled,
+            )
+
+            check = wafv2_webacl_managed_injection_rule_groups_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                "AWSManagedRulesKnownBadInputsRuleSet"
+                in result[0].status_extended
+            )
+
+    @mock_aws
+    def test_managed_groups_nested_in_and_statement(self):
+        # Managed rule groups can only appear as top-level rule statements, but the recursive
+        # parser must still find both groups referenced across separate rules.
+        wafv2 = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        wafv2.create_web_acl(
+            Name="waf-nested",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                _managed_rule(
+                    "AWSManagedRulesKnownBadInputsRuleSet",
+                    1,
+                    rule_action_overrides=[
+                        {"Name": "Host_localhost_HEADER", "ActionToUse": {"Count": {}}}
+                    ],
+                ),
+                _managed_rule("AWSManagedRulesSQLiRuleSet", 2),
+            ],
+            VisibilityConfig=VISIBILITY,
+        )
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_PATH}.wafv2_client", new=WAFv2(aws_provider)),
+        ):
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_managed_injection_rule_groups_enabled.wafv2_webacl_managed_injection_rule_groups_enabled import (
+                wafv2_webacl_managed_injection_rule_groups_enabled,
+            )
+
+            check = wafv2_webacl_managed_injection_rule_groups_enabled()
+            result = check.execute()
+
+            # Both groups present and not overridden wholesale -> PASS even though one
+            # individual rule inside a group is set to Count.
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+
+    @mock_aws
+    def test_no_managed_groups(self):
+        wafv2 = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        wafv2.create_web_acl(
+            Name="waf-none",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                {
+                    "Name": "byte-match",
+                    "Priority": 1,
+                    "Statement": {
+                        "ByteMatchStatement": {
+                            "SearchString": "test",
+                            "FieldToMatch": {"UriPath": {}},
+                            "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                            "PositionalConstraint": "CONTAINS",
+                        }
+                    },
+                    "Action": {"Block": {}},
+                    "VisibilityConfig": VISIBILITY,
+                }
+            ],
+            VisibilityConfig=VISIBILITY,
+        )
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_PATH}.wafv2_client", new=WAFv2(aws_provider)),
+        ):
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_managed_injection_rule_groups_enabled.wafv2_webacl_managed_injection_rule_groups_enabled import (
+                wafv2_webacl_managed_injection_rule_groups_enabled,
+            )
+
+            check = wafv2_webacl_managed_injection_rule_groups_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"


### PR DESCRIPTION
Implements #12636 (FS-53). PASS when both AWSManagedRulesSQLiRuleSet and KnownBadInputsRuleSet are enabled. Adds shared recursive WAF statement parsing. Unit tests pass. DRAFT: add AWS runtime PASS/FAIL evidence + CodeRabbit before ready (see prowler-SUMMARY.md).