### PR TITLE
fix(m365): pin ExchangeOnlineManagement to a PowerShell 7.5-compatible version

### DIFF
--- a/prowler/changelog.d/exchange-online-management-version.fixed.md
+++ b/prowler/changelog.d/exchange-online-management-version.fixed.md
@@ -1,0 +1,1 @@
+`ExchangeOnlineManagement` pinned to version 3.9.2 for compatibility with Prowler's Linux PowerShell 7.5 runtime

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -1154,19 +1154,26 @@ def initialize_m365_powershell_modules():
     try:
         for module in REQUIRED_MODULES:
             try:
+                required_version = REQUIRED_MODULE_VERSIONS.get(module)
+                version_parameter = (
+                    f" -RequiredVersion '{required_version}'"
+                    if required_version
+                    else ""
+                )
+
                 # Check if module is already installed
-                result = pwsh.execute(f"Get-Module -ListAvailable {module}", timeout=5)
+                availability_command = (
+                    "Get-Module -ListAvailable -FullyQualifiedName "
+                    f"@{{ ModuleName = '{module}'; RequiredVersion = '{required_version}' }}"
+                    if required_version
+                    else f"Get-Module -ListAvailable -Name '{module}'"
+                )
+                result = pwsh.execute(availability_command, timeout=5)
 
                 # Install module if not installed
                 if not result:
-                    required_version = REQUIRED_MODULE_VERSIONS.get(module)
-                    version_parameter = (
-                        f" -RequiredVersion {required_version}"
-                        if required_version
-                        else ""
-                    )
                     install_command = (
-                        f"Install-Module {module}{version_parameter} "
+                        f"Install-Module -Name '{module}'{version_parameter} "
                         "-Force -AllowClobber -Scope CurrentUser"
                     )
                     install_result = pwsh.execute(
@@ -1180,9 +1187,10 @@ def initialize_m365_powershell_modules():
                     else:
                         logger.info(f"Successfully installed module {module}")
 
+                if not result or required_version:
                     # Import module
                     pwsh.execute(
-                        f'Import-Module "{module}"{version_parameter} -Force',
+                        f"Import-Module -Name '{module}'{version_parameter} -Force",
                         timeout=1,
                     )
 

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -1148,6 +1148,7 @@ def initialize_m365_powershell_modules():
         "MicrosoftTeams",
         "MSAL.PS",
     ]
+    REQUIRED_MODULE_VERSIONS = {"ExchangeOnlineManagement": "3.9.2"}
 
     pwsh = PowerShellSession()
     try:
@@ -1158,8 +1159,18 @@ def initialize_m365_powershell_modules():
 
                 # Install module if not installed
                 if not result:
+                    required_version = REQUIRED_MODULE_VERSIONS.get(module)
+                    version_parameter = (
+                        f" -RequiredVersion {required_version}"
+                        if required_version
+                        else ""
+                    )
+                    install_command = (
+                        f"Install-Module {module}{version_parameter} "
+                        "-Force -AllowClobber -Scope CurrentUser"
+                    )
                     install_result = pwsh.execute(
-                        f"Install-Module {module} -Force -AllowClobber -Scope CurrentUser",
+                        install_command,
                         timeout=60,
                     )
                     if install_result:
@@ -1170,7 +1181,10 @@ def initialize_m365_powershell_modules():
                         logger.info(f"Successfully installed module {module}")
 
                     # Import module
-                    pwsh.execute(f'Import-Module "{module}" -Force', timeout=1)
+                    pwsh.execute(
+                        f'Import-Module "{module}"{version_parameter} -Force',
+                        timeout=1,
+                    )
 
             except Exception as error:
                 logger.error(f"Failed to initialize module {module}: {str(error)}")

--- a/tests/providers/m365/lib/powershell/m365_powershell_test.py
+++ b/tests/providers/m365/lib/powershell/m365_powershell_test.py
@@ -438,15 +438,16 @@ class Testm365PowerShell:
             )  # number of modules * 3 commands each
             mock_execute_obj.assert_any_call(
                 (
-                    "Install-Module ExchangeOnlineManagement -RequiredVersion 3.9.2 "
+                    "Install-Module -Name 'ExchangeOnlineManagement' "
+                    "-RequiredVersion '3.9.2' "
                     "-Force -AllowClobber -Scope CurrentUser"
                 ),
                 timeout=60,
             )
             mock_execute_obj.assert_any_call(
                 (
-                    'Import-Module "ExchangeOnlineManagement" '
-                    "-RequiredVersion 3.9.2 -Force"
+                    "Import-Module -Name 'ExchangeOnlineManagement' "
+                    "-RequiredVersion '3.9.2' -Force"
                 ),
                 timeout=1,
             )
@@ -455,6 +456,56 @@ class Testm365PowerShell:
                 "Successfully installed module ExchangeOnlineManagement"
             )
             mock_info.assert_any_call("Successfully installed module MicrosoftTeams")
+
+    @patch("subprocess.Popen")
+    def test_initialize_m365_powershell_modules_installs_required_exchange_version(
+        self, mock_popen
+    ):
+        """Install the required Exchange module when only another version exists."""
+        mock_popen.return_value = MagicMock()
+
+        # Given: 3.10.0 satisfies the old name-only query, while the exact
+        # required-version query correctly reports that 3.9.2 is absent.
+        exchange_availability = {
+            "Get-Module -ListAvailable ExchangeOnlineManagement": "3.10.0",
+            (
+                "Get-Module -ListAvailable -FullyQualifiedName "
+                "@{ ModuleName = 'ExchangeOnlineManagement'; "
+                "RequiredVersion = '3.9.2' }"
+            ): None,
+        }
+
+        def mock_execute(command, *_args, **_kwargs):
+            if command in exchange_availability:
+                return exchange_availability[command]
+            if "Get-Module" in command:
+                return "installed"
+            return None
+
+        with patch.object(
+            PowerShellSession, "execute", side_effect=mock_execute
+        ) as mock_execute_obj:
+            from prowler.providers.m365.lib.powershell.m365_powershell import (
+                initialize_m365_powershell_modules,
+            )
+
+            result = initialize_m365_powershell_modules()
+
+        assert result is True
+        mock_execute_obj.assert_any_call(
+            (
+                "Install-Module -Name 'ExchangeOnlineManagement' "
+                "-RequiredVersion '3.9.2' -Force -AllowClobber -Scope CurrentUser"
+            ),
+            timeout=60,
+        )
+        mock_execute_obj.assert_any_call(
+            (
+                "Import-Module -Name 'ExchangeOnlineManagement' "
+                "-RequiredVersion '3.9.2' -Force"
+            ),
+            timeout=1,
+        )
 
     @patch("subprocess.Popen")
     def test_initialize_m365_powershell_modules_failure(self, mock_popen):

--- a/tests/providers/m365/lib/powershell/m365_powershell_test.py
+++ b/tests/providers/m365/lib/powershell/m365_powershell_test.py
@@ -409,7 +409,7 @@ class Testm365PowerShell:
         mock_popen.return_value = mock_process
 
         # Mock the execute method to simulate successful module installation
-        def mock_execute(command, *args, **kwargs):
+        def mock_execute(command, *_args, **_kwargs):
             if "Get-Module" in command:
                 return None  # Module not installed
             elif "Install-Module" in command:
@@ -436,6 +436,20 @@ class Testm365PowerShell:
             assert (
                 mock_execute_obj.call_count == 3 * 3
             )  # number of modules * 3 commands each
+            mock_execute_obj.assert_any_call(
+                (
+                    "Install-Module ExchangeOnlineManagement -RequiredVersion 3.9.2 "
+                    "-Force -AllowClobber -Scope CurrentUser"
+                ),
+                timeout=60,
+            )
+            mock_execute_obj.assert_any_call(
+                (
+                    'Import-Module "ExchangeOnlineManagement" '
+                    "-RequiredVersion 3.9.2 -Force"
+                ),
+                timeout=1,
+            )
             # Verify success messages were logged
             mock_info.assert_any_call(
                 "Successfully installed module ExchangeOnlineManagement"
@@ -449,7 +463,7 @@ class Testm365PowerShell:
         mock_popen.return_value = mock_process
 
         # Mock the execute method to simulate installation failure
-        def mock_execute(command, *args, **kwargs):
+        def mock_execute(command, *_args, **_kwargs):
             if "Get-Module" in command:
                 return None  # Module not installed
             elif "Install-Module" in command:
@@ -484,7 +498,7 @@ class Testm365PowerShell:
         mock_popen.return_value = mock_process
 
         # Mock the execute method to simulate successful module installation
-        def mock_execute(command, *args, **kwargs):
+        def mock_execute(command, *_args, **_kwargs):
             if "Get-Module" in command:
                 return None  # Module not installed
             elif "Install-Module" in command:
@@ -522,7 +536,7 @@ class Testm365PowerShell:
         mock_popen.return_value = mock_process
 
         # Mock the execute method to simulate installation failure
-        def mock_execute(command, *args, **kwargs):
+        def mock_execute(command, *_args, **_kwargs):
             if "Get-Module" in command:
                 return None  # Module not installed
             elif "Install-Module" in command:
@@ -670,7 +684,7 @@ class Testm365PowerShell:
         session = M365PowerShell(credentials, identity)
 
         # Mock execute to return valid responses
-        def mock_execute(command, *args, **kwargs):
+        def mock_execute(command, *_args, **_kwargs):
             if "Write-Output $exchangeToken" in command:
                 return "valid_exchange_token"
             return None
@@ -720,7 +734,7 @@ class Testm365PowerShell:
         session = M365PowerShell(credentials, identity)
 
         # Mock execute to return valid token but decode returns no permissions
-        def mock_execute(command, *args, **kwargs):
+        def mock_execute(command, *_args, **_kwargs):
             if "Write-Output $exchangeToken" in command:
                 return "valid_exchange_token"
             return None


### PR DESCRIPTION
### Context

The latest `ExchangeOnlineManagement` release requires PowerShell 7.4 or earlier on Linux, while Prowler's M365 runtime uses PowerShell 7.5. Fresh M365 initialization can therefore install a module version that cannot be imported.

Fixes #12644

### Description

- Pin `ExchangeOnlineManagement` installation and import to version `3.9.2`, the latest compatible GA release.
- Keep the existing latest-version behavior for the remaining M365 PowerShell modules.
- Add regression assertions for the exact installation and import commands.
- Add the required SDK changelog fragment.

No new runtime dependencies are introduced.

### Steps to review

1. Run `uv run pytest tests/providers/m365/lib/powershell/m365_powershell_test.py -q`.
2. Run `uv run prek run --files prowler/changelog.d/exchange-online-management-version.fixed.md prowler/providers/m365/lib/powershell/m365_powershell.py tests/providers/m365/lib/powershell/m365_powershell_test.py`.
3. Verify that fresh module initialization uses `-RequiredVersion 3.9.2` for both `Install-Module` and `Import-Module` only when processing `ExchangeOnlineManagement`.
4. Optionally reproduce in PowerShell 7.5 on Linux by installing and importing `ExchangeOnlineManagement` 3.9.2.

Local evidence:

- Focused PowerShell tests: `47 passed`.
- M365 library tests before the lint-only mock parameter cleanup: `99 passed`.
- All applicable prek hooks pass, including Black, flake8, pylint, Bandit, Vulture, markdownlint, and TruffleHog.
- PowerShell 7.5.0 on Ubuntu 22.04 successfully installed and imported `ExchangeOnlineManagement` 3.9.2.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Not applicable.

#### UI
- Not applicable.

#### API
- Not applicable.

#### MCP Server
- Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned the ExchangeOnlineManagement PowerShell module to version 3.9.2 for compatibility with the supported Linux PowerShell runtime.
  * Ensured the specified module version is used during availability checks, installation, and import.
  * Automatically installs version 3.9.2 when it is not already available, even if another version is installed.
  * Preserved existing installation and import behavior for modules without a specified version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->