### PR TITLE
fix(compliance): add M365 mappings to Cyber Essentials 3.3

### DIFF
--- a/prowler/changelog.d/cyber-essentials-3.3-m365.added.md
+++ b/prowler/changelog.d/cyber-essentials-3.3-m365.added.md
@@ -1,0 +1,1 @@
+M365 check mappings for the NCSC Cyber Essentials 3.3 compliance framework

--- a/prowler/compliance/cyber_essentials_3.3.json
+++ b/prowler/compliance/cyber_essentials_3.3.json
@@ -132,7 +132,8 @@
           "network_ssh_internet_access_restricted",
           "network_udp_internet_access_restricted",
           "network_http_internet_access_restricted"
-        ]
+        ],
+        "m365": []
       }
     },
     {
@@ -147,7 +148,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     },
     {
@@ -168,6 +170,10 @@
           "keyvault_access_only_through_private_endpoints",
           "network_rdp_internet_access_restricted",
           "network_ssh_internet_access_restricted"
+        ],
+        "m365": [
+          "entra_conditional_access_policy_require_mfa_for_management_api",
+          "entra_conditional_access_policy_untrusted_locations_blocked"
         ]
       }
     },
@@ -189,7 +195,8 @@
           "network_udp_internet_access_restricted",
           "network_http_internet_access_restricted",
           "storage_account_public_network_access_disabled"
-        ]
+        ],
+        "m365": []
       }
     },
     {
@@ -204,7 +211,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     },
     {
@@ -219,7 +227,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     },
     {
@@ -234,7 +243,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     },
     {
@@ -252,7 +262,8 @@
         "azure": [
           "entra_policy_guest_users_access_restrictions",
           "entra_policy_guest_invite_only_for_admin_roles"
-        ]
+        ],
+        "m365": []
       }
     },
     {
@@ -269,6 +280,10 @@
       "checks": {
         "azure": [
           "entra_security_defaults_enabled"
+        ],
+        "m365": [
+          "entra_password_protection_custom_banned_list_enforced",
+          "entra_password_protection_on_premises_enforced"
         ]
       }
     },
@@ -284,7 +299,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     },
     {
@@ -299,7 +315,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     },
     {
@@ -320,6 +337,13 @@
           "storage_account_public_network_access_disabled",
           "storage_ensure_minimum_tls_version_12",
           "keyvault_rbac_enabled"
+        ],
+        "m365": [
+          "entra_legacy_authentication_blocked",
+          "exchange_organization_modern_authentication_enabled",
+          "sharepoint_modern_authentication_required",
+          "teams_meeting_anonymous_user_join_disabled",
+          "teams_meeting_chat_anonymous_users_disabled"
         ]
       }
     },
@@ -335,7 +359,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     },
     {
@@ -350,7 +375,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     },
     {
@@ -365,7 +391,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     },
     {
@@ -380,7 +407,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     },
     {
@@ -398,7 +426,8 @@
         "azure": [
           "defender_ensure_system_updates_are_applied",
           "defender_auto_provisioning_vulnerabilty_assessments_machines_on"
-        ]
+        ],
+        "m365": []
       }
     },
     {
@@ -413,7 +442,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     },
     {
@@ -431,7 +461,8 @@
         "azure": [
           "entra_security_defaults_enabled",
           "storage_default_to_entra_authorization_enabled"
-        ]
+        ],
+        "m365": []
       }
     },
     {
@@ -446,7 +477,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     },
     {
@@ -467,6 +499,11 @@
           "entra_conditional_access_policy_require_mfa_for_admin_portals",
           "entra_conditional_access_policy_require_mfa_for_management_api",
           "entra_user_with_vm_access_has_mfa"
+        ],
+        "m365": [
+          "entra_users_mfa_enabled",
+          "entra_conditional_access_policy_mfa_enforced_for_guest_users",
+          "entra_conditional_access_policy_require_mfa_for_management_api"
         ]
       }
     },
@@ -486,7 +523,8 @@
           "entra_global_admin_in_less_than_five_users",
           "iam_role_user_access_admin_restricted",
           "iam_subscription_roles_owner_custom_not_created"
-        ]
+        ],
+        "m365": []
       }
     },
     {
@@ -504,7 +542,8 @@
         "azure": [
           "entra_global_admin_in_less_than_five_users",
           "iam_role_user_access_admin_restricted"
-        ]
+        ],
+        "m365": []
       }
     },
     {
@@ -522,6 +561,11 @@
         "azure": [
           "entra_security_defaults_enabled",
           "entra_privileged_user_has_mfa"
+        ],
+        "m365": [
+          "entra_users_mfa_enabled",
+          "entra_password_protection_lockout_threshold_limited",
+          "entra_password_protection_lockout_duration_configured"
         ]
       }
     },
@@ -541,6 +585,12 @@
           "entra_security_defaults_enabled",
           "entra_privileged_user_has_mfa",
           "entra_non_privileged_user_has_mfa"
+        ],
+        "m365": [
+          "entra_users_mfa_enabled",
+          "entra_password_protection_custom_banned_list_enforced",
+          "entra_password_protection_on_premises_enforced",
+          "admincenter_settings_password_never_expire"
         ]
       }
     },
@@ -560,6 +610,12 @@
           "defender_assessments_vm_endpoint_protection_installed",
           "defender_ensure_wdatp_is_enabled",
           "defender_ensure_defender_for_server_is_on"
+        ],
+        "m365": [
+          "defender_malware_policy_common_attachments_filter_enabled",
+          "defender_safe_attachments_policy_enabled",
+          "defender_atp_safe_attachments_and_docs_configured",
+          "defender_zap_for_teams_enabled"
         ]
       }
     },
@@ -579,6 +635,14 @@
           "defender_ensure_wdatp_is_enabled",
           "defender_ensure_defender_for_server_is_on",
           "defender_ensure_defender_for_storage_is_on"
+        ],
+        "m365": [
+          "defender_strict_preset_security_policy_enabled",
+          "defender_malware_policy_comprehensive_attachments_filter_applied",
+          "defender_safe_attachments_policy_enabled",
+          "defender_atp_safe_attachments_and_docs_configured",
+          "defender_zap_for_teams_enabled",
+          "defender_safelinks_policy_enabled"
         ]
       }
     },
@@ -594,7 +658,8 @@
         "References": "NCSC Cyber Essentials: Requirements for IT Infrastructure v3.3 (April 2026), Section E"
       },
       "checks": {
-        "azure": []
+        "azure": [],
+        "m365": []
       }
     }
   ]

--- a/tests/lib/check/universal_compliance_models_test.py
+++ b/tests/lib/check/universal_compliance_models_test.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic.v1 import ValidationError
 
+from prowler.config.config import get_available_compliance_frameworks
 from prowler.lib.check.compliance_models import (
     AttributeMetadata,
     ChartConfig,
@@ -908,13 +909,139 @@ class TestCyberEssentialsFramework:
         )
         return os.path.normpath(base)
 
-    def test_loads_and_supports_azure(self):
+    def test_loads_and_supports_azure_and_m365(self):
         fw = load_compliance_framework_universal(self._path())
         assert fw is not None
         assert fw.framework == "Cyber-Essentials"
         assert fw.version == "3.3"
-        assert fw.get_providers() == ["azure"]
+        assert fw.get_providers() == ["azure", "m365"]
         assert fw.supports_provider("azure")
+        assert fw.supports_provider("m365")
+
+    def test_every_requirement_declares_m365_checks(self):
+        fw = load_compliance_framework_universal(self._path())
+        assert fw is not None
+        assert len(fw.requirements) == 28
+
+        missing = [req.id for req in fw.requirements if "m365" not in req.checks]
+        assert not missing, f"Requirements without M365 mappings: {missing}"
+
+    def test_m365_mappings_reference_existing_checks(self):
+        fw = load_compliance_framework_universal(self._path())
+        assert fw is not None
+
+        referenced = {
+            check
+            for requirement in fw.requirements
+            for check in requirement.checks.get("m365", [])
+        }
+        assert referenced, "Cyber Essentials must reference M365 checks"
+
+        services_dir = os.path.normpath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "..",
+                "..",
+                "prowler",
+                "providers",
+                "m365",
+                "services",
+            )
+        )
+        existing = {
+            filename.removesuffix(".metadata.json")
+            for _, _, files in os.walk(services_dir)
+            for filename in files
+            if filename.endswith(".metadata.json")
+        }
+        missing = sorted(referenced - existing)
+        assert not missing, f"M365 checks that do not exist: {missing}"
+
+    def test_m365_mappings_and_inventory_are_exact(self):
+        fw = load_compliance_framework_universal(self._path())
+        assert fw is not None
+
+        expected = {
+            "CE-FW-01": [],
+            "CE-FW-02": [],
+            "CE-FW-03": [
+                "entra_conditional_access_policy_require_mfa_for_management_api",
+                "entra_conditional_access_policy_untrusted_locations_blocked",
+            ],
+            "CE-FW-04": [],
+            "CE-FW-05": [],
+            "CE-FW-06": [],
+            "CE-FW-07": [],
+            "CE-SC-01": [],
+            "CE-SC-02": [
+                "entra_password_protection_custom_banned_list_enforced",
+                "entra_password_protection_on_premises_enforced",
+            ],
+            "CE-SC-03": [],
+            "CE-SC-04": [],
+            "CE-SC-05": [
+                "entra_legacy_authentication_blocked",
+                "exchange_organization_modern_authentication_enabled",
+                "sharepoint_modern_authentication_required",
+                "teams_meeting_anonymous_user_join_disabled",
+                "teams_meeting_chat_anonymous_users_disabled",
+            ],
+            "CE-SC-06": [],
+            "CE-SUM-01": [],
+            "CE-SUM-02": [],
+            "CE-SUM-03": [],
+            "CE-SUM-04": [],
+            "CE-UAC-01": [],
+            "CE-UAC-02": [],
+            "CE-UAC-03": [],
+            "CE-UAC-04": [
+                "entra_users_mfa_enabled",
+                "entra_conditional_access_policy_mfa_enforced_for_guest_users",
+                "entra_conditional_access_policy_require_mfa_for_management_api",
+            ],
+            "CE-UAC-05": [],
+            "CE-UAC-06": [],
+            "CE-UAC-07": [
+                "entra_users_mfa_enabled",
+                "entra_password_protection_lockout_threshold_limited",
+                "entra_password_protection_lockout_duration_configured",
+            ],
+            "CE-UAC-08": [
+                "entra_users_mfa_enabled",
+                "entra_password_protection_custom_banned_list_enforced",
+                "entra_password_protection_on_premises_enforced",
+                "admincenter_settings_password_never_expire",
+            ],
+            "CE-MP-01": [
+                "defender_malware_policy_common_attachments_filter_enabled",
+                "defender_safe_attachments_policy_enabled",
+                "defender_atp_safe_attachments_and_docs_configured",
+                "defender_zap_for_teams_enabled",
+            ],
+            "CE-MP-02": [
+                "defender_strict_preset_security_policy_enabled",
+                "defender_malware_policy_comprehensive_attachments_filter_applied",
+                "defender_safe_attachments_policy_enabled",
+                "defender_atp_safe_attachments_and_docs_configured",
+                "defender_zap_for_teams_enabled",
+                "defender_safelinks_policy_enabled",
+            ],
+            "CE-MP-03": [],
+        }
+        actual = {
+            requirement.id: requirement.checks["m365"]
+            for requirement in fw.requirements
+        }
+
+        assert actual == expected
+        assert len(actual) == 28
+        assert sum(bool(checks) for checks in actual.values()) == 8
+        assert sum(not checks for checks in actual.values()) == 20
+        mapped_checks = [check for checks in actual.values() for check in checks]
+        assert len(mapped_checks) == 29
+        assert len(set(mapped_checks)) == 21
+        assert "cyber_essentials_3.3" in get_available_compliance_frameworks("m365")
 
     def test_covers_all_five_themes(self):
         fw = load_compliance_framework_universal(self._path())


### PR DESCRIPTION
### Context

Fix #12593

Cyber Essentials 3.3 only exposed Azure mappings. Microsoft 365 users could not select the framework for compliance reporting.

### Description

- Add an `m365` key to all 28 Cyber Essentials 3.3 requirements
- Map 8 requirements to 21 existing Microsoft 365 checks and leave 20 unsupported requirements empty
- Preserve every Azure mapping, shared attribute, and other framework field
- Add focused tests for provider discovery, exact mapping decisions, complete coverage, and check ID validity
- Add the SDK changelog fragment

No new checks, permissions, or dependencies are included.

### Steps to review

1. Review `prowler/compliance/cyber_essentials_3.3.json` and confirm each mapping directly evidences its requirement.
2. Run `uv run pytest tests/lib/check/universal_compliance_models_test.py -q`.
3. Run `uv run pytest tests/lib/check/compliance_catalog_integrity_test.py -q -k cyber_essentials_3.3`.
4. Run `uv run pytest -n auto tests/lib/outputs/compliance/ tests/lib/check/ -q`.
5. Confirm `cyber_essentials_3.3` appears in the Microsoft 365 compliance list.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Microsoft 365 check mappings for the NCSC Cyber Essentials 3.3 compliance framework.
  - Cyber Essentials 3.3 assessments now include Microsoft 365 requirements alongside Azure coverage.
  - The framework’s compliance inventory has been expanded to identify the relevant Microsoft 365 checks and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->