### PR TITLE
fix(tests): isolate provider mock in agentcore passrole

### DIFF
--- a/tests/providers/aws/services/iam/iam_policy_passrole_to_bedrock_agentcore_restricted/iam_policy_passrole_to_bedrock_agentcore_restricted_test.py
+++ b/tests/providers/aws/services/iam/iam_policy_passrole_to_bedrock_agentcore_restricted/iam_policy_passrole_to_bedrock_agentcore_restricted_test.py
@@ -105,7 +105,8 @@ def _run(policies: list, scan_unused_services: bool = True):
     iam_client = mock.MagicMock()
     iam_client.policies = {policy.arn: policy for policy in policies}
     iam_client.region = AWS_REGION_US_EAST_1
-    iam_client.provider.scan_unused_services = scan_unused_services
+    # Own mock: other test files set MagicMock.provider at class level to a real AwsProvider.
+    iam_client.provider = mock.MagicMock(scan_unused_services=scan_unused_services)
 
     aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 


### PR DESCRIPTION
### Context

`sdk-tests` is red on master since #12664. Every run touching AWS fails with 132 errors in `iam_policy_passrole_to_bedrock_agentcore_restricted_test.py`:

```
AttributeError: property 'scan_unused_services' of 'AwsProvider' object has no setter
```

The file passes on its own, it only fails when run with the rest of the AWS suite.

### Description

Several tests (macie, networkfirewall) do `client = mock.MagicMock` (the class, no parentheses) and then `client.provider = set_mocked_aws_provider(...)`. That leaves a real `AwsProvider` as a class attribute of `MagicMock` for the rest of the worker, so any later `MagicMock().provider` returns it.

The new test did `iam_client.provider.scan_unused_services = ...` on a fresh mock and hit that read-only property.

Fix: give the test its own provider mock, `iam_client.provider = mock.MagicMock(scan_unused_services=...)`.

Cleaning up the class-level `mock.MagicMock` pattern across the test suite is out of scope here.

### Steps to review

```
uv run pytest tests/providers/aws/services/macie tests/providers/aws/services/networkfirewall tests/providers/aws/services/iam/iam_policy_passrole_to_bedrock_agentcore_restricted
```

Fails on master, passes with this change.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by ensuring the IAM test uses its own provider mock.
  * Prevented the test from depending on setup performed by other test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->