### PR TITLE
fix(ui): avoid missing selector in scan tour

### DIFF
--- a/ui/changelog.d/view-first-scan-tour-selector.fixed.md
+++ b/ui/changelog.d/view-first-scan-tour-selector.fixed.md
@@ -1,0 +1,1 @@
+Scan Jobs onboarding tour no longer targets an unmounted In Progress row from other tabs

--- a/ui/components/scans/scans-page-shell.test.tsx
+++ b/ui/components/scans/scans-page-shell.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { OnboardingFlow } from "@/lib/onboarding";
 import { useScansStore } from "@/store";
 import { ProviderProps } from "@/types";
 
@@ -114,6 +115,18 @@ vi.mock("@/components/onboarding", () => ({
   },
   PageReady: () => <div data-testid="page-ready" />,
 }));
+
+interface OnboardingTriggerProps {
+  flow: OnboardingFlow;
+}
+
+const getTriggeredTourTargets = () => {
+  const triggerProps = onboardingTriggerSpy.mock.calls.at(-1)?.[0] as
+    | OnboardingTriggerProps
+    | undefined;
+
+  return triggerProps?.flow.tour.steps.map((step) => step.target);
+};
 
 const providers: ProviderProps[] = [
   {
@@ -592,6 +605,50 @@ describe("ScansPageShell", () => {
     );
 
     expect(screen.getByTestId("onboarding-trigger")).toBeInTheDocument();
+  });
+
+  it("uses only mounted tour targets when an active scan exists on the completed tab", () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+    searchParamsValue.current = "tab=completed";
+
+    // When
+    render(
+      <ScansPageShell
+        providers={providers}
+        hasManageScansPermission
+        activeScanCount={1}
+      >
+        <div>Scans table</div>
+      </ScansPageShell>,
+    );
+
+    // Then
+    expect(getTriggeredTourTargets()).toEqual([undefined, "launch", "tabs"]);
+  });
+
+  it("targets the running scan when its row is mounted on the in progress tab", () => {
+    // Given
+    vi.stubEnv("UI_CLOUD_ENABLED", "false");
+    searchParamsValue.current = "tab=active";
+
+    // When
+    render(
+      <ScansPageShell
+        providers={providers}
+        hasManageScansPermission
+        activeScanCount={1}
+      >
+        <div>Scans table</div>
+      </ScansPageShell>,
+    );
+
+    // Then
+    expect(getTriggeredTourTargets()).toEqual([
+      undefined,
+      "in-progress",
+      "launch",
+    ]);
   });
 
   it("suppresses the view-first-scan tour when no provider is connected, since Launch Scan is disabled", () => {

--- a/ui/components/scans/scans-page-shell.tsx
+++ b/ui/components/scans/scans-page-shell.tsx
@@ -80,9 +80,10 @@ export function ScansPageShell({
   const launchDisabled = !hasManageScansPermission || !hasConnectedProviders;
   const launchOpen =
     !launchDisabled && (isLaunchScanModalOpen || urlLaunchOpen);
-  // When a scan is already running, the tour highlights its row (anchored in
-  // ScanJobsTable); otherwise it falls back to the Launch Scan button + tabs.
-  const hasInProgressScan = activeScanCount > 0;
+  // ScanJobsTable only mounts the in-progress row anchor on the active tab.
+  // Other tabs use the fallback tour so every target exists in the current DOM.
+  const hasVisibleInProgressScan =
+    activeScanCount > 0 && filters.activeTab === SCAN_JOBS_TAB.ACTIVE;
 
   const getTabLabel = (tab: ScanJobsTab) => {
     const label = SCAN_TAB_LABELS[tab];
@@ -122,7 +123,7 @@ export function ScansPageShell({
           <OnboardingTrigger
             flow={{
               ...viewFirstScanFlow,
-              tour: buildViewFirstScanTour(hasInProgressScan),
+              tour: buildViewFirstScanTour(hasVisibleInProgressScan),
             }}
           />
         </Suspense>

--- a/ui/lib/tours/__tests__/use-driver-tour.test.tsx
+++ b/ui/lib/tours/__tests__/use-driver-tour.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { addProviderTour } from "../add-provider.tour";
 import type { TourCompletionRecord } from "../tour-types";
@@ -92,5 +92,66 @@ describe("adaptStep autoAdvance", () => {
     });
 
     expect(driveStep.popover?.showButtons).toBeUndefined();
+  });
+});
+
+describe("adaptStep selector fallback", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("uses the fallback target when the primary target disappears", () => {
+    // Given
+    const fallbackElement = document.createElement("div");
+    fallbackElement.dataset.tourId = "view-first-scan-tabs";
+    document.body.append(fallbackElement);
+    const driveStep = adaptStep("view-first-scan", {
+      target: "in-progress",
+      fallbackTarget: "tabs",
+      title: "Your scan is running",
+    });
+
+    // When
+    const resolvedElement = (driveStep.element as () => Element)();
+
+    // Then
+    expect(resolvedElement).toBe(fallbackElement);
+  });
+
+  it("keeps the primary target when both targets exist", () => {
+    // Given
+    const primaryElement = document.createElement("div");
+    primaryElement.dataset.tourId = "view-first-scan-in-progress";
+    const fallbackElement = document.createElement("div");
+    fallbackElement.dataset.tourId = "view-first-scan-tabs";
+    document.body.append(primaryElement, fallbackElement);
+    const driveStep = adaptStep("view-first-scan", {
+      target: "in-progress",
+      fallbackTarget: "tabs",
+      title: "Your scan is running",
+    });
+
+    // When
+    const resolvedElement = (driveStep.element as () => Element)();
+
+    // Then
+    expect(resolvedElement).toBe(primaryElement);
+  });
+
+  it("still reports configuration drift when both targets are missing", () => {
+    // Given
+    const driveStep = adaptStep("view-first-scan", {
+      target: "in-progress",
+      fallbackTarget: "tabs",
+      title: "Your scan is running",
+    });
+
+    // When
+    const resolveElement = () => (driveStep.element as () => Element)();
+
+    // Then
+    expect(resolveElement).toThrow(
+      'Tour "view-first-scan" references missing selector: [data-tour-id="view-first-scan-in-progress"]',
+    );
   });
 });

--- a/ui/lib/tours/__tests__/view-first-scan.tour.test.ts
+++ b/ui/lib/tours/__tests__/view-first-scan.tour.test.ts
@@ -72,6 +72,19 @@ describe("buildViewFirstScanTour with a running scan", () => {
     expect(tour.version).toBe(viewFirstScanTour.version);
   });
 
+  it("falls back to the stable tabs anchor if the running row disappears", () => {
+    // Given
+    const runningScanStep = tour.steps.find(
+      (step) => step.target === "in-progress",
+    );
+
+    // When
+    const fallbackTarget = runningScanStep?.fallbackTarget;
+
+    // Then
+    expect(fallbackTarget).toBe("tabs");
+  });
+
   it("never targets an element outside the allowed anchor set", () => {
     for (const target of definedTargets(tour)) {
       expect(ALLOWED_TARGETS).toContain(target);

--- a/ui/lib/tours/tour-types.ts
+++ b/ui/lib/tours/tour-types.ts
@@ -45,6 +45,9 @@ export interface TourCompletionRecord {
 // Modal step omits `target`; anchored step provides the `data-tour-id` value (no brackets).
 export interface TourStep<TTarget extends string = string> {
   target?: TTarget;
+  // Optional stable anchor used when a volatile primary target disappears before
+  // driver.js resolves the step (for example, a running scan row that completes).
+  fallbackTarget?: TTarget;
   title?: string;
   description?: string;
   side?: TourStepSide;

--- a/ui/lib/tours/use-driver-tour.ts
+++ b/ui/lib/tours/use-driver-tour.ts
@@ -172,11 +172,16 @@ export function adaptStep<TTarget extends string>(
 
   if (step.target) {
     const selector = toSelector(`${tourId}-${step.target}`);
+    const fallbackSelector = step.fallbackTarget
+      ? toSelector(`${tourId}-${step.fallbackTarget}`)
+      : undefined;
     driveStep.element = () => {
       if (typeof document === "undefined") {
         throw new Error("Tour element resolved without a DOM");
       }
-      const found = document.querySelector(selector);
+      const found =
+        document.querySelector(selector) ??
+        (fallbackSelector ? document.querySelector(fallbackSelector) : null);
       if (!found) {
         throw new Error(
           `Tour "${tourId}" references missing selector: ${selector}`,

--- a/ui/lib/tours/view-first-scan.tour.ts
+++ b/ui/lib/tours/view-first-scan.tour.ts
@@ -33,9 +33,8 @@ const INTRO_STEP = {
 /**
  * Builds the tour for the scans page. When a scan is already running we anchor the
  * In Progress row first (and mention the other tabs in copy); otherwise we fall back
- * to highlighting Launch Scan and the tabs. Gating on `hasInProgressScan` keeps the
- * tour from anchoring to a missing row — the same guard pattern the findings tour
- * uses for an empty table.
+ * to highlighting Launch Scan and the tabs. The volatile row step itself falls back
+ * to the stable tabs anchor if the scan completes while the tour is open.
  */
 export function buildViewFirstScanTour(
   hasInProgressScan: boolean,
@@ -49,6 +48,7 @@ export function buildViewFirstScanTour(
         INTRO_STEP,
         {
           target: "in-progress",
+          fallbackTarget: "tabs",
           side: TOUR_STEP_SIDES.BOTTOM,
           align: TOUR_STEP_ALIGNMENTS.START,
           title: "Your scan is running",

--- a/ui/scripts/check-tour-alignment.mjs
+++ b/ui/scripts/check-tour-alignment.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-// Tour alignment check (syntactic). Extracts `data-tour-id` values from every
-// `ui/lib/tours/*.tour.ts` and verifies a matching attribute exists under `ui/`,
-// in either the JSX form (`data-tour-id="..."`) or the object-property form
-// (`"data-tour-id": "..."`) used for dynamically-spread anchors. Two directions:
-//   - Tour → DOM: fails on any tour `target` with no matching attribute.
+// Tour alignment check (syntactic). Extracts primary and fallback `data-tour-id`
+// values from every `ui/lib/tours/*.tour.ts` and verifies a matching attribute
+// exists under `ui/`, in either the JSX form (`data-tour-id="..."`) or the
+// object-property form (`"data-tour-id": "..."`) used for dynamically-spread
+// anchors. Two directions:
+//   - Tour → DOM: fails on any `target` or `fallbackTarget` without an attribute.
 //   - DOM → tour: warns on any `data-tour-id` not referenced by any tour
 //     (does not fail — staged anchors during multi-PR rollouts are OK).
 // Complements the semantic `prowler-tour` skill for CI/local runs without
@@ -41,7 +42,18 @@ async function findTourFiles(dir) {
 }
 
 const TOUR_ID_PATTERN = /\bid\s*:\s*["']([a-z0-9-]+)["']/m;
-const TARGET_PATTERN = /\btarget\s*:\s*["']([a-z0-9-]+)["']/g;
+const TARGET_PATTERN =
+  /\b(?:target|fallbackTarget)\s*:\s*["']([a-z0-9-]+)["']/g;
+
+/**
+ * Extracts every primary and fallback target declared by a tour.
+ *
+ * @param {string} source
+ * @returns {string[]}
+ */
+export function extractTourTargets(source) {
+  return Array.from(source.matchAll(TARGET_PATTERN), (match) => match[1]);
+}
 
 async function parseTour(filePath) {
   const source = await readFile(filePath, "utf8");
@@ -53,10 +65,7 @@ async function parseTour(filePath) {
   }
   const tourId = idMatch[1];
 
-  const targets = [];
-  for (const match of source.matchAll(TARGET_PATTERN)) {
-    targets.push(match[1]);
-  }
+  const targets = extractTourTargets(source);
 
   return {
     file: relative(UI_DIR, filePath),
@@ -155,7 +164,7 @@ async function main() {
   if (tourOrphans.length === 0) {
     const referenced = tours.reduce((sum, t) => sum + t.selectors.length, 0);
     console.log(
-      `✓ Tour alignment OK — ${tours.length} tour(s), ${referenced} anchored step(s).`,
+      `✓ Tour alignment OK — ${tours.length} tour(s), ${referenced} anchor reference(s).`,
     );
     return;
   }
@@ -172,7 +181,10 @@ async function main() {
   process.exit(1);
 }
 
-main().catch((err) => {
-  console.error(err.stack || err.message);
-  process.exit(1);
-});
+const entryPoint = process.argv[1];
+if (entryPoint && resolve(entryPoint) === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err.stack || err.message);
+    process.exit(1);
+  });
+}

--- a/ui/scripts/check-tour-alignment.test.ts
+++ b/ui/scripts/check-tour-alignment.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { extractTourTargets } from "./check-tour-alignment.mjs";
+
+describe("tour target extraction", () => {
+  it("should include primary and fallback targets", () => {
+    // Given
+    const source = `
+      {
+        target: "volatile-row",
+        fallbackTarget: "stable-tabs",
+      }
+    `;
+
+    // When
+    const targets = extractTourTargets(source);
+
+    // Then
+    expect(targets).toEqual(["volatile-row", "stable-tabs"]);
+  });
+
+  it("should include a target used only as a fallback", () => {
+    // Given
+    const source = `
+      {
+        fallbackTarget: "fallback-only-anchor",
+        title: "Fallback-only step",
+      }
+    `;
+
+    // When
+    const targets = extractTourTargets(source);
+
+    // Then
+    expect(targets).toEqual(["fallback-only-anchor"]);
+  });
+});


### PR DESCRIPTION
### Context

Sentry issue `CLOUD-UI-1N8` reports the `view-first-scan` tour throwing when it advances to `[data-tour-id="view-first-scan-in-progress"]` from `/scans`.

The Scans page defaults to the Completed tab. When any active scan existed, the tour still selected its In Progress variant even though that tab and its row anchor were not mounted. The same row can also disappear if a scan completes while the tour remains open.

### Description

- Use the In Progress tour variant only when an active scan exists and the In Progress tab is visible.
- Fall back to the Launch Scan and tabs anchors from Completed or Scheduled, where those targets are mounted.
- Add optional stable fallback targets for volatile tour steps while preserving missing-selector errors when both targets are absent.
- Configure the running scan step to fall back to the stable tabs anchor if the row disappears during the tour.
- Add regression coverage for tab selection, primary target resolution, fallback resolution, and genuine selector drift.
- Add the required UI changelog fragment.

No dependencies added.

### Steps to review

1. Open `/scans?onboarding=view-first-scan` on the Completed tab while at least one scan is active.
2. Advance past the welcome step and confirm the tour targets Launch Scan without throwing a missing-selector error.
3. Open `/scans?tab=active&onboarding=view-first-scan` and confirm the tour targets the first running scan row.
4. Let that scan complete before advancing, or remove the row in browser developer tools, and confirm the step falls back to the tabs anchor without throwing.
5. Run:
   - `pnpm exec vitest run --project unit components/scans/scans-page-shell.test.tsx components/scans/table/__tests__/scan-jobs-table.test.tsx lib/tours/__tests__/use-driver-tour.test.tsx lib/tours/__tests__/view-first-scan.tour.test.ts`
   - `pnpm typecheck`
   - `pnpm exec eslint lib/tours/tour-types.ts lib/tours/use-driver-tour.ts lib/tours/view-first-scan.tour.ts lib/tours/__tests__/use-driver-tour.test.tsx lib/tours/__tests__/view-first-scan.tour.test.ts components/scans/scans-page-shell.tsx components/scans/scans-page-shell.test.tsx --max-warnings 0`
   - `pnpm tour:check`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient. (N/A: no dependency changes)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

Screenshots are not applicable because this changes target selection without altering visual design.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Scan Jobs onboarding tour so it no longer points to scan rows that are not mounted on the current tab.
  * Added a stable fallback to the tab navigation when an in-progress scan completes or disappears while the tour is open.
  * Improved tour behavior across completed and in-progress scan views.

* **Tests**
  * Added coverage for tour target fallbacks and cross-tab alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->