### PR TITLE
fix(bedrock): treat Regions without ListCustomModels as having no custom models

### DIFF
--- a/prowler/changelog.d/bedrock-custom-models-unsupported-region.fixed.md
+++ b/prowler/changelog.d/bedrock-custom-models-unsupported-region.fixed.md
@@ -1,0 +1,1 @@
+`bedrock_custom_model_encrypted_with_cmk` no longer reports MANUAL for Regions where Bedrock does not offer `ListCustomModels`: the `UnknownOperationException` those Regions return is now treated like the `ValidationException` others return for the same condition, and both are logged as a warning instead of an error

--- a/prowler/providers/aws/services/bedrock/bedrock_service.py
+++ b/prowler/providers/aws/services/bedrock/bedrock_service.py
@@ -163,13 +163,20 @@ class Bedrock(AWSService):
                         )
         except ClientError as error:
             code = error.response["Error"].get("Code", error.__class__.__name__)
-            # ValidationException means Bedrock is unavailable in the region:
-            # a definite "no models", so it must not become a MANUAL finding.
-            if code != "ValidationException":
+            # ValidationException and UnknownOperationException both mean the Region does not
+            # offer ListCustomModels -- AWS varies the code (and the message casing) by Region
+            # for the same condition. Either way it is a definite "no custom models", so it must
+            # not become a MANUAL finding, and an expected regional rejection is logged as a
+            # warning rather than an error.
+            if code in ("ValidationException", "UnknownOperationException"):
+                logger.warning(
+                    f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
+            else:
                 self.custom_models_scan_errors[regional_client.region] = code
-            logger.error(
-                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-            )
+                logger.error(
+                    f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
         except Exception as error:
             self.custom_models_scan_errors[regional_client.region] = (
                 error.__class__.__name__

--- a/tests/providers/aws/services/bedrock/bedrock_service_test.py
+++ b/tests/providers/aws/services/bedrock/bedrock_service_test.py
@@ -491,3 +491,74 @@ class TestBedrockPromptPagination:
 
         assert bedrock_agent_service.prompts == {}
         assert bedrock_agent_service.prompt_scanned_regions == set()
+
+
+def mock_make_api_call_list_custom_models_error(code):
+    """Build a _make_api_call mock that rejects ListCustomModels with the given error code."""
+
+    def _mock(self, operation_name, kwarg):
+        if operation_name == "ListCustomModels":
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": code, "Message": "Unknown Operation"}},
+                operation_name,
+            )
+        return mock_make_api_call(self, operation_name, kwarg)
+
+    return _mock
+
+
+class Test_Bedrock_ListCustomModels_Errors:
+    """A Region without ListCustomModels is a definite "no custom models", not a scan error.
+
+    AWS spells the same regional rejection two ways -- ValidationException in some Regions and
+    UnknownOperationException in others -- so both must stay out of custom_models_scan_errors,
+    or bedrock_custom_model_encrypted_with_cmk reports MANUAL for Regions where custom models
+    cannot exist. Both are logged as a warning, not an error, because the rejection is expected.
+    """
+
+    @pytest.mark.parametrize(
+        "code", ["ValidationException", "UnknownOperationException"]
+    )
+    @mock_aws
+    def test_unsupported_region_is_not_a_scan_error(self, code):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        with (
+            mock.patch(
+                "botocore.client.BaseClient._make_api_call",
+                new=mock_make_api_call_list_custom_models_error(code),
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.bedrock.bedrock_service.logger"
+            ) as mock_logger,
+        ):
+            bedrock = Bedrock(aws_provider)
+
+        assert bedrock.custom_models_scan_errors == {}
+        assert bedrock.custom_models == {}
+        warned = [str(c) for c in mock_logger.warning.call_args_list]
+        assert any("ListCustomModels" in w for w in warned)
+        errored = [str(c) for c in mock_logger.error.call_args_list]
+        assert not any("ListCustomModels" in e for e in errored)
+
+    @mock_aws
+    def test_denied_region_is_still_a_scan_error(self):
+        """A genuine read failure must keep recording, so the CMK check still reports MANUAL."""
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        with (
+            mock.patch(
+                "botocore.client.BaseClient._make_api_call",
+                new=mock_make_api_call_list_custom_models_error(
+                    "AccessDeniedException"
+                ),
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.bedrock.bedrock_service.logger"
+            ) as mock_logger,
+        ):
+            bedrock = Bedrock(aws_provider)
+
+        assert bedrock.custom_models_scan_errors == {
+            AWS_REGION_US_EAST_1: "AccessDeniedException"
+        }
+        errored = [str(c) for c in mock_logger.error.call_args_list]
+        assert any("ListCustomModels" in e for e in errored)


### PR DESCRIPTION
### Context

Live scans log six ERROR lines for `ListCustomModels` in Regions where Bedrock does not offer the operation, and three of those Regions also produce false MANUAL findings from `bedrock_custom_model_encrypted_with_cmk`, telling the operator to verify custom models in Regions where none can exist.

AWS spells the same regional rejection two ways: `ValidationException` ("Unknown Operation") in some Regions and `UnknownOperationException` in others, with the message casing varying too. The collector special-cased only the first, so the second was recorded in `custom_models_scan_errors` and became a MANUAL finding per Region on every scan. Observed live on a development account: eu-north-1, us-west-1 and ap-northeast-3 return `ValidationException` while ap-southeast-1, us-east-2 and ap-northeast-2 return `UnknownOperationException` for the identical condition.

### Description

- `_list_custom_models` now treats `UnknownOperationException` like `ValidationException`: a definite "no custom models in this Region", not a scan error.
- Both expected regional rejections are logged at `warning` instead of `error`, so a plain scan with `--log-level ERROR` no longer prints six lines for normal AWS behavior.
- Any other failure (for example `AccessDeniedException`) keeps recording the scan error, so the check still reports MANUAL for genuine read failures.
- Three regression tests: both silenced codes stay out of `custom_models_scan_errors` and log at warning, and a denial still records and logs at error. Both silenced-code tests fail on the unpatched collector.

### Steps to review

1. Run `prowler aws --log-level ERROR --check bedrock_custom_model_encrypted_with_cmk` on an account scanning Regions such as us-east-2 or ap-southeast-1: on master this prints ERROR lines and emits MANUAL findings for those Regions; with this fix it prints nothing at ERROR level and emits no finding for them.
2. `uv run pytest tests/providers/aws/services/bedrock/ -q` (178 tests pass).

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Ensure a changelog fragment is added under prowler/changelog.d/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bedrock custom model scans no longer report a manual result in Regions where custom model listing isn’t supported.
  * Unsupported-region responses are treated as expected conditions and logged as warnings.
  * Genuine access or API errors continue to be recorded and reported as scan errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->