### PR TITLE
fix(tests): isolate mock class attrs leaking across tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+from unittest import mock
+
+import pytest
+
+_MOCK_CLASSES = (
+    mock.Mock,
+    mock.MagicMock,
+    mock.AsyncMock,
+    mock.NonCallableMock,
+    mock.NonCallableMagicMock,
+)
+_MOCK_CLASS_BASELINE = {cls: frozenset(vars(cls)) for cls in _MOCK_CLASSES}
+
+
+@pytest.fixture(autouse=True)
+def _reset_mock_class_attributes():
+    """Drop attributes a test sets on the mock classes themselves (`c = mock.MagicMock; c.provider = ...`), so they cannot leak into other tests' instances."""
+    yield
+    for cls, baseline in _MOCK_CLASS_BASELINE.items():
+        for name in set(vars(cls)) - baseline:
+            delattr(cls, name)

--- a/tests/providers/aws/services/iam/iam_policy_no_agentcore_workload_access_token_wildcard/iam_policy_no_agentcore_workload_access_token_wildcard_test.py
+++ b/tests/providers/aws/services/iam/iam_policy_no_agentcore_workload_access_token_wildcard/iam_policy_no_agentcore_workload_access_token_wildcard_test.py
@@ -48,7 +48,7 @@ def _run(policies: list, scan_unused_services: bool = True):
     iam_client = mock.MagicMock()
     iam_client.policies = {policy.arn: policy for policy in policies}
     iam_client.region = AWS_REGION_US_EAST_1
-    iam_client.provider.scan_unused_services = scan_unused_services
+    iam_client.provider = mock.MagicMock(scan_unused_services=scan_unused_services)
 
     aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 

--- a/tests/providers/aws/services/inspector2/inspector2_active_findings_exist/inspector2_active_findings_exist_test.py
+++ b/tests/providers/aws/services/inspector2/inspector2_active_findings_exist/inspector2_active_findings_exist_test.py
@@ -15,7 +15,7 @@ FINDING_ARN = (
 class Test_inspector2_active_findings_exist:
     def test_enabled_no_finding(self):
         # Mock the inspector2 client
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
 
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
@@ -69,7 +69,7 @@ class Test_inspector2_active_findings_exist:
 
     def test_enabled_with_no_active_finding(self):
         # Mock the inspector2 client
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
 
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
@@ -123,7 +123,7 @@ class Test_inspector2_active_findings_exist:
 
     def test_enabled_with_active_finding(self):
         # Mock the inspector2 client
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
 
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
@@ -176,7 +176,7 @@ class Test_inspector2_active_findings_exist:
 
     def test_enabled_with_none_finding(self):
         # Mock the inspector2 client
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
 
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
@@ -219,14 +219,14 @@ class Test_inspector2_active_findings_exist:
 
     def test_inspector2_disabled_ignoring(self):
         # Mock the inspector2 client
-        inspector2_client = mock.MagicMock
-        awslambda_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
+        awslambda_client = mock.MagicMock()
         awslambda_client.functions = {}
-        ecr_client = mock.MagicMock
+        ecr_client = mock.MagicMock()
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION_EU_WEST_1] = mock.MagicMock
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = mock.MagicMock()
         ecr_client.registries[AWS_REGION_EU_WEST_1].repositories = []
-        ec2_client = mock.MagicMock
+        ec2_client = mock.MagicMock()
         ec2_client.instances = []
         ec2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         ecr_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])

--- a/tests/providers/aws/services/inspector2/inspector2_is_enabled/inspector2_is_enabled_test.py
+++ b/tests/providers/aws/services/inspector2/inspector2_is_enabled/inspector2_is_enabled_test.py
@@ -75,10 +75,10 @@ class Test_inspector2_is_enabled:
 
     def test_inspector2_disabled(self):
         # Mock the inspector2 client
-        inspector2_client = mock.MagicMock
-        awslambda_client = mock.MagicMock
-        ecr_client = mock.MagicMock
-        ec2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
+        awslambda_client = mock.MagicMock()
+        ecr_client = mock.MagicMock()
+        ec2_client = mock.MagicMock()
         ec2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         ecr_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         awslambda_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
@@ -133,7 +133,7 @@ class Test_inspector2_is_enabled:
 
     def test_all_enabled(self):
         # Mock the inspector2 client
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -235,7 +235,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_ec2_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -286,7 +286,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_ecr_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -337,7 +337,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_lambda_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -388,7 +388,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_lambda_code_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -439,7 +439,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_ec2_ecr_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -490,7 +490,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_ec2_lambda_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -541,7 +541,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_ec2_lambda_code_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -592,7 +592,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_ecr_lambda_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -643,7 +643,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_ecr_lambda_code_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -694,7 +694,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_lambda_lambda_code_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -745,7 +745,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_ec2_ecr_lambda_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -796,7 +796,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_ec2_ecr_lambda_code_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -847,7 +847,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_ec2_lambda_lambda_code_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (
@@ -898,7 +898,7 @@ class Test_inspector2_is_enabled:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_ecr_lambda_lambda_code_disabled(self):
-        inspector2_client = mock.MagicMock
+        inspector2_client = mock.MagicMock()
         inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
         inspector2_client.audited_account_arn = (

--- a/tests/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled_test.py
+++ b/tests/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled_test.py
@@ -13,7 +13,7 @@ from tests.providers.aws.utils import (
 class Test_macie_automated_sensitive_data_discovery_enabled:
     @mock_aws
     def test_macie_disabled(self):
-        macie_client = mock.MagicMock
+        macie_client = mock.MagicMock()
         macie_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         macie_client.audited_account = AWS_ACCOUNT_NUMBER
         macie_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -56,7 +56,7 @@ class Test_macie_automated_sensitive_data_discovery_enabled:
 
     @mock_aws
     def test_macie_enabled_automated_discovery_disabled(self):
-        macie_client = mock.MagicMock
+        macie_client = mock.MagicMock()
         macie_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         macie_client.audited_account = AWS_ACCOUNT_NUMBER
         macie_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -109,7 +109,7 @@ class Test_macie_automated_sensitive_data_discovery_enabled:
 
     @mock_aws
     def test_macie_enabled_automated_discovery_enabled(self):
-        macie_client = mock.MagicMock
+        macie_client = mock.MagicMock()
         macie_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         macie_client.audited_account = AWS_ACCOUNT_NUMBER
         macie_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"

--- a/tests/providers/aws/services/macie/macie_is_enabled/macie_is_enabled_test.py
+++ b/tests/providers/aws/services/macie/macie_is_enabled/macie_is_enabled_test.py
@@ -14,12 +14,12 @@ from tests.providers.aws.utils import (
 class Test_macie_is_enabled:
     @mock_aws
     def test_macie_disabled(self):
-        s3_client = mock.MagicMock
+        s3_client = mock.MagicMock()
         s3_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         s3_client.buckets = {}
         s3_client.regions_with_buckets = []
 
-        macie_client = mock.MagicMock
+        macie_client = mock.MagicMock()
         macie_client.provider = set_mocked_aws_provider(
             [AWS_REGION_EU_WEST_1], create_default_organization=False
         )
@@ -74,12 +74,12 @@ class Test_macie_is_enabled:
 
     @mock_aws
     def test_macie_enabled(self):
-        s3_client = mock.MagicMock
+        s3_client = mock.MagicMock()
         s3_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         s3_client.buckets = {}
         s3_client.regions_with_buckets = []
 
-        macie_client = mock.MagicMock
+        macie_client = mock.MagicMock()
         macie_client.provider = set_mocked_aws_provider(
             [AWS_REGION_EU_WEST_1], create_default_organization=False
         )
@@ -134,12 +134,12 @@ class Test_macie_is_enabled:
 
     @mock_aws
     def test_macie_suspended_ignored(self):
-        s3_client = mock.MagicMock
+        s3_client = mock.MagicMock()
         s3_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         s3_client.buckets = {}
         s3_client.regions_with_buckets = []
 
-        macie_client = mock.MagicMock
+        macie_client = mock.MagicMock()
         macie_client.provider = set_mocked_aws_provider(
             [AWS_REGION_EU_WEST_1], create_default_organization=False
         )
@@ -189,7 +189,7 @@ class Test_macie_is_enabled:
 
     @mock_aws
     def test_macie_suspended_ignored_with_buckets(self):
-        s3_client = mock.MagicMock
+        s3_client = mock.MagicMock()
         s3_client.regions_with_buckets = [AWS_REGION_EU_WEST_1]
         s3_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         s3_client.buckets = [
@@ -200,7 +200,7 @@ class Test_macie_is_enabled:
             )
         ]
 
-        macie_client = mock.MagicMock
+        macie_client = mock.MagicMock()
         macie_client.provider = set_mocked_aws_provider(
             [AWS_REGION_EU_WEST_1], create_default_organization=False
         )
@@ -258,10 +258,10 @@ class Test_macie_is_enabled:
 
     @mock_aws
     def test_macie_suspended(self):
-        s3_client = mock.MagicMock
+        s3_client = mock.MagicMock()
         s3_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
 
-        macie_client = mock.MagicMock
+        macie_client = mock.MagicMock()
         macie_client.provider = set_mocked_aws_provider(
             [AWS_REGION_EU_WEST_1], create_default_organization=False
         )

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_deletion_protection/networkfirewall_deletion_protection_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_deletion_protection/networkfirewall_deletion_protection_test.py
@@ -14,7 +14,7 @@ POLICY_ARN = "arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/my
 
 class Test_networkfirewall_deletion_protection:
     def test_no_networkfirewall(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -42,7 +42,7 @@ class Test_networkfirewall_deletion_protection:
                 assert len(result) == 0
 
     def test_networkfirewall_deletion_protection_disabled(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -89,7 +89,7 @@ class Test_networkfirewall_deletion_protection:
                 assert result[0].resource_arn == FIREWALL_ARN
 
     def test_networkfirewall_deletion_protection_enabled(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc_test.py
@@ -15,13 +15,13 @@ POLICY_ARN = "arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/my
 
 class Test_networkfirewall_in_all_vpc:
     def test_no_vpcs(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
         networkfirewall_client.network_firewalls = {}
-        vpc_client = mock.MagicMock
+        vpc_client = mock.MagicMock()
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1
         vpc_client.vpcs = {}
@@ -51,7 +51,7 @@ class Test_networkfirewall_in_all_vpc:
                     assert len(result) == 0
 
     def test_vpcs_with_firewall_all(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -68,7 +68,7 @@ class Test_networkfirewall_in_all_vpc:
                 deletion_protection=True,
             )
         }
-        vpc_client = mock.MagicMock
+        vpc_client = mock.MagicMock()
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1
         vpc_client.vpcs = {
@@ -134,13 +134,13 @@ class Test_networkfirewall_in_all_vpc:
                     assert result[0].resource_arn == "arn_test"
 
     def test_vpcs_without_firewall(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
         networkfirewall_client.network_firewalls = {}
-        vpc_client = mock.MagicMock
+        vpc_client = mock.MagicMock()
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1
         vpc_client.vpcs = {
@@ -206,14 +206,14 @@ class Test_networkfirewall_in_all_vpc:
                     assert result[0].resource_arn == "arn_test"
 
     def test_vpcs_with_name_without_firewall(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
         networkfirewall_client.network_firewalls = {}
 
-        vpc_client = mock.MagicMock
+        vpc_client = mock.MagicMock()
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1
         vpc_client.vpcs = {
@@ -279,7 +279,7 @@ class Test_networkfirewall_in_all_vpc:
                     assert result[0].resource_arn == "arn_test"
 
     def test_vpcs_with_and_without_firewall(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -296,7 +296,7 @@ class Test_networkfirewall_in_all_vpc:
                 deletion_protection=True,
             )
         }
-        vpc_client = mock.MagicMock
+        vpc_client = mock.MagicMock()
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1
         vpc_client.vpcs = {
@@ -400,13 +400,13 @@ class Test_networkfirewall_in_all_vpc:
                             assert r.resource_arn == "arn_test"
 
     def test_vpcs_without_firewall_ignoring(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
         networkfirewall_client.network_firewalls = {}
-        vpc_client = mock.MagicMock
+        vpc_client = mock.MagicMock()
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1
         vpc_client.vpcs = {
@@ -464,13 +464,13 @@ class Test_networkfirewall_in_all_vpc:
                     assert len(result) == 0
 
     def test_vpcs_without_firewall_ignoring_vpc_in_use(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
         networkfirewall_client.network_firewalls = {}
-        vpc_client = mock.MagicMock
+        vpc_client = mock.MagicMock()
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1
         vpc_client.vpcs = {

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_logging_enabled/networkfirewall_logging_enabled_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_logging_enabled/networkfirewall_logging_enabled_test.py
@@ -17,7 +17,7 @@ POLICY_ARN = "arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/my
 
 class Test_networkfirewall_logging_enabled:
     def test_no_networkfirewall(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -45,7 +45,7 @@ class Test_networkfirewall_logging_enabled:
                 assert len(result) == 0
 
     def test_networkfirewall_logging_disabled(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -93,7 +93,7 @@ class Test_networkfirewall_logging_enabled:
                 assert result[0].resource_arn == FIREWALL_ARN
 
     def test_networkfirewall_logging_enabled(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_multi_az/networkfirewall_multi_az_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_multi_az/networkfirewall_multi_az_test.py
@@ -16,7 +16,7 @@ POLICY_ARN = "arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/my
 
 class Test_networkfirewall_multi_az:
     def test_no_networkfirewall(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -44,7 +44,7 @@ class Test_networkfirewall_multi_az:
                 assert len(result) == 0
 
     def test_networkfirewall_multi_az_disabled(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -97,7 +97,7 @@ class Test_networkfirewall_multi_az:
                 assert result[0].resource_arn == FIREWALL_ARN
 
     def test_networkfirewall_multi_az_enabled(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_policy_default_action_fragmented_packets/networkfirewall_policy_default_action_fragmented_packets_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_policy_default_action_fragmented_packets/networkfirewall_policy_default_action_fragmented_packets_test.py
@@ -14,7 +14,7 @@ POLICY_ARN = "arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/my
 
 class Test_networkfirewall_policy_default_action_fragmented_packets:
     def test_no_networkfirewall(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -42,7 +42,7 @@ class Test_networkfirewall_policy_default_action_fragmented_packets:
                 assert len(result) == 0
 
     def test_networkfirewall_default_stateless_action_drop(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -90,7 +90,7 @@ class Test_networkfirewall_policy_default_action_fragmented_packets:
                 assert result[0].resource_arn == FIREWALL_ARN
 
     def test_networkfirewall_default_stateless_action_forward(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -139,7 +139,7 @@ class Test_networkfirewall_policy_default_action_fragmented_packets:
                 assert result[0].resource_arn == FIREWALL_ARN
 
     def test_networkfirewall_default_stateless_action_pass(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_policy_default_action_full_packets/networkfirewall_policy_default_action_full_packets_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_policy_default_action_full_packets/networkfirewall_policy_default_action_full_packets_test.py
@@ -14,7 +14,7 @@ POLICY_ARN = "arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/my
 
 class Test_networkfirewall_policy_default_action_full_packets:
     def test_no_networkfirewall(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -42,7 +42,7 @@ class Test_networkfirewall_policy_default_action_full_packets:
                 assert len(result) == 0
 
     def test_networkfirewall_policy_default_action_drop(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -90,7 +90,7 @@ class Test_networkfirewall_policy_default_action_full_packets:
                 assert result[0].resource_arn == FIREWALL_ARN
 
     def test_networkfirewall_policy_default_action_forward(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -139,7 +139,7 @@ class Test_networkfirewall_policy_default_action_full_packets:
                 assert result[0].resource_arn == FIREWALL_ARN
 
     def test_networkfirewall_policy_default_action_pass(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_policy_rule_group_associated/networkfirewall_policy_rule_group_associated_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_policy_rule_group_associated/networkfirewall_policy_rule_group_associated_test.py
@@ -14,7 +14,7 @@ POLICY_ARN = "arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/my
 
 class Test_networkfirewall_policy_rule_group_associated:
     def test_no_networkfirewall(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -42,7 +42,7 @@ class Test_networkfirewall_policy_rule_group_associated:
                 assert len(result) == 0
 
     def test_networkfirewall_policy_stateless_rule_group_associated(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -92,7 +92,7 @@ class Test_networkfirewall_policy_rule_group_associated:
                 assert result[0].resource_arn == FIREWALL_ARN
 
     def test_networkfirewall_policy_stateful_rule_group_associated(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -142,7 +142,7 @@ class Test_networkfirewall_policy_rule_group_associated:
                 assert result[0].resource_arn == FIREWALL_ARN
 
     def test_networkfirewall_policy_both_rule_groups_associated(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
@@ -196,7 +196,7 @@ class Test_networkfirewall_policy_rule_group_associated:
                 assert result[0].resource_arn == FIREWALL_ARN
 
     def test_networkfirewall_policy_no_rule_groups_associated(self):
-        networkfirewall_client = mock.MagicMock
+        networkfirewall_client = mock.MagicMock()
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )


### PR DESCRIPTION
### Context

`iam_policy_no_agentcore_workload_access_token_wildcard` and `iam_policy_passrole_to_bedrock_agentcore_restricted` fail randomly in CI with `can't set attribute 'scan_unused_services'` (see #12713, #12714). #12724 fixed only the first file that hit it.

The real cause is older. Several tests use the `MagicMock` class itself as the client (`macie_client = mock.MagicMock`) and then set `macie_client.provider = set_mocked_aws_provider(...)`. That leaves a real `AwsProvider` as a class attribute on `MagicMock`, so every `MagicMock()` in the same xdist worker gets it. `scan_unused_services` is a read-only property there, so any later test that writes `client.provider.scan_unused_services = ...` blows up. It only shows when xdist puts one of those tests before the victim in the same worker, hence the flakiness.

### Description

- New `tests/conftest.py` with an autouse fixture that removes any attribute a test leaves on the mock classes (`Mock`, `MagicMock`, `AsyncMock`, `NonCallable*`). This is what stops it from happening again.
- The 11 AWS tests that set `.provider` on the class (macie, inspector2, networkfirewall) now use `mock.MagicMock()` instances.
- `iam_policy_no_agentcore_workload_access_token_wildcard` gets its own provider mock, same as #12724.

Tests that patch the service class (e.g. `sns_service.SNS`) are left as they are: they rely on class attribute inheritance to work and the fixture already covers their leak.

### Steps to review

Deterministic repro on master (fails 75 tests):

```
uv run pytest -p no:xdist tests/providers/aws/services/macie/macie_is_enabled tests/providers/aws/services/iam/iam_policy_no_agentcore_workload_access_token_wildcard
```

Same command on this branch passes. Full `tests/` run with `-n auto` locally.

Needs backport to `v5.41`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test isolation by preventing mock attributes from leaking between tests.
  * Corrected mocked AWS service clients so tests consistently use independent mock instances.

* **Tests**
  * Updated IAM, Inspector2, Macie, and Network Firewall test coverage with reliable mock setup.
  * Preserved all existing test scenarios, assertions, and expected behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->