### PR TITLE
fix(cloudflare): handle missing challenge passage TTL

### DIFF
--- a/prowler/changelog.d/cloudflare-challenge-ttl-none.fixed.md
+++ b/prowler/changelog.d/cloudflare-challenge-ttl-none.fixed.md
@@ -1,0 +1,1 @@
+`zone_challenge_passage_configured` no longer fails when a Cloudflare zone has no challenge passage TTL configured

--- a/prowler/changelog.d/cloudflare-challenge-ttl-none.fixed.md
+++ b/prowler/changelog.d/cloudflare-challenge-ttl-none.fixed.md
@@ -1,1 +1,1 @@
-`zone_challenge_passage_configured` no longer fails when a Cloudflare zone has no challenge passage TTL configured
+Zones without a challenge passage TTL are reported as non-compliant by `zone_challenge_passage_configured`

--- a/prowler/providers/cloudflare/services/zone/zone_challenge_passage_configured/zone_challenge_passage_configured.py
+++ b/prowler/providers/cloudflare/services/zone/zone_challenge_passage_configured/zone_challenge_passage_configured.py
@@ -29,17 +29,23 @@ class zone_challenge_passage_configured(Check):
                 metadata=self.metadata(),
                 resource=zone,
             )
-            # API returns seconds, convert to minutes
-            challenge_ttl_minutes = zone.settings.challenge_ttl // 60
-
-            if min_minutes <= challenge_ttl_minutes <= max_minutes:
-                report.status = "PASS"
-                report.status_extended = f"Challenge Passage is set to {challenge_ttl_minutes} minutes for zone {zone.name}."
-            else:
+            challenge_ttl = zone.settings.challenge_ttl
+            if challenge_ttl is None:
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"Challenge Passage is set to {challenge_ttl_minutes} minutes for zone {zone.name} "
-                    f"(recommended: between {min_minutes} and {max_minutes} minutes)."
+                    f"Challenge Passage is not configured for zone {zone.name}."
                 )
+            else:
+                # API returns seconds, convert to minutes
+                challenge_ttl_minutes = challenge_ttl // 60
+                if min_minutes <= challenge_ttl_minutes <= max_minutes:
+                    report.status = "PASS"
+                    report.status_extended = f"Challenge Passage is set to {challenge_ttl_minutes} minutes for zone {zone.name}."
+                else:
+                    report.status = "FAIL"
+                    report.status_extended = (
+                        f"Challenge Passage is set to {challenge_ttl_minutes} minutes for zone {zone.name} "
+                        f"(recommended: between {min_minutes} and {max_minutes} minutes)."
+                    )
             findings.append(report)
         return findings

--- a/tests/providers/cloudflare/cloudflare_provider_test.py
+++ b/tests/providers/cloudflare/cloudflare_provider_test.py
@@ -318,6 +318,7 @@ class TestCloudflareValidateCredentials:
             response=MagicMock(status_code=403),
             body=None,
         )
+        mock_client.accounts.list.return_value = iter([])
 
         session = CloudflareSession(
             client=mock_client,
@@ -328,6 +329,7 @@ class TestCloudflareValidateCredentials:
 
         with pytest.raises(CloudflareNoAccountsError):
             CloudflareProvider.validate_credentials(session)
+        mock_client.user.get.assert_called_once()
         mock_client.accounts.list.assert_called_once()
 
     def test_validate_credentials_invalid_api_token(self):
@@ -497,6 +499,7 @@ class TestCloudflareTestConnection:
             response=MagicMock(status_code=403),
             body=None,
         )
+        mock_client.accounts.list.return_value = iter([])
 
         with patch(
             "prowler.providers.cloudflare.cloudflare_provider.CloudflareProvider.setup_session",
@@ -514,6 +517,7 @@ class TestCloudflareTestConnection:
             assert connection.is_connected is False
             assert isinstance(connection.error, CloudflareNoAccountsError)
             assert "No Cloudflare accounts found" in str(connection.error)
+            mock_client.user.get.assert_called_once()
             mock_client.accounts.list.assert_called_once()
 
     def test_test_connection_invalid_api_key(self):

--- a/tests/providers/cloudflare/cloudflare_provider_test.py
+++ b/tests/providers/cloudflare/cloudflare_provider_test.py
@@ -9,7 +9,6 @@ from prowler.providers.cloudflare.exceptions.exceptions import (
     CloudflareInvalidAPIKeyError,
     CloudflareInvalidAPITokenError,
     CloudflareNoAccountsError,
-    CloudflareUserTokenRequiredError,
 )
 from prowler.providers.cloudflare.models import (
     CloudflareAccount,
@@ -308,8 +307,8 @@ class TestCloudflareValidateCredentials:
         CloudflareProvider.validate_credentials(session)
         mock_client.user.get.assert_called_once()
 
-    def test_validate_credentials_user_token_required(self):
-        """Test that user token required error is raised for Account tokens."""
+    def test_validate_credentials_account_token_without_accounts(self):
+        """Test that account tokens fall back to account discovery."""
         mock_client = MagicMock()
         # Simulate error code 9109 - user-level authentication required
         from cloudflare._exceptions import PermissionDeniedError
@@ -327,8 +326,9 @@ class TestCloudflareValidateCredentials:
             api_email=None,
         )
 
-        with pytest.raises(CloudflareUserTokenRequiredError):
+        with pytest.raises(CloudflareNoAccountsError):
             CloudflareProvider.validate_credentials(session)
+        mock_client.accounts.list.assert_called_once()
 
     def test_validate_credentials_invalid_api_token(self):
         """Test that invalid API token error is raised."""
@@ -487,8 +487,8 @@ class TestCloudflareTestConnection:
             assert connection.is_connected is False
             assert isinstance(connection.error, CloudflareInvalidAPITokenError)
 
-    def test_test_connection_user_token_required(self):
-        """Test that user token required error is properly returned."""
+    def test_test_connection_account_token_without_accounts(self):
+        """Test that account tokens without accessible accounts return an error."""
         mock_client = MagicMock()
         from cloudflare._exceptions import PermissionDeniedError
 
@@ -512,9 +512,9 @@ class TestCloudflareTestConnection:
             )
 
             assert connection.is_connected is False
-            assert isinstance(connection.error, CloudflareUserTokenRequiredError)
-            # Verify the error message is user-friendly
-            assert "User-level API token required" in str(connection.error)
+            assert isinstance(connection.error, CloudflareNoAccountsError)
+            assert "No Cloudflare accounts found" in str(connection.error)
+            mock_client.accounts.list.assert_called_once()
 
     def test_test_connection_invalid_api_key(self):
         """Test that invalid API key error is properly returned."""

--- a/tests/providers/cloudflare/services/zone/zone_challenge_passage_configured/zone_challenge_passage_configured_test.py
+++ b/tests/providers/cloudflare/services/zone/zone_challenge_passage_configured/zone_challenge_passage_configured_test.py
@@ -240,3 +240,7 @@ class Test_zone_challenge_passage_configured:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Challenge Passage is not configured for zone {ZONE_NAME}."
+            )

--- a/tests/providers/cloudflare/services/zone/zone_development_mode_disabled/zone_development_mode_disabled_test.py
+++ b/tests/providers/cloudflare/services/zone/zone_development_mode_disabled/zone_development_mode_disabled_test.py
@@ -102,8 +102,10 @@ class Test_zone_development_mode_disabled:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert "Development mode is enabled" in result[0].status_extended
-            assert "bypasses" in result[0].status_extended
+            assert (
+                result[0].status_extended
+                == f"Development mode is enabled for zone {ZONE_NAME}."
+            )
 
     def test_zone_development_mode_none(self):
         zone_client = mock.MagicMock


### PR DESCRIPTION
### Context

Cloudflare zones can return `challenge_ttl: null` when no challenge passage TTL is configured. The `zone_challenge_passage_configured` check currently compares that value with an integer and raises `TypeError`, aborting the check instead of reporting the configuration state.

### Description

- Treat a missing challenge passage TTL as a non-compliant finding with clear status text
- Align Cloudflare provider fallback tests with the intentional `accounts.list()` behavior for user API tokens
- Align the development-mode test with the current production message
- Add an SDK changelog fragment for the fix

No new dependency is required.

### Steps to review

1. Run `uv run pytest -n 2 tests/providers/cloudflare` and confirm all 208 tests pass.
2. Review the null-TTL case in `zone_challenge_passage_configured.py` and its regression test.
3. Confirm the provider fallback still raises `CloudflareNoAccountsError` when `accounts.list()` cannot return an account.
4. Run Black and the SDK Flake8 configuration against the four changed Python files.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) — no README change is needed.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - No provider permission update is required.

#### UI

Not applicable.

#### API

Not applicable.

#### MCP Server

Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cloudflare zone checks now correctly identify zones without a configured challenge passage duration as non-compliant.
  - Unconfigured challenge passages now display a clear failure message.
  - Cloudflare authentication now falls back to account discovery when user-level authentication is unavailable.
  - Development mode and challenge passage checks now provide more precise status messages, improving result clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->