### PR TITLE
fix(sdk): report all-users 2sv override failures

### DIFF
--- a/prowler/changelog.d/googleworkspace-2sv-all-users-overrides.fixed.md
+++ b/prowler/changelog.d/googleworkspace-2sv-all-users-overrides.fixed.md
@@ -1,0 +1,1 @@
+`security_2sv_enforced` reports domain-wide 2-Step Verification failures as FAIL even when every failing setting is overridden for a group or organizational unit

--- a/prowler/providers/googleworkspace/services/security/security_2sv_enforced/security_2sv_enforced.py
+++ b/prowler/providers/googleworkspace/services/security/security_2sv_enforced/security_2sv_enforced.py
@@ -8,7 +8,6 @@ from prowler.providers.googleworkspace.services.security.lib.durations import (
     parse_duration_seconds,
 )
 from prowler.providers.googleworkspace.services.security.lib.scope import (
-    failures_shadowed_by_overrides,
     override_caveat,
     unevaluable_reason,
 )
@@ -145,23 +144,9 @@ class security_2sv_enforced(Check):
                     )
                 )
 
-            failing_settings = frozenset(setting for setting, _ in issues)
             reasons = "; ".join(text for _, text in issues)
 
-            if issues and failures_shadowed_by_overrides(policies, failing_settings):
-                # The audited scope (e.g. the admin group of 4.1.1.1) may get
-                # the overriding value, which the Policy API does not expose,
-                # so the domain-wide failure cannot be confirmed for it.
-                report.status = "MANUAL"
-                report.status_extended = (
-                    f"2-Step Verification is not enforced as required in the "
-                    f"domain-wide policy of {domain}: {reasons}. However, every "
-                    f"failing setting is also overridden for at least one group "
-                    f"or organizational unit, so the audited scope may be "
-                    f"configured correctly. Review those overrides in the Admin "
-                    f"console."
-                )
-            elif issues:
+            if issues:
                 report.status = "FAIL"
                 report.status_extended = (
                     f"2-Step Verification is not enforced as required in domain "

--- a/tests/providers/googleworkspace/services/security/security_2sv_enforced/security_2sv_enforced_test.py
+++ b/tests/providers/googleworkspace/services/security/security_2sv_enforced/security_2sv_enforced_test.py
@@ -224,8 +224,8 @@ class TestSecurity2svEnforced:
         assert "trust their device" in findings[0].status_extended
         assert "also overridden" in findings[0].status_extended
 
-    def test_manual_when_every_failing_setting_is_overridden(self):
-        """The overriding value is not exposed, so the failure is unconfirmed"""
+    def test_fail_when_every_failing_setting_is_overridden(self):
+        """The all-users requirement still fails for users outside the override"""
         findings = run_check(
             **{
                 **COMPLIANT,
@@ -235,11 +235,9 @@ class TestSecurity2svEnforced:
         )
 
         assert len(findings) == 1
-        assert findings[0].status == "MANUAL"
+        assert findings[0].status == "FAIL"
         assert "trust their device" in findings[0].status_extended
-        assert "every failing setting is also overridden" in (
-            findings[0].status_extended
-        )
+        assert "also overridden" in findings[0].status_extended
 
     def test_fail_when_only_some_failing_settings_are_overridden(self):
         """A failure no override reaches is still proven for the whole domain"""


### PR DESCRIPTION
### Context

Fixes #12692.

`security_2sv_enforced` is mapped to both administrator-scoped and all-users Google Workspace 2-Step Verification requirements. The check currently returns `MANUAL` when every failing domain-wide setting is overridden for a group or organizational unit. That uncertainty is appropriate for administrator-scoped checks, but the all-users requirement still has a proven domain-wide failure for users outside the override.

### Description

This keeps domain-wide 2-Step Verification failures as `FAIL` in `security_2sv_enforced`, while preserving the existing override caveat in the finding message. The administrator-specific `security_2sv_hardware_keys_admins` check keeps its `MANUAL` downgrade because the overriding group may be the audited admin group.

A focused changelog fragment is included under `prowler/changelog.d/`.

### Steps to review

```bash
uv run pytest tests/providers/googleworkspace/services/security/security_2sv_enforced/security_2sv_enforced_test.py tests/providers/googleworkspace/services/security/security_2sv_hardware_keys_admins/security_2sv_hardware_keys_admins_test.py -q
uv run --group dev flake8 prowler/providers/googleworkspace/services/security/security_2sv_enforced/security_2sv_enforced.py tests/providers/googleworkspace/services/security/security_2sv_enforced/security_2sv_enforced_test.py --ignore=E266,W503,E203,E501,W605,E128
uv run --group dev black --check prowler/providers/googleworkspace/services/security/security_2sv_enforced/security_2sv_enforced.py tests/providers/googleworkspace/services/security/security_2sv_enforced/security_2sv_enforced_test.py
uv run --group dev pylint --disable=W,C,R,E -rn -sn prowler/providers/googleworkspace/services/security/security_2sv_enforced/security_2sv_enforced.py
git diff --check
```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues/12692) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues/12692) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure a changelog fragment is added under <component>/changelog.d/, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Google Workspace 2-Step Verification check to report a **FAIL** when domain-wide enforcement is not met, even if failing settings are overridden for groups or organizational units.
  - Improved failure messaging to clearly indicate when overridden settings still contribute to the domain-wide failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->