### PR TITLE
fix(googleworkspace): report all-users 2sv override failures (hardware keys)

### DIFF
--- a/prowler/changelog.d/googleworkspace-2sv-hardware-keys-all-users-overrides.fixed.md
+++ b/prowler/changelog.d/googleworkspace-2sv-hardware-keys-all-users-overrides.fixed.md
@@ -1,0 +1,1 @@
+`security_2sv_hardware_keys_admins` reports domain-wide phishing-resistant MFA failures as FAIL even when every failing setting is overridden for a group or organizational unit

--- a/prowler/providers/googleworkspace/services/security/security_2sv_hardware_keys_admins/security_2sv_hardware_keys_admins.py
+++ b/prowler/providers/googleworkspace/services/security/security_2sv_hardware_keys_admins/security_2sv_hardware_keys_admins.py
@@ -8,7 +8,6 @@ from prowler.providers.googleworkspace.services.security.lib.durations import (
     parse_duration_seconds,
 )
 from prowler.providers.googleworkspace.services.security.lib.scope import (
-    failures_shadowed_by_overrides,
     override_caveat,
     unevaluable_reason,
 )
@@ -130,23 +129,9 @@ class security_2sv_hardware_keys_admins(Check):
                     )
                 )
 
-            failing_settings = frozenset(setting for setting, _ in issues)
             reasons = "; ".join(text for _, text in issues)
 
-            if issues and failures_shadowed_by_overrides(policies, failing_settings):
-                # The admin group of 4.1.1.2 may get the overriding value,
-                # which the Policy API does not expose, so the domain-wide
-                # failure cannot be confirmed for it.
-                report.status = "MANUAL"
-                report.status_extended = (
-                    f"2-Step Verification does not require security keys in the "
-                    f"domain-wide policy of {domain}: {reasons}. However, every "
-                    f"failing setting is also overridden for at least one group "
-                    f"or organizational unit, so the administrative accounts may "
-                    f"be configured correctly. Review those overrides in the "
-                    f"Admin console."
-                )
-            elif issues:
+            if issues:
                 report.status = "FAIL"
                 report.status_extended = (
                     f"2-Step Verification does not require security keys as "

--- a/tests/providers/googleworkspace/services/security/security_2sv_hardware_keys_admins/security_2sv_hardware_keys_admins_test.py
+++ b/tests/providers/googleworkspace/services/security/security_2sv_hardware_keys_admins/security_2sv_hardware_keys_admins_test.py
@@ -215,8 +215,8 @@ class TestSecurity2svHardwareKeysAdmins:
         assert "accepted method is ALL" in findings[0].status_extended
         assert "also overridden" in findings[0].status_extended
 
-    def test_manual_when_every_failing_setting_is_overridden(self):
-        """The admin group may get the overriding value, which is not exposed"""
+    def test_fail_when_every_failing_setting_is_overridden(self):
+        """SCuBA GWS.COMMONCONTROLS.1.1 still fails for users outside the override"""
         findings = run_check(
             **{
                 **COMPLIANT,
@@ -228,11 +228,9 @@ class TestSecurity2svHardwareKeysAdmins:
         )
 
         assert len(findings) == 1
-        assert findings[0].status == "MANUAL"
+        assert findings[0].status == "FAIL"
         assert "accepted method is ALL" in findings[0].status_extended
-        assert "administrative accounts may be configured correctly" in (
-            findings[0].status_extended
-        )
+        assert "also overridden" in findings[0].status_extended
 
     def test_fail_when_only_some_failing_settings_are_overridden(self):
         """A failure no override reaches is still proven for the whole domain"""


### PR DESCRIPTION
### Context

Fixes #12715.

`security_2sv_hardware_keys_admins` is mapped to SCuBA `GWS.COMMONCONTROLS.1.1` (phishing-resistant MFA for all users), and it is the only Prowler check that covers that requirement. The check currently returns `MANUAL` when every failing domain-wide setting is overridden for a group or organizational unit. That uncertainty is appropriate for its administrator-scoped mappings (CIS Google Workspace 4.1.1.2, CIS Controls 8.1 6.5), but the SCuBA all-users requirement still has a proven domain-wide failure for users outside the override.

### Description

This mirrors the fix in #12700 for `security_2sv_enforced`: it removes the MANUAL-on-shadow branch so a proven domain-wide failure surfaces as `FAIL`, with the existing override caveat preserved in the finding message.

For the two administrator-scoped mappings this slightly overstates FAIL when the overriding group happens to cover the admins, the same trade-off #12700 accepted for its 4.1.1.1 mapping. Unmapping SCuBA 1.1 from the check was considered and discarded, as it would leave the requirement with zero coverage.

A focused changelog fragment is included under `prowler/changelog.d/`.

### Steps to review

```bash
uv run pytest tests/providers/googleworkspace/services/security/security_2sv_hardware_keys_admins/security_2sv_hardware_keys_admins_test.py -q
uv run --group dev flake8 prowler/providers/googleworkspace/services/security/security_2sv_hardware_keys_admins/security_2sv_hardware_keys_admins.py tests/providers/googleworkspace/services/security/security_2sv_hardware_keys_admins/security_2sv_hardware_keys_admins_test.py --ignore=E266,W503,E203,E501,W605,E128
uv run --group dev black --check prowler/providers/googleworkspace/services/security/security_2sv_hardware_keys_admins/security_2sv_hardware_keys_admins.py tests/providers/googleworkspace/services/security/security_2sv_hardware_keys_admins/security_2sv_hardware_keys_admins_test.py
uv run --group dev pylint --disable=W,C,R,E -rn -sn prowler/providers/googleworkspace/services/security/security_2sv_hardware_keys_admins/security_2sv_hardware_keys_admins.py
git diff --check
```

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure a changelog fragment is added under <component>/changelog.d/, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Google Workspace phishing-resistant MFA checks now report **FAIL** when domain-wide hardware-key requirements are not met, even if all failing settings are overridden for a group or organizational unit.
  - Failure results now include clarification that affected users may remain outside the applicable override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->