### PR TITLE
feat(cloudwatch): add Bedrock Agent alarm coverage check

### DIFF
--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -126,6 +126,7 @@ jobs:
               "autoscaling": ["dynamodb"],
               "awslambda": ["ec2", "inspector2"],
               "backup": ["dynamodb", "ec2", "rds"],
+              "bedrock": ["cloudwatch"],
               "cloudfront": ["shield"],
               "cloudtrail": ["awslambda", "cloudwatch"],
               "cloudwatch": ["bedrock"],

--- a/docs/developer-guide/unit-testing.mdx
+++ b/docs/developer-guide/unit-testing.mdx
@@ -97,6 +97,7 @@ The table maps a service (key) to the list of services that depend on it (values
 | `autoscaling` | `dynamodb` |
 | `awslambda` | `ec2`, `inspector2` |
 | `backup` | `dynamodb`, `ec2`, `rds` |
+| `bedrock` | `cloudwatch` |
 | `cloudfront` | `shield` |
 | `cloudtrail` | `awslambda`, `cloudwatch` |
 | `cloudwatch` | `bedrock` |

--- a/prowler/changelog.d/cloudwatch-bedrock-agent-alarms.added.md
+++ b/prowler/changelog.d/cloudwatch-bedrock-agent-alarms.added.md
@@ -1,0 +1,1 @@
+`cloudwatch_bedrock_agent_alarms_configured` check for CloudWatch alarms covering Amazon Bedrock Agent invocation and throttling metrics

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_bedrock_agent_alarms_configured/cloudwatch_bedrock_agent_alarms_configured.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_bedrock_agent_alarms_configured/cloudwatch_bedrock_agent_alarms_configured.metadata.json
@@ -1,0 +1,43 @@
+{
+  "Provider": "aws",
+  "CheckID": "cloudwatch_bedrock_agent_alarms_configured",
+  "CheckTitle": "Bedrock Agent invocation rates have enabled CloudWatch alarms",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices"
+  ],
+  "ServiceName": "cloudwatch",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "AwsCloudWatchAlarm",
+  "ResourceGroup": "monitoring",
+  "Description": "Regions with Bedrock Agents have an enabled CloudWatch alarm for `InvocationCount` or `InvocationThrottles` in the `AWS/Bedrock/Agents` namespace. Direct and metric-math alarms are evaluated with the documented Agent dimensions.",
+  "Risk": "Without rate alarms, looping or runaway agents can keep invoking services unnoticed. This can exhaust quotas, increase costs, and disrupt workloads before operators can respond.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring-agents-cw-metrics.html",
+    "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws cloudwatch put-metric-alarm --alarm-name example_resource --namespace AWS/Bedrock/Agents --metric-name InvocationCount --dimensions Name=Operation,Value=InvokeAgent --statistic Sum --period 300 --evaluation-periods 1 --threshold 1000 --comparison-operator GreaterThanThreshold --actions-enabled",
+      "NativeIaC": "```yaml\nResources:\n  ExampleResource:\n    Type: AWS::CloudWatch::Alarm\n    Properties:\n      Namespace: AWS/Bedrock/Agents\n      MetricName: InvocationCount\n      Dimensions:\n        - Name: Operation\n          Value: InvokeAgent\n      Statistic: Sum\n      Period: 300\n      EvaluationPeriods: 1\n      Threshold: 1000\n      ComparisonOperator: GreaterThanThreshold\n      ActionsEnabled: true\n```",
+      "Other": "1. Open CloudWatch and choose Alarms > All alarms > Create alarm\n2. Select `AWS/Bedrock/Agents` and the `InvocationCount` or `InvocationThrottles` metric\n3. Set a threshold based on expected traffic\n4. Add a notification action and create the alarm",
+      "Terraform": "```hcl\nresource \"aws_cloudwatch_metric_alarm\" \"example_resource\" {\n  alarm_name          = \"example_resource\"\n  namespace           = \"AWS/Bedrock/Agents\"\n  metric_name         = \"InvocationCount\"\n  statistic           = \"Sum\"\n  period              = 300\n  evaluation_periods  = 1\n  threshold           = 1000\n  comparison_operator = \"GreaterThanThreshold\"\n  actions_enabled     = true\n\n  dimensions = {\n    Operation = \"InvokeAgent\"\n  }\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Set CloudWatch alarms for Bedrock Agent invocation counts and throttles using thresholds based on normal peak traffic. Keep alarm actions enabled and use the related alarm-action check to verify that notifications or automation are configured.",
+      "Url": "https://hub.prowler.com/check/cloudwatch_bedrock_agent_alarms_configured"
+    }
+  },
+  "Categories": [
+    "gen-ai",
+    "threat-detection"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [
+    "cloudwatch_alarm_actions_enabled",
+    "cloudwatch_alarm_actions_alarm_state_configured"
+  ],
+  "Notes": "Returns one finding per region with Bedrock Agents. Inventory or alarm collection errors return MANUAL; regions with no agents return no finding. Alarm action targets are evaluated by the related check."
+}

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_bedrock_agent_alarms_configured/cloudwatch_bedrock_agent_alarms_configured.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_bedrock_agent_alarms_configured/cloudwatch_bedrock_agent_alarms_configured.py
@@ -1,0 +1,98 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.bedrock.bedrock_agent_client import (
+    bedrock_agent_client,
+)
+from prowler.providers.aws.services.cloudwatch.cloudwatch_client import (
+    cloudwatch_client,
+)
+
+AGENT_METRICS = {
+    ("AWS/Bedrock/Agents", "InvocationCount"),
+    ("AWS/Bedrock/Agents", "InvocationThrottles"),
+}
+AGENT_OPERATIONS = {"InvokeAgent", "InvokeInlineAgent"}
+AGENT_DIMENSIONS = {
+    frozenset({"Operation"}),
+    frozenset({"Operation", "AgentAliasArn", "ModelId"}),
+}
+
+
+class cloudwatch_bedrock_agent_alarms_configured(Check):
+    """Check Bedrock Agent rate alarm coverage by region."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Return regional findings for agents and inventory errors."""
+        findings = []
+        agent_regions = {agent.region for agent in bedrock_agent_client.agents.values()}
+        agent_regions.update(bedrock_agent_client.agents_scan_errors)
+        covered_regions = {
+            alarm.region
+            for alarm in cloudwatch_client.all_metric_alarms or []
+            if alarm.actions_enabled
+            and any(self._covers_agent_metric(ref) for ref in alarm.metric_references)
+        }
+
+        for region in sorted(agent_regions):
+            report = self._report_for_region(region)
+            bedrock_error = bedrock_agent_client.agents_scan_errors.get(region)
+            cloudwatch_error = cloudwatch_client.metric_alarms_scan_errors.get(region)
+            if bedrock_error:
+                report.status = "MANUAL"
+                report.status_extended = (
+                    "Cannot evaluate Bedrock Agent alarm coverage in region "
+                    f"{region}: bedrock:ListAgents returned {bedrock_error}. "
+                    "Check API access and retry the scan."
+                )
+            elif cloudwatch_error:
+                report.status = "MANUAL"
+                report.status_extended = (
+                    "Cannot evaluate Bedrock Agent alarm coverage in region "
+                    f"{region}: cloudwatch:DescribeAlarms returned "
+                    f"{cloudwatch_error}. Check API access and retry the scan."
+                )
+            elif region not in cloudwatch_client.metric_alarms_scanned_regions:
+                report.status = "MANUAL"
+                report.status_extended = (
+                    "Cannot evaluate Bedrock Agent alarm coverage in region "
+                    f"{region}: CloudWatch alarms were not scanned."
+                )
+            elif region in covered_regions:
+                report.status = "PASS"
+                report.status_extended = (
+                    "CloudWatch has an enabled alarm for Bedrock Agent invocation "
+                    f"or throttling metrics in region {region}."
+                )
+            else:
+                report.status = "FAIL"
+                report.status_extended = (
+                    "CloudWatch has no enabled alarms for Bedrock Agent invocation "
+                    f"or throttling metrics in region {region}."
+                )
+            findings.append(report)
+
+        return findings
+
+    @staticmethod
+    def _covers_agent_metric(reference) -> bool:
+        if (reference.namespace, reference.name) not in AGENT_METRICS:
+            return False
+        if (
+            reference.account_id is not None
+            and reference.account_id != cloudwatch_client.audited_account
+        ):
+            return False
+        if frozenset(reference.dimensions) not in AGENT_DIMENSIONS:
+            return False
+        return reference.dimensions.get("Operation") in AGENT_OPERATIONS and all(
+            reference.dimensions.values()
+        )
+
+    def _report_for_region(self, region: str) -> Check_Report_AWS:
+        report = Check_Report_AWS(metadata=self.metadata(), resource={})
+        report.region = region
+        report.resource_id = "bedrock-agent-alarms"
+        report.resource_arn = (
+            f"arn:{cloudwatch_client.audited_partition}:cloudwatch:{region}:"
+            f"{cloudwatch_client.audited_account}:alarm"
+        )
+        return report

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_bedrock_agent_alarms_configured/cloudwatch_bedrock_agent_alarms_configured.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_bedrock_agent_alarms_configured/cloudwatch_bedrock_agent_alarms_configured.py
@@ -74,6 +74,14 @@ class cloudwatch_bedrock_agent_alarms_configured(Check):
 
     @staticmethod
     def _covers_agent_metric(reference) -> bool:
+        """Return whether a metric reference covers an Agent rate signal.
+
+        Args:
+            reference: Metric reference collected from an alarm.
+
+        Returns:
+            True for an in-account Agent invocation or throttling metric.
+        """
         if (reference.namespace, reference.name) not in AGENT_METRICS:
             return False
         if (
@@ -88,6 +96,14 @@ class cloudwatch_bedrock_agent_alarms_configured(Check):
         )
 
     def _report_for_region(self, region: str) -> Check_Report_AWS:
+        """Create the report identity for an AWS region.
+
+        Args:
+            region: AWS region being evaluated.
+
+        Returns:
+            Report populated with the check's regional resource identity.
+        """
         report = Check_Report_AWS(metadata=self.metadata(), resource={})
         report.region = region
         report.resource_id = "bedrock-agent-alarms"

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -1,9 +1,10 @@
 import json
+import re
 from datetime import datetime, timezone
 from typing import Optional
 
 from botocore.exceptions import ClientError
-from pydantic.v1 import BaseModel
+from pydantic.v1 import BaseModel, Field
 
 from prowler.lib.logger import logger
 from prowler.lib.resource_limit import (
@@ -13,16 +14,81 @@ from prowler.lib.resource_limit import (
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
 from prowler.providers.aws.lib.service.service import AWSService
 
+_QUERY_ID = re.compile(r"\b[a-z][A-Za-z0-9_]*\b")
+_QUOTED_TEXT = re.compile(r"""(?:"[^"]*"|'[^']*')""")
+_METRICS_CALL = re.compile(r"""\bMETRICS\(\s*(?:(["'])(.*?)\1)?\s*\)""", re.IGNORECASE)
+
+
+def _watched_metric_ids(queries):
+    queries_by_id = {query["Id"]: query for query in queries if query.get("Id")}
+    metric_ids = {
+        query_id for query_id, query in queries_by_id.items() if "MetricStat" in query
+    }
+    pending = [
+        query_id
+        for query_id, query in queries_by_id.items()
+        if query.get("ReturnData", True)
+    ]
+    watched = set()
+    visited = set()
+
+    while pending:
+        query_id = pending.pop()
+        if query_id in visited:
+            continue
+        visited.add(query_id)
+        query = queries_by_id[query_id]
+        if "MetricStat" in query:
+            watched.add(query_id)
+            continue
+
+        expression = query.get("Expression", "")
+        for match in _METRICS_CALL.finditer(expression):
+            needle = match.group(2)
+            pending.extend(
+                metric_id
+                for metric_id in metric_ids
+                if needle is None or needle in metric_id
+            )
+
+        expression = _QUOTED_TEXT.sub("", expression)
+        pending.extend(set(_QUERY_ID.findall(expression)) & queries_by_id.keys())
+
+    return watched
+
+
+def _metric_reference(metric, account_id=None):
+    namespace = metric.get("Namespace")
+    name = metric.get("MetricName")
+    if not namespace or not name:
+        return None
+    dimensions = tuple(
+        sorted(
+            (dimension["Name"], dimension["Value"])
+            for dimension in metric.get("Dimensions", [])
+        )
+    )
+    return namespace, name, dimensions, account_id
+
 
 class CloudWatch(AWSService):
     def __init__(self, provider):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.metric_alarms = []
+        self.all_metric_alarms = []
         # True when DescribeAlarms was denied in at least one audited region,
         # so the alarm inventory may be incomplete.
         self.metric_alarms_unavailable = False
+        self.metric_alarms_scanned_regions = set()
+        self.metric_alarms_scan_errors = {}
         self.__threading_call__(self._describe_alarms)
+        if (
+            not self.metric_alarms
+            and not self.metric_alarms_scanned_regions
+            and "AccessDenied" in self.metric_alarms_scan_errors.values()
+        ):
+            self.metric_alarms = None
         if self.metric_alarms:
             self._list_tags_for_resource()
 
@@ -32,46 +98,78 @@ class CloudWatch(AWSService):
             describe_alarms_paginator = regional_client.get_paginator("describe_alarms")
             for page in describe_alarms_paginator.paginate():
                 for alarm in page["MetricAlarms"]:
+                    metric_name = alarm.get("MetricName")
+                    namespace = alarm.get("Namespace")
+                    namespaces = {namespace} if namespace else set()
+                    metric_references = set()
+                    direct_reference = _metric_reference(alarm)
+                    if direct_reference:
+                        metric_references.add(direct_reference)
+                    queries = alarm.get("Metrics", [])
+                    for query in queries:
+                        metric = query.get("MetricStat", {}).get("Metric", {})
+                        query_namespace = metric.get("Namespace")
+                        if query_namespace:
+                            namespaces.add(query_namespace)
+                    watched_metric_ids = _watched_metric_ids(queries)
+                    for query in queries:
+                        if query.get("Id") not in watched_metric_ids:
+                            continue
+                        metric = query.get("MetricStat", {}).get("Metric", {})
+                        reference = _metric_reference(metric, query.get("AccountId"))
+                        if reference:
+                            metric_references.add(reference)
+                    metric_alarm = MetricAlarm(
+                        arn=alarm["AlarmArn"],
+                        name=alarm["AlarmName"],
+                        metric=metric_name,
+                        name_space=namespace,
+                        namespaces=sorted(namespaces),
+                        metric_references=[
+                            MetricReference(
+                                namespace=reference[0],
+                                name=reference[1],
+                                dimensions=dict(reference[2]),
+                                account_id=reference[3],
+                            )
+                            for reference in sorted(
+                                metric_references,
+                                key=lambda item: (
+                                    item[0],
+                                    item[1],
+                                    item[2],
+                                    item[3] or "",
+                                ),
+                            )
+                        ],
+                        region=regional_client.region,
+                        alarm_actions=alarm.get("AlarmActions", []),
+                        actions_enabled=alarm.get("ActionsEnabled", False),
+                    )
+                    self.all_metric_alarms.append(metric_alarm)
                     if not self.audit_resources or (
                         is_resource_filtered(alarm["AlarmArn"], self.audit_resources)
                     ):
-                        metric_name = None
-                        if "MetricName" in alarm:
-                            metric_name = alarm["MetricName"]
-                        namespace = None
-                        if "Namespace" in alarm:
-                            namespace = alarm["Namespace"]
-                        if self.metric_alarms is None:
-                            self.metric_alarms = []
-                        self.metric_alarms.append(
-                            MetricAlarm(
-                                arn=alarm["AlarmArn"],
-                                name=alarm["AlarmName"],
-                                metric=metric_name,
-                                name_space=namespace,
-                                region=regional_client.region,
-                                alarm_actions=alarm.get("AlarmActions", []),
-                                actions_enabled=alarm.get("ActionsEnabled", False),
-                            )
-                        )
+                        self.metric_alarms.append(metric_alarm)
         except ClientError as error:
-            if error.response["Error"]["Code"] == "AccessDenied":
-                logger.error(
-                    f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                )
-                self.metric_alarms_unavailable = True
-                if not self.metric_alarms:
-                    self.metric_alarms = None
-            else:
-                self.metric_alarms_unavailable = True
-                logger.error(
-                    f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                )
-        except Exception as error:
+            error_code = error.response.get("Error", {}).get(
+                "Code", error.__class__.__name__
+            )
             self.metric_alarms_unavailable = True
+            self.metric_alarms_scan_errors[regional_client.region] = error_code
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
+        except Exception as error:
+            self.metric_alarms_unavailable = True
+            self.metric_alarms_scan_errors[regional_client.region] = (
+                error.__class__.__name__
+            )
+            logger.error(
+                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+        else:
+            self.metric_alarms_scanned_regions.add(regional_client.region)
 
     def _list_tags_for_resource(self):
         logger.info("CloudWatch - List Tags...")
@@ -357,11 +455,20 @@ class Logs(AWSService):
             )
 
 
+class MetricReference(BaseModel):
+    namespace: str
+    name: str
+    dimensions: dict[str, str] = Field(default_factory=dict)
+    account_id: Optional[str] = None
+
+
 class MetricAlarm(BaseModel):
     arn: str
     name: str
     metric: Optional[str] = None
     name_space: Optional[str] = None
+    namespaces: list[str] = Field(default_factory=list)
+    metric_references: list[MetricReference] = Field(default_factory=list)
     region: str
     tags: Optional[list] = []
     alarm_actions: list

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -456,6 +456,15 @@ class Logs(AWSService):
 
 
 class MetricReference(BaseModel):
+    """Metric identity referenced by a CloudWatch alarm.
+
+    Attributes:
+        namespace: CloudWatch metric namespace.
+        name: CloudWatch metric name.
+        dimensions: Dimensions attached to the metric.
+        account_id: Optional source account set on a metric query.
+    """
+
     namespace: str
     name: str
     dimensions: dict[str, str] = Field(default_factory=dict)

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_bedrock_agent_alarms_configured/cloudwatch_bedrock_agent_alarms_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_bedrock_agent_alarms_configured/cloudwatch_bedrock_agent_alarms_configured_test.py
@@ -1,0 +1,397 @@
+from unittest import mock
+
+import pytest
+from moto import mock_aws
+
+from prowler.providers.aws.services.bedrock.bedrock_service import Agent
+from prowler.providers.aws.services.cloudwatch.cloudwatch_service import (
+    MetricAlarm,
+    MetricReference,
+)
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+CHECK_PATH = (
+    "prowler.providers.aws.services.cloudwatch."
+    "cloudwatch_bedrock_agent_alarms_configured."
+    "cloudwatch_bedrock_agent_alarms_configured"
+)
+_UNSET = object()
+
+
+def _run_check(bedrock_agent_client, cloudwatch_client, regions=None):
+    with (
+        mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider(regions or [AWS_REGION_US_EAST_1]),
+        ),
+        mock.patch(f"{CHECK_PATH}.bedrock_agent_client", new=bedrock_agent_client),
+        mock.patch(f"{CHECK_PATH}.cloudwatch_client", new=cloudwatch_client),
+    ):
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_bedrock_agent_alarms_configured.cloudwatch_bedrock_agent_alarms_configured import (
+            cloudwatch_bedrock_agent_alarms_configured,
+        )
+
+        return cloudwatch_bedrock_agent_alarms_configured().execute()
+
+
+def _agent(region=AWS_REGION_US_EAST_1, agent_id="agent-id"):
+    return Agent(
+        id=agent_id,
+        name=f"test-{agent_id}",
+        arn=f"arn:aws:bedrock:{region}:{AWS_ACCOUNT_NUMBER}:agent/{agent_id}",
+        region=region,
+    )
+
+
+def _bedrock_client(agents=None, errors=None):
+    client = mock.MagicMock()
+    client.agents = {agent.arn: agent for agent in agents or []}
+    client.agents_scan_errors = errors or {}
+    return client
+
+
+def _cloudwatch_client(
+    alarms=_UNSET,
+    scanned_regions=None,
+    errors=None,
+    all_alarms=_UNSET,
+):
+    client = mock.MagicMock()
+    client.metric_alarms = [] if alarms is _UNSET else alarms
+    client.all_metric_alarms = (
+        client.metric_alarms if all_alarms is _UNSET else all_alarms
+    )
+    client.metric_alarms_scanned_regions = scanned_regions or set()
+    client.metric_alarms_scan_errors = errors or {}
+    client.audited_partition = "aws"
+    client.audited_account = AWS_ACCOUNT_NUMBER
+    return client
+
+
+def _alarm(
+    *,
+    region=AWS_REGION_US_EAST_1,
+    enabled=True,
+    references=None,
+):
+    return MetricAlarm(
+        arn=f"arn:aws:cloudwatch:{region}:{AWS_ACCOUNT_NUMBER}:alarm:agent-rate",
+        name="agent-rate",
+        region=region,
+        alarm_actions=[],
+        actions_enabled=enabled,
+        metric_references=references or [],
+    )
+
+
+def _agent_metric(
+    name="InvocationCount",
+    dimensions=None,
+    account_id=None,
+):
+    if dimensions is None:
+        dimensions = {"Operation": "InvokeAgent"}
+    return MetricReference(
+        namespace="AWS/Bedrock/Agents",
+        name=name,
+        dimensions=dimensions,
+        account_id=account_id,
+    )
+
+
+class Test_cloudwatch_bedrock_agent_alarms_configured:
+    @mock_aws
+    def test_direct_alarm_pass(self):
+        alarm = _alarm(references=[_agent_metric()])
+        result = _run_check(
+            _bedrock_client([_agent()]),
+            _cloudwatch_client([alarm], {AWS_REGION_US_EAST_1}),
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert result[0].status_extended == (
+            "CloudWatch has an enabled alarm for Bedrock Agent invocation or "
+            f"throttling metrics in region {AWS_REGION_US_EAST_1}."
+        )
+        assert result[0].region == AWS_REGION_US_EAST_1
+        assert result[0].resource_id == "bedrock-agent-alarms"
+        assert result[0].resource_arn == (
+            f"arn:aws:cloudwatch:{AWS_REGION_US_EAST_1}:" f"{AWS_ACCOUNT_NUMBER}:alarm"
+        )
+
+    @mock_aws
+    def test_metric_math_alarm_pass(self):
+        alarm = _alarm(references=[_agent_metric("InvocationThrottles")])
+
+        result = _run_check(
+            _bedrock_client([_agent()]),
+            _cloudwatch_client([alarm], {AWS_REGION_US_EAST_1}),
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+
+    @pytest.mark.parametrize(
+        ("enabled", "references"),
+        [
+            (
+                False,
+                [
+                    MetricReference(
+                        namespace="AWS/Bedrock/Agents",
+                        name="InvocationCount",
+                    )
+                ],
+            ),
+            (
+                True,
+                [MetricReference(namespace="AWS/Bedrock/Agents", name="TotalTime")],
+            ),
+            (
+                True,
+                [MetricReference(namespace="Custom/App", name="InvocationCount")],
+            ),
+            (
+                True,
+                [
+                    MetricReference(namespace="AWS/Bedrock/Agents", name="TotalTime"),
+                    MetricReference(namespace="Custom/App", name="InvocationCount"),
+                ],
+            ),
+            (
+                True,
+                [
+                    MetricReference(
+                        namespace="AWS/Bedrock/Agents",
+                        name="ModelInvocationCount",
+                    )
+                ],
+            ),
+        ],
+    )
+    @mock_aws
+    def test_unqualified_alarm_fail(self, enabled, references):
+        result = _run_check(
+            _bedrock_client([_agent()]),
+            _cloudwatch_client(
+                [_alarm(enabled=enabled, references=references)],
+                {AWS_REGION_US_EAST_1},
+            ),
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+
+    @pytest.mark.parametrize(
+        "reference",
+        [
+            MetricReference(namespace="AWS/Bedrock/Agents", name="InvocationCount"),
+            _agent_metric(dimensions={"Operation": "FakeOperation"}),
+            _agent_metric(
+                dimensions={"Operation": "InvokeAgent", "ModelId": "model-id"}
+            ),
+            _agent_metric(account_id="111122223333"),
+        ],
+    )
+    @mock_aws
+    def test_wrong_metric_identity_fail(self, reference):
+        result = _run_check(
+            _bedrock_client([_agent()]),
+            _cloudwatch_client(
+                [_alarm(references=[reference])],
+                {AWS_REGION_US_EAST_1},
+            ),
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+
+    @pytest.mark.parametrize(
+        "reference",
+        [
+            _agent_metric(dimensions={"Operation": "InvokeInlineAgent"}),
+            _agent_metric(account_id=AWS_ACCOUNT_NUMBER),
+            _agent_metric(
+                dimensions={
+                    "Operation": "InvokeAgent",
+                    "AgentAliasArn": "arn:aws:bedrock:us-east-1:123456789012:agent-alias/agent/alias",
+                    "ModelId": "model-id",
+                }
+            ),
+        ],
+    )
+    @mock_aws
+    def test_valid_metric_identity_pass(self, reference):
+        result = _run_check(
+            _bedrock_client([_agent()]),
+            _cloudwatch_client(
+                [_alarm(references=[reference])],
+                {AWS_REGION_US_EAST_1},
+            ),
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+
+    @mock_aws
+    def test_no_agents_no_findings(self):
+        result = _run_check(
+            _bedrock_client(),
+            _cloudwatch_client(scanned_regions={AWS_REGION_US_EAST_1}),
+        )
+
+        assert result == []
+
+    @mock_aws
+    def test_no_qualifying_alarm_fail(self):
+        result = _run_check(
+            _bedrock_client([_agent()]),
+            _cloudwatch_client(scanned_regions={AWS_REGION_US_EAST_1}),
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert result[0].status_extended == (
+            "CloudWatch has no enabled alarms for Bedrock Agent invocation or "
+            f"throttling metrics in region {AWS_REGION_US_EAST_1}."
+        )
+
+    @mock_aws
+    def test_regions_are_checked_separately(self):
+        alarm = _alarm(
+            region=AWS_REGION_US_EAST_1,
+            references=[_agent_metric()],
+        )
+        agents = [
+            _agent(agent_id="east-a"),
+            _agent(agent_id="east-b"),
+            _agent(region=AWS_REGION_EU_WEST_1, agent_id="west"),
+        ]
+
+        result = _run_check(
+            _bedrock_client(agents),
+            _cloudwatch_client(
+                [alarm],
+                {AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1},
+            ),
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1],
+        )
+
+        assert [(item.region, item.status) for item in result] == [
+            (AWS_REGION_EU_WEST_1, "FAIL"),
+            (AWS_REGION_US_EAST_1, "PASS"),
+        ]
+
+    @mock_aws
+    def test_filtered_agent_uses_full_alarm_inventory(self):
+        alarm = _alarm(references=[_agent_metric()])
+        result = _run_check(
+            _bedrock_client([_agent()]),
+            _cloudwatch_client(
+                [],
+                {AWS_REGION_US_EAST_1},
+                all_alarms=[alarm],
+            ),
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+
+    @mock_aws
+    def test_cloudwatch_error_is_manual(self):
+        alarm = _alarm(references=[_agent_metric()])
+        result = _run_check(
+            _bedrock_client([_agent()]),
+            _cloudwatch_client(
+                [alarm],
+                errors={AWS_REGION_US_EAST_1: "AccessDenied"},
+            ),
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+        assert result[0].status_extended == (
+            "Cannot evaluate Bedrock Agent alarm coverage in region "
+            f"{AWS_REGION_US_EAST_1}: cloudwatch:DescribeAlarms returned "
+            "AccessDenied. Check API access and retry the scan."
+        )
+
+    @mock_aws
+    def test_bedrock_error_is_manual(self):
+        result = _run_check(
+            _bedrock_client(errors={AWS_REGION_US_EAST_1: "AccessDeniedException"}),
+            _cloudwatch_client(scanned_regions={AWS_REGION_US_EAST_1}),
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+        assert result[0].status_extended == (
+            "Cannot evaluate Bedrock Agent alarm coverage in region "
+            f"{AWS_REGION_US_EAST_1}: bedrock:ListAgents returned "
+            "AccessDeniedException. Check API access and retry the scan."
+        )
+
+    @mock_aws
+    def test_partial_bedrock_error_overrides_alarm(self):
+        alarm = _alarm(references=[_agent_metric()])
+        result = _run_check(
+            _bedrock_client(
+                [_agent()],
+                {AWS_REGION_US_EAST_1: "ThrottlingException"},
+            ),
+            _cloudwatch_client([alarm], {AWS_REGION_US_EAST_1}),
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+
+    @mock_aws
+    def test_cloudwatch_error_without_agents_has_no_findings(self):
+        result = _run_check(
+            _bedrock_client(),
+            _cloudwatch_client(errors={AWS_REGION_US_EAST_1: "AccessDenied"}),
+        )
+
+        assert result == []
+
+    @mock_aws
+    def test_unscanned_cloudwatch_region_is_manual(self):
+        result = _run_check(
+            _bedrock_client([_agent()]),
+            _cloudwatch_client(),
+        )
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+        assert result[0].status_extended == (
+            "Cannot evaluate Bedrock Agent alarm coverage in region "
+            f"{AWS_REGION_US_EAST_1}: CloudWatch alarms were not scanned."
+        )
+
+    @mock_aws
+    def test_legacy_unavailable_inventory_stays_regional(self):
+        result = _run_check(
+            _bedrock_client(
+                [
+                    _agent(),
+                    _agent(region=AWS_REGION_EU_WEST_1, agent_id="west"),
+                ]
+            ),
+            _cloudwatch_client(
+                None,
+                scanned_regions={AWS_REGION_EU_WEST_1},
+                errors={AWS_REGION_US_EAST_1: "AccessDenied"},
+            ),
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1],
+        )
+
+        assert [(item.region, item.status) for item in result] == [
+            (AWS_REGION_EU_WEST_1, "FAIL"),
+            (AWS_REGION_US_EAST_1, "MANUAL"),
+        ]

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py
@@ -10,17 +10,51 @@ from prowler.providers.aws.services.cloudwatch.cloudwatch_service import (
     CloudWatch,
     LogGroup,
     Logs,
+    _watched_metric_ids,
 )
 from prowler.providers.aws.services.cloudwatch.lib.metric_filters import (
     build_metric_filter_pattern,
 )
 from tests.providers.aws.utils import (
     AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
     AWS_REGION_US_EAST_1,
+    mocked_api_response,
     set_mocked_aws_provider,
 )
 
 make_api_call = botocore.client.BaseClient._make_api_call
+
+
+@pytest.mark.parametrize(
+    ("expression_queries", "expected"),
+    [
+        (
+            [
+                {"Id": "base", "Expression": "agent_calls", "ReturnData": False},
+                {"Id": "alarm", "Expression": "base * 2", "ReturnData": True},
+            ],
+            {"agent_calls"},
+        ),
+        (
+            [
+                {
+                    "Id": "alarm",
+                    "Expression": 'SUM(METRICS("agent"))',
+                    "ReturnData": True,
+                }
+            ],
+            {"agent_calls"},
+        ),
+    ],
+)
+def test_watched_metric_ids(expression_queries, expected):
+    metric_queries = [
+        {"Id": "agent_calls", "MetricStat": {}, "ReturnData": False},
+        {"Id": "requests", "MetricStat": {}, "ReturnData": False},
+    ]
+
+    assert _watched_metric_ids(metric_queries + expression_queries) == expected
 
 
 class Test_CloudWatch_Service:
@@ -134,6 +168,7 @@ class Test_CloudWatch_Service:
         )
         cloudwatch = CloudWatch(aws_provider)
         assert len(cloudwatch.metric_alarms) == 1
+        assert len(cloudwatch.all_metric_alarms) == 1
         assert (
             cloudwatch.metric_alarms[0].arn
             == f"arn:aws:cloudwatch:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:alarm:test"
@@ -141,12 +176,310 @@ class Test_CloudWatch_Service:
         assert cloudwatch.metric_alarms[0].name == "test"
         assert cloudwatch.metric_alarms[0].metric == "test_metric"
         assert cloudwatch.metric_alarms[0].name_space == "test_namespace"
+        assert cloudwatch.metric_alarms[0].namespaces == ["test_namespace"]
+        assert [
+            (reference.namespace, reference.name)
+            for reference in cloudwatch.metric_alarms[0].metric_references
+        ] == [("test_namespace", "test_metric")]
+        assert cloudwatch.metric_alarms[0].metric_references[0].dimensions == {
+            "InstanceId": "i-0123457"
+        }
+        assert cloudwatch.metric_alarms[0].metric_references[0].account_id is None
         assert cloudwatch.metric_alarms[0].region == AWS_REGION_US_EAST_1
         assert cloudwatch.metric_alarms[0].tags == [
             {"Key": "key-1", "Value": "value-1"}
         ]
         assert cloudwatch.metric_alarms[0].alarm_actions == ["arn:alarm"]
         assert cloudwatch.metric_alarms[0].actions_enabled
+        assert cloudwatch.metric_alarms_scanned_regions == {AWS_REGION_US_EAST_1}
+        assert cloudwatch.metric_alarms_scan_errors == {}
+
+    @mock_aws
+    def test_describe_metric_math_alarm(self):
+        cw_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        cw_client.put_metric_alarm(
+            AlarmName="agent-rate",
+            ComparisonOperator="GreaterThanThreshold",
+            EvaluationPeriods=1,
+            Threshold=10,
+            ActionsEnabled=True,
+            Metrics=[
+                {
+                    "Id": "agent_calls",
+                    "MetricStat": {
+                        "Metric": {
+                            "Namespace": "AWS/Bedrock/Agents",
+                            "MetricName": "InvocationCount",
+                            "Dimensions": [
+                                {"Name": "Operation", "Value": "InvokeAgent"}
+                            ],
+                        },
+                        "Period": 60,
+                        "Stat": "Sum",
+                    },
+                    "ReturnData": False,
+                },
+                {
+                    "Id": "requests",
+                    "MetricStat": {
+                        "Metric": {
+                            "Namespace": "Custom/App",
+                            "MetricName": "RequestCount",
+                        },
+                        "Period": 60,
+                        "Stat": "Sum",
+                    },
+                    "ReturnData": False,
+                },
+                {
+                    "Id": "rate",
+                    "Expression": "agent_calls / requests",
+                    "ReturnData": True,
+                },
+            ],
+        )
+
+        cloudwatch = CloudWatch(set_mocked_aws_provider())
+
+        assert len(cloudwatch.metric_alarms) == 1
+        alarm = cloudwatch.metric_alarms[0]
+        assert alarm.metric is None
+        assert alarm.name_space is None
+        assert alarm.namespaces == ["AWS/Bedrock/Agents", "Custom/App"]
+        assert [
+            (reference.namespace, reference.name)
+            for reference in alarm.metric_references
+        ] == [
+            ("AWS/Bedrock/Agents", "InvocationCount"),
+            ("Custom/App", "RequestCount"),
+        ]
+        assert alarm.metric_references[0].dimensions == {"Operation": "InvokeAgent"}
+        assert alarm.metric_references[0].account_id is None
+        assert alarm.metric_references[1].dimensions == {}
+        assert alarm.metric_references[1].account_id is None
+
+    def test_describe_metric_math_alarm_keeps_account_id(self):
+        class Paginator:
+            def paginate(self):
+                yield mocked_api_response(
+                    "cloudwatch",
+                    "DescribeAlarms",
+                    {
+                        "MetricAlarms": [
+                            {
+                                "AlarmArn": "arn:aws:cloudwatch:us-east-1:123456789012:alarm:cross-account",
+                                "AlarmName": "cross-account",
+                                "ActionsEnabled": True,
+                                "Metrics": [
+                                    {
+                                        "Id": "agent_calls",
+                                        "AccountId": AWS_ACCOUNT_NUMBER,
+                                        "MetricStat": {
+                                            "Metric": {
+                                                "Namespace": "AWS/Bedrock/Agents",
+                                                "MetricName": "InvocationCount",
+                                                "Dimensions": [
+                                                    {
+                                                        "Name": "Operation",
+                                                        "Value": "InvokeAgent",
+                                                    }
+                                                ],
+                                            },
+                                            "Period": 60,
+                                            "Stat": "Sum",
+                                        },
+                                        "ReturnData": True,
+                                    }
+                                ],
+                            }
+                        ]
+                    },
+                )
+
+        class CloudWatchClient:
+            region = AWS_REGION_US_EAST_1
+
+            def get_paginator(self, name):
+                assert name == "describe_alarms"
+                return Paginator()
+
+        cloudwatch = CloudWatch.__new__(CloudWatch)
+        cloudwatch.audit_resources = [
+            "arn:aws:bedrock:us-east-1:123456789012:agent/agent-id"
+        ]
+        cloudwatch.metric_alarms = []
+        cloudwatch.all_metric_alarms = []
+        cloudwatch.metric_alarms_scanned_regions = set()
+        cloudwatch.metric_alarms_scan_errors = {}
+
+        cloudwatch._describe_alarms(CloudWatchClient())
+
+        assert cloudwatch.metric_alarms == []
+        reference = cloudwatch.all_metric_alarms[0].metric_references[0]
+        assert reference.account_id == AWS_ACCOUNT_NUMBER
+
+    @mock_aws
+    def test_describe_metric_math_ignores_unused_metric(self):
+        cw_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        cw_client.put_metric_alarm(
+            AlarmName="request-rate",
+            ComparisonOperator="GreaterThanThreshold",
+            EvaluationPeriods=1,
+            Threshold=10,
+            ActionsEnabled=True,
+            Metrics=[
+                {
+                    "Id": "agent_calls",
+                    "MetricStat": {
+                        "Metric": {
+                            "Namespace": "AWS/Bedrock/Agents",
+                            "MetricName": "InvocationCount",
+                            "Dimensions": [
+                                {"Name": "Operation", "Value": "InvokeAgent"}
+                            ],
+                        },
+                        "Period": 60,
+                        "Stat": "Sum",
+                    },
+                    "ReturnData": False,
+                },
+                {
+                    "Id": "requests",
+                    "MetricStat": {
+                        "Metric": {
+                            "Namespace": "Custom/App",
+                            "MetricName": "RequestCount",
+                        },
+                        "Period": 60,
+                        "Stat": "Sum",
+                    },
+                    "ReturnData": False,
+                },
+                {
+                    "Id": "rate",
+                    "Expression": "requests",
+                    "ReturnData": True,
+                },
+            ],
+        )
+
+        cloudwatch = CloudWatch(set_mocked_aws_provider())
+
+        assert [
+            (reference.namespace, reference.name)
+            for reference in cloudwatch.metric_alarms[0].metric_references
+        ] == [("Custom/App", "RequestCount")]
+
+    def test_describe_alarms_keeps_partial_region_error(self):
+        class PartialPaginator:
+            def paginate(self):
+                yield mocked_api_response(
+                    "cloudwatch",
+                    "DescribeAlarms",
+                    {
+                        "MetricAlarms": [
+                            {
+                                "AlarmArn": "arn:aws:cloudwatch:us-east-1:123456789012:alarm:partial",
+                                "AlarmName": "partial",
+                                "Namespace": "AWS/Bedrock/Agents",
+                                "MetricName": "InvocationCount",
+                                "ActionsEnabled": True,
+                            }
+                        ]
+                    },
+                )
+                raise ClientError(
+                    {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                    "DescribeAlarms",
+                )
+
+        class PartialCloudWatchClient:
+            region = AWS_REGION_US_EAST_1
+
+            def get_paginator(self, name):
+                assert name == "describe_alarms"
+                return PartialPaginator()
+
+        cloudwatch = CloudWatch.__new__(CloudWatch)
+        cloudwatch.audit_resources = []
+        cloudwatch.metric_alarms = []
+        cloudwatch.all_metric_alarms = []
+        cloudwatch.metric_alarms_scanned_regions = set()
+        cloudwatch.metric_alarms_scan_errors = {}
+
+        cloudwatch._describe_alarms(PartialCloudWatchClient())
+
+        assert len(cloudwatch.metric_alarms) == 1
+        assert cloudwatch.metric_alarms_scan_errors == {
+            AWS_REGION_US_EAST_1: "AccessDenied"
+        }
+        assert cloudwatch.metric_alarms_scanned_regions == set()
+
+    def test_describe_alarms_tracks_regions_independently(self):
+        class Paginator:
+            def __init__(self, error=None):
+                self.error = error
+
+            def paginate(self):
+                if self.error:
+                    raise self.error
+                yield mocked_api_response(
+                    "cloudwatch", "DescribeAlarms", {"MetricAlarms": []}
+                )
+
+        class CloudWatchClient:
+            def __init__(self, region, error=None):
+                self.region = region
+                self.error = error
+
+            def get_paginator(self, name):
+                assert name == "describe_alarms"
+                return Paginator(self.error)
+
+        denied = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+            "DescribeAlarms",
+        )
+        cloudwatch = CloudWatch.__new__(CloudWatch)
+        cloudwatch.audit_resources = []
+        cloudwatch.metric_alarms = []
+        cloudwatch.all_metric_alarms = []
+        cloudwatch.metric_alarms_scanned_regions = set()
+        cloudwatch.metric_alarms_scan_errors = {}
+
+        cloudwatch._describe_alarms(CloudWatchClient(AWS_REGION_US_EAST_1, denied))
+        cloudwatch._describe_alarms(CloudWatchClient(AWS_REGION_EU_WEST_1))
+
+        assert cloudwatch.metric_alarms == []
+        assert cloudwatch.metric_alarms_scan_errors == {
+            AWS_REGION_US_EAST_1: "AccessDenied"
+        }
+        assert cloudwatch.metric_alarms_scanned_regions == {AWS_REGION_EU_WEST_1}
+
+    @mock_aws
+    def test_describe_alarms_access_denied_keeps_legacy_none(self):
+        def deny_describe_alarms(self, operation_name, kwargs):
+            if operation_name == "DescribeAlarms":
+                raise ClientError(
+                    {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                    operation_name,
+                )
+            return make_api_call(self, operation_name, kwargs)
+
+        provider = set_mocked_aws_provider(audited_regions=[AWS_REGION_US_EAST_1])
+        with patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=deny_describe_alarms,
+        ):
+            cloudwatch = CloudWatch(provider)
+
+        assert cloudwatch.metric_alarms is None
+        assert cloudwatch.all_metric_alarms == []
+        assert cloudwatch.metric_alarms_unavailable
+        assert cloudwatch.metric_alarms_scan_errors == {
+            AWS_REGION_US_EAST_1: "AccessDenied"
+        }
+        assert cloudwatch.metric_alarms_scanned_regions == set()
 
     # Test Logs Filters
     @mock_aws


### PR DESCRIPTION
### Context

Fixes #12630.

Bedrock Agent alarms were easy to miss because the CloudWatch collector only kept its filtered alarm view and did not retain which metric queries an alarm actually watched. That could hide a valid alarm or, with metric math, count an unused metric source.

I also reviewed #12683. It adds a different Bedrock runtime alarm check and touches the same collector. This PR keeps the existing namespace fields compatible and adds the structured references and regional error state needed for the Agent check.

### Description

- Keep a complete CloudWatch metric-alarm inventory alongside the existing filtered view.
- Resolve direct metrics and only the metric-math queries reachable from `ReturnData=true` outputs.
- Match enabled `AWS/Bedrock/Agents` alarms for `InvocationCount` or `InvocationThrottles`, including the documented Agent dimensions.
- Return one PASS, FAIL, or MANUAL result per region with Bedrock Agents, and no result when there are no agents.
- Keep partial inventory and API errors separate so unreadable data cannot turn into PASS.
- Add the service dependency, metadata, docs, changelog fragment, and regression coverage.

No provider permission update is needed; this uses the existing Bedrock Agent inventory and CloudWatch `DescribeAlarms` collector permissions.

### Steps to review

1. Check the collector tests for direct alarms, nested metric math, unused metric sources, account IDs, resource filtering, and regional errors.
2. Check the new check tests for PASS, FAIL, MANUAL, empty inventory, regional isolation, disabled alarms, unrelated metrics, dimensions, and partial scans.
3. Run:

```bash
uv run pytest -q tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py tests/providers/aws/services/cloudwatch/cloudwatch_bedrock_agent_alarms_configured/cloudwatch_bedrock_agent_alarms_configured_test.py
```

Post-rebase result: `58 passed`.

The full CloudWatch and Bedrock service suites also passed locally (`416 passed`), along with `make lint-sdk`, `uv lock --check`, Black, flake8, pylint, Bandit, vulture, YAML validation, actionlint, and zizmor.

### Runtime evidence

The redacted real-AWS PASS and FAIL runs required by #12630 are still pending an authorized sandbox account. I did not use or inspect any local AWS account from this environment, so this PR is staying in draft until that evidence is added.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature is listed in the open issues.
- [x] The issue is assigned to me.
- [x] I reviewed the open pull requests and confirmed there is no PR implementing the same Agent-alarm outcome.

</details>

- [x] The code is covered by tests.
- [x] Comments and docstrings follow the repository style.
- [x] Backport was reviewed and is not needed for this new check.
- [x] README impact was reviewed; no README change is needed.
- [x] A Prowler changelog fragment is included.

#### SDK/CLI

- New check: Yes
- Provider permission update: No

#### UI / API / MCP Server

Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a check to verify CloudWatch alarms monitor Amazon Bedrock Agent invocation and throttling activity.
  - Findings now evaluate alarm coverage by AWS Region and identify missing or insufficient monitoring.
  - Improved detection of alarms using metric math, cross-account metrics, and detailed metric dimensions.
  - Scanning reports manual review when regional inventory or service access is incomplete.

- **Documentation**
  - Updated unit-testing guidance to include the Bedrock–CloudWatch service relationship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->