### PR TITLE
fix(kms): surface incomplete key inventory

### DIFF
--- a/prowler/changelog.d/kms-incomplete-inventory.fixed.md
+++ b/prowler/changelog.d/kms-incomplete-inventory.fixed.md
@@ -1,0 +1,1 @@
+`KMS` checks now report `MANUAL` findings when regional key inventory or key metadata cannot be retrieved, preventing silent omissions and unverified Amazon MSK encryption-at-rest results

--- a/prowler/changelog.d/kms-incomplete-inventory.fixed.md
+++ b/prowler/changelog.d/kms-incomplete-inventory.fixed.md
@@ -1,1 +1,1 @@
-`KMS` checks now report `MANUAL` findings when regional key inventory or key metadata cannot be retrieved, preventing silent omissions and unverified Amazon MSK encryption-at-rest results
+KMS inventory and metadata failures reported as `MANUAL` findings, including Amazon MSK encryption-at-rest checks

--- a/prowler/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk.py
+++ b/prowler/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk.py
@@ -4,7 +4,15 @@ from prowler.providers.aws.services.kms.kms_client import kms_client
 
 
 class kafka_cluster_encryption_at_rest_uses_cmk(Check):
-    def execute(self):
+    """Ensure Amazon MSK clusters use a customer-managed KMS key at rest."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the Amazon MSK encryption-at-rest check.
+
+        Returns:
+            list[Check_Report_AWS]: Reports for Amazon MSK clusters, including
+            manual results when KMS evidence is incomplete.
+        """
         findings = []
         kms_scan_errors = getattr(kms_client, "keys_scan_errors", {})
         if not isinstance(kms_scan_errors, dict):

--- a/prowler/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk.py
+++ b/prowler/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk.py
@@ -6,6 +6,9 @@ from prowler.providers.aws.services.kms.kms_client import kms_client
 class kafka_cluster_encryption_at_rest_uses_cmk(Check):
     def execute(self):
         findings = []
+        kms_scan_errors = getattr(kms_client, "keys_scan_errors", {})
+        if not isinstance(kms_scan_errors, dict):
+            kms_scan_errors = {}
 
         for cluster in kafka_client.clusters.values():
             report = Check_Report_AWS(metadata=self.metadata(), resource=cluster)
@@ -16,16 +19,31 @@ class kafka_cluster_encryption_at_rest_uses_cmk(Check):
             if cluster.kafka_version == "SERVERLESS":
                 report.status = "PASS"
                 report.status_extended = f"Kafka cluster '{cluster.name}' is serverless and always has encryption at rest enabled by default."
-            # For provisioned clusters, check if they use a customer managed KMS key
-            elif any(
-                (
-                    cluster.data_volume_kms_key_id == key.arn
-                    and getattr(key, "manager", "") == "CUSTOMER"
+            else:
+                matching_key = next(
+                    (
+                        key
+                        for key in kms_client.keys
+                        if cluster.data_volume_kms_key_id == key.arn
+                    ),
+                    None,
                 )
-                for key in kms_client.keys
-            ):
-                report.status = "PASS"
-                report.status_extended = f"Kafka cluster '{cluster.name}' has encryption at rest enabled with a CMK."
+                if cluster.region in kms_scan_errors:
+                    error = kms_scan_errors[cluster.region]
+                    report.status = "MANUAL"
+                    report.status_extended = f"KMS keys could not be listed in region {cluster.region} ({error}), so encryption at rest for Kafka cluster '{cluster.name}' cannot be verified."
+                elif matching_key is not None and not getattr(
+                    matching_key, "detail_retrieved", False
+                ):
+                    error = (
+                        getattr(matching_key, "detail_fetch_error", None)
+                        or "UnknownError"
+                    )
+                    report.status = "MANUAL"
+                    report.status_extended = f"KMS key {matching_key.arn} could not be described in region {cluster.region} ({error}), so encryption at rest for Kafka cluster '{cluster.name}' cannot be verified."
+                elif matching_key is not None and matching_key.manager == "CUSTOMER":
+                    report.status = "PASS"
+                    report.status_extended = f"Kafka cluster '{cluster.name}' has encryption at rest enabled with a CMK."
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used.py
@@ -7,7 +7,15 @@ from prowler.providers.aws.services.kms.lib.inventory import (
 
 
 class kms_cmk_are_used(Check):
-    def execute(self):
+    """Assess whether customer-managed KMS keys are in use."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the KMS key usage check.
+
+        Returns:
+            list[Check_Report_AWS]: Reports for customer-managed keys and any
+            incomplete KMS inventory evidence.
+        """
         findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         for key in kms_client.keys:
             if not key.detail_retrieved:

--- a/prowler/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used.py
@@ -1,11 +1,18 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.kms.kms_client import kms_client
+from prowler.providers.aws.services.kms.lib.inventory import (
+    get_kms_inventory_error_reports,
+    get_kms_key_detail_error_report,
+)
 
 
 class kms_cmk_are_used(Check):
     def execute(self):
-        findings = []
+        findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         for key in kms_client.keys:
+            if not key.detail_retrieved:
+                findings.append(get_kms_key_detail_error_report(self.metadata(), key))
+                continue
             # Only check CMKs keys
             if key.manager == "CUSTOMER":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=key)

--- a/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally.py
@@ -7,7 +7,15 @@ from prowler.providers.aws.services.kms.lib.inventory import (
 
 
 class kms_cmk_not_deleted_unintentionally(Check):
-    def execute(self):
+    """Ensure customer-managed KMS keys are not pending deletion."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the KMS key deletion check.
+
+        Returns:
+            list[Check_Report_AWS]: Reports for customer-managed keys and any
+            incomplete KMS inventory evidence.
+        """
         findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         for key in kms_client.keys:
             if not key.detail_retrieved:

--- a/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally.py
@@ -1,11 +1,18 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.kms.kms_client import kms_client
+from prowler.providers.aws.services.kms.lib.inventory import (
+    get_kms_inventory_error_reports,
+    get_kms_key_detail_error_report,
+)
 
 
 class kms_cmk_not_deleted_unintentionally(Check):
     def execute(self):
-        findings = []
+        findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         for key in kms_client.keys:
+            if not key.detail_retrieved:
+                findings.append(get_kms_key_detail_error_report(self.metadata(), key))
+                continue
             if key.manager == "CUSTOMER":
                 if key.state != "Disabled" or kms_client.provider.scan_unused_services:
                     report = Check_Report_AWS(metadata=self.metadata(), resource=key)

--- a/prowler/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.kms.kms_client import kms_client
 from prowler.providers.aws.services.kms.lib.inventory import (
@@ -9,9 +7,15 @@ from prowler.providers.aws.services.kms.lib.inventory import (
 
 
 class kms_cmk_not_multi_region(Check):
-    """kms_cmk_not_multi_region verifies if a KMS key is multi-regional"""
+    """Ensure customer-managed KMS keys are single-region."""
 
-    def execute(self) -> List[Check_Report_AWS]:
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the KMS multi-region key check.
+
+        Returns:
+            list[Check_Report_AWS]: Reports for customer-managed keys and any
+            incomplete KMS inventory evidence.
+        """
         findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
 
         for key in kms_client.keys:

--- a/prowler/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region.py
@@ -2,15 +2,22 @@ from typing import List
 
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.kms.kms_client import kms_client
+from prowler.providers.aws.services.kms.lib.inventory import (
+    get_kms_inventory_error_reports,
+    get_kms_key_detail_error_report,
+)
 
 
 class kms_cmk_not_multi_region(Check):
     """kms_cmk_not_multi_region verifies if a KMS key is multi-regional"""
 
     def execute(self) -> List[Check_Report_AWS]:
-        findings = []
+        findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
 
         for key in kms_client.keys:
+            if not key.detail_retrieved:
+                findings.append(get_kms_key_detail_error_report(self.metadata(), key))
+                continue
             if key.manager == "CUSTOMER" and key.state == "Enabled":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=key)
                 report.status = "PASS"

--- a/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled.py
@@ -1,11 +1,18 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.kms.kms_client import kms_client
+from prowler.providers.aws.services.kms.lib.inventory import (
+    get_kms_inventory_error_reports,
+    get_kms_key_detail_error_report,
+)
 
 
 class kms_cmk_rotation_enabled(Check):
     def execute(self):
-        findings = []
+        findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         for key in kms_client.keys:
+            if not key.detail_retrieved:
+                findings.append(get_kms_key_detail_error_report(self.metadata(), key))
+                continue
             report = Check_Report_AWS(metadata=self.metadata(), resource=key)
             # Only check enabled CMKs keys
             if (

--- a/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled.py
@@ -7,7 +7,15 @@ from prowler.providers.aws.services.kms.lib.inventory import (
 
 
 class kms_cmk_rotation_enabled(Check):
-    def execute(self):
+    """Ensure eligible customer-managed KMS keys use automatic rotation."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the KMS key rotation check.
+
+        Returns:
+            list[Check_Report_AWS]: Reports for eligible customer-managed keys
+            and any incomplete KMS inventory evidence.
+        """
         findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         for key in kms_client.keys:
             if not key.detail_retrieved:

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_bypassable_path/kms_key_enclave_attestation_bypassable_path.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_bypassable_path/kms_key_enclave_attestation_bypassable_path.py
@@ -6,6 +6,10 @@ from prowler.providers.aws.services.kms.lib.enclave import (
     statement_is_covered_by_deny,
     statement_targets_sensitive_actions,
 )
+from prowler.providers.aws.services.kms.lib.inventory import (
+    get_kms_inventory_error_reports,
+    get_kms_key_detail_error_report,
+)
 
 
 class kms_key_enclave_attestation_bypassable_path(Check):
@@ -46,8 +50,11 @@ class kms_key_enclave_attestation_bypassable_path(Check):
         Returns:
             list[Check_Report_AWS]: one report per enclave KMS key.
         """
-        findings = []
+        findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         for key in kms_client.keys:
+            if not key.detail_retrieved:
+                findings.append(get_kms_key_detail_error_report(self.metadata(), key))
+                continue
             if (
                 key.manager != "CUSTOMER"
                 or key.state != "Enabled"

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_no_deployment_binding/kms_key_enclave_attestation_no_deployment_binding.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_no_deployment_binding/kms_key_enclave_attestation_no_deployment_binding.py
@@ -6,6 +6,10 @@ from prowler.providers.aws.services.kms.lib.enclave import (
     statement_binds_deployment,
     statement_targets_sensitive_actions,
 )
+from prowler.providers.aws.services.kms.lib.inventory import (
+    get_kms_inventory_error_reports,
+    get_kms_key_detail_error_report,
+)
 
 
 class kms_key_enclave_attestation_no_deployment_binding(Check):
@@ -57,8 +61,11 @@ class kms_key_enclave_attestation_no_deployment_binding(Check):
         Returns:
             list[Check_Report_AWS]: One report per selected enclave KMS key.
         """
-        findings = []
+        findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         for key in kms_client.keys:
+            if not key.detail_retrieved:
+                findings.append(get_kms_key_detail_error_report(self.metadata(), key))
+                continue
             if (
                 key.manager != "CUSTOMER"
                 or key.state != "Enabled"

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_not_enforced/kms_key_enclave_attestation_not_enforced.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_not_enforced/kms_key_enclave_attestation_not_enforced.py
@@ -5,6 +5,10 @@ from prowler.providers.aws.services.kms.lib.enclave import (
     is_enclave_key,
     statement_targets_sensitive_actions,
 )
+from prowler.providers.aws.services.kms.lib.inventory import (
+    get_kms_inventory_error_reports,
+    get_kms_key_detail_error_report,
+)
 
 
 class kms_key_enclave_attestation_not_enforced(Check):
@@ -33,8 +37,11 @@ class kms_key_enclave_attestation_not_enforced(Check):
         Returns:
             list[Check_Report_AWS]: One report per selected enclave KMS key.
         """
-        findings = []
+        findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         for key in kms_client.keys:
+            if not key.detail_retrieved:
+                findings.append(get_kms_key_detail_error_report(self.metadata(), key))
+                continue
             if (
                 key.manager != "CUSTOMER"
                 or key.state != "Enabled"

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_pcr_mismatch/kms_key_enclave_attestation_pcr_mismatch.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_pcr_mismatch/kms_key_enclave_attestation_pcr_mismatch.py
@@ -8,6 +8,10 @@ from prowler.providers.aws.services.kms.lib.enclave import (
     normalize_golden_pcr_config,
     statement_targets_sensitive_actions,
 )
+from prowler.providers.aws.services.kms.lib.inventory import (
+    get_kms_inventory_error_reports,
+    get_kms_key_detail_error_report,
+)
 
 
 class kms_key_enclave_attestation_pcr_mismatch(Check):
@@ -43,12 +47,15 @@ class kms_key_enclave_attestation_pcr_mismatch(Check):
         Returns:
             list[Check_Report_AWS]: One report per selected enclave KMS key.
         """
-        findings = []
+        findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         golden = normalize_golden_pcr_config(
             kms_client.audit_config.get(GOLDEN_PCR_CONFIG_KEY)
         )
 
         for key in kms_client.keys:
+            if not key.detail_retrieved:
+                findings.append(get_kms_key_detail_error_report(self.metadata(), key))
+                continue
             if (
                 key.manager != "CUSTOMER"
                 or key.state != "Enabled"

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_unknown_image/kms_key_enclave_attestation_unknown_image.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_unknown_image/kms_key_enclave_attestation_unknown_image.py
@@ -21,6 +21,9 @@ from prowler.providers.aws.services.kms.lib.enclave import (
     synthetic_account_kms_resource,
     unknown_pcrs,
 )
+from prowler.providers.aws.services.kms.lib.inventory import (
+    get_kms_inventory_error_reports,
+)
 
 
 class kms_key_enclave_attestation_unknown_image(Check):
@@ -68,7 +71,7 @@ class kms_key_enclave_attestation_unknown_image(Check):
         Returns:
             list[Check_Report_AWS]: one report per KMS key evaluated.
         """
-        findings = []
+        findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         cfg = kms_client.audit_config or {}
 
         golden = normalize_golden_pcr_config(cfg.get(GOLDEN_PCR_CONFIG_KEY))

--- a/prowler/providers/aws/services/kms/kms_key_enclave_debug_attestation_detected/kms_key_enclave_debug_attestation_detected.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_debug_attestation_detected/kms_key_enclave_debug_attestation_detected.py
@@ -15,6 +15,9 @@ from prowler.providers.aws.services.kms.lib.enclave import (
     resolve_kms_key_resource,
     synthetic_account_kms_resource,
 )
+from prowler.providers.aws.services.kms.lib.inventory import (
+    get_kms_inventory_error_reports,
+)
 
 
 class kms_key_enclave_debug_attestation_detected(Check):
@@ -50,7 +53,7 @@ class kms_key_enclave_debug_attestation_detected(Check):
         Returns:
             list[Check_Report_AWS]: one report per KMS key evaluated.
         """
-        findings = []
+        findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
 
         lookback_hours = kms_client.audit_config.get(
             ENCLAVE_DEBUG_CONFIG_LOOKBACK_KEY,
@@ -81,7 +84,8 @@ class kms_key_enclave_debug_attestation_detected(Check):
             list(cloudtrail_client.trails.values()) if cloudtrail_client.trails else []
         )
         if not trails:
-            return self._emit_no_trail_manual(target_key_ids)
+            findings.extend(self._emit_no_trail_manual(target_key_ids))
+            return findings
 
         # LookupEvents is a per-region API even for multi-region trails, so
         # iterate over every audited region. A multi-region trail in us-east-1

--- a/prowler/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
@@ -8,7 +8,15 @@ from prowler.providers.aws.services.kms.lib.inventory import (
 
 
 class kms_key_not_publicly_accessible(Check):
-    def execute(self):
+    """Ensure customer-managed KMS keys are not publicly accessible."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the KMS key public-access check.
+
+        Returns:
+            list[Check_Report_AWS]: Reports for customer-managed keys and any
+            incomplete KMS inventory evidence.
+        """
         findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         for key in kms_client.keys:
             if not key.detail_retrieved:

--- a/prowler/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
@@ -1,12 +1,33 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.iam.lib.policy import is_policy_public
 from prowler.providers.aws.services.kms.kms_client import kms_client
+from prowler.providers.aws.services.kms.lib.inventory import (
+    get_kms_inventory_error_reports,
+    get_kms_key_detail_error_report,
+)
 
 
 class kms_key_not_publicly_accessible(Check):
     def execute(self):
-        findings = []
+        findings = get_kms_inventory_error_reports(self.metadata(), kms_client)
         for key in kms_client.keys:
+            if not key.detail_retrieved:
+                findings.append(get_kms_key_detail_error_report(self.metadata(), key))
+                continue
+            if (
+                key.manager == "CUSTOMER"
+                and key.state == "Enabled"
+                and key.policy is None
+                and key.policy_fetch_error
+            ):
+                report = Check_Report_AWS(metadata=self.metadata(), resource=key)
+                report.status = "MANUAL"
+                report.status_extended = (
+                    f"KMS key {key.id} policy could not be fetched "
+                    f"({key.policy_fetch_error}); public access cannot be verified."
+                )
+                findings.append(report)
+                continue
             if (
                 key.manager == "CUSTOMER"
                 and key.state == "Enabled"

--- a/prowler/providers/aws/services/kms/kms_service.py
+++ b/prowler/providers/aws/services/kms/kms_service.py
@@ -10,7 +10,14 @@ from prowler.providers.aws.lib.service.service import AWSService
 
 
 class KMS(AWSService):
+    """Retrieve AWS KMS key inventory and supporting metadata."""
+
     def __init__(self, provider):
+        """Initialize the KMS service.
+
+        Args:
+            provider: AWS provider used to create regional KMS clients.
+        """
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.keys = []
@@ -24,6 +31,11 @@ class KMS(AWSService):
             self.__threading_call__(self._list_aliases)
 
     def _list_keys(self, regional_client):
+        """Collect the KMS keys available through a regional client.
+
+        Args:
+            regional_client: Regional KMS client used to list keys.
+        """
         logger.info("KMS - Listing Keys...")
         region_keys = []
         try:
@@ -184,6 +196,8 @@ class KMS(AWSService):
 
 
 class Key(BaseModel):
+    """Represent an AWS KMS key and the metadata required by checks."""
+
     id: str
     arn: str
     state: Optional[str]

--- a/prowler/providers/aws/services/kms/kms_service.py
+++ b/prowler/providers/aws/services/kms/kms_service.py
@@ -55,6 +55,11 @@ class KMS(AWSService):
             )
 
     def _describe_key(self):
+        """Retrieve metadata for each discovered KMS key.
+
+        Records the error code or exception type on keys whose metadata cannot
+        be retrieved so checks can report incomplete evidence.
+        """
         logger.info("KMS - Describing Key...")
         for key in self.keys:
             try:

--- a/prowler/providers/aws/services/kms/kms_service.py
+++ b/prowler/providers/aws/services/kms/kms_service.py
@@ -1,6 +1,7 @@
 import json
 from typing import Optional
 
+from botocore.exceptions import ClientError
 from pydantic.v1 import BaseModel
 
 from prowler.lib.logger import logger
@@ -13,6 +14,7 @@ class KMS(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.keys = []
+        self.keys_scan_errors = {}
         self.__threading_call__(self._list_keys)
         if self.keys:
             self._describe_key()
@@ -23,51 +25,67 @@ class KMS(AWSService):
 
     def _list_keys(self, regional_client):
         logger.info("KMS - Listing Keys...")
+        region_keys = []
         try:
             list_keys_paginator = regional_client.get_paginator("list_keys")
             for page in list_keys_paginator.paginate():
                 for key in page["Keys"]:
-                    try:
-                        if not self.audit_resources or (
-                            is_resource_filtered(key["KeyArn"], self.audit_resources)
-                        ):
-                            self.keys.append(
-                                Key(
-                                    id=key["KeyId"],
-                                    arn=key["KeyArn"],
-                                    region=regional_client.region,
-                                )
+                    if not self.audit_resources or (
+                        is_resource_filtered(key["KeyArn"], self.audit_resources)
+                    ):
+                        region_keys.append(
+                            Key(
+                                id=key["KeyId"],
+                                arn=key["KeyArn"],
+                                region=regional_client.region,
                             )
-                    except Exception as error:
-                        logger.error(
-                            f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
                         )
+            self.keys.extend(region_keys)
+        except ClientError as error:
+            self.keys_scan_errors[regional_client.region] = error.response["Error"].get(
+                "Code", error.__class__.__name__
+            )
+            logger.error(
+                f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
+            )
         except Exception as error:
+            self.keys_scan_errors[regional_client.region] = error.__class__.__name__
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
     def _describe_key(self):
         logger.info("KMS - Describing Key...")
-        try:
-            for key in self.keys:
+        for key in self.keys:
+            try:
                 regional_client = self.regional_clients[key.region]
-                try:
-                    response = regional_client.describe_key(KeyId=key.id)
-                    key.state = response["KeyMetadata"]["KeyState"]
-                    key.origin = response["KeyMetadata"]["Origin"]
-                    key.manager = response["KeyMetadata"]["KeyManager"]
-                    key.spec = response["KeyMetadata"]["CustomerMasterKeySpec"]
-                    key.multi_region = response["KeyMetadata"]["MultiRegion"]
-                    key.description = response["KeyMetadata"].get("Description", "")
-                except Exception as error:
-                    logger.error(
-                        f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
-                    )
-        except Exception as error:
-            logger.error(
-                f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
-            )
+                metadata = regional_client.describe_key(KeyId=key.id)["KeyMetadata"]
+                state = metadata["KeyState"]
+                origin = metadata["Origin"]
+                manager = metadata["KeyManager"]
+                spec = metadata["CustomerMasterKeySpec"]
+                multi_region = metadata.get("MultiRegion", False)
+                description = metadata.get("Description", "")
+
+                key.state = state
+                key.origin = origin
+                key.manager = manager
+                key.spec = spec
+                key.multi_region = multi_region
+                key.description = description
+                key.detail_retrieved = True
+            except ClientError as error:
+                key.detail_fetch_error = error.response["Error"].get(
+                    "Code", error.__class__.__name__
+                )
+                logger.error(
+                    f"{key.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
+                )
+            except Exception as error:
+                key.detail_fetch_error = error.__class__.__name__
+                logger.error(
+                    f"{key.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
+                )
 
     def _get_key_rotation_status(self):
         logger.info("KMS - Get Key Rotation Status...")
@@ -173,6 +191,10 @@ class Key(BaseModel):
     # error class name). Checks that make security assertions from the policy
     # should emit MANUAL when this is set, not silently skip the key.
     policy_fetch_error: Optional[str] = None
+    # False when DescribeKey failed. Checks that require key metadata must
+    # report MANUAL instead of treating absent fields as configuration values.
+    detail_retrieved: bool = False
+    detail_fetch_error: Optional[str] = None
     spec: Optional[str]
     region: str
     multi_region: Optional[bool]

--- a/prowler/providers/aws/services/kms/lib/inventory.py
+++ b/prowler/providers/aws/services/kms/lib/inventory.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+from prowler.lib.check.models import Check_Report_AWS
+
+
+def get_kms_inventory_error_reports(
+    metadata: dict, kms_client_ref: Any
+) -> list[Check_Report_AWS]:
+    """Build findings for regions with an incomplete key inventory.
+
+    Args:
+        metadata: Metadata for the check emitting the findings.
+        kms_client_ref: KMS service instance containing regional scan errors.
+
+    Returns:
+        One MANUAL finding for each region whose keys could not be listed.
+    """
+    findings = []
+    scan_errors = getattr(kms_client_ref, "keys_scan_errors", {})
+    if not isinstance(scan_errors, dict):
+        return findings
+
+    for region, error in sorted(scan_errors.items()):
+        report = Check_Report_AWS(metadata=metadata, resource={"region": region})
+        report.region = region
+        report.resource_id = "key/unknown"
+        report.resource_arn = (
+            f"arn:{kms_client_ref.audited_partition}:kms:{region}:"
+            f"{kms_client_ref.audited_account}:key/unknown"
+        )
+        report.status = "MANUAL"
+        report.status_extended = (
+            f"KMS keys could not be listed in region {region} ({error}); "
+            f"KMS resources in this region could not be evaluated and must "
+            f"be verified manually."
+        )
+        findings.append(report)
+
+    return findings
+
+
+def get_kms_key_detail_error_report(metadata: dict, key: Any) -> Check_Report_AWS:
+    """Build a finding for a key whose metadata could not be retrieved.
+
+    Args:
+        metadata: Metadata for the check emitting the finding.
+        key: KMS key whose DescribeKey call failed.
+
+    Returns:
+        A MANUAL finding for the incomplete key.
+    """
+    error = getattr(key, "detail_fetch_error", None) or "UnknownError"
+    report = Check_Report_AWS(metadata=metadata, resource=key)
+    report.status = "MANUAL"
+    report.status_extended = (
+        f"KMS key {key.id} could not be described in region {key.region} "
+        f"({error}); its configuration could not be evaluated and must be "
+        f"verified manually."
+    )
+    return report

--- a/tests/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk_test.py
+++ b/tests/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk_test.py
@@ -8,6 +8,27 @@ from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provi
 
 
 class Test_kafka_cluster_encryption_at_rest_uses_cmk:
+    @staticmethod
+    def _provisioned_cluster():
+        return Cluster(
+            id="6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5",
+            name="demo-cluster-1",
+            arn="arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster-1/6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5",
+            region=AWS_REGION_US_EAST_1,
+            tags=[],
+            state="ACTIVE",
+            kafka_version="2.2.1",
+            data_volume_kms_key_id=f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/a7ca56d5-0768-4b64-a670-339a9fbef81c",
+            encryption_in_transit=EncryptionInTransit(
+                client_broker="TLS_PLAINTEXT",
+                in_cluster=True,
+            ),
+            tls_authentication=True,
+            public_access=True,
+            unauthentication_access=False,
+            enhanced_monitoring="DEFAULT",
+        )
+
     def test_kafka_no_clusters(self):
         kafka_client = MagicMock()
         kafka_client.clusters = {}
@@ -223,3 +244,75 @@ class Test_kafka_cluster_encryption_at_rest_uses_cmk:
             )
             assert result[0].resource_tags == []
             assert result[0].region == AWS_REGION_US_EAST_1
+
+    def test_kafka_cluster_reports_manual_when_kms_inventory_fails(self):
+        kafka_client = MagicMock()
+        cluster = self._provisioned_cluster()
+        kafka_client.clusters = {cluster.arn: cluster}
+
+        kms_client = MagicMock()
+        kms_client.keys = []
+        kms_client.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            ),
+            patch(
+                "prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk.kafka_client",
+                new=kafka_client,
+            ),
+            patch(
+                "prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk.kms_client",
+                new=kms_client,
+            ),
+        ):
+            from prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk import (
+                kafka_cluster_encryption_at_rest_uses_cmk,
+            )
+
+            result = kafka_cluster_encryption_at_rest_uses_cmk().execute()
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+        assert "KMS keys could not be listed" in result[0].status_extended
+        assert "AccessDeniedException" in result[0].status_extended
+
+    def test_kafka_cluster_reports_manual_when_kms_key_detail_fails(self):
+        kafka_client = MagicMock()
+        cluster = self._provisioned_cluster()
+        kafka_client.clusters = {cluster.arn: cluster}
+
+        key = MagicMock()
+        key.arn = cluster.data_volume_kms_key_id
+        key.detail_retrieved = False
+        key.detail_fetch_error = "AccessDeniedException"
+        kms_client = MagicMock()
+        kms_client.keys = [key]
+        kms_client.keys_scan_errors = {}
+
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            ),
+            patch(
+                "prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk.kafka_client",
+                new=kafka_client,
+            ),
+            patch(
+                "prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk.kms_client",
+                new=kms_client,
+            ),
+        ):
+            from prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk import (
+                kafka_cluster_encryption_at_rest_uses_cmk,
+            )
+
+            result = kafka_cluster_encryption_at_rest_uses_cmk().execute()
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+        assert "could not be described" in result[0].status_extended
+        assert "AccessDeniedException" in result[0].status_extended

--- a/tests/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used_test.py
+++ b/tests/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used_test.py
@@ -71,7 +71,7 @@ class Test_kms_cmk_are_used:
             assert result[0].resource_arn == key["Arn"]
 
     @pytest.mark.parametrize(
-        "no_of_keys_created,expected_no_of_results",
+        "no_of_keys_created,expected_no_of_passes",
         [
             (5, 3),
             (7, 5),
@@ -80,7 +80,7 @@ class Test_kms_cmk_are_used:
     )
     @mock_aws
     def test_kms_cmk_are_used_when_describe_key_fails_on_2_keys_out_of_x_keys(
-        self, no_of_keys_created: int, expected_no_of_results: int
+        self, no_of_keys_created: int, expected_no_of_passes: int
     ) -> None:
         # Generate KMS Client
         kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
@@ -131,7 +131,10 @@ class Test_kms_cmk_are_used:
             check = kms_cmk_are_used()
             result = check.execute()
 
-            assert len(result) == expected_no_of_results
+            assert len(result) == no_of_keys_created
+            statuses = [report.status for report in result]
+            assert statuses.count("PASS") == expected_no_of_passes
+            assert statuses.count("MANUAL") == 2
 
     @mock_aws
     def test_kms_key_with_deletion(self):

--- a/tests/providers/aws/services/kms/kms_inventory_errors_test.py
+++ b/tests/providers/aws/services/kms/kms_inventory_errors_test.py
@@ -1,0 +1,201 @@
+from contextlib import ExitStack
+from unittest import mock
+
+import pytest
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+KMS_CHECKS = (
+    "kms_cmk_are_used",
+    "kms_cmk_not_deleted_unintentionally",
+    "kms_cmk_not_multi_region",
+    "kms_cmk_rotation_enabled",
+    "kms_key_not_publicly_accessible",
+    "kms_key_enclave_attestation_not_enforced",
+    "kms_key_enclave_attestation_no_deployment_binding",
+    "kms_key_enclave_attestation_unknown_image",
+    "kms_key_enclave_attestation_bypassable_path",
+    "kms_key_enclave_attestation_pcr_mismatch",
+    "kms_key_enclave_debug_attestation_detected",
+)
+
+DETAIL_DEPENDENT_CHECKS = tuple(
+    check
+    for check in KMS_CHECKS
+    if check
+    not in {
+        "kms_key_enclave_attestation_unknown_image",
+        "kms_key_enclave_debug_attestation_detected",
+    }
+)
+
+
+class FakeKMSClient:
+    def __init__(self, keys=None, scan_errors=None):
+        self.keys = keys or []
+        self.keys_scan_errors = scan_errors or {}
+        self.audited_partition = "aws"
+        self.audited_account = AWS_ACCOUNT_NUMBER
+        self.region = AWS_REGION_US_EAST_1
+        self.audit_config = {}
+
+
+class IncompleteKey:
+    def __init__(self):
+        self.id = "incomplete-key"
+        self.arn = (
+            f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/{self.id}"
+        )
+        self.region = AWS_REGION_US_EAST_1
+        self.tags = []
+        self.manager = None
+        self.state = None
+        self.origin = None
+        self.spec = None
+        self.multi_region = None
+        self.rotation_enabled = None
+        self.policy = None
+        self.detail_retrieved = False
+        self.detail_fetch_error = "AccessDeniedException"
+
+    def dict(self):
+        return self.__dict__
+
+
+def _get_check_class(check_name):
+    if check_name == "kms_cmk_are_used":
+        from prowler.providers.aws.services.kms.kms_cmk_are_used.kms_cmk_are_used import (
+            kms_cmk_are_used,
+        )
+
+        return kms_cmk_are_used
+    if check_name == "kms_cmk_not_deleted_unintentionally":
+        from prowler.providers.aws.services.kms.kms_cmk_not_deleted_unintentionally.kms_cmk_not_deleted_unintentionally import (
+            kms_cmk_not_deleted_unintentionally,
+        )
+
+        return kms_cmk_not_deleted_unintentionally
+    if check_name == "kms_cmk_not_multi_region":
+        from prowler.providers.aws.services.kms.kms_cmk_not_multi_region.kms_cmk_not_multi_region import (
+            kms_cmk_not_multi_region,
+        )
+
+        return kms_cmk_not_multi_region
+    if check_name == "kms_cmk_rotation_enabled":
+        from prowler.providers.aws.services.kms.kms_cmk_rotation_enabled.kms_cmk_rotation_enabled import (
+            kms_cmk_rotation_enabled,
+        )
+
+        return kms_cmk_rotation_enabled
+    if check_name == "kms_key_not_publicly_accessible":
+        from prowler.providers.aws.services.kms.kms_key_not_publicly_accessible.kms_key_not_publicly_accessible import (
+            kms_key_not_publicly_accessible,
+        )
+
+        return kms_key_not_publicly_accessible
+    if check_name == "kms_key_enclave_attestation_not_enforced":
+        from prowler.providers.aws.services.kms.kms_key_enclave_attestation_not_enforced.kms_key_enclave_attestation_not_enforced import (
+            kms_key_enclave_attestation_not_enforced,
+        )
+
+        return kms_key_enclave_attestation_not_enforced
+    if check_name == "kms_key_enclave_attestation_no_deployment_binding":
+        from prowler.providers.aws.services.kms.kms_key_enclave_attestation_no_deployment_binding.kms_key_enclave_attestation_no_deployment_binding import (
+            kms_key_enclave_attestation_no_deployment_binding,
+        )
+
+        return kms_key_enclave_attestation_no_deployment_binding
+    if check_name == "kms_key_enclave_attestation_unknown_image":
+        from prowler.providers.aws.services.kms.kms_key_enclave_attestation_unknown_image.kms_key_enclave_attestation_unknown_image import (
+            kms_key_enclave_attestation_unknown_image,
+        )
+
+        return kms_key_enclave_attestation_unknown_image
+    if check_name == "kms_key_enclave_attestation_bypassable_path":
+        from prowler.providers.aws.services.kms.kms_key_enclave_attestation_bypassable_path.kms_key_enclave_attestation_bypassable_path import (
+            kms_key_enclave_attestation_bypassable_path,
+        )
+
+        return kms_key_enclave_attestation_bypassable_path
+    if check_name == "kms_key_enclave_attestation_pcr_mismatch":
+        from prowler.providers.aws.services.kms.kms_key_enclave_attestation_pcr_mismatch.kms_key_enclave_attestation_pcr_mismatch import (
+            kms_key_enclave_attestation_pcr_mismatch,
+        )
+
+        return kms_key_enclave_attestation_pcr_mismatch
+    if check_name == "kms_key_enclave_debug_attestation_detected":
+        from prowler.providers.aws.services.kms.kms_key_enclave_debug_attestation_detected.kms_key_enclave_debug_attestation_detected import (
+            kms_key_enclave_debug_attestation_detected,
+        )
+
+        return kms_key_enclave_debug_attestation_detected
+    raise AssertionError(f"Unsupported check: {check_name}")
+
+
+def _execute_with_client(check_name, kms_client):
+    provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+    with mock.patch(
+        "prowler.providers.common.provider.Provider.get_global_provider",
+        return_value=provider,
+    ):
+        check_class = _get_check_class(check_name)
+        with ExitStack() as stack:
+            stack.enter_context(
+                mock.patch(f"{check_class.__module__}.kms_client", new=kms_client)
+            )
+            if check_name in {
+                "kms_key_enclave_attestation_unknown_image",
+                "kms_key_enclave_debug_attestation_detected",
+            }:
+                cloudtrail_client = mock.MagicMock()
+                cloudtrail_client.trails = {}
+                cloudtrail_client.regional_clients = {}
+                stack.enter_context(
+                    mock.patch(
+                        f"{check_class.__module__}.cloudtrail_client",
+                        new=cloudtrail_client,
+                    )
+                )
+            return check_class().execute()
+
+
+@pytest.mark.parametrize("check_name", KMS_CHECKS)
+@mock_aws
+def test_kms_check_reports_regional_inventory_error(check_name):
+    kms_client = FakeKMSClient(
+        scan_errors={AWS_REGION_US_EAST_1: "AccessDeniedException"}
+    )
+
+    result = _execute_with_client(check_name, kms_client)
+
+    inventory_finding = next(
+        finding
+        for finding in result
+        if finding.resource_id == "key/unknown"
+        and "could not be listed" in finding.status_extended
+    )
+    assert inventory_finding.status == "MANUAL"
+    assert inventory_finding.region == AWS_REGION_US_EAST_1
+    assert inventory_finding.resource_arn == (
+        f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/unknown"
+    )
+    assert "AccessDeniedException" in inventory_finding.status_extended
+
+
+@pytest.mark.parametrize("check_name", DETAIL_DEPENDENT_CHECKS)
+@mock_aws
+def test_kms_check_reports_incomplete_key_detail(check_name):
+    kms_client = FakeKMSClient(keys=[IncompleteKey()])
+
+    result = _execute_with_client(check_name, kms_client)
+
+    assert len(result) == 1
+    assert result[0].status == "MANUAL"
+    assert result[0].resource_id == "incomplete-key"
+    assert "could not be described" in result[0].status_extended
+    assert "AccessDeniedException" in result[0].status_extended

--- a/tests/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_test.py
@@ -352,6 +352,7 @@ class Test_kms_key_not_publicly_accessible:
             check = kms_key_not_publicly_accessible()
             result = check.execute()
 
-            assert len(result) == expected_no_of_passes
+            assert len(result) == no_of_keys_created
             statuses = [r.status for r in result]
             assert statuses.count("PASS") == expected_no_of_passes
+            assert statuses.count("MANUAL") == 2

--- a/tests/providers/aws/services/kms/kms_service_test.py
+++ b/tests/providers/aws/services/kms/kms_service_test.py
@@ -1,18 +1,21 @@
 import json
+from unittest import mock
 
+import pytest
 from boto3 import client
+from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from prowler.providers.aws.services.kms.kms_service import KMS
 from tests.providers.aws.utils import (
     AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_provider,
 )
 
 
 class Test_KMS_Service:
-
     # Test KMS Service
     @mock_aws
     def test_service(self):
@@ -60,6 +63,7 @@ class Test_KMS_Service:
         assert len(kms.keys) == 2
         assert kms.keys[0].arn == key1["Arn"]
         assert kms.keys[1].arn == key2["Arn"]
+        assert kms.keys_scan_errors == {}
 
     # Test KMS Describe Keys
     @mock_aws
@@ -85,6 +89,165 @@ class Test_KMS_Service:
         assert kms.keys[0].tags == [
             {"TagKey": "test", "TagValue": "test"},
         ]
+        assert kms.keys[0].detail_retrieved is True
+        assert kms.keys[0].detail_fetch_error is None
+
+    @pytest.mark.parametrize(
+        "error_code", ["AccessDeniedException", "ThrottlingException"]
+    )
+    @mock_aws
+    def test_list_keys_client_error_records_region_and_discards_partial_results(
+        self, error_code
+    ):
+        regional_client = client("kms", region_name=AWS_REGION_US_EAST_1)
+        regional_client.__dict__["region"] = AWS_REGION_US_EAST_1
+
+        class PartialPaginator:
+            def paginate(self):
+                yield {
+                    "Keys": [
+                        {
+                            "KeyId": "partial-key",
+                            "KeyArn": f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/partial-key",
+                        }
+                    ]
+                }
+                raise ClientError(
+                    {
+                        "Error": {
+                            "Code": error_code,
+                            "Message": "not authorized",
+                        }
+                    },
+                    "ListKeys",
+                )
+
+        regional_client.get_paginator = lambda _: PartialPaginator()
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.aws.aws_provider.AwsProvider.generate_regional_clients",
+            return_value={AWS_REGION_US_EAST_1: regional_client},
+        ):
+            kms = KMS(aws_provider)
+
+        assert kms.keys == []
+        assert kms.keys_scan_errors == {AWS_REGION_US_EAST_1: error_code}
+
+    @mock_aws
+    def test_list_keys_error_preserves_successful_regions(self):
+        east_client = client("kms", region_name=AWS_REGION_US_EAST_1)
+        east_client.__dict__["region"] = AWS_REGION_US_EAST_1
+        east_key = east_client.create_key(MultiRegion=False)["KeyMetadata"]
+        west_client = client("kms", region_name=AWS_REGION_EU_WEST_1)
+        west_client.__dict__["region"] = AWS_REGION_EU_WEST_1
+        original_get_paginator = west_client.get_paginator
+
+        def get_west_paginator(operation_name):
+            if operation_name == "list_keys":
+                raise ClientError(
+                    {
+                        "Error": {
+                            "Code": "AccessDeniedException",
+                            "Message": "not authorized",
+                        }
+                    },
+                    "ListKeys",
+                )
+            return original_get_paginator(operation_name)
+
+        west_client.get_paginator = get_west_paginator
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
+
+        with mock.patch(
+            "prowler.providers.aws.aws_provider.AwsProvider.generate_regional_clients",
+            return_value={
+                AWS_REGION_US_EAST_1: east_client,
+                AWS_REGION_EU_WEST_1: west_client,
+            },
+        ):
+            kms = KMS(aws_provider)
+
+        assert [key.id for key in kms.keys] == [east_key["KeyId"]]
+        assert kms.keys[0].detail_retrieved is True
+        assert kms.keys_scan_errors == {AWS_REGION_EU_WEST_1: "AccessDeniedException"}
+
+    @mock_aws
+    def test_list_keys_generic_error_records_error_class(self):
+        regional_client = client("kms", region_name=AWS_REGION_US_EAST_1)
+        regional_client.__dict__["region"] = AWS_REGION_US_EAST_1
+
+        def raise_runtime_error(_):
+            raise RuntimeError("temporary failure")
+
+        regional_client.get_paginator = raise_runtime_error
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.aws.aws_provider.AwsProvider.generate_regional_clients",
+            return_value={AWS_REGION_US_EAST_1: regional_client},
+        ):
+            kms = KMS(aws_provider)
+
+        assert kms.keys == []
+        assert kms.keys_scan_errors == {AWS_REGION_US_EAST_1: "RuntimeError"}
+
+    @mock_aws
+    def test_describe_key_error_records_incomplete_detail(self):
+        regional_client = client("kms", region_name=AWS_REGION_US_EAST_1)
+        regional_client.__dict__["region"] = AWS_REGION_US_EAST_1
+        key = regional_client.create_key()["KeyMetadata"]
+
+        def raise_access_denied(**_):
+            raise ClientError(
+                {
+                    "Error": {
+                        "Code": "AccessDeniedException",
+                        "Message": "not authorized",
+                    }
+                },
+                "DescribeKey",
+            )
+
+        regional_client.describe_key = raise_access_denied
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.aws.aws_provider.AwsProvider.generate_regional_clients",
+            return_value={AWS_REGION_US_EAST_1: regional_client},
+        ):
+            kms = KMS(aws_provider)
+
+        assert len(kms.keys) == 1
+        assert kms.keys[0].id == key["KeyId"]
+        assert kms.keys[0].detail_retrieved is False
+        assert kms.keys[0].detail_fetch_error == "AccessDeniedException"
+        assert kms.keys[0].manager is None
+
+    @mock_aws
+    def test_describe_key_generic_error_records_error_class(self):
+        regional_client = client("kms", region_name=AWS_REGION_US_EAST_1)
+        regional_client.__dict__["region"] = AWS_REGION_US_EAST_1
+        key = regional_client.create_key()["KeyMetadata"]
+
+        def raise_runtime_error(**_):
+            raise RuntimeError("temporary failure")
+
+        regional_client.describe_key = raise_runtime_error
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.aws.aws_provider.AwsProvider.generate_regional_clients",
+            return_value={AWS_REGION_US_EAST_1: regional_client},
+        ):
+            kms = KMS(aws_provider)
+
+        assert len(kms.keys) == 1
+        assert kms.keys[0].id == key["KeyId"]
+        assert kms.keys[0].detail_retrieved is False
+        assert kms.keys[0].detail_fetch_error == "RuntimeError"
 
     # Test KMS Get rotation status
     @mock_aws


### PR DESCRIPTION
### Context

AWS KMS inventory failures were treated as empty or partially valid inventories. This could cause KMS checks to omit findings and the Amazon MSK encryption-at-rest check to report an unverified failure.

Fix #12711

### Description

- Track regional ListKeys failures and discard partial pages for the failed region.
- Track whether DescribeKey completed for each discovered key.
- Emit MANUAL findings when regional inventory, key metadata, or key policy evidence is unavailable.
- Apply the availability handling across the affected KMS checks and the Amazon MSK CMK consumer.
- Add focused regression coverage and a changelog fragment.

No dependencies were added.

### Steps to review

1. Run `uv run pytest tests/providers/aws/services/kms tests/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk`.
2. Verify denied or interrupted ListKeys calls create a regional MANUAL finding without retaining partial regional inventory.
3. Verify DescribeKey failures create per-key MANUAL findings.
4. Verify provisioned Amazon MSK clusters return MANUAL when the referenced KMS evidence is unavailable while serverless behavior is unchanged.

Local result: 219 tests passed.

Security validation: Semgrep default and secrets rules, Bandit, Gitleaks, detect-secrets, and TruffleHog returned no findings.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This issue is listed in the open issues.
- [x] Assignment was requested in issue #12711.
- [x] I reviewed the open pull requests and confirmed there is no existing PR that implements the same outcome.

</details>

- [x] The code is covered by tests.
- [x] The code and documentation follow the Python style guidance.
- [ ] Review if backport is needed.
- [x] The README does not need to change.
- [x] A changelog fragment is included under prowler/changelog.d/.

#### SDK/CLI

- Are there new checks included in this PR? No.
- Provider permissions do not need to change.

#### UI

Not applicable; this is an SDK/CLI change.

#### API

Not applicable; this is an SDK/CLI change.

#### MCP Server

Not applicable; this is an SDK/CLI change.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * KMS checks now report `MANUAL` findings when regional key inventories or key metadata cannot be retrieved.
  * Amazon MSK encryption checks distinguish unverifiable KMS key details from confirmed failures and passes.
  * Public-access checks identify cases where key policies cannot be retrieved and verification is incomplete.
* **Tests**
  * Added coverage for regional inventory failures, incomplete key details, and related manual findings across KMS and MSK checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->