### PR TITLE
feat(wafv2): add wafv2_webacl_xss_protection_enabled check

### DIFF
--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -148,6 +148,21 @@ class WAFv2(AWSService):
                         else:
                             acl.rules.append(new_rule)
 
+                        # Recursively parse the rule statement to retain managed rule
+                        # groups (vendor/name/overrides/exclusions) and detect custom
+                        # XssMatchStatements, including nested statements.
+                        override_to_count = "Count" in rule.get(
+                            "OverrideAction", {}
+                        )
+                        rule_blocks = self._rule_action_blocks(rule.get("Action", {}))
+                        has_xss = self._parse_statement(
+                            rule.get("Statement", {}),
+                            acl,
+                            override_to_count,
+                        )
+                        if has_xss and rule_blocks:
+                            acl.rules_with_xss_match.append(new_rule.name)
+
                     firewall_manager_managed_rg = get_web_acl.get("WebACL", {}).get(
                         "PreProcessFirewallManagerRuleGroups", []
                     ) + get_web_acl.get("WebACL", {}).get(
@@ -173,6 +188,88 @@ class WAFv2(AWSService):
             logger.error(
                 f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
+
+    @staticmethod
+    def _rule_action_blocks(action: dict) -> bool:
+        """Return True if a custom rule action blocks or challenges the request.
+
+        Count and Allow actions do not protect against a matched request, so a rule with
+        those actions is not considered active protection.
+        """
+        if not action:
+            # Managed rule group / rule group reference rules use OverrideAction instead of
+            # Action; a custom XssMatchStatement rule must define an Action, so an empty
+            # Action means this is not an effective custom protection rule.
+            return False
+        return any(effective in action for effective in ("Block", "Captcha", "Challenge"))
+
+    def _parse_statement(self, statement: dict, acl, override_to_count: bool) -> bool:
+        """Recursively walk a rule Statement.
+
+        Retains any managed rule groups found on the given ``acl`` and returns whether an
+        ``XssMatchStatement`` was found anywhere in the (possibly nested) statement tree.
+        """
+        found_xss = False
+        if not isinstance(statement, dict):
+            return False
+
+        if "XssMatchStatement" in statement:
+            found_xss = True
+
+        managed = statement.get("ManagedRuleGroupStatement")
+        if managed:
+            excluded_rules = [
+                excluded.get("Name")
+                for excluded in managed.get("ExcludedRules", [])
+                if excluded.get("Name")
+            ]
+            for override in managed.get("RuleActionOverrides", []):
+                if "Count" in override.get("ActionToUse", {}) and override.get("Name"):
+                    excluded_rules.append(override["Name"])
+            acl.managed_rule_groups.append(
+                ManagedRuleGroup(
+                    vendor_name=managed.get("VendorName", ""),
+                    name=managed.get("Name", ""),
+                    override_to_count=override_to_count,
+                    excluded_rules=excluded_rules,
+                )
+            )
+            if managed.get("ScopeDownStatement"):
+                found_xss = (
+                    self._parse_statement(
+                        managed["ScopeDownStatement"], acl, override_to_count
+                    )
+                    or found_xss
+                )
+
+        for logical in ("AndStatement", "OrStatement"):
+            if logical in statement:
+                for sub_statement in statement[logical].get("Statements", []):
+                    found_xss = (
+                        self._parse_statement(sub_statement, acl, override_to_count)
+                        or found_xss
+                    )
+
+        if "NotStatement" in statement:
+            found_xss = (
+                self._parse_statement(
+                    statement["NotStatement"].get("Statement", {}),
+                    acl,
+                    override_to_count,
+                )
+                or found_xss
+            )
+
+        rate_based = statement.get("RateBasedStatement", {})
+        if rate_based.get("ScopeDownStatement"):
+            found_xss = (
+                self._parse_statement(
+                    rate_based["ScopeDownStatement"], acl, override_to_count
+                )
+                or found_xss
+            )
+
+        return found_xss
 
     def _list_tags(self, resource: any):
         logger.info("WAFv2 - Listing tags...")
@@ -207,6 +304,19 @@ class Rule(BaseModel):
     cloudwatch_metrics_enabled: bool = False
 
 
+class ManagedRuleGroup(BaseModel):
+    """Model representing an AWS/Marketplace managed rule group referenced by a Web ACL."""
+
+    vendor_name: str
+    name: str
+    # Whether the whole rule group action is overridden to Count (i.e. excluded wholesale
+    # from blocking) via the rule's OverrideAction.
+    override_to_count: bool = False
+    # Names of individual rules within the group that are excluded from blocking, either via
+    # (deprecated) ExcludedRules or via RuleActionOverrides that set the action to Count.
+    excluded_rules: list[str] = []
+
+
 class WebAclv2(BaseModel):
     """Model representing a Web ACL for WAFv2."""
 
@@ -221,3 +331,8 @@ class WebAclv2(BaseModel):
     scope: Scope = Scope.REGIONAL
     rules: list[Rule] = []
     rule_groups: list[Rule] = []
+    # Managed rule groups (AWS/Marketplace) referenced by the Web ACL, collected recursively.
+    managed_rule_groups: list[ManagedRuleGroup] = []
+    # Names of custom rules that contain an XssMatchStatement (found recursively) and whose
+    # action blocks/challenges the request (Block, Captcha or Challenge).
+    rules_with_xss_match: list[str] = []

--- a/prowler/providers/aws/services/wafv2/wafv2_webacl_xss_protection_enabled/wafv2_webacl_xss_protection_enabled.metadata.json
+++ b/prowler/providers/aws/services/wafv2/wafv2_webacl_xss_protection_enabled/wafv2_webacl_xss_protection_enabled.metadata.json
@@ -1,0 +1,40 @@
+{
+  "Provider": "aws",
+  "CheckID": "wafv2_webacl_xss_protection_enabled",
+  "CheckTitle": "AWS WAFv2 Web ACL has cross-site scripting (XSS) protection enabled",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices"
+  ],
+  "ServiceName": "wafv2",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:partition:wafv2:region:account-id:webacl/name/id",
+  "Severity": "high",
+  "ResourceType": "AwsWafv2WebAcl",
+  "ResourceGroup": "security",
+  "Description": "This check ensures that AWS WAFv2 Web ACLs provide cross-site scripting (XSS) protection, either through the AWSManagedRulesCommonRuleSet managed rule group (which contains the CrossSiteScripting_* rules) enabled and not excluded wholesale, or through a custom rule with an XssMatchStatement that blocks or challenges matching requests.",
+  "Risk": "Without XSS protection, attackers can inject malicious scripts into requests that reach the application, leading to session hijacking, credential theft, defacement, and execution of arbitrary code in victims' browsers.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html",
+    "https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-xss-match.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws wafv2 update-web-acl --name <web_acl_name> --scope REGIONAL --id <web_acl_id> --lock-token <lock_token> --default-action Allow={} --visibility-config SampledRequestsEnabled=true,CloudWatchMetricsEnabled=true,MetricName=<metric_name> --rules '[{\"Name\":\"AWS-CommonRuleSet\",\"Priority\":1,\"Statement\":{\"ManagedRuleGroupStatement\":{\"VendorName\":\"AWS\",\"Name\":\"AWSManagedRulesCommonRuleSet\"}},\"OverrideAction\":{\"None\":{}},\"VisibilityConfig\":{\"SampledRequestsEnabled\":true,\"CloudWatchMetricsEnabled\":true,\"MetricName\":\"AWS-CommonRuleSet\"}}]'",
+      "NativeIaC": "```yaml\n# CloudFormation: enable XSS protection via the AWS Core rule set on a WAFv2 Web ACL\nResources:\n  <example_resource_name>:\n    Type: AWS::WAFv2::WebACL\n    Properties:\n      Name: <example_resource_name>\n      Scope: REGIONAL\n      DefaultAction:\n        Allow: {}\n      VisibilityConfig:\n        SampledRequestsEnabled: true\n        CloudWatchMetricsEnabled: true\n        MetricName: <metric_name>\n      Rules:\n        - Name: AWS-CommonRuleSet\n          Priority: 1\n          OverrideAction:\n            None: {}  # Blocking mode; do not override the group to Count\n          Statement:\n            ManagedRuleGroupStatement:\n              VendorName: AWS\n              Name: AWSManagedRulesCommonRuleSet\n          VisibilityConfig:\n            SampledRequestsEnabled: true\n            CloudWatchMetricsEnabled: true\n            MetricName: AWS-CommonRuleSet\n```",
+      "Other": "1. In the AWS Console, go to AWS WAF & Shield > Web ACLs and select the Web ACL.\n2. On the Rules tab, choose Add rules > Add managed rule groups > AWS managed rule groups and enable 'Core rule set' (AWSManagedRulesCommonRuleSet), which includes the CrossSiteScripting_* rules; ensure it is in Block mode (not Count).\n3. Alternatively, add a custom rule with an XSS match statement (Inspect: the request component; Match type: XSS) and set its action to Block, then Save.",
+      "Terraform": "```hcl\n# Terraform: enable XSS protection via the AWS Core rule set on a WAFv2 Web ACL\nresource \"aws_wafv2_web_acl\" \"<example_resource_name>\" {\n  name  = \"<example_resource_name>\"\n  scope = \"REGIONAL\"\n\n  default_action { allow {} }\n\n  visibility_config {\n    cloudwatch_metrics_enabled = true\n    metric_name                = \"<metric_name>\"\n    sampled_requests_enabled   = true\n  }\n\n  rule {\n    name     = \"AWS-CommonRuleSet\"\n    priority = 1\n    override_action { none {} }  # Blocking mode\n    statement {\n      managed_rule_group_statement {\n        vendor_name = \"AWS\"\n        name        = \"AWSManagedRulesCommonRuleSet\"\n      }\n    }\n    visibility_config {\n      cloudwatch_metrics_enabled = true\n      metric_name                = \"AWS-CommonRuleSet\"\n      sampled_requests_enabled   = true\n    }\n  }\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Enable the AWSManagedRulesCommonRuleSet managed rule group in blocking mode (its CrossSiteScripting_* rules provide XSS protection) and/or add custom XssMatchStatement rules that inspect all relevant request components (body, query string, URI, headers, cookies) and block matching requests. Avoid overriding these rules to Count.",
+      "Url": "https://hub.prowler.com/check/wafv2_webacl_xss_protection_enabled"
+    }
+  },
+  "Categories": [
+    "internet-exposed"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/wafv2/wafv2_webacl_xss_protection_enabled/wafv2_webacl_xss_protection_enabled.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_webacl_xss_protection_enabled/wafv2_webacl_xss_protection_enabled.py
@@ -1,0 +1,49 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.wafv2.wafv2_client import wafv2_client
+
+# The AWS Core rule set includes cross-site scripting (XSS) protection rules.
+XSS_MANAGED_RULE_GROUP = "AWSManagedRulesCommonRuleSet"
+
+
+class wafv2_webacl_xss_protection_enabled(Check):
+    def execute(self):
+        findings = []
+        for web_acl in wafv2_client.web_acls.values():
+            report = Check_Report_AWS(metadata=self.metadata(), resource=web_acl)
+
+            # XSS protection via the AWS Core rule set (which contains the
+            # CrossSiteScripting_* rules), enabled and not excluded wholesale.
+            managed_xss_enabled = any(
+                managed_rule_group.vendor_name == "AWS"
+                and managed_rule_group.name == XSS_MANAGED_RULE_GROUP
+                and not managed_rule_group.override_to_count
+                for managed_rule_group in web_acl.managed_rule_groups
+            )
+
+            # XSS protection via a custom XssMatchStatement rule that blocks/challenges.
+            custom_xss_enabled = bool(web_acl.rules_with_xss_match)
+
+            if managed_xss_enabled or custom_xss_enabled:
+                report.status = "PASS"
+                if managed_xss_enabled and custom_xss_enabled:
+                    protection = (
+                        f"the {XSS_MANAGED_RULE_GROUP} managed rule group and custom "
+                        "XssMatchStatement rules"
+                    )
+                elif managed_xss_enabled:
+                    protection = f"the {XSS_MANAGED_RULE_GROUP} managed rule group"
+                else:
+                    protection = "custom XssMatchStatement rules"
+                report.status_extended = (
+                    f"AWS WAFv2 Web ACL {web_acl.name} has XSS protection enabled through "
+                    f"{protection}."
+                )
+            else:
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"AWS WAFv2 Web ACL {web_acl.name} does not have XSS protection enabled."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/aws/services/wafv2/wafv2_webacl_xss_protection_enabled/wafv2_webacl_xss_protection_enabled_test.py
+++ b/tests/providers/aws/services/wafv2/wafv2_webacl_xss_protection_enabled/wafv2_webacl_xss_protection_enabled_test.py
@@ -1,0 +1,226 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
+
+CHECK_PATH = "prowler.providers.aws.services.wafv2.wafv2_webacl_xss_protection_enabled.wafv2_webacl_xss_protection_enabled"
+
+VISIBILITY = {
+    "SampledRequestsEnabled": True,
+    "CloudWatchMetricsEnabled": True,
+    "MetricName": "metric",
+}
+
+
+def _common_rule_set_rule(priority=1, override_to_count=False):
+    return {
+        "Name": "AWS-CommonRuleSet",
+        "Priority": priority,
+        "Statement": {
+            "ManagedRuleGroupStatement": {
+                "VendorName": "AWS",
+                "Name": "AWSManagedRulesCommonRuleSet",
+            }
+        },
+        "OverrideAction": {"Count": {}} if override_to_count else {"None": {}},
+        "VisibilityConfig": {**VISIBILITY, "MetricName": "AWS-CommonRuleSet"},
+    }
+
+
+def _xss_rule(name="xss", priority=1, action=None, nested=False):
+    xss_statement = {
+        "XssMatchStatement": {
+            "FieldToMatch": {"Body": {}},
+            "TextTransformations": [{"Type": "URL_DECODE", "Priority": 0}],
+        }
+    }
+    if nested:
+        statement = {
+            "AndStatement": {
+                "Statements": [
+                    {
+                        "ByteMatchStatement": {
+                            "SearchString": "x",
+                            "FieldToMatch": {"UriPath": {}},
+                            "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                            "PositionalConstraint": "CONTAINS",
+                        }
+                    },
+                    xss_statement,
+                ]
+            }
+        }
+    else:
+        statement = xss_statement
+    return {
+        "Name": name,
+        "Priority": priority,
+        "Statement": statement,
+        "Action": action or {"Block": {}},
+        "VisibilityConfig": {**VISIBILITY, "MetricName": name},
+    }
+
+
+def _run_check(aws_provider):
+    from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+    with (
+        mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ),
+        mock.patch(f"{CHECK_PATH}.wafv2_client", new=WAFv2(aws_provider)),
+    ):
+        from prowler.providers.aws.services.wafv2.wafv2_webacl_xss_protection_enabled.wafv2_webacl_xss_protection_enabled import (
+            wafv2_webacl_xss_protection_enabled,
+        )
+
+        return wafv2_webacl_xss_protection_enabled().execute()
+
+
+class Test_wafv2_webacl_xss_protection_enabled:
+    @mock_aws
+    def test_no_web_acls(self):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        result = _run_check(aws_provider)
+        assert len(result) == 0
+
+    @mock_aws
+    def test_common_rule_set_enabled(self):
+        wafv2 = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        waf = wafv2.create_web_acl(
+            Name="waf-crs",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[_common_rule_set_rule()],
+            VisibilityConfig=VISIBILITY,
+        )["Summary"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        result = _run_check(aws_provider)
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert (
+            result[0].status_extended
+            == "AWS WAFv2 Web ACL waf-crs has XSS protection enabled through the "
+            "AWSManagedRulesCommonRuleSet managed rule group."
+        )
+        assert result[0].resource_id == waf["Id"]
+        assert result[0].resource_arn == waf["ARN"]
+        assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_custom_xss_match_statement(self):
+        wafv2 = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        wafv2.create_web_acl(
+            Name="waf-custom-xss",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[_xss_rule()],
+            VisibilityConfig=VISIBILITY,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        result = _run_check(aws_provider)
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert (
+            result[0].status_extended
+            == "AWS WAFv2 Web ACL waf-custom-xss has XSS protection enabled through "
+            "custom XssMatchStatement rules."
+        )
+
+    @mock_aws
+    def test_custom_xss_match_statement_nested(self):
+        wafv2 = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        wafv2.create_web_acl(
+            Name="waf-nested-xss",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[_xss_rule(name="nested", nested=True)],
+            VisibilityConfig=VISIBILITY,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        result = _run_check(aws_provider)
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+
+    @mock_aws
+    def test_custom_xss_match_statement_count_action_not_protective(self):
+        # An XssMatchStatement with a Count action does not block malicious requests, so it
+        # is not counted as active protection.
+        wafv2 = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        wafv2.create_web_acl(
+            Name="waf-xss-count",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[_xss_rule(name="xss-count", action={"Count": {}})],
+            VisibilityConfig=VISIBILITY,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        result = _run_check(aws_provider)
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert (
+            result[0].status_extended
+            == "AWS WAFv2 Web ACL waf-xss-count does not have XSS protection enabled."
+        )
+
+    @mock_aws
+    def test_common_rule_set_overridden_to_count(self):
+        wafv2 = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        wafv2.create_web_acl(
+            Name="waf-crs-count",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[_common_rule_set_rule(override_to_count=True)],
+            VisibilityConfig=VISIBILITY,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        result = _run_check(aws_provider)
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+
+    @mock_aws
+    def test_no_xss_protection(self):
+        wafv2 = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        wafv2.create_web_acl(
+            Name="waf-no-xss",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                {
+                    "Name": "sqli",
+                    "Priority": 1,
+                    "Statement": {
+                        "ManagedRuleGroupStatement": {
+                            "VendorName": "AWS",
+                            "Name": "AWSManagedRulesSQLiRuleSet",
+                        }
+                    },
+                    "OverrideAction": {"None": {}},
+                    "VisibilityConfig": {**VISIBILITY, "MetricName": "sqli"},
+                }
+            ],
+            VisibilityConfig=VISIBILITY,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        result = _run_check(aws_provider)
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert (
+            result[0].status_extended
+            == "AWS WAFv2 Web ACL waf-no-xss does not have XSS protection enabled."
+        )


### PR DESCRIPTION
Implements #12637 (FS-56). PASS when a CommonRuleSet XSS rule or a custom XssMatchStatement covers inputs. Reuses the recursive WAF parser. Unit tests pass. DRAFT: add AWS runtime PASS/FAIL evidence + CodeRabbit before ready (see prowler-SUMMARY.md).