### PR TITLE
chore(trivy): suppress CVE-2026-84304 in embedded grpc

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -20,11 +20,13 @@ ignore:
   # CVE-2026-84304 is the same temporary exception documented in .trivyignore.yaml:
   # Trivy 0.74.0 still embeds grpc 1.82.1, while the 1.83.1 fix is not in any release.
   # Prowler only runs `trivy image` / `trivy fs`, never client/server mode, so no gRPC
-  # endpoint exists in the image. Remove with the Trivy exception by 2026-10-15.
+  # endpoint exists in the image. Pinned to the embedded version so the rule stops
+  # matching on its own once Trivy bumps grpc. Remove with the Trivy exception by 2026-10-15.
   # https://github.com/aquasecurity/trivy/pull/11176
   - vulnerability: CVE-2026-84304
     package:
       name: google.golang.org/grpc
+      version: v1.82.1
   - vulnerability: CVE-2026-56852
     package:
       name: golang.org/x/text

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -17,6 +17,14 @@ ignore:
   - vulnerability: CVE-2026-71556
     package:
       name: github.com/go-git/go-git/v5
+  # CVE-2026-84304 is the same temporary exception documented in .trivyignore.yaml:
+  # Trivy 0.74.0 still embeds grpc 1.82.1, while the 1.83.1 fix is not in any release.
+  # Prowler only runs `trivy image` / `trivy fs`, never client/server mode, so no gRPC
+  # endpoint exists in the image. Remove with the Trivy exception by 2026-10-15.
+  # https://github.com/aquasecurity/trivy/pull/11176
+  - vulnerability: CVE-2026-84304
+    package:
+      name: google.golang.org/grpc
   - vulnerability: CVE-2026-56852
     package:
       name: golang.org/x/text

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -148,6 +148,22 @@ vulnerabilities:
       - "pkg:golang/github.com/go-git/go-git/v5"
     expired_at: 2026-09-15
 
+  # CVE-2026-84304 is a DoS in grpc-go <= 1.83.0: a peer fragments a gRPC stream into
+  # millions of tiny HTTP/2 DATA frames until the receiver runs out of heap. Fixed in
+  # 1.83.1 (published 2026-09-01). Trivy 0.74.0, the latest published release and the
+  # version the images ship, pins 1.82.1 as an indirect dependency:
+  # https://github.com/aquasecurity/trivy/blob/v0.74.0/go.mod
+  # Upstream bump still open: https://github.com/aquasecurity/trivy/pull/11176
+  # Trivy only speaks gRPC in client/server mode (`trivy server`, `--server`). Prowler
+  # invokes it exclusively as `trivy image` and `trivy fs` on a local path, so no gRPC
+  # listener or connection ever exists in the image and the affected path is not
+  # reachable. Remove this temporary suppression as soon as a Trivy release pins
+  # grpc >= 1.83.1.
+  - id: CVE-2026-84304
+    purls:
+      - "pkg:golang/google.golang.org/grpc"
+    expired_at: 2026-10-15
+
   - id: CVE-2026-56852
     purls:
       - "pkg:golang/golang.org/x/text"


### PR DESCRIPTION
### Context

`sdk-container-build-and-scan` and `api-container-build-and-scan` started failing on master with a HIGH from CVE-2026-84304 (grpc-go <= 1.83.0, DoS via HTTP/2 frame fragmentation). It comes from the Trivy 0.74.0 binary we ship in the images, which pins grpc 1.82.1. No Trivy release has the fix yet, the bump is still open upstream: https://github.com/aquasecurity/trivy/pull/11176

### Description

Adds a scoped suppression for `google.golang.org/grpc` to `.trivyignore.yaml` (expiring 2026-10-15) and `.grype.yaml`, since both scanners gate the image.

Trivy only uses gRPC in client/server mode. Prowler runs it as `trivy image` and `trivy fs` only, so there is no gRPC listener or connection in the image and the vulnerable path is not reachable.

Once a Trivy release pins grpc >= 1.83.1, bump `TRIVY_VERSION` in both Dockerfiles and drop the entry.

### Steps to review

- Check the reasoning in the new `.trivyignore.yaml` / `.grype.yaml` entries
- Both container-scan checks should be green on this PR

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated security scanning configuration to account for a reported vulnerability in an embedded dependency.
  - Added documented, temporary exceptions because the affected server/client functionality is not used.
  - Included remediation details and an expiration date for reviewing and removing the exceptions by October 15, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->