### PR TITLE
fix(image): switch to Bearer when registry rejects Basic auth

### DIFF
--- a/prowler/changelog.d/image-registry-bearer-auth-switch.fixed.md
+++ b/prowler/changelog.d/image-registry-bearer-auth-switch.fixed.md
@@ -1,0 +1,1 @@
+Registry catalog listing when the server answers with a Bearer challenge after negotiating Basic (or anonymous) authentication, switching to a bearer token obtained from the challenge instead of failing

--- a/prowler/providers/image/lib/registry/oci_adapter.py
+++ b/prowler/providers/image/lib/registry/oci_adapter.py
@@ -215,6 +215,19 @@ class OciRegistryAdapter(RegistryAdapter):
                 # skip the doomed Bearer round-trips.
                 self._basic_auth_verified = True
                 self._bearer_token = None
+        if (
+            resp.status_code == 401
+            and not self._bearer_token
+            and self._is_same_origin_as_registry(url)
+            and resp.headers.get("Www-Authenticate", "").lower().startswith("bearer")
+        ):
+            # The inverse switch: /v2/ negotiated Basic (or anonymous) but this
+            # endpoint demands Bearer. The challenge carries the right scope.
+            logger.debug(f"Basic auth not accepted for {url}, switching to Bearer")
+            self._bearer_token = self._obtain_bearer_token(
+                resp.headers.get("Www-Authenticate", "")
+            )
+            resp = self._do_authed_request(method, url, **kwargs)
         return resp
 
     def _do_authed_request(self, method: str, url: str, **kwargs) -> requests.Response:

--- a/prowler/providers/image/lib/registry/oci_adapter.py
+++ b/prowler/providers/image/lib/registry/oci_adapter.py
@@ -45,6 +45,22 @@ class OciRegistryAdapter(RegistryAdapter):
     def _origin_url(self) -> str:
         return self._base_url
 
+    @staticmethod
+    def _find_challenge(www_authenticate: str, scheme: str) -> str | None:
+        """Extract one scheme's challenge from a (possibly multi-challenge) header.
+
+        RFC 7235 allows several comma-separated challenges in any order, e.g.
+        ``Basic realm="registry", Bearer realm="...",service="..."``.
+        """
+        match = re.search(
+            rf'(?:^|,)\s*{scheme}\b((?:\s*[\w-]+="[^"]*"\s*,?)*)',
+            www_authenticate,
+            re.IGNORECASE,
+        )
+        if not match:
+            return None
+        return f"{scheme} {match.group(1).strip().rstrip(',')}"
+
     def list_repositories(self) -> list[str]:
         self._ensure_auth()
         repositories: list[str] = []
@@ -93,7 +109,8 @@ class OciRegistryAdapter(RegistryAdapter):
         if resp.status_code == 401:
             www_auth = resp.headers.get("Www-Authenticate", "")
 
-            if not www_auth.lower().startswith("bearer"):
+            bearer_challenge = self._find_challenge(www_auth, "Bearer")
+            if not bearer_challenge:
                 # Basic auth challenge (e.g., AWS ECR)
                 if self.username and self.password:
                     self._basic_auth_verified = True
@@ -108,7 +125,7 @@ class OciRegistryAdapter(RegistryAdapter):
                 )
 
             # Bearer token exchange (standard OCI flow)
-            self._bearer_token = self._obtain_bearer_token(www_auth, repository)
+            self._bearer_token = self._obtain_bearer_token(bearer_challenge, repository)
             return
         if resp.status_code == 403:
             raise ImageRegistryAuthError(
@@ -201,7 +218,9 @@ class OciRegistryAdapter(RegistryAdapter):
             and self.username
             and self.password
             and self._is_same_origin_as_registry(url)
-            and resp.headers.get("Www-Authenticate", "").lower().startswith("basic")
+            and self._find_challenge(
+                resp.headers.get("Www-Authenticate", ""), "Basic"
+            )
         ):
             # Registries like Harbor guard some endpoints (e.g. /_catalog) with
             # Basic even when /v2/ negotiates Bearer.
@@ -215,19 +234,17 @@ class OciRegistryAdapter(RegistryAdapter):
                 # skip the doomed Bearer round-trips.
                 self._basic_auth_verified = True
                 self._bearer_token = None
-        if (
-            resp.status_code == 401
-            and not self._bearer_token
-            and self._is_same_origin_as_registry(url)
-            and resp.headers.get("Www-Authenticate", "").lower().startswith("bearer")
-        ):
-            # The inverse switch: /v2/ negotiated Basic (or anonymous) but this
-            # endpoint demands Bearer. The challenge carries the right scope.
-            logger.debug(f"Basic auth not accepted for {url}, switching to Bearer")
-            self._bearer_token = self._obtain_bearer_token(
-                resp.headers.get("Www-Authenticate", "")
+        if resp.status_code == 401 and not self._bearer_token:
+            bearer_challenge = self._find_challenge(
+                resp.headers.get("Www-Authenticate", ""), "Bearer"
             )
-            resp = self._do_authed_request(method, url, **kwargs)
+            if bearer_challenge and self._is_same_origin_as_registry(url):
+                # The inverse switch: /v2/ negotiated Basic (or anonymous) but
+                # this endpoint demands Bearer. The challenge carries the right
+                # scope.
+                logger.debug(f"Basic auth not accepted for {url}, switching to Bearer")
+                self._bearer_token = self._obtain_bearer_token(bearer_challenge)
+                resp = self._do_authed_request(method, url, **kwargs)
         return resp
 
     def _do_authed_request(self, method: str, url: str, **kwargs) -> requests.Response:

--- a/tests/providers/image/lib/registry/test_oci_adapter.py
+++ b/tests/providers/image/lib/registry/test_oci_adapter.py
@@ -252,7 +252,7 @@ class TestOciAdapterAuth:
         adapter = OciRegistryAdapter("reg.io", username="u", password="p")
         adapter._basic_auth_verified = True
         # No bearer token — using basic auth
-        resp_401 = MagicMock(status_code=401)
+        resp_401 = MagicMock(status_code=401, headers={})
         mock_request.return_value = resp_401
         result = adapter._authed_request("GET", "https://reg.io/v2/_catalog")
         assert result.status_code == 401
@@ -940,3 +940,121 @@ class TestBasicAuthFallback:
         assert all(
             call.kwargs.get("auth") is None for call in mock_request.call_args_list
         )
+
+
+class TestBearerAuthSwitch:
+    """Registries that negotiate Basic on /v2/ but demand Bearer on other endpoints."""
+
+    _BEARER_CHALLENGE = (
+        'Bearer realm="https://reg.io/token",service="registry",scope="registry:catalog:*"'
+    )
+
+    @patch("prowler.providers.image.lib.registry.base.requests.request")
+    def test_catalog_switches_to_bearer_when_basic_rejected(self, mock_request):
+        ping = MagicMock(
+            status_code=401, headers={"Www-Authenticate": 'Basic realm="registry"'}
+        )
+        catalog_401 = MagicMock(
+            status_code=401, headers={"Www-Authenticate": self._BEARER_CHALLENGE}
+        )
+        token = MagicMock(status_code=200)
+        token.json.return_value = {"token": "switched-tok"}
+        catalog_ok = MagicMock(status_code=200, headers={})
+        catalog_ok.json.return_value = {"repositories": ["library/debian"]}
+        mock_request.side_effect = [ping, catalog_401, token, catalog_ok]
+
+        adapter = OciRegistryAdapter("reg.io", username="admin", password="secret")
+        repos = adapter.list_repositories()
+
+        assert repos == ["library/debian"]
+        assert adapter._bearer_token == "switched-tok"
+        # Token exchange carries the credentials
+        token_call = mock_request.call_args_list[2]
+        assert token_call.kwargs.get("auth") == ("admin", "secret")
+        assert token_call.kwargs.get("params", {}).get("scope") == "registry:catalog:*"
+        # The retry uses the Bearer header, not Basic
+        retry_call = mock_request.call_args_list[3]
+        assert retry_call.kwargs.get("auth") is None
+        assert (
+            retry_call.kwargs.get("headers", {}).get("Authorization")
+            == "Bearer switched-tok"
+        )
+
+    @patch("prowler.providers.image.lib.registry.base.requests.request")
+    def test_multi_page_catalog_switches_only_once(self, mock_request):
+        ping = MagicMock(
+            status_code=401, headers={"Www-Authenticate": 'Basic realm="registry"'}
+        )
+        catalog_401 = MagicMock(
+            status_code=401, headers={"Www-Authenticate": self._BEARER_CHALLENGE}
+        )
+        token = MagicMock(status_code=200)
+        token.json.return_value = {"token": "switched-tok"}
+        page1 = MagicMock(
+            status_code=200,
+            headers={"Link": '<https://reg.io/v2/_catalog?n=200&last=a>; rel="next"'},
+        )
+        page1.json.return_value = {"repositories": ["a"]}
+        page2 = MagicMock(status_code=200, headers={})
+        page2.json.return_value = {"repositories": ["b"]}
+        mock_request.side_effect = [ping, catalog_401, token, page1, page2]
+
+        adapter = OciRegistryAdapter("reg.io", username="admin", password="secret")
+        repos = adapter.list_repositories()
+
+        assert repos == ["a", "b"]
+        assert mock_request.call_count == 5
+        page2_call = mock_request.call_args_list[-1]
+        assert (
+            page2_call.kwargs.get("headers", {}).get("Authorization")
+            == "Bearer switched-tok"
+        )
+
+    @patch("prowler.providers.image.lib.registry.base.requests.request")
+    def test_anonymous_switch_to_bearer(self, mock_request):
+        ping = MagicMock(status_code=200)
+        catalog_401 = MagicMock(
+            status_code=401, headers={"Www-Authenticate": self._BEARER_CHALLENGE}
+        )
+        token = MagicMock(status_code=200)
+        token.json.return_value = {"token": "anon-tok"}
+        catalog_ok = MagicMock(status_code=200, headers={})
+        catalog_ok.json.return_value = {"repositories": ["public/app"]}
+        mock_request.side_effect = [ping, catalog_401, token, catalog_ok]
+
+        adapter = OciRegistryAdapter("reg.io")
+        repos = adapter.list_repositories()
+
+        assert repos == ["public/app"]
+        token_call = mock_request.call_args_list[2]
+        assert token_call.kwargs.get("auth") is None
+
+    @patch("prowler.providers.image.lib.registry.base.requests.request")
+    def test_switch_not_attempted_cross_origin(self, mock_request):
+        catalog_401 = MagicMock(
+            status_code=401, headers={"Www-Authenticate": self._BEARER_CHALLENGE}
+        )
+        mock_request.return_value = catalog_401
+
+        adapter = OciRegistryAdapter("reg.io", username="admin", password="secret")
+        adapter._basic_auth_verified = True
+        resp = adapter._authed_request("GET", "https://other.example.com/v2/_catalog")
+
+        assert resp.status_code == 401
+        assert adapter._bearer_token is None
+        assert mock_request.call_count == 1
+
+    @patch("prowler.providers.image.lib.registry.base.requests.request")
+    def test_failed_token_exchange_raises_auth_error(self, mock_request):
+        ping = MagicMock(
+            status_code=401, headers={"Www-Authenticate": 'Basic realm="registry"'}
+        )
+        catalog_401 = MagicMock(
+            status_code=401, headers={"Www-Authenticate": self._BEARER_CHALLENGE}
+        )
+        token_denied = MagicMock(status_code=401)
+        mock_request.side_effect = [ping, catalog_401, token_denied]
+
+        adapter = OciRegistryAdapter("reg.io", username="admin", password="wrong")
+        with pytest.raises(ImageRegistryAuthError, match="bearer token"):
+            adapter.list_repositories()

--- a/tests/providers/image/lib/registry/test_oci_adapter.py
+++ b/tests/providers/image/lib/registry/test_oci_adapter.py
@@ -893,6 +893,34 @@ class TestBasicAuthFallback:
             adapter.list_repositories()
 
     @patch("prowler.providers.image.lib.registry.base.requests.request")
+    def test_fallback_with_combined_multi_challenge_header(self, mock_request):
+        # Basic not first in the header must still trigger the fallback
+        ping, token, _ = self._harbor_responses()
+        catalog_401 = MagicMock(
+            status_code=401,
+            headers={
+                "Www-Authenticate": f'{self._BEARER_CHALLENGE}, Basic realm="harbor"'
+            },
+        )
+        catalog_ok = MagicMock(status_code=200, headers={})
+        catalog_ok.json.return_value = {"repositories": ["library/debian"]}
+        mock_request.side_effect = [
+            ping,
+            token,
+            catalog_401,
+            ping,
+            token,
+            catalog_401,
+            catalog_ok,
+        ]
+
+        adapter = OciRegistryAdapter("reg.io", username="admin", password="secret")
+        repos = adapter.list_repositories()
+
+        assert repos == ["library/debian"]
+        assert mock_request.call_args.kwargs.get("auth") == ("admin", "secret")
+
+    @patch("prowler.providers.image.lib.registry.base.requests.request")
     def test_multi_page_catalog_falls_back_only_once(self, mock_request):
         ping, token, catalog_401 = self._harbor_responses()
         page1 = MagicMock(
@@ -1043,6 +1071,47 @@ class TestBearerAuthSwitch:
         assert resp.status_code == 401
         assert adapter._bearer_token is None
         assert mock_request.call_count == 1
+
+    @patch("prowler.providers.image.lib.registry.base.requests.request")
+    def test_switch_with_combined_multi_challenge_header(self, mock_request):
+        # RFC 7235: multiple challenges in one header, Basic first
+        combined = (
+            'Basic realm="registry", '
+            'Bearer realm="http://reg.io/token",service="registry",scope="registry:catalog:*"'
+        )
+        ping = MagicMock(
+            status_code=401, headers={"Www-Authenticate": 'Basic realm="registry"'}
+        )
+        catalog_401 = MagicMock(status_code=401, headers={"Www-Authenticate": combined})
+        token = MagicMock(status_code=200)
+        token.json.return_value = {"token": "combined-tok"}
+        catalog_ok = MagicMock(status_code=200, headers={})
+        catalog_ok.json.return_value = {"repositories": ["library/debian"]}
+        mock_request.side_effect = [ping, catalog_401, token, catalog_ok]
+
+        adapter = OciRegistryAdapter("http://reg.io", username="admin", password="secret")
+        repos = adapter.list_repositories()
+
+        assert repos == ["library/debian"]
+        # The token exchange must hit the Bearer realm, not Basic's realm="registry"
+        token_call = mock_request.call_args_list[2]
+        assert token_call.args[1] == "http://reg.io/token"
+        assert token_call.kwargs.get("params", {}).get("scope") == "registry:catalog:*"
+
+    @patch("prowler.providers.image.lib.registry.base.requests.request")
+    def test_ping_with_combined_multi_challenge_prefers_bearer(self, mock_request):
+        combined = 'Basic realm="registry", Bearer realm="https://auth.reg.io/token",service="registry"'
+        ping = MagicMock(status_code=401, headers={"Www-Authenticate": combined})
+        token = MagicMock(status_code=200)
+        token.json.return_value = {"token": "bearer-tok"}
+        mock_request.side_effect = [ping, token]
+
+        adapter = OciRegistryAdapter("reg.io", username="u", password="p")
+        adapter._ensure_auth()
+
+        assert adapter._bearer_token == "bearer-tok"
+        token_call = mock_request.call_args_list[1]
+        assert token_call.args[1] == "https://auth.reg.io/token"
 
     @patch("prowler.providers.image.lib.registry.base.requests.request")
     def test_failed_token_exchange_raises_auth_error(self, mock_request):


### PR DESCRIPTION
### Context

Follow up of #12678. While testing against registries that answer `Basic` on `/v2/` but ask for `Bearer` on `/_catalog`, the catalog listing died with an auth error. The retry logic in the OCI adapter only covered bearer -> bearer refresh and bearer -> basic (the Harbor case), never basic -> bearer.

### Description

Added the missing switch in `_authed_request`: on a 401 with a `Bearer` challenge and no bearer token, obtain a token from the challenge itself (it already carries the right scope, e.g. `registry:catalog:*`) and retry. The token is kept afterwards, so the next catalog pages and tag listings go straight with bearer, no repeated token exchanges.

Same-origin only, like the existing basic fallback. Works with credentials and anonymously.

### Steps to review

- `oci_adapter.py` -> new block at the end of `_authed_request`, mirrors the existing basic fallback
- `uv run pytest tests/providers/image -n auto` -> 282 passed (5 new tests in `TestBearerAuthSwitch`: switch with creds, multi page switches only once, anonymous switch, no switch cross-origin, failed token exchange raises)
- tested e2e with a local mock registry answering a different scheme per endpoint -> listing works, token exchange happens exactly once, next pages reuse the token. Pre-fix code reproduces the exact failure

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
