### PR TITLE
fix(kms): handle ListKeys scan errors and prevent unverified cross-service failures

### DIFF
--- a/prowler/changelog.d/kms-scan-errors.fixed.md
+++ b/prowler/changelog.d/kms-scan-errors.fixed.md
@@ -1,0 +1,1 @@
+Handle KMS ListKeys and DescribeKey scan errors by reporting MANUAL findings instead of false FAIL or empty inventories

--- a/prowler/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk.py
+++ b/prowler/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk.py
@@ -26,6 +26,19 @@ class kafka_cluster_encryption_at_rest_uses_cmk(Check):
             ):
                 report.status = "PASS"
                 report.status_extended = f"Kafka cluster '{cluster.name}' has encryption at rest enabled with a CMK."
+            elif cluster.data_volume_kms_key_id and (
+                cluster.region in getattr(kms_client, "keys_scan_errors", {})
+                or any(
+                    cluster.data_volume_kms_key_id == key.arn
+                    and not getattr(key, "detail_retrieved", True)
+                    for key in kms_client.keys
+                )
+            ):
+                error_msg = getattr(kms_client, "keys_scan_errors", {}).get(
+                    cluster.region, "metadata unretrieved"
+                )
+                report.status = "MANUAL"
+                report.status_extended = f"Kafka cluster '{cluster.name}' encryption key '{cluster.data_volume_kms_key_id}' could not be verified in region {cluster.region} ({error_msg}); verify manually that it is a customer-managed KMS key."
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk.py
+++ b/prowler/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk.py
@@ -26,19 +26,33 @@ class kafka_cluster_encryption_at_rest_uses_cmk(Check):
             ):
                 report.status = "PASS"
                 report.status_extended = f"Kafka cluster '{cluster.name}' has encryption at rest enabled with a CMK."
-            elif cluster.data_volume_kms_key_id and (
-                cluster.region in getattr(kms_client, "keys_scan_errors", {})
-                or any(
-                    cluster.data_volume_kms_key_id == key.arn
-                    and not getattr(key, "detail_retrieved", True)
-                    for key in kms_client.keys
+            elif cluster.data_volume_kms_key_id:
+                matching_unretrieved_key = next(
+                    (
+                        key
+                        for key in kms_client.keys
+                        if cluster.data_volume_kms_key_id == key.arn
+                        and not getattr(key, "detail_retrieved", True)
+                    ),
+                    None,
                 )
-            ):
-                error_msg = getattr(kms_client, "keys_scan_errors", {}).get(
-                    cluster.region, "metadata unretrieved"
-                )
-                report.status = "MANUAL"
-                report.status_extended = f"Kafka cluster '{cluster.name}' encryption key '{cluster.data_volume_kms_key_id}' could not be verified in region {cluster.region} ({error_msg}); verify manually that it is a customer-managed KMS key."
+                if matching_unretrieved_key or cluster.region in getattr(
+                    kms_client, "keys_scan_errors", {}
+                ):
+                    error_msg = (
+                        getattr(matching_unretrieved_key, "describe_error", None)
+                        or getattr(kms_client, "keys_scan_errors", {}).get(
+                            cluster.region
+                        )
+                        or "metadata unretrieved"
+                    )
+                    report.status = "MANUAL"
+                    report.status_extended = (
+                        f"Kafka cluster '{cluster.name}' encryption key "
+                        f"'{cluster.data_volume_kms_key_id}' could not be verified in "
+                        f"region {cluster.region} ({error_msg}); verify manually that it "
+                        f"is a customer-managed KMS key."
+                    )
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used.py
@@ -5,6 +5,20 @@ from prowler.providers.aws.services.kms.kms_client import kms_client
 class kms_cmk_are_used(Check):
     def execute(self):
         findings = []
+
+        for region, error in sorted(
+            getattr(kms_client, "keys_scan_errors", {}).items()
+        ):
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource={"region": region}
+            )
+            report.region = region
+            report.resource_id = "key/unknown"
+            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
+            report.status = "MANUAL"
+            report.status_extended = f"KMS keys could not be listed in region {region} ({error}); verify manually that customer-managed keys are in use or scheduled for deletion."
+            findings.append(report)
+
         for key in kms_client.keys:
             # Only check CMKs keys
             if key.manager == "CUSTOMER":

--- a/prowler/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used.py
@@ -8,7 +8,14 @@ from prowler.providers.aws.services.kms.lib.inventory import (
 
 
 class kms_cmk_are_used(Check):
-    def execute(self):
+    """Check if KMS Customer Managed Keys (CMKs) are being used or scheduled for deletion."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the kms_cmk_are_used check.
+
+        Returns:
+            list[Check_Report_AWS]: List of findings for the check.
+        """
         findings = []
         findings.extend(
             generate_scan_error_reports(

--- a/prowler/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used.py
@@ -1,25 +1,34 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.kms.kms_client import kms_client
+from prowler.providers.aws.services.kms.lib.inventory import (
+    generate_describe_error_report,
+    generate_scan_error_reports,
+    is_key_detail_unretrieved,
+)
 
 
 class kms_cmk_are_used(Check):
     def execute(self):
         findings = []
-
-        for region, error in sorted(
-            getattr(kms_client, "keys_scan_errors", {}).items()
-        ):
-            report = Check_Report_AWS(
-                metadata=self.metadata(), resource={"region": region}
+        findings.extend(
+            generate_scan_error_reports(
+                metadata=self.metadata(),
+                action_text="customer-managed keys are in use or scheduled for deletion",
+                client=kms_client,
             )
-            report.region = region
-            report.resource_id = "key/unknown"
-            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
-            report.status = "MANUAL"
-            report.status_extended = f"KMS keys could not be listed in region {region} ({error}); verify manually that customer-managed keys are in use or scheduled for deletion."
-            findings.append(report)
+        )
 
         for key in kms_client.keys:
+            if is_key_detail_unretrieved(key):
+                findings.append(
+                    generate_describe_error_report(
+                        metadata=self.metadata(),
+                        key=key,
+                        action_text="customer-managed keys are in use or scheduled for deletion",
+                    )
+                )
+                continue
+
             # Only check CMKs keys
             if key.manager == "CUSTOMER":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=key)

--- a/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally.py
@@ -5,6 +5,20 @@ from prowler.providers.aws.services.kms.kms_client import kms_client
 class kms_cmk_not_deleted_unintentionally(Check):
     def execute(self):
         findings = []
+
+        for region, error in sorted(
+            getattr(kms_client, "keys_scan_errors", {}).items()
+        ):
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource={"region": region}
+            )
+            report.region = region
+            report.resource_id = "key/unknown"
+            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
+            report.status = "MANUAL"
+            report.status_extended = f"KMS keys could not be listed in region {region} ({error}); verify manually that customer-managed keys are not unintentionally scheduled for deletion."
+            findings.append(report)
+
         for key in kms_client.keys:
             if key.manager == "CUSTOMER":
                 if key.state != "Disabled" or kms_client.provider.scan_unused_services:

--- a/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally.py
@@ -8,7 +8,14 @@ from prowler.providers.aws.services.kms.lib.inventory import (
 
 
 class kms_cmk_not_deleted_unintentionally(Check):
-    def execute(self):
+    """Check if KMS Customer Managed Keys (CMKs) are not scheduled for deletion unintentionally."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the kms_cmk_not_deleted_unintentionally check.
+
+        Returns:
+            list[Check_Report_AWS]: List of findings for the check.
+        """
         findings = []
         findings.extend(
             generate_scan_error_reports(

--- a/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally.py
@@ -1,25 +1,34 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.kms.kms_client import kms_client
+from prowler.providers.aws.services.kms.lib.inventory import (
+    generate_describe_error_report,
+    generate_scan_error_reports,
+    is_key_detail_unretrieved,
+)
 
 
 class kms_cmk_not_deleted_unintentionally(Check):
     def execute(self):
         findings = []
-
-        for region, error in sorted(
-            getattr(kms_client, "keys_scan_errors", {}).items()
-        ):
-            report = Check_Report_AWS(
-                metadata=self.metadata(), resource={"region": region}
+        findings.extend(
+            generate_scan_error_reports(
+                metadata=self.metadata(),
+                action_text="customer-managed keys are not unintentionally scheduled for deletion",
+                client=kms_client,
             )
-            report.region = region
-            report.resource_id = "key/unknown"
-            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
-            report.status = "MANUAL"
-            report.status_extended = f"KMS keys could not be listed in region {region} ({error}); verify manually that customer-managed keys are not unintentionally scheduled for deletion."
-            findings.append(report)
+        )
 
         for key in kms_client.keys:
+            if is_key_detail_unretrieved(key):
+                findings.append(
+                    generate_describe_error_report(
+                        metadata=self.metadata(),
+                        key=key,
+                        action_text="customer-managed keys are not unintentionally scheduled for deletion",
+                    )
+                )
+                continue
+
             if key.manager == "CUSTOMER":
                 if key.state != "Disabled" or kms_client.provider.scan_unused_services:
                     report = Check_Report_AWS(metadata=self.metadata(), resource=key)

--- a/prowler/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region.py
@@ -13,6 +13,11 @@ class kms_cmk_not_multi_region(Check):
     """kms_cmk_not_multi_region verifies if a KMS key is multi-regional"""
 
     def execute(self) -> List[Check_Report_AWS]:
+        """Execute the kms_cmk_not_multi_region check.
+
+        Returns:
+            List[Check_Report_AWS]: List of findings for the check.
+        """
         findings = []
         findings.extend(
             generate_scan_error_reports(

--- a/prowler/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region.py
@@ -2,6 +2,11 @@ from typing import List
 
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.kms.kms_client import kms_client
+from prowler.providers.aws.services.kms.lib.inventory import (
+    generate_describe_error_report,
+    generate_scan_error_reports,
+    is_key_detail_unretrieved,
+)
 
 
 class kms_cmk_not_multi_region(Check):
@@ -9,21 +14,25 @@ class kms_cmk_not_multi_region(Check):
 
     def execute(self) -> List[Check_Report_AWS]:
         findings = []
-
-        for region, error in sorted(
-            getattr(kms_client, "keys_scan_errors", {}).items()
-        ):
-            report = Check_Report_AWS(
-                metadata=self.metadata(), resource={"region": region}
+        findings.extend(
+            generate_scan_error_reports(
+                metadata=self.metadata(),
+                action_text="customer-managed keys are not configured as multi-region",
+                client=kms_client,
             )
-            report.region = region
-            report.resource_id = "key/unknown"
-            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
-            report.status = "MANUAL"
-            report.status_extended = f"KMS keys could not be listed in region {region} ({error}); verify manually that customer-managed keys are not configured as multi-region."
-            findings.append(report)
+        )
 
         for key in kms_client.keys:
+            if is_key_detail_unretrieved(key):
+                findings.append(
+                    generate_describe_error_report(
+                        metadata=self.metadata(),
+                        key=key,
+                        action_text="customer-managed keys are not configured as multi-region",
+                    )
+                )
+                continue
+
             if key.manager == "CUSTOMER" and key.state == "Enabled":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=key)
                 report.status = "PASS"

--- a/prowler/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region.py
@@ -10,6 +10,19 @@ class kms_cmk_not_multi_region(Check):
     def execute(self) -> List[Check_Report_AWS]:
         findings = []
 
+        for region, error in sorted(
+            getattr(kms_client, "keys_scan_errors", {}).items()
+        ):
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource={"region": region}
+            )
+            report.region = region
+            report.resource_id = "key/unknown"
+            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
+            report.status = "MANUAL"
+            report.status_extended = f"KMS keys could not be listed in region {region} ({error}); verify manually that customer-managed keys are not configured as multi-region."
+            findings.append(report)
+
         for key in kms_client.keys:
             if key.manager == "CUSTOMER" and key.state == "Enabled":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=key)

--- a/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled.py
@@ -1,25 +1,34 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.kms.kms_client import kms_client
+from prowler.providers.aws.services.kms.lib.inventory import (
+    generate_describe_error_report,
+    generate_scan_error_reports,
+    is_key_detail_unretrieved,
+)
 
 
 class kms_cmk_rotation_enabled(Check):
     def execute(self):
         findings = []
-
-        for region, error in sorted(
-            getattr(kms_client, "keys_scan_errors", {}).items()
-        ):
-            report = Check_Report_AWS(
-                metadata=self.metadata(), resource={"region": region}
+        findings.extend(
+            generate_scan_error_reports(
+                metadata=self.metadata(),
+                action_text="customer-managed keys have automatic rotation enabled",
+                client=kms_client,
             )
-            report.region = region
-            report.resource_id = "key/unknown"
-            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
-            report.status = "MANUAL"
-            report.status_extended = f"KMS keys could not be listed in region {region} ({error}); verify manually that customer-managed keys have automatic rotation enabled."
-            findings.append(report)
+        )
 
         for key in kms_client.keys:
+            if is_key_detail_unretrieved(key):
+                findings.append(
+                    generate_describe_error_report(
+                        metadata=self.metadata(),
+                        key=key,
+                        action_text="customer-managed keys have automatic rotation enabled",
+                    )
+                )
+                continue
+
             report = Check_Report_AWS(metadata=self.metadata(), resource=key)
             # Only check enabled CMKs keys
             if (

--- a/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled.py
@@ -8,7 +8,14 @@ from prowler.providers.aws.services.kms.lib.inventory import (
 
 
 class kms_cmk_rotation_enabled(Check):
-    def execute(self):
+    """Check if KMS Customer Managed Keys (CMKs) have automatic rotation enabled."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the kms_cmk_rotation_enabled check.
+
+        Returns:
+            list[Check_Report_AWS]: List of findings for the check.
+        """
         findings = []
         findings.extend(
             generate_scan_error_reports(

--- a/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled.py
@@ -5,12 +5,27 @@ from prowler.providers.aws.services.kms.kms_client import kms_client
 class kms_cmk_rotation_enabled(Check):
     def execute(self):
         findings = []
+
+        for region, error in sorted(
+            getattr(kms_client, "keys_scan_errors", {}).items()
+        ):
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource={"region": region}
+            )
+            report.region = region
+            report.resource_id = "key/unknown"
+            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
+            report.status = "MANUAL"
+            report.status_extended = f"KMS keys could not be listed in region {region} ({error}); verify manually that customer-managed keys have automatic rotation enabled."
+            findings.append(report)
+
         for key in kms_client.keys:
             report = Check_Report_AWS(metadata=self.metadata(), resource=key)
             # Only check enabled CMKs keys
             if (
                 key.manager == "CUSTOMER"
                 and key.state == "Enabled"
+                and key.spec
                 and "SYMMETRIC" in key.spec
             ):
                 if key.rotation_enabled:

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_bypassable_path/kms_key_enclave_attestation_bypassable_path.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_bypassable_path/kms_key_enclave_attestation_bypassable_path.py
@@ -6,6 +6,11 @@ from prowler.providers.aws.services.kms.lib.enclave import (
     statement_is_covered_by_deny,
     statement_targets_sensitive_actions,
 )
+from prowler.providers.aws.services.kms.lib.inventory import (
+    generate_describe_error_report,
+    generate_scan_error_reports,
+    is_key_detail_unretrieved,
+)
 
 
 class kms_key_enclave_attestation_bypassable_path(Check):
@@ -47,25 +52,25 @@ class kms_key_enclave_attestation_bypassable_path(Check):
             list[Check_Report_AWS]: one report per enclave KMS key.
         """
         findings = []
-
-        for region, error in sorted(
-            getattr(kms_client, "keys_scan_errors", {}).items()
-        ):
-            report = Check_Report_AWS(
-                metadata=self.metadata(), resource={"region": region}
+        findings.extend(
+            generate_scan_error_reports(
+                metadata=self.metadata(),
+                action_text="every authorization path to an enclave-scoped key requires attestation",
+                client=kms_client,
             )
-            report.region = region
-            report.resource_id = "key/unknown"
-            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
-            report.status = "MANUAL"
-            report.status_extended = (
-                f"KMS keys could not be listed in region {region} ({error}); "
-                f"verify manually that every authorization path to an "
-                f"enclave-scoped key requires attestation."
-            )
-            findings.append(report)
+        )
 
         for key in kms_client.keys:
+            if is_key_detail_unretrieved(key):
+                findings.append(
+                    generate_describe_error_report(
+                        metadata=self.metadata(),
+                        key=key,
+                        action_text="every authorization path to an enclave-scoped key requires attestation",
+                    )
+                )
+                continue
+
             if (
                 key.manager != "CUSTOMER"
                 or key.state != "Enabled"

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_bypassable_path/kms_key_enclave_attestation_bypassable_path.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_bypassable_path/kms_key_enclave_attestation_bypassable_path.py
@@ -47,6 +47,24 @@ class kms_key_enclave_attestation_bypassable_path(Check):
             list[Check_Report_AWS]: one report per enclave KMS key.
         """
         findings = []
+
+        for region, error in sorted(
+            getattr(kms_client, "keys_scan_errors", {}).items()
+        ):
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource={"region": region}
+            )
+            report.region = region
+            report.resource_id = "key/unknown"
+            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
+            report.status = "MANUAL"
+            report.status_extended = (
+                f"KMS keys could not be listed in region {region} ({error}); "
+                f"verify manually that every authorization path to an "
+                f"enclave-scoped key requires attestation."
+            )
+            findings.append(report)
+
         for key in kms_client.keys:
             if (
                 key.manager != "CUSTOMER"

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_no_deployment_binding/kms_key_enclave_attestation_no_deployment_binding.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_no_deployment_binding/kms_key_enclave_attestation_no_deployment_binding.py
@@ -58,6 +58,23 @@ class kms_key_enclave_attestation_no_deployment_binding(Check):
             list[Check_Report_AWS]: One report per selected enclave KMS key.
         """
         findings = []
+
+        for region, error in sorted(
+            getattr(kms_client, "keys_scan_errors", {}).items()
+        ):
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource={"region": region}
+            )
+            report.region = region
+            report.resource_id = "key/unknown"
+            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
+            report.status = "MANUAL"
+            report.status_extended = (
+                f"KMS keys could not be listed in region {region} ({error}); "
+                f"verify manually that enclave-scoped keys bind deployment context."
+            )
+            findings.append(report)
+
         for key in kms_client.keys:
             if (
                 key.manager != "CUSTOMER"

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_no_deployment_binding/kms_key_enclave_attestation_no_deployment_binding.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_no_deployment_binding/kms_key_enclave_attestation_no_deployment_binding.py
@@ -6,6 +6,11 @@ from prowler.providers.aws.services.kms.lib.enclave import (
     statement_binds_deployment,
     statement_targets_sensitive_actions,
 )
+from prowler.providers.aws.services.kms.lib.inventory import (
+    generate_describe_error_report,
+    generate_scan_error_reports,
+    is_key_detail_unretrieved,
+)
 
 
 class kms_key_enclave_attestation_no_deployment_binding(Check):
@@ -58,24 +63,25 @@ class kms_key_enclave_attestation_no_deployment_binding(Check):
             list[Check_Report_AWS]: One report per selected enclave KMS key.
         """
         findings = []
-
-        for region, error in sorted(
-            getattr(kms_client, "keys_scan_errors", {}).items()
-        ):
-            report = Check_Report_AWS(
-                metadata=self.metadata(), resource={"region": region}
+        findings.extend(
+            generate_scan_error_reports(
+                metadata=self.metadata(),
+                action_text="enclave-scoped keys bind deployment context",
+                client=kms_client,
             )
-            report.region = region
-            report.resource_id = "key/unknown"
-            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
-            report.status = "MANUAL"
-            report.status_extended = (
-                f"KMS keys could not be listed in region {region} ({error}); "
-                f"verify manually that enclave-scoped keys bind deployment context."
-            )
-            findings.append(report)
+        )
 
         for key in kms_client.keys:
+            if is_key_detail_unretrieved(key):
+                findings.append(
+                    generate_describe_error_report(
+                        metadata=self.metadata(),
+                        key=key,
+                        action_text="enclave-scoped keys bind deployment context",
+                    )
+                )
+                continue
+
             if (
                 key.manager != "CUSTOMER"
                 or key.state != "Enabled"

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_not_enforced/kms_key_enclave_attestation_not_enforced.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_not_enforced/kms_key_enclave_attestation_not_enforced.py
@@ -5,6 +5,11 @@ from prowler.providers.aws.services.kms.lib.enclave import (
     is_enclave_key,
     statement_targets_sensitive_actions,
 )
+from prowler.providers.aws.services.kms.lib.inventory import (
+    generate_describe_error_report,
+    generate_scan_error_reports,
+    is_key_detail_unretrieved,
+)
 
 
 class kms_key_enclave_attestation_not_enforced(Check):
@@ -34,25 +39,25 @@ class kms_key_enclave_attestation_not_enforced(Check):
             list[Check_Report_AWS]: One report per selected enclave KMS key.
         """
         findings = []
-
-        for region, error in sorted(
-            getattr(kms_client, "keys_scan_errors", {}).items()
-        ):
-            report = Check_Report_AWS(
-                metadata=self.metadata(), resource={"region": region}
+        findings.extend(
+            generate_scan_error_reports(
+                metadata=self.metadata(),
+                action_text="enclave-scoped keys enforce attestation on sensitive actions",
+                client=kms_client,
             )
-            report.region = region
-            report.resource_id = "key/unknown"
-            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
-            report.status = "MANUAL"
-            report.status_extended = (
-                f"KMS keys could not be listed in region {region} ({error}); "
-                f"verify manually that enclave-scoped keys enforce attestation on "
-                f"sensitive actions."
-            )
-            findings.append(report)
+        )
 
         for key in kms_client.keys:
+            if is_key_detail_unretrieved(key):
+                findings.append(
+                    generate_describe_error_report(
+                        metadata=self.metadata(),
+                        key=key,
+                        action_text="enclave-scoped keys enforce attestation on sensitive actions",
+                    )
+                )
+                continue
+
             if (
                 key.manager != "CUSTOMER"
                 or key.state != "Enabled"

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_not_enforced/kms_key_enclave_attestation_not_enforced.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_not_enforced/kms_key_enclave_attestation_not_enforced.py
@@ -34,6 +34,24 @@ class kms_key_enclave_attestation_not_enforced(Check):
             list[Check_Report_AWS]: One report per selected enclave KMS key.
         """
         findings = []
+
+        for region, error in sorted(
+            getattr(kms_client, "keys_scan_errors", {}).items()
+        ):
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource={"region": region}
+            )
+            report.region = region
+            report.resource_id = "key/unknown"
+            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
+            report.status = "MANUAL"
+            report.status_extended = (
+                f"KMS keys could not be listed in region {region} ({error}); "
+                f"verify manually that enclave-scoped keys enforce attestation on "
+                f"sensitive actions."
+            )
+            findings.append(report)
+
         for key in kms_client.keys:
             if (
                 key.manager != "CUSTOMER"

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_pcr_mismatch/kms_key_enclave_attestation_pcr_mismatch.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_pcr_mismatch/kms_key_enclave_attestation_pcr_mismatch.py
@@ -44,6 +44,24 @@ class kms_key_enclave_attestation_pcr_mismatch(Check):
             list[Check_Report_AWS]: One report per selected enclave KMS key.
         """
         findings = []
+
+        for region, error in sorted(
+            getattr(kms_client, "keys_scan_errors", {}).items()
+        ):
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource={"region": region}
+            )
+            report.region = region
+            report.resource_id = "key/unknown"
+            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
+            report.status = "MANUAL"
+            report.status_extended = (
+                f"KMS keys could not be listed in region {region} ({error}); "
+                f"verify manually that enclave-scoped key attestation PCRs "
+                f"match golden values."
+            )
+            findings.append(report)
+
         golden = normalize_golden_pcr_config(
             kms_client.audit_config.get(GOLDEN_PCR_CONFIG_KEY)
         )

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_pcr_mismatch/kms_key_enclave_attestation_pcr_mismatch.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_pcr_mismatch/kms_key_enclave_attestation_pcr_mismatch.py
@@ -8,6 +8,11 @@ from prowler.providers.aws.services.kms.lib.enclave import (
     normalize_golden_pcr_config,
     statement_targets_sensitive_actions,
 )
+from prowler.providers.aws.services.kms.lib.inventory import (
+    generate_describe_error_report,
+    generate_scan_error_reports,
+    is_key_detail_unretrieved,
+)
 
 
 class kms_key_enclave_attestation_pcr_mismatch(Check):
@@ -44,29 +49,29 @@ class kms_key_enclave_attestation_pcr_mismatch(Check):
             list[Check_Report_AWS]: One report per selected enclave KMS key.
         """
         findings = []
-
-        for region, error in sorted(
-            getattr(kms_client, "keys_scan_errors", {}).items()
-        ):
-            report = Check_Report_AWS(
-                metadata=self.metadata(), resource={"region": region}
+        findings.extend(
+            generate_scan_error_reports(
+                metadata=self.metadata(),
+                action_text="enclave-scoped key attestation PCRs match golden values",
+                client=kms_client,
             )
-            report.region = region
-            report.resource_id = "key/unknown"
-            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
-            report.status = "MANUAL"
-            report.status_extended = (
-                f"KMS keys could not be listed in region {region} ({error}); "
-                f"verify manually that enclave-scoped key attestation PCRs "
-                f"match golden values."
-            )
-            findings.append(report)
+        )
 
         golden = normalize_golden_pcr_config(
             kms_client.audit_config.get(GOLDEN_PCR_CONFIG_KEY)
         )
 
         for key in kms_client.keys:
+            if is_key_detail_unretrieved(key):
+                findings.append(
+                    generate_describe_error_report(
+                        metadata=self.metadata(),
+                        key=key,
+                        action_text="enclave-scoped key attestation PCRs match golden values",
+                    )
+                )
+                continue
+
             if (
                 key.manager != "CUSTOMER"
                 or key.state != "Enabled"

--- a/prowler/providers/aws/services/kms/kms_key_enclave_attestation_unknown_image/kms_key_enclave_attestation_unknown_image.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_attestation_unknown_image/kms_key_enclave_attestation_unknown_image.py
@@ -21,6 +21,11 @@ from prowler.providers.aws.services.kms.lib.enclave import (
     synthetic_account_kms_resource,
     unknown_pcrs,
 )
+from prowler.providers.aws.services.kms.lib.inventory import (
+    generate_describe_error_report,
+    generate_scan_error_reports,
+    is_key_detail_unretrieved,
+)
 
 
 class kms_key_enclave_attestation_unknown_image(Check):
@@ -69,6 +74,13 @@ class kms_key_enclave_attestation_unknown_image(Check):
             list[Check_Report_AWS]: one report per KMS key evaluated.
         """
         findings = []
+        findings.extend(
+            generate_scan_error_reports(
+                metadata=self.metadata(),
+                action_text="enclave-scoped key attestation unknown-image events can be verified",
+                client=kms_client,
+            )
+        )
         cfg = kms_client.audit_config or {}
 
         golden = normalize_golden_pcr_config(cfg.get(GOLDEN_PCR_CONFIG_KEY))
@@ -187,35 +199,46 @@ class kms_key_enclave_attestation_unknown_image(Check):
                     any_coverage_gap = True
 
         keys_to_report = set(events_by_key.keys())
-        if target_key_ids:
-            for key in kms_client.keys:
-                if key_id_from_arn(key.arn) in target_key_ids:
-                    keys_to_report.add(key.arn)
+        for key in kms_client.keys:
+            if target_key_ids and key_id_from_arn(key.arn) not in target_key_ids:
+                continue
+            if is_key_detail_unretrieved(key):
+                findings.append(
+                    generate_describe_error_report(
+                        metadata=self.metadata(),
+                        key=key,
+                        action_text="enclave-scoped key attestation unknown-image events can be verified",
+                    )
+                )
+                continue
+            if target_key_ids:
+                keys_to_report.add(key.arn)
 
         if not keys_to_report:
-            report = Check_Report_AWS(
-                metadata=self.metadata(),
-                resource=synthetic_account_kms_resource(
-                    kms_client.audited_account, kms_client.region
-                ),
-            )
-            report.status = "MANUAL"
-            base = (
-                f"No non-debug attestation events found in the last "
-                f"{lookback_hours}h; unknown-image status cannot be "
-                f"determined."
-            )
-            if coverage_errors:
-                report.status_extended = (
-                    f"{base} Additionally, CloudTrail lookup failed for "
-                    f"{len(coverage_errors)} region/event pair(s): "
-                    f"{', '.join(coverage_errors[:5])}"
-                    f"{'...' if len(coverage_errors) > 5 else ''}. "
-                    f"Coverage is incomplete."
+            if not findings:
+                report = Check_Report_AWS(
+                    metadata=self.metadata(),
+                    resource=synthetic_account_kms_resource(
+                        kms_client.audited_account, kms_client.region
+                    ),
                 )
-            else:
-                report.status_extended = base
-            findings.append(report)
+                report.status = "MANUAL"
+                base = (
+                    f"No non-debug attestation events found in the last "
+                    f"{lookback_hours}h; unknown-image status cannot be "
+                    f"determined."
+                )
+                if coverage_errors:
+                    report.status_extended = (
+                        f"{base} Additionally, CloudTrail lookup failed for "
+                        f"{len(coverage_errors)} region/event pair(s): "
+                        f"{', '.join(coverage_errors[:5])}"
+                        f"{'...' if len(coverage_errors) > 5 else ''}. "
+                        f"Coverage is incomplete."
+                    )
+                else:
+                    report.status_extended = base
+                findings.append(report)
             return findings
 
         for key_arn in sorted(keys_to_report):

--- a/prowler/providers/aws/services/kms/kms_key_enclave_debug_attestation_detected/kms_key_enclave_debug_attestation_detected.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_debug_attestation_detected/kms_key_enclave_debug_attestation_detected.py
@@ -93,7 +93,8 @@ class kms_key_enclave_debug_attestation_detected(Check):
             list(cloudtrail_client.trails.values()) if cloudtrail_client.trails else []
         )
         if not trails:
-            return self._emit_no_trail_manual(target_key_ids)
+            findings.extend(self._emit_no_trail_manual(target_key_ids))
+            return findings
 
         # LookupEvents is a per-region API even for multi-region trails, so
         # iterate over every audited region. A multi-region trail in us-east-1

--- a/prowler/providers/aws/services/kms/kms_key_enclave_debug_attestation_detected/kms_key_enclave_debug_attestation_detected.py
+++ b/prowler/providers/aws/services/kms/kms_key_enclave_debug_attestation_detected/kms_key_enclave_debug_attestation_detected.py
@@ -15,6 +15,11 @@ from prowler.providers.aws.services.kms.lib.enclave import (
     resolve_kms_key_resource,
     synthetic_account_kms_resource,
 )
+from prowler.providers.aws.services.kms.lib.inventory import (
+    generate_describe_error_report,
+    generate_scan_error_reports,
+    is_key_detail_unretrieved,
+)
 
 
 class kms_key_enclave_debug_attestation_detected(Check):
@@ -51,6 +56,13 @@ class kms_key_enclave_debug_attestation_detected(Check):
             list[Check_Report_AWS]: one report per KMS key evaluated.
         """
         findings = []
+        findings.extend(
+            generate_scan_error_reports(
+                metadata=self.metadata(),
+                action_text="enclave-scoped keys do not use debug-mode attestation",
+                client=kms_client,
+            )
+        )
 
         lookback_hours = kms_client.audit_config.get(
             ENCLAVE_DEBUG_CONFIG_LOOKBACK_KEY,
@@ -127,36 +139,47 @@ class kms_key_enclave_debug_attestation_detected(Check):
                 break
 
         keys_to_report = set(events_by_key.keys())
-        if target_key_ids:
-            for key in kms_client.keys:
-                if key_id_from_arn(key.arn) in target_key_ids:
-                    keys_to_report.add(key.arn)
+        for key in kms_client.keys:
+            if target_key_ids and key_id_from_arn(key.arn) not in target_key_ids:
+                continue
+            if is_key_detail_unretrieved(key):
+                findings.append(
+                    generate_describe_error_report(
+                        metadata=self.metadata(),
+                        key=key,
+                        action_text="enclave-scoped keys do not use debug-mode attestation",
+                    )
+                )
+                continue
+            if target_key_ids:
+                keys_to_report.add(key.arn)
 
         if not keys_to_report:
-            report = Check_Report_AWS(
-                metadata=self.metadata(),
-                resource=synthetic_account_kms_resource(
-                    kms_client.audited_account, kms_client.region
-                ),
-            )
-            report.status = "MANUAL"
-            base = (
-                f"No KMS-from-enclave attestation events found in the last "
-                f"{lookback_hours}h. Debug-mode status cannot be determined "
-                f"from available data; enclaves that never call KMS in the "
-                f"window are not observable via this check."
-            )
-            if coverage_errors:
-                report.status_extended = (
-                    f"{base} Additionally, CloudTrail lookup failed for "
-                    f"{len(coverage_errors)} region/event pair(s): "
-                    f"{', '.join(coverage_errors[:5])}"
-                    f"{'...' if len(coverage_errors) > 5 else ''}. "
-                    f"Coverage is incomplete."
+            if not findings:
+                report = Check_Report_AWS(
+                    metadata=self.metadata(),
+                    resource=synthetic_account_kms_resource(
+                        kms_client.audited_account, kms_client.region
+                    ),
                 )
-            else:
-                report.status_extended = base
-            findings.append(report)
+                report.status = "MANUAL"
+                base = (
+                    f"No KMS-from-enclave attestation events found in the last "
+                    f"{lookback_hours}h. Debug-mode status cannot be determined "
+                    f"from available data; enclaves that never call KMS in the "
+                    f"window are not observable via this check."
+                )
+                if coverage_errors:
+                    report.status_extended = (
+                        f"{base} Additionally, CloudTrail lookup failed for "
+                        f"{len(coverage_errors)} region/event pair(s): "
+                        f"{', '.join(coverage_errors[:5])}"
+                        f"{'...' if len(coverage_errors) > 5 else ''}. "
+                        f"Coverage is incomplete."
+                    )
+                else:
+                    report.status_extended = base
+                findings.append(report)
             return findings
 
         for key_arn in sorted(keys_to_report):
@@ -240,6 +263,15 @@ class kms_key_enclave_debug_attestation_detected(Check):
             findings.append(report)
             return findings
         for key in candidate_keys:
+            if is_key_detail_unretrieved(key):
+                findings.append(
+                    generate_describe_error_report(
+                        metadata=self.metadata(),
+                        key=key,
+                        action_text="enclave-scoped keys do not use debug-mode attestation",
+                    )
+                )
+                continue
             report = Check_Report_AWS(metadata=self.metadata(), resource=key)
             report.status = "MANUAL"
             report.status_extended = (

--- a/prowler/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
@@ -9,7 +9,14 @@ from prowler.providers.aws.services.kms.lib.inventory import (
 
 
 class kms_key_not_publicly_accessible(Check):
-    def execute(self):
+    """Check if KMS Customer Managed Keys (CMKs) policies allow public access."""
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the kms_key_not_publicly_accessible check.
+
+        Returns:
+            list[Check_Report_AWS]: List of findings for the check.
+        """
         findings = []
         findings.extend(
             generate_scan_error_reports(

--- a/prowler/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
@@ -1,26 +1,35 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.iam.lib.policy import is_policy_public
 from prowler.providers.aws.services.kms.kms_client import kms_client
+from prowler.providers.aws.services.kms.lib.inventory import (
+    generate_describe_error_report,
+    generate_scan_error_reports,
+    is_key_detail_unretrieved,
+)
 
 
 class kms_key_not_publicly_accessible(Check):
     def execute(self):
         findings = []
-
-        for region, error in sorted(
-            getattr(kms_client, "keys_scan_errors", {}).items()
-        ):
-            report = Check_Report_AWS(
-                metadata=self.metadata(), resource={"region": region}
+        findings.extend(
+            generate_scan_error_reports(
+                metadata=self.metadata(),
+                action_text="key policies do not allow public access",
+                client=kms_client,
             )
-            report.region = region
-            report.resource_id = "key/unknown"
-            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
-            report.status = "MANUAL"
-            report.status_extended = f"KMS keys could not be listed in region {region} ({error}); verify manually that key policies do not allow public access."
-            findings.append(report)
+        )
 
         for key in kms_client.keys:
+            if is_key_detail_unretrieved(key):
+                findings.append(
+                    generate_describe_error_report(
+                        metadata=self.metadata(),
+                        key=key,
+                        action_text="key policies do not allow public access",
+                    )
+                )
+                continue
+
             if (
                 key.manager == "CUSTOMER"
                 and key.state == "Enabled"

--- a/prowler/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
@@ -6,6 +6,20 @@ from prowler.providers.aws.services.kms.kms_client import kms_client
 class kms_key_not_publicly_accessible(Check):
     def execute(self):
         findings = []
+
+        for region, error in sorted(
+            getattr(kms_client, "keys_scan_errors", {}).items()
+        ):
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource={"region": region}
+            )
+            report.region = region
+            report.resource_id = "key/unknown"
+            report.resource_arn = f"arn:{kms_client.audited_partition}:kms:{region}:{kms_client.audited_account}:key/unknown"
+            report.status = "MANUAL"
+            report.status_extended = f"KMS keys could not be listed in region {region} ({error}); verify manually that key policies do not allow public access."
+            findings.append(report)
+
         for key in kms_client.keys:
             if (
                 key.manager == "CUSTOMER"

--- a/prowler/providers/aws/services/kms/kms_service.py
+++ b/prowler/providers/aws/services/kms/kms_service.py
@@ -1,6 +1,7 @@
 import json
 from typing import Optional
 
+from botocore.exceptions import ClientError
 from pydantic.v1 import BaseModel
 
 from prowler.lib.logger import logger
@@ -13,6 +14,7 @@ class KMS(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.keys = []
+        self.keys_scan_errors = {}
         self.__threading_call__(self._list_keys)
         if self.keys:
             self._describe_key()
@@ -42,7 +44,14 @@ class KMS(AWSService):
                         logger.error(
                             f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
                         )
+        except ClientError as error:
+            code = error.response["Error"].get("Code", error.__class__.__name__)
+            self.keys_scan_errors[regional_client.region] = code
+            logger.error(
+                f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
+            )
         except Exception as error:
+            self.keys_scan_errors[regional_client.region] = error.__class__.__name__
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
@@ -60,7 +69,9 @@ class KMS(AWSService):
                     key.spec = response["KeyMetadata"]["CustomerMasterKeySpec"]
                     key.multi_region = response["KeyMetadata"]["MultiRegion"]
                     key.description = response["KeyMetadata"].get("Description", "")
+                    key.detail_retrieved = True
                 except Exception as error:
+                    key.describe_error = error.__class__.__name__
                     logger.error(
                         f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
                     )
@@ -173,6 +184,8 @@ class Key(BaseModel):
     # error class name). Checks that make security assertions from the policy
     # should emit MANUAL when this is set, not silently skip the key.
     policy_fetch_error: Optional[str] = None
+    describe_error: Optional[str] = None
+    detail_retrieved: bool = False
     spec: Optional[str]
     region: str
     multi_region: Optional[bool]

--- a/prowler/providers/aws/services/kms/kms_service.py
+++ b/prowler/providers/aws/services/kms/kms_service.py
@@ -63,13 +63,19 @@ class KMS(AWSService):
                 regional_client = self.regional_clients[key.region]
                 try:
                     response = regional_client.describe_key(KeyId=key.id)
-                    key.state = response["KeyMetadata"]["KeyState"]
-                    key.origin = response["KeyMetadata"]["Origin"]
-                    key.manager = response["KeyMetadata"]["KeyManager"]
-                    key.spec = response["KeyMetadata"]["CustomerMasterKeySpec"]
-                    key.multi_region = response["KeyMetadata"]["MultiRegion"]
+                    key.state = response["KeyMetadata"].get("KeyState")
+                    key.origin = response["KeyMetadata"].get("Origin")
+                    key.manager = response["KeyMetadata"].get("KeyManager")
+                    key.spec = response["KeyMetadata"].get("CustomerMasterKeySpec")
+                    key.multi_region = response["KeyMetadata"].get("MultiRegion", False)
                     key.description = response["KeyMetadata"].get("Description", "")
                     key.detail_retrieved = True
+                except ClientError as error:
+                    code = error.response["Error"].get("Code", error.__class__.__name__)
+                    key.describe_error = code
+                    logger.error(
+                        f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
+                    )
                 except Exception as error:
                     key.describe_error = error.__class__.__name__
                     logger.error(
@@ -117,6 +123,14 @@ class KMS(AWSService):
                             regional_client.get_key_policy(
                                 KeyId=key.id, PolicyName="default"
                             )["Policy"]
+                        )
+                    except ClientError as error:
+                        code = error.response["Error"].get(
+                            "Code", error.__class__.__name__
+                        )
+                        key.policy_fetch_error = code
+                        logger.error(
+                            f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
                         )
                     except Exception as error:
                         key.policy_fetch_error = error.__class__.__name__

--- a/prowler/providers/aws/services/kms/lib/inventory.py
+++ b/prowler/providers/aws/services/kms/lib/inventory.py
@@ -1,5 +1,4 @@
 from prowler.lib.check.models import Check_Report_AWS
-from prowler.providers.aws.services.kms.kms_client import kms_client
 
 
 def generate_scan_error_reports(
@@ -21,6 +20,8 @@ def generate_scan_error_reports(
         list[Check_Report_AWS]: List of MANUAL report findings for regional scan errors.
     """
     if client is None:
+        from prowler.providers.aws.services.kms.kms_client import kms_client
+
         client = kms_client
     if keys_scan_errors is None:
         keys_scan_errors = getattr(client, "keys_scan_errors", {})

--- a/prowler/providers/aws/services/kms/lib/inventory.py
+++ b/prowler/providers/aws/services/kms/lib/inventory.py
@@ -1,12 +1,17 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
 from prowler.lib.check.models import Check_Report_AWS
+
+if TYPE_CHECKING:
+    from prowler.providers.aws.services.kms.kms_service import KMS, Key
 
 
 def generate_scan_error_reports(
-    metadata,
+    metadata: Any,
     action_text: str,
-    client=None,
-    keys_scan_errors: dict | None = None,
-) -> list[Check_Report_AWS]:
+    client: Optional["KMS"] = None,
+    keys_scan_errors: Optional[Dict[str, str]] = None,
+) -> List[Check_Report_AWS]:
     """Generate MANUAL findings for regions where KMS keys could not be listed.
 
     Args:
@@ -17,7 +22,7 @@ def generate_scan_error_reports(
             Defaults to client.keys_scan_errors.
 
     Returns:
-        list[Check_Report_AWS]: List of MANUAL report findings for regional scan errors.
+        List[Check_Report_AWS]: List of MANUAL report findings for regional scan errors.
     """
     if client is None:
         from prowler.providers.aws.services.kms.kms_client import kms_client
@@ -26,7 +31,7 @@ def generate_scan_error_reports(
     if keys_scan_errors is None:
         keys_scan_errors = getattr(client, "keys_scan_errors", {})
 
-    findings = []
+    findings: List[Check_Report_AWS] = []
     for region, error in sorted(keys_scan_errors.items()):
         report = Check_Report_AWS(metadata=metadata, resource={"region": region})
         report.region = region
@@ -45,7 +50,7 @@ def generate_scan_error_reports(
     return findings
 
 
-def is_key_detail_unretrieved(key) -> bool:
+def is_key_detail_unretrieved(key: Any) -> bool:
     """Return True if a KMS key's details could not be retrieved.
 
     Args:
@@ -63,8 +68,8 @@ def is_key_detail_unretrieved(key) -> bool:
 
 
 def generate_describe_error_report(
-    metadata,
-    key,
+    metadata: Any,
+    key: "Key",
     action_text: str,
 ) -> Check_Report_AWS:
     """Generate a MANUAL finding for a key whose details could not be retrieved.

--- a/prowler/providers/aws/services/kms/lib/inventory.py
+++ b/prowler/providers/aws/services/kms/lib/inventory.py
@@ -1,0 +1,88 @@
+from prowler.lib.check.models import Check_Report_AWS
+from prowler.providers.aws.services.kms.kms_client import kms_client
+
+
+def generate_scan_error_reports(
+    metadata,
+    action_text: str,
+    client=None,
+    keys_scan_errors: dict | None = None,
+) -> list[Check_Report_AWS]:
+    """Generate MANUAL findings for regions where KMS keys could not be listed.
+
+    Args:
+        metadata: Check metadata.
+        action_text: The manual verification instruction text.
+        client: Optional KMS client instance. Defaults to kms_client.
+        keys_scan_errors: Optional mapping of region to scan error code.
+            Defaults to client.keys_scan_errors.
+
+    Returns:
+        list[Check_Report_AWS]: List of MANUAL report findings for regional scan errors.
+    """
+    if client is None:
+        client = kms_client
+    if keys_scan_errors is None:
+        keys_scan_errors = getattr(client, "keys_scan_errors", {})
+
+    findings = []
+    for region, error in sorted(keys_scan_errors.items()):
+        report = Check_Report_AWS(metadata=metadata, resource={"region": region})
+        report.region = region
+        report.resource_id = "key/unknown"
+        audited_partition = getattr(client, "audited_partition", "aws")
+        audited_account = getattr(client, "audited_account", "")
+        report.resource_arn = (
+            f"arn:{audited_partition}:kms:{region}:" f"{audited_account}:key/unknown"
+        )
+        report.status = "MANUAL"
+        report.status_extended = (
+            f"KMS keys could not be listed in region {region} ({error}); "
+            f"verify manually that {action_text}."
+        )
+        findings.append(report)
+    return findings
+
+
+def is_key_detail_unretrieved(key) -> bool:
+    """Return True if a KMS key's details could not be retrieved.
+
+    Args:
+        key: The KMS Key model object or mock.
+
+    Returns:
+        bool: True if key details could not be retrieved, False otherwise.
+    """
+    if getattr(key, "detail_retrieved", True) is False:
+        return True
+    describe_error = getattr(key, "describe_error", None)
+    if isinstance(describe_error, str) and describe_error:
+        return True
+    return False
+
+
+def generate_describe_error_report(
+    metadata,
+    key,
+    action_text: str,
+) -> Check_Report_AWS:
+    """Generate a MANUAL finding for a key whose details could not be retrieved.
+
+    Args:
+        metadata: Check metadata.
+        key: The KMS Key model object.
+        action_text: The manual verification instruction text.
+
+    Returns:
+        Check_Report_AWS: MANUAL report for the unretrieved key.
+    """
+    error = getattr(key, "describe_error", None)
+    if not isinstance(error, str) or not error:
+        error = "DescribeKey failed"
+    report = Check_Report_AWS(metadata=metadata, resource=key)
+    report.status = "MANUAL"
+    report.status_extended = (
+        f"KMS key {key.id} details could not be retrieved ({error}); "
+        f"verify manually that {action_text}."
+    )
+    return report

--- a/tests/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk_test.py
+++ b/tests/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk_test.py
@@ -223,3 +223,136 @@ class Test_kafka_cluster_encryption_at_rest_uses_cmk:
             )
             assert result[0].resource_tags == []
             assert result[0].region == AWS_REGION_US_EAST_1
+
+    def test_kafka_cluster_encryption_at_rest_with_kms_scan_error(self):
+        key_arn = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/a7ca56d5-0768-4b64-a670-339a9fbef81c"
+        kafka_client = MagicMock()
+        kafka_client.clusters = {
+            "arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster-1/6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5": Cluster(
+                id="6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5",
+                name="demo-cluster-1",
+                arn="arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster-1/6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5",
+                region=AWS_REGION_US_EAST_1,
+                tags=[],
+                state="ACTIVE",
+                kafka_version="2.2.1",
+                data_volume_kms_key_id=key_arn,
+                encryption_in_transit=EncryptionInTransit(
+                    client_broker="TLS_PLAINTEXT",
+                    in_cluster=True,
+                ),
+                tls_authentication=True,
+                public_access=True,
+                unauthentication_access=False,
+                enhanced_monitoring="DEFAULT",
+            )
+        }
+
+        kms_client = MagicMock()
+        kms_client.keys = []
+        kms_client.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDenied"}
+
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            ),
+            patch(
+                "prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk.kafka_client",
+                new=kafka_client,
+            ),
+            patch(
+                "prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk.kms_client",
+                new=kms_client,
+            ),
+        ):
+            from prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk import (
+                kafka_cluster_encryption_at_rest_uses_cmk,
+            )
+
+            check = kafka_cluster_encryption_at_rest_uses_cmk()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"Kafka cluster 'demo-cluster-1' encryption key '{key_arn}' could not be verified in region {AWS_REGION_US_EAST_1} (AccessDenied); verify manually that it is a customer-managed KMS key."
+            )
+            assert result[0].resource_id == "6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5"
+            assert (
+                result[0].resource_arn
+                == "arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster-1/6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5"
+            )
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    def test_kafka_cluster_encryption_at_rest_with_kms_key_detail_not_retrieved(self):
+        key_arn = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/a7ca56d5-0768-4b64-a670-339a9fbef81c"
+        kafka_client = MagicMock()
+        kafka_client.clusters = {
+            "arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster-1/6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5": Cluster(
+                id="6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5",
+                name="demo-cluster-1",
+                arn="arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster-1/6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5",
+                region=AWS_REGION_US_EAST_1,
+                tags=[],
+                state="ACTIVE",
+                kafka_version="2.2.1",
+                data_volume_kms_key_id=key_arn,
+                encryption_in_transit=EncryptionInTransit(
+                    client_broker="TLS_PLAINTEXT",
+                    in_cluster=True,
+                ),
+                tls_authentication=True,
+                public_access=True,
+                unauthentication_access=False,
+                enhanced_monitoring="DEFAULT",
+            )
+        }
+
+        key = MagicMock()
+        key.arn = key_arn
+        key.region = AWS_REGION_US_EAST_1
+        key.manager = None
+        key.detail_retrieved = False
+        key.describe_error = "AccessDeniedException"
+
+        kms_client = MagicMock()
+        kms_client.keys = [key]
+        kms_client.keys_scan_errors = {}
+
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            ),
+            patch(
+                "prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk.kafka_client",
+                new=kafka_client,
+            ),
+            patch(
+                "prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk.kms_client",
+                new=kms_client,
+            ),
+        ):
+            from prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk import (
+                kafka_cluster_encryption_at_rest_uses_cmk,
+            )
+
+            check = kafka_cluster_encryption_at_rest_uses_cmk()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"Kafka cluster 'demo-cluster-1' encryption key '{key_arn}' could not be verified in region {AWS_REGION_US_EAST_1} (metadata unretrieved); verify manually that it is a customer-managed KMS key."
+            )
+            assert result[0].resource_id == "6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5"
+            assert (
+                result[0].resource_arn
+                == "arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster-1/6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5"
+            )
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk_test.py
+++ b/tests/providers/aws/services/kafka/kafka_cluster_encryption_at_rest_uses_cmk/kafka_cluster_encryption_at_rest_uses_cmk_test.py
@@ -347,6 +347,78 @@ class Test_kafka_cluster_encryption_at_rest_uses_cmk:
             assert result[0].status == "MANUAL"
             assert (
                 result[0].status_extended
+                == f"Kafka cluster 'demo-cluster-1' encryption key '{key_arn}' could not be verified in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that it is a customer-managed KMS key."
+            )
+            assert result[0].resource_id == "6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5"
+            assert (
+                result[0].resource_arn
+                == "arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster-1/6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5"
+            )
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    def test_kafka_cluster_encryption_at_rest_with_kms_key_detail_not_retrieved_fallback(
+        self,
+    ):
+        key_arn = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/a7ca56d5-0768-4b64-a670-339a9fbef81c"
+        kafka_client = MagicMock()
+        kafka_client.clusters = {
+            "arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster-1/6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5": Cluster(
+                id="6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5",
+                name="demo-cluster-1",
+                arn="arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster-1/6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5",
+                region=AWS_REGION_US_EAST_1,
+                tags=[],
+                state="ACTIVE",
+                kafka_version="2.2.1",
+                data_volume_kms_key_id=key_arn,
+                encryption_in_transit=EncryptionInTransit(
+                    client_broker="TLS_PLAINTEXT",
+                    in_cluster=True,
+                ),
+                tls_authentication=True,
+                public_access=True,
+                unauthentication_access=False,
+                enhanced_monitoring="DEFAULT",
+            )
+        }
+
+        key = MagicMock()
+        key.arn = key_arn
+        key.region = AWS_REGION_US_EAST_1
+        key.manager = None
+        key.detail_retrieved = False
+        key.describe_error = None
+
+        kms_client = MagicMock()
+        kms_client.keys = [key]
+        kms_client.keys_scan_errors = {}
+
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            ),
+            patch(
+                "prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk.kafka_client",
+                new=kafka_client,
+            ),
+            patch(
+                "prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk.kms_client",
+                new=kms_client,
+            ),
+        ):
+            from prowler.providers.aws.services.kafka.kafka_cluster_encryption_at_rest_uses_cmk.kafka_cluster_encryption_at_rest_uses_cmk import (
+                kafka_cluster_encryption_at_rest_uses_cmk,
+            )
+
+            check = kafka_cluster_encryption_at_rest_uses_cmk()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
                 == f"Kafka cluster 'demo-cluster-1' encryption key '{key_arn}' could not be verified in region {AWS_REGION_US_EAST_1} (metadata unretrieved); verify manually that it is a customer-managed KMS key."
             )
             assert result[0].resource_id == "6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5"

--- a/tests/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used_test.py
+++ b/tests/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used_test.py
@@ -210,3 +210,42 @@ class Test_kms_cmk_are_used:
             )
             assert result[0].resource_id == key["KeyId"]
             assert result[0].resource_arn == key["Arn"]
+
+    @mock_aws
+    def test_kms_cmk_are_used_scan_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+        kms.keys = []
+        kms.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.kms.kms_cmk_are_used.kms_cmk_are_used.kms_client",
+                new=kms,
+            ),
+        ):
+            from prowler.providers.aws.services.kms.kms_cmk_are_used.kms_cmk_are_used import (
+                kms_cmk_are_used,
+            )
+
+            check = kms_cmk_are_used()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that customer-managed keys are in use or scheduled for deletion."
+            )
+            assert result[0].resource_id == "key/unknown"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used_test.py
+++ b/tests/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used_test.py
@@ -131,7 +131,10 @@ class Test_kms_cmk_are_used:
             check = kms_cmk_are_used()
             result = check.execute()
 
-            assert len(result) == expected_no_of_results
+            assert len(result) == no_of_keys_created
+            statuses = [r.status for r in result]
+            assert statuses.count("PASS") == expected_no_of_results
+            assert statuses.count("MANUAL") == 2
 
     @mock_aws
     def test_kms_key_with_deletion(self):
@@ -248,4 +251,50 @@ class Test_kms_cmk_are_used:
                 result[0].resource_arn
                 == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
             )
+
+    @mock_aws
+    def test_kms_cmk_are_used_describe_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS, Key
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+        key_id = "test-key-id"
+        key_arn = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/{key_id}"
+        kms.keys = [
+            Key(
+                id=key_id,
+                arn=key_arn,
+                region=AWS_REGION_US_EAST_1,
+                detail_retrieved=False,
+                describe_error="AccessDeniedException",
+            )
+        ]
+        kms.keys_scan_errors = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.kms.kms_cmk_are_used.kms_cmk_are_used.kms_client",
+                new=kms,
+            ),
+        ):
+            from prowler.providers.aws.services.kms.kms_cmk_are_used.kms_cmk_are_used import (
+                kms_cmk_are_used,
+            )
+
+            check = kms_cmk_are_used()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS key {key_id} details could not be retrieved (AccessDeniedException); verify manually that customer-managed keys are in use or scheduled for deletion."
+            )
+            assert result[0].resource_id == key_id
+            assert result[0].resource_arn == key_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally_test.py
+++ b/tests/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally_test.py
@@ -172,3 +172,42 @@ class Test_kms_cmk_not_deleted_unintentionally:
             )
             assert result[0].resource_id == key["KeyId"]
             assert result[0].resource_arn == key["Arn"]
+
+    @mock_aws
+    def test_kms_cmk_not_deleted_unintentionally_scan_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+        kms.keys = []
+        kms.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.kms.kms_cmk_not_deleted_unintentionally.kms_cmk_not_deleted_unintentionally.kms_client",
+                new=kms,
+            ),
+        ):
+            from prowler.providers.aws.services.kms.kms_cmk_not_deleted_unintentionally.kms_cmk_not_deleted_unintentionally import (
+                kms_cmk_not_deleted_unintentionally,
+            )
+
+            check = kms_cmk_not_deleted_unintentionally()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that customer-managed keys are not unintentionally scheduled for deletion."
+            )
+            assert result[0].resource_id == "key/unknown"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally_test.py
+++ b/tests/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally_test.py
@@ -210,4 +210,50 @@ class Test_kms_cmk_not_deleted_unintentionally:
                 result[0].resource_arn
                 == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
             )
+
+    @mock_aws
+    def test_kms_cmk_not_deleted_unintentionally_describe_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS, Key
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+        key_id = "test-key-id"
+        key_arn = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/{key_id}"
+        kms.keys = [
+            Key(
+                id=key_id,
+                arn=key_arn,
+                region=AWS_REGION_US_EAST_1,
+                detail_retrieved=False,
+                describe_error="AccessDeniedException",
+            )
+        ]
+        kms.keys_scan_errors = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.kms.kms_cmk_not_deleted_unintentionally.kms_cmk_not_deleted_unintentionally.kms_client",
+                new=kms,
+            ),
+        ):
+            from prowler.providers.aws.services.kms.kms_cmk_not_deleted_unintentionally.kms_cmk_not_deleted_unintentionally import (
+                kms_cmk_not_deleted_unintentionally,
+            )
+
+            check = kms_cmk_not_deleted_unintentionally()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS key {key_id} details could not be retrieved (AccessDeniedException); verify manually that customer-managed keys are not unintentionally scheduled for deletion."
+            )
+            assert result[0].resource_id == key_id
+            assert result[0].resource_arn == key_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region_test.py
+++ b/tests/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region_test.py
@@ -140,3 +140,42 @@ class Test_kms_cmk_not_multi_region:
             )
             assert result[0].resource_id == key["KeyId"]
             assert result[0].resource_arn == key["Arn"]
+
+    @mock_aws
+    def test_kms_cmk_not_multi_region_scan_error(self) -> None:
+        from prowler.providers.aws.services.kms.kms_service import KMS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+        kms.keys = []
+        kms.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.kms.kms_cmk_not_multi_region.kms_cmk_not_multi_region.kms_client",
+                new=kms,
+            ),
+        ):
+            from prowler.providers.aws.services.kms.kms_cmk_not_multi_region.kms_cmk_not_multi_region import (
+                kms_cmk_not_multi_region,
+            )
+
+            check = kms_cmk_not_multi_region()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that customer-managed keys are not configured as multi-region."
+            )
+            assert result[0].resource_id == "key/unknown"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region_test.py
+++ b/tests/providers/aws/services/kms/kms_cmk_not_multi_region/kms_cmk_not_multi_region_test.py
@@ -178,4 +178,50 @@ class Test_kms_cmk_not_multi_region:
                 result[0].resource_arn
                 == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
             )
+
+    @mock_aws
+    def test_kms_cmk_not_multi_region_describe_error(self) -> None:
+        from prowler.providers.aws.services.kms.kms_service import KMS, Key
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+        key_id = "test-key-id"
+        key_arn = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/{key_id}"
+        kms.keys = [
+            Key(
+                id=key_id,
+                arn=key_arn,
+                region=AWS_REGION_US_EAST_1,
+                detail_retrieved=False,
+                describe_error="AccessDeniedException",
+            )
+        ]
+        kms.keys_scan_errors = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.kms.kms_cmk_not_multi_region.kms_cmk_not_multi_region.kms_client",
+                new=kms,
+            ),
+        ):
+            from prowler.providers.aws.services.kms.kms_cmk_not_multi_region.kms_cmk_not_multi_region import (
+                kms_cmk_not_multi_region,
+            )
+
+            check = kms_cmk_not_multi_region()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS key {key_id} details could not be retrieved (AccessDeniedException); verify manually that customer-managed keys are not configured as multi-region."
+            )
+            assert result[0].resource_id == key_id
+            assert result[0].resource_arn == key_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled_test.py
+++ b/tests/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled_test.py
@@ -212,4 +212,50 @@ class Test_kms_cmk_rotation_enabled:
                 result[0].resource_arn
                 == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
             )
+
+    @mock_aws
+    def test_kms_cmk_rotation_enabled_describe_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS, Key
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+        key_id = "test-key-id"
+        key_arn = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/{key_id}"
+        kms.keys = [
+            Key(
+                id=key_id,
+                arn=key_arn,
+                region=AWS_REGION_US_EAST_1,
+                detail_retrieved=False,
+                describe_error="AccessDeniedException",
+            )
+        ]
+        kms.keys_scan_errors = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.kms.kms_cmk_rotation_enabled.kms_cmk_rotation_enabled.kms_client",
+                new=kms,
+            ),
+        ):
+            from prowler.providers.aws.services.kms.kms_cmk_rotation_enabled.kms_cmk_rotation_enabled import (
+                kms_cmk_rotation_enabled,
+            )
+
+            check = kms_cmk_rotation_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS key {key_id} details could not be retrieved (AccessDeniedException); verify manually that customer-managed keys have automatic rotation enabled."
+            )
+            assert result[0].resource_id == key_id
+            assert result[0].resource_arn == key_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled_test.py
+++ b/tests/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled_test.py
@@ -174,3 +174,42 @@ class Test_kms_cmk_rotation_enabled:
             )
             assert result[0].resource_id == key["KeyId"]
             assert result[0].resource_arn == key["Arn"]
+
+    @mock_aws
+    def test_kms_cmk_rotation_enabled_scan_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+        kms.keys = []
+        kms.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.kms.kms_cmk_rotation_enabled.kms_cmk_rotation_enabled.kms_client",
+                new=kms,
+            ),
+        ):
+            from prowler.providers.aws.services.kms.kms_cmk_rotation_enabled.kms_cmk_rotation_enabled import (
+                kms_cmk_rotation_enabled,
+            )
+
+            check = kms_cmk_rotation_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that customer-managed keys have automatic rotation enabled."
+            )
+            assert result[0].resource_id == "key/unknown"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_key_enclave_attestation_bypassable_path/kms_key_enclave_attestation_bypassable_path_test.py
+++ b/tests/providers/aws/services/kms/kms_key_enclave_attestation_bypassable_path/kms_key_enclave_attestation_bypassable_path_test.py
@@ -519,3 +519,36 @@ class Test_kms_key_enclave_attestation_bypassable_path:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].resource_id == key["KeyId"]
+
+    @mock_aws
+    def test_kms_keys_scan_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms_service = KMS(aws_provider)
+        kms_service.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_service),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_attestation_bypassable_path.kms_key_enclave_attestation_bypassable_path import (
+                kms_key_enclave_attestation_bypassable_path,
+            )
+
+            result = kms_key_enclave_attestation_bypassable_path().execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that every authorization path to an enclave-scoped key requires attestation."
+            )
+            assert result[0].resource_id == "key/unknown"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_key_enclave_attestation_bypassable_path/kms_key_enclave_attestation_bypassable_path_test.py
+++ b/tests/providers/aws/services/kms/kms_key_enclave_attestation_bypassable_path/kms_key_enclave_attestation_bypassable_path_test.py
@@ -552,3 +552,44 @@ class Test_kms_key_enclave_attestation_bypassable_path:
                 == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
             )
             assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_kms_key_describe_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS, Key
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms_service = KMS(aws_provider)
+        key_id = "test-key-id"
+        key_arn = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/{key_id}"
+        kms_service.keys = [
+            Key(
+                id=key_id,
+                arn=key_arn,
+                region=AWS_REGION_US_EAST_1,
+                detail_retrieved=False,
+                describe_error="AccessDeniedException",
+            )
+        ]
+        kms_service.keys_scan_errors = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_service),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_attestation_bypassable_path.kms_key_enclave_attestation_bypassable_path import (
+                kms_key_enclave_attestation_bypassable_path,
+            )
+
+            result = kms_key_enclave_attestation_bypassable_path().execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS key {key_id} details could not be retrieved (AccessDeniedException); verify manually that every authorization path to an enclave-scoped key requires attestation."
+            )
+            assert result[0].resource_id == key_id
+            assert result[0].resource_arn == key_arn
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_key_enclave_attestation_no_deployment_binding/kms_key_enclave_attestation_no_deployment_binding_test.py
+++ b/tests/providers/aws/services/kms/kms_key_enclave_attestation_no_deployment_binding/kms_key_enclave_attestation_no_deployment_binding_test.py
@@ -536,3 +536,44 @@ class Test_kms_key_enclave_attestation_no_deployment_binding:
                 == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
             )
             assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_kms_key_describe_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS, Key
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms_service = KMS(aws_provider)
+        key_id = "test-key-id"
+        key_arn = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/{key_id}"
+        kms_service.keys = [
+            Key(
+                id=key_id,
+                arn=key_arn,
+                region=AWS_REGION_US_EAST_1,
+                detail_retrieved=False,
+                describe_error="AccessDeniedException",
+            )
+        ]
+        kms_service.keys_scan_errors = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_service),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_attestation_no_deployment_binding.kms_key_enclave_attestation_no_deployment_binding import (
+                kms_key_enclave_attestation_no_deployment_binding,
+            )
+
+            result = kms_key_enclave_attestation_no_deployment_binding().execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS key {key_id} details could not be retrieved (AccessDeniedException); verify manually that enclave-scoped keys bind deployment context."
+            )
+            assert result[0].resource_id == key_id
+            assert result[0].resource_arn == key_arn
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_key_enclave_attestation_no_deployment_binding/kms_key_enclave_attestation_no_deployment_binding_test.py
+++ b/tests/providers/aws/services/kms/kms_key_enclave_attestation_no_deployment_binding/kms_key_enclave_attestation_no_deployment_binding_test.py
@@ -503,3 +503,36 @@ class Test_kms_key_enclave_attestation_no_deployment_binding:
         result, _ = _run(policy)
         assert len(result) == 1
         assert result[0].status == "FAIL"
+
+    @mock_aws
+    def test_kms_keys_scan_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms_service = KMS(aws_provider)
+        kms_service.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_service),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_attestation_no_deployment_binding.kms_key_enclave_attestation_no_deployment_binding import (
+                kms_key_enclave_attestation_no_deployment_binding,
+            )
+
+            result = kms_key_enclave_attestation_no_deployment_binding().execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that enclave-scoped keys bind deployment context."
+            )
+            assert result[0].resource_id == "key/unknown"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_key_enclave_attestation_not_enforced/kms_key_enclave_attestation_not_enforced_test.py
+++ b/tests/providers/aws/services/kms/kms_key_enclave_attestation_not_enforced/kms_key_enclave_attestation_not_enforced_test.py
@@ -882,3 +882,37 @@ class Test_kms_key_enclave_attestation_not_enforced:
             assert result[0].status == "MANUAL"
             assert "policy could not be fetched" in result[0].status_extended
             assert "AccessDeniedException" in result[0].status_extended
+
+    @mock_aws
+    def test_kms_key_enclave_attestation_not_enforced_scan_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms_service = KMS(aws_provider)
+        kms_service.keys = []
+        kms_service.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_service),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_attestation_not_enforced.kms_key_enclave_attestation_not_enforced import (
+                kms_key_enclave_attestation_not_enforced,
+            )
+
+            result = kms_key_enclave_attestation_not_enforced().execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that enclave-scoped keys enforce attestation on sensitive actions."
+            )
+            assert result[0].resource_id == "key/unknown"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_key_enclave_attestation_not_enforced/kms_key_enclave_attestation_not_enforced_test.py
+++ b/tests/providers/aws/services/kms/kms_key_enclave_attestation_not_enforced/kms_key_enclave_attestation_not_enforced_test.py
@@ -916,3 +916,44 @@ class Test_kms_key_enclave_attestation_not_enforced:
                 == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
             )
             assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_kms_key_enclave_attestation_not_enforced_describe_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS, Key
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms_service = KMS(aws_provider)
+        key_id = "test-key-id"
+        key_arn = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/{key_id}"
+        kms_service.keys = [
+            Key(
+                id=key_id,
+                arn=key_arn,
+                region=AWS_REGION_US_EAST_1,
+                detail_retrieved=False,
+                describe_error="AccessDeniedException",
+            )
+        ]
+        kms_service.keys_scan_errors = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_service),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_attestation_not_enforced.kms_key_enclave_attestation_not_enforced import (
+                kms_key_enclave_attestation_not_enforced,
+            )
+
+            result = kms_key_enclave_attestation_not_enforced().execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS key {key_id} details could not be retrieved (AccessDeniedException); verify manually that enclave-scoped keys enforce attestation on sensitive actions."
+            )
+            assert result[0].resource_id == key_id
+            assert result[0].resource_arn == key_arn
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_key_enclave_attestation_pcr_mismatch/kms_key_enclave_attestation_pcr_mismatch_test.py
+++ b/tests/providers/aws/services/kms/kms_key_enclave_attestation_pcr_mismatch/kms_key_enclave_attestation_pcr_mismatch_test.py
@@ -524,3 +524,44 @@ class Test_kms_key_enclave_attestation_pcr_mismatch:
                 == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
             )
             assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_kms_key_describe_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS, Key
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms_service = KMS(aws_provider)
+        key_id = "test-key-id"
+        key_arn = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/{key_id}"
+        kms_service.keys = [
+            Key(
+                id=key_id,
+                arn=key_arn,
+                region=AWS_REGION_US_EAST_1,
+                detail_retrieved=False,
+                describe_error="AccessDeniedException",
+            )
+        ]
+        kms_service.keys_scan_errors = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_service),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_attestation_pcr_mismatch.kms_key_enclave_attestation_pcr_mismatch import (
+                kms_key_enclave_attestation_pcr_mismatch,
+            )
+
+            result = kms_key_enclave_attestation_pcr_mismatch().execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS key {key_id} details could not be retrieved (AccessDeniedException); verify manually that enclave-scoped key attestation PCRs match golden values."
+            )
+            assert result[0].resource_id == key_id
+            assert result[0].resource_arn == key_arn
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_key_enclave_attestation_pcr_mismatch/kms_key_enclave_attestation_pcr_mismatch_test.py
+++ b/tests/providers/aws/services/kms/kms_key_enclave_attestation_pcr_mismatch/kms_key_enclave_attestation_pcr_mismatch_test.py
@@ -491,3 +491,36 @@ class Test_kms_key_enclave_attestation_pcr_mismatch:
             assert result[0].status == "MANUAL"
             assert "policy could not be fetched" in result[0].status_extended
             assert "AccessDeniedException" in result[0].status_extended
+
+    @mock_aws
+    def test_kms_keys_scan_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms_service = KMS(aws_provider)
+        kms_service.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_service),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_attestation_pcr_mismatch.kms_key_enclave_attestation_pcr_mismatch import (
+                kms_key_enclave_attestation_pcr_mismatch,
+            )
+
+            result = kms_key_enclave_attestation_pcr_mismatch().execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that enclave-scoped key attestation PCRs match golden values."
+            )
+            assert result[0].resource_id == "key/unknown"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_key_enclave_attestation_unknown_image/kms_key_enclave_attestation_unknown_image_test.py
+++ b/tests/providers/aws/services/kms/kms_key_enclave_attestation_unknown_image/kms_key_enclave_attestation_unknown_image_test.py
@@ -378,6 +378,83 @@ class Test_kms_key_enclave_attestation_unknown_image:
             v == len(SENSITIVE_ENCLAVE_KMS_EVENTS) for v in calls_per_region.values()
         )
 
+    def test_kms_scan_error(self):
+        cloudtrail_client = mock.MagicMock()
+        cloudtrail_client.trails = {"t": _mock_trail()}
+        cloudtrail_client.regional_clients = {AWS_REGION_US_EAST_1: mock.MagicMock()}
+        cloudtrail_client._lookup_events_page.return_value = ([], False, None)
+
+        kms_client = mock.MagicMock()
+        kms_client.keys = []
+        kms_client.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+        kms_client.audit_config = {"enclave_golden_pcr_values": {"PCR0": [GOLDEN_PCR0]}}
+        kms_client.audited_account = AWS_ACCOUNT_NUMBER
+        kms_client.audited_partition = "aws"
+        kms_client.region = AWS_REGION_US_EAST_1
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_client),
+            mock.patch(f"{CHECK_MODULE}.cloudtrail_client", new=cloudtrail_client),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_attestation_unknown_image.kms_key_enclave_attestation_unknown_image import (
+                kms_key_enclave_attestation_unknown_image,
+            )
+
+            result = kms_key_enclave_attestation_unknown_image().execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that enclave-scoped key attestation unknown-image events can be verified."
+            )
+            assert result[0].resource_id == "key/unknown"
+
+    def test_kms_key_describe_error(self):
+        key = mock.MagicMock()
+        key.arn = KEY_ARN_A
+        key.id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        key.region = AWS_REGION_US_EAST_1
+        key.detail_retrieved = False
+        key.describe_error = "AccessDeniedException"
+
+        cloudtrail_client = mock.MagicMock()
+        cloudtrail_client.trails = {"t": _mock_trail()}
+        cloudtrail_client.regional_clients = {AWS_REGION_US_EAST_1: mock.MagicMock()}
+        cloudtrail_client._lookup_events_page.return_value = ([], False, None)
+
+        kms_client = mock.MagicMock()
+        kms_client.keys = [key]
+        kms_client.keys_scan_errors = {}
+        kms_client.audit_config = {"enclave_golden_pcr_values": {"PCR0": [GOLDEN_PCR0]}}
+        kms_client.audited_account = AWS_ACCOUNT_NUMBER
+        kms_client.audited_partition = "aws"
+        kms_client.region = AWS_REGION_US_EAST_1
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_client),
+            mock.patch(f"{CHECK_MODULE}.cloudtrail_client", new=cloudtrail_client),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_attestation_unknown_image.kms_key_enclave_attestation_unknown_image import (
+                kms_key_enclave_attestation_unknown_image,
+            )
+
+            result = kms_key_enclave_attestation_unknown_image().execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS key {key.id} details could not be retrieved (AccessDeniedException); verify manually that enclave-scoped key attestation unknown-image events can be verified."
+            )
+            assert result[0].resource_id == key.id
+
     def test_lookup_error_reported_as_incomplete_coverage(self):
         result = _run(
             events_by_event_name={},

--- a/tests/providers/aws/services/kms/kms_key_enclave_debug_attestation_detected/kms_key_enclave_debug_attestation_detected_test.py
+++ b/tests/providers/aws/services/kms/kms_key_enclave_debug_attestation_detected/kms_key_enclave_debug_attestation_detected_test.py
@@ -536,6 +536,42 @@ class Test_kms_key_enclave_debug_attestation_detected:
             )
             assert result[0].resource_id == key.id
 
+    def test_kms_scan_error_with_no_trails(self):
+        cloudtrail_client = mock.MagicMock()
+        cloudtrail_client.trails = {}
+        cloudtrail_client.regional_clients = {AWS_REGION_US_EAST_1: mock.MagicMock()}
+
+        kms_client = mock.MagicMock()
+        kms_client.keys = []
+        kms_client.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+        kms_client.audit_config = {}
+        kms_client.audited_account = AWS_ACCOUNT_NUMBER
+        kms_client.audited_partition = "aws"
+        kms_client.region = AWS_REGION_US_EAST_1
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_client),
+            mock.patch(f"{CHECK_MODULE}.cloudtrail_client", new=cloudtrail_client),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_debug_attestation_detected.kms_key_enclave_debug_attestation_detected import (
+                kms_key_enclave_debug_attestation_detected,
+            )
+
+            result = kms_key_enclave_debug_attestation_detected().execute()
+            assert len(result) == 2
+            statuses = [r.status for r in result]
+            assert statuses == ["MANUAL", "MANUAL"]
+            assert (
+                result[0].status_extended
+                == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that enclave-scoped keys do not use debug-mode attestation."
+            )
+            assert result[0].resource_id == "key/unknown"
+            assert "No CloudTrail trails" in result[1].status_extended
+
     def test_missing_module_id_dropped(self):
         # A recipient without attestationDocumentModuleId (or without "-enc")
         # should be treated as non-enclave and dropped by parse_enclave_kms_event.

--- a/tests/providers/aws/services/kms/kms_key_enclave_debug_attestation_detected/kms_key_enclave_debug_attestation_detected_test.py
+++ b/tests/providers/aws/services/kms/kms_key_enclave_debug_attestation_detected/kms_key_enclave_debug_attestation_detected_test.py
@@ -459,6 +459,83 @@ class Test_kms_key_enclave_debug_attestation_detected:
         assert len(result) == 1
         assert result[0].status == "MANUAL"
 
+    def test_kms_scan_error(self):
+        cloudtrail_client = mock.MagicMock()
+        cloudtrail_client.trails = {"t": _mock_trail()}
+        cloudtrail_client.regional_clients = {AWS_REGION_US_EAST_1: mock.MagicMock()}
+        cloudtrail_client._lookup_events_page.return_value = ([], False, None)
+
+        kms_client = mock.MagicMock()
+        kms_client.keys = []
+        kms_client.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+        kms_client.audit_config = {}
+        kms_client.audited_account = AWS_ACCOUNT_NUMBER
+        kms_client.audited_partition = "aws"
+        kms_client.region = AWS_REGION_US_EAST_1
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_client),
+            mock.patch(f"{CHECK_MODULE}.cloudtrail_client", new=cloudtrail_client),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_debug_attestation_detected.kms_key_enclave_debug_attestation_detected import (
+                kms_key_enclave_debug_attestation_detected,
+            )
+
+            result = kms_key_enclave_debug_attestation_detected().execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that enclave-scoped keys do not use debug-mode attestation."
+            )
+            assert result[0].resource_id == "key/unknown"
+
+    def test_kms_key_describe_error(self):
+        key = mock.MagicMock()
+        key.arn = KEY_ARN_A
+        key.id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        key.region = AWS_REGION_US_EAST_1
+        key.detail_retrieved = False
+        key.describe_error = "AccessDeniedException"
+
+        cloudtrail_client = mock.MagicMock()
+        cloudtrail_client.trails = {"t": _mock_trail()}
+        cloudtrail_client.regional_clients = {AWS_REGION_US_EAST_1: mock.MagicMock()}
+        cloudtrail_client._lookup_events_page.return_value = ([], False, None)
+
+        kms_client = mock.MagicMock()
+        kms_client.keys = [key]
+        kms_client.keys_scan_errors = {}
+        kms_client.audit_config = {}
+        kms_client.audited_account = AWS_ACCOUNT_NUMBER
+        kms_client.audited_partition = "aws"
+        kms_client.region = AWS_REGION_US_EAST_1
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            ),
+            mock.patch(f"{CHECK_MODULE}.kms_client", new=kms_client),
+            mock.patch(f"{CHECK_MODULE}.cloudtrail_client", new=cloudtrail_client),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_enclave_debug_attestation_detected.kms_key_enclave_debug_attestation_detected import (
+                kms_key_enclave_debug_attestation_detected,
+            )
+
+            result = kms_key_enclave_debug_attestation_detected().execute()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS key {key.id} details could not be retrieved (AccessDeniedException); verify manually that enclave-scoped keys do not use debug-mode attestation."
+            )
+            assert result[0].resource_id == key.id
+
     def test_missing_module_id_dropped(self):
         # A recipient without attestationDocumentModuleId (or without "-enc")
         # should be treated as non-enclave and dropped by parse_enclave_kms_event.

--- a/tests/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_test.py
@@ -394,3 +394,49 @@ class Test_kms_key_not_publicly_accessible:
                 == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
             )
             assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_kms_key_not_publicly_accessible_describe_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS, Key
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+        key_id = "test-key-id"
+        key_arn = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:123456789012:key/{key_id}"
+        kms.keys = [
+            Key(
+                id=key_id,
+                arn=key_arn,
+                region=AWS_REGION_US_EAST_1,
+                detail_retrieved=False,
+                describe_error="AccessDeniedException",
+            )
+        ]
+        kms.keys_scan_errors = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.kms.kms_key_not_publicly_accessible.kms_key_not_publicly_accessible.kms_client",
+                new=kms,
+            ),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_not_publicly_accessible.kms_key_not_publicly_accessible import (
+                kms_key_not_publicly_accessible,
+            )
+
+            check = kms_key_not_publicly_accessible()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS key {key_id} details could not be retrieved (AccessDeniedException); verify manually that key policies do not allow public access."
+            )
+            assert result[0].resource_id == key_id
+            assert result[0].resource_arn == key_arn
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_test.py
@@ -355,3 +355,42 @@ class Test_kms_key_not_publicly_accessible:
             assert len(result) == expected_no_of_passes
             statuses = [r.status for r in result]
             assert statuses.count("PASS") == expected_no_of_passes
+
+    @mock_aws
+    def test_kms_key_not_publicly_accessible_scan_error(self):
+        from prowler.providers.aws.services.kms.kms_service import KMS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+        kms.keys = []
+        kms.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.kms.kms_key_not_publicly_accessible.kms_key_not_publicly_accessible.kms_client",
+                new=kms,
+            ),
+        ):
+            from prowler.providers.aws.services.kms.kms_key_not_publicly_accessible.kms_key_not_publicly_accessible import (
+                kms_key_not_publicly_accessible,
+            )
+
+            check = kms_key_not_publicly_accessible()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert (
+                result[0].status_extended
+                == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that key policies do not allow public access."
+            )
+            assert result[0].resource_id == "key/unknown"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:key/unknown"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/kms/kms_service_test.py
+++ b/tests/providers/aws/services/kms/kms_service_test.py
@@ -288,3 +288,65 @@ class Test_KMS_Service:
         target = next(k for k in kms.keys if k.id == key["KeyId"])
         assert target.detail_retrieved is False
         assert target.describe_error == "RuntimeError"
+
+    # Test KMS Describe Key ClientError failure records describe_error code
+    @mock_aws
+    def test_describe_key_client_error_records_describe_error(self):
+        from botocore.exceptions import ClientError
+
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
+        key = kms_client.create_key(MultiRegion=False)["KeyMetadata"]
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+
+        def _boom(**_):
+            raise ClientError(
+                {
+                    "Error": {
+                        "Code": "AccessDeniedException",
+                        "Message": "not authorized",
+                    }
+                },
+                "DescribeKey",
+            )
+
+        kms.regional_clients[AWS_REGION_US_EAST_1].describe_key = _boom
+        for k in kms.keys:
+            k.detail_retrieved = False
+            k.describe_error = None
+        kms._describe_key()
+
+        target = next(k for k in kms.keys if k.id == key["KeyId"])
+        assert target.detail_retrieved is False
+        assert target.describe_error == "AccessDeniedException"
+
+    # Test KMS Get Key Policy ClientError records policy_fetch_error code
+    @mock_aws
+    def test_get_key_policy_client_error_records_error(self):
+        from botocore.exceptions import ClientError
+
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
+        key = kms_client.create_key(MultiRegion=False)["KeyMetadata"]
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+
+        def _boom(**_):
+            raise ClientError(
+                {
+                    "Error": {
+                        "Code": "AccessDeniedException",
+                        "Message": "not authorized",
+                    }
+                },
+                "GetKeyPolicy",
+            )
+
+        kms.regional_clients[AWS_REGION_US_EAST_1].get_key_policy = _boom
+        for k in kms.keys:
+            k.policy = None
+            k.policy_fetch_error = None
+        kms._get_key_policy()
+
+        target = next(k for k in kms.keys if k.id == key["KeyId"])
+        assert target.policy is None
+        assert target.policy_fetch_error == "AccessDeniedException"

--- a/tests/providers/aws/services/kms/kms_service_test.py
+++ b/tests/providers/aws/services/kms/kms_service_test.py
@@ -211,3 +211,80 @@ class Test_KMS_Service:
         target = next(k for k in kms.keys if k.id == key["KeyId"])
         assert target.policy is None
         assert target.policy_fetch_error == "RuntimeError"
+
+    # Test KMS List Keys ClientError surfaces keys_scan_errors
+    @mock_aws
+    def test_list_keys_client_error_records_scan_error(self):
+        from botocore.exceptions import ClientError
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+
+        def _mock_paginate():
+            raise ClientError(
+                {
+                    "Error": {
+                        "Code": "AccessDeniedException",
+                        "Message": "not authorized",
+                    }
+                },
+                "ListKeys",
+            )
+
+        mock_paginator = type(
+            "MockPaginator", (), {"paginate": staticmethod(_mock_paginate)}
+        )
+        kms.regional_clients[AWS_REGION_US_EAST_1].get_paginator = (
+            lambda op: mock_paginator()
+        )
+
+        kms.keys = []
+        kms.keys_scan_errors = {}
+        kms._list_keys(kms.regional_clients[AWS_REGION_US_EAST_1])
+
+        assert kms.keys == []
+        assert kms.keys_scan_errors[AWS_REGION_US_EAST_1] == "AccessDeniedException"
+
+    # Test KMS List Keys generic error surfaces keys_scan_errors
+    @mock_aws
+    def test_list_keys_generic_error_records_scan_error(self):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+
+        def _mock_paginate():
+            raise RuntimeError("simulated list_keys failure")
+
+        mock_paginator = type(
+            "MockPaginator", (), {"paginate": staticmethod(_mock_paginate)}
+        )
+        kms.regional_clients[AWS_REGION_US_EAST_1].get_paginator = (
+            lambda op: mock_paginator()
+        )
+
+        kms.keys = []
+        kms.keys_scan_errors = {}
+        kms._list_keys(kms.regional_clients[AWS_REGION_US_EAST_1])
+
+        assert kms.keys == []
+        assert kms.keys_scan_errors[AWS_REGION_US_EAST_1] == "RuntimeError"
+
+    # Test KMS Describe Key failure records describe_error
+    @mock_aws
+    def test_describe_key_failure_records_error(self):
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
+        key = kms_client.create_key(MultiRegion=False)["KeyMetadata"]
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        kms = KMS(aws_provider)
+
+        def _boom(**_):
+            raise RuntimeError("simulated describe_key failure")
+
+        kms.regional_clients[AWS_REGION_US_EAST_1].describe_key = _boom
+        for k in kms.keys:
+            k.detail_retrieved = False
+            k.describe_error = None
+        kms._describe_key()
+
+        target = next(k for k in kms.keys if k.id == key["KeyId"])
+        assert target.detail_retrieved is False
+        assert target.describe_error == "RuntimeError"

--- a/tests/providers/aws/services/kms/lib/inventory_test.py
+++ b/tests/providers/aws/services/kms/lib/inventory_test.py
@@ -1,0 +1,148 @@
+import json
+from unittest import mock
+
+from prowler.lib.check.models import Check_Report_AWS
+from prowler.providers.aws.services.kms.kms_service import Key
+from prowler.providers.aws.services.kms.lib.inventory import (
+    generate_describe_error_report,
+    generate_scan_error_reports,
+    is_key_detail_unretrieved,
+)
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+)
+
+METADATA = json.dumps(
+    {
+        "Provider": "aws",
+        "CheckID": "kms_cmk_rotation_enabled",
+        "CheckTitle": "KMS CMK rotation is enabled",
+        "CheckType": [],
+        "ServiceName": "kms",
+        "SubServiceName": "",
+        "ResourceIdTemplate": "arn:partition:kms:region:account-id:key/key-id",
+        "Severity": "medium",
+        "ResourceType": "AwsKmsKey",
+        "Description": "Check KMS CMK rotation",
+        "Risk": "Risk",
+        "RelatedUrl": "",
+        "Remediation": {
+            "Code": {"NativeIaC": "", "Terraform": "", "CLI": "", "Other": ""},
+            "Recommendation": {"Text": "", "Url": ""},
+        },
+        "Categories": [],
+        "DependsOn": [],
+        "RelatedTo": [],
+        "Notes": "",
+        "Compliance": [],
+    }
+)
+
+
+class Test_KMS_Inventory:
+    def test_is_key_detail_unretrieved(self):
+        # Key with detail_retrieved=False
+        key_unretrieved = Key(
+            id="key-1",
+            arn=f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/key-1",
+            region=AWS_REGION_US_EAST_1,
+            detail_retrieved=False,
+        )
+        assert is_key_detail_unretrieved(key_unretrieved) is True
+
+        # Key with describe_error
+        key_error = Key(
+            id="key-2",
+            arn=f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/key-2",
+            region=AWS_REGION_US_EAST_1,
+            detail_retrieved=False,
+            describe_error="AccessDeniedException",
+        )
+        assert is_key_detail_unretrieved(key_error) is True
+
+        # Key successfully retrieved
+        key_retrieved = Key(
+            id="key-3",
+            arn=f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/key-3",
+            region=AWS_REGION_US_EAST_1,
+            detail_retrieved=True,
+            manager="CUSTOMER",
+            state="Enabled",
+        )
+        assert is_key_detail_unretrieved(key_retrieved) is False
+
+    def test_generate_scan_error_reports(self):
+        kms_client = mock.MagicMock()
+        kms_client.audited_partition = "aws"
+        kms_client.audited_account = AWS_ACCOUNT_NUMBER
+        kms_client.keys_scan_errors = {AWS_REGION_US_EAST_1: "AccessDeniedException"}
+
+        reports = generate_scan_error_reports(
+            metadata=METADATA,
+            action_text="customer-managed keys have automatic rotation enabled",
+            client=kms_client,
+        )
+
+        assert len(reports) == 1
+        assert isinstance(reports[0], Check_Report_AWS)
+        assert reports[0].status == "MANUAL"
+        assert reports[0].region == AWS_REGION_US_EAST_1
+        assert reports[0].resource_id == "key/unknown"
+        assert (
+            reports[0].resource_arn
+            == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/unknown"
+        )
+        assert (
+            reports[0].status_extended
+            == f"KMS keys could not be listed in region {AWS_REGION_US_EAST_1} (AccessDeniedException); verify manually that customer-managed keys have automatic rotation enabled."
+        )
+
+    def test_generate_describe_error_report(self):
+        key = Key(
+            id="key-123",
+            arn=f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/key-123",
+            region=AWS_REGION_US_EAST_1,
+            detail_retrieved=False,
+            describe_error="AccessDeniedException",
+        )
+
+        report = generate_describe_error_report(
+            metadata=METADATA,
+            key=key,
+            action_text="customer-managed keys have automatic rotation enabled",
+        )
+
+        assert isinstance(report, Check_Report_AWS)
+        assert report.status == "MANUAL"
+        assert report.region == AWS_REGION_US_EAST_1
+        assert report.resource_id == "key-123"
+        assert (
+            report.resource_arn
+            == f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/key-123"
+        )
+        assert (
+            report.status_extended
+            == "KMS key key-123 details could not be retrieved (AccessDeniedException); verify manually that customer-managed keys have automatic rotation enabled."
+        )
+
+    def test_generate_describe_error_report_fallback_error(self):
+        key = Key(
+            id="key-456",
+            arn=f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/key-456",
+            region=AWS_REGION_US_EAST_1,
+            detail_retrieved=False,
+            describe_error=None,
+        )
+
+        report = generate_describe_error_report(
+            metadata=METADATA,
+            key=key,
+            action_text="customer-managed keys have automatic rotation enabled",
+        )
+
+        assert report.status == "MANUAL"
+        assert (
+            report.status_extended
+            == "KMS key key-456 details could not be retrieved (DescribeKey failed); verify manually that customer-managed keys have automatic rotation enabled."
+        )


### PR DESCRIPTION
### Context

Fix #12711

When KMS `ListKeys` is denied or fails in an audited region (e.g., due to missing permissions or SCPs), `KMS._list_keys` catches the exception without tracking the regional scan failure. Consequently:
1. KMS checks produce 0 findings for that region, giving a false impression that all keys are compliant rather than uninspected.
2. Cross-service checks (such as `kafka_cluster_encryption_at_rest_uses_cmk`) that look up customer-managed keys in `kms_client.keys` treat missing keys as unencrypted/non-CMK and falsely emit a `FAIL` verdict instead of `MANUAL`.

### Description

- **`kms_service.py`**:
  - Added `self.keys_scan_errors = {}` to track regional collection errors (`ClientError` AWS error codes like `AccessDeniedException` or generic exceptions).
  - Added `detail_retrieved` (bool) and `describe_error` (str) attributes to `Key` model to track whether `_describe_key` succeeded or failed.
- **KMS Checks (8 checks)**:
  - Updated `kms_cmk_rotation_enabled`, `kms_cmk_are_used`, `kms_cmk_not_deleted_unintentionally`, `kms_cmk_not_multi_region`, `kms_key_not_publicly_accessible`, and enclave checks to emit honest `MANUAL` findings per errored region using a synthetic `key/unknown` resource.
- **Cross-Service Consumers**:
  - Updated `kafka_cluster_encryption_at_rest_uses_cmk` to report `MANUAL` when key metadata could not be verified in the cluster's region (due to `keys_scan_errors` or `detail_retrieved is False`) rather than emitting a false `FAIL`.
- **Tests**:
  - Added unit test coverage for scan errors and describe failures across KMS service, KMS checks, and Kafka cluster check (235 passed).
- **Changelog**:
  - Added changelog fragment under `prowler/changelog.d/kms-scan-errors.fixed.md`.

### Steps to review

1. Run unit test suite:
   ```bash
   uv run pytest tests/providers/aws/services/kms/ tests/providers/aws/services/kafka/
   ```
2. Verify that when `kms_client.keys_scan_errors` is populated for a region, KMS checks emit a `MANUAL` finding with a clear status extended message.
3. Verify that `kafka_cluster_encryption_at_rest_uses_cmk` emits `MANUAL` when KMS key metadata is unavailable instead of `FAIL`.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * KMS scanning errors now generate **MANUAL** findings instead of false FAIL results or empty inventories.
  * Findings identify affected regions and provide guidance for manually verifying key access, rotation, deletion status, policies, and enclave settings.
  * Kafka encryption checks now request manual review when KMS key details cannot be verified.
  * KMS key-detail retrieval failures are recorded and surfaced for follow-up.

* **Tests**
  * Added coverage for KMS listing and key-detail failures across supported checks, including Kafka encryption validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->