### PR TITLE
fix(gcp): report CSEK retirement in the instance encryption check

### DIFF
--- a/prowler/changelog.d/gcp-csek-deprecation-notice.changed.md
+++ b/prowler/changelog.d/gcp-csek-deprecation-notice.changed.md
@@ -1,0 +1,1 @@
+`compute_instance_encryption_with_csek_enabled` FAIL message now explains why the finding is not remediable: Google disabled CSEK encryption on July 20, 2026, and the check will be deprecated on July 20, 2027 when CSEK is removed from Compute Engine

--- a/prowler/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled.metadata.json
+++ b/prowler/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled.metadata.json
@@ -12,6 +12,7 @@
   "Risk": "Without **CSEK**, encryption depends on provider-managed keys, reducing control over key lifecycle and access. This weakens confidentiality, impedes separation of duties, and can delay key revocation, increasing exposure to unauthorized data access and regulatory gaps.",
   "RelatedUrl": "",
   "AdditionalURLs": [
+    "https://docs.cloud.google.com/compute/docs/deprecations/csek-deprecation-in-compute-engine",
     "https://cloud.google.com/storage/docs/encryption/using-customer-supplied-keys",
     "https://www.trendmicro.com/trendaivisiononecloudriskmanagement/knowledge-base/gcp/ComputeEngine/enable-encryption-with-csek.html"
   ],
@@ -32,5 +33,5 @@
   ],
   "DependsOn": [],
   "RelatedTo": [],
-  "Notes": ""
+  "Notes": "CSEK is being retired: since July 20, 2026 it can no longer be applied to Compute Engine resources, and it will be removed entirely on July 20, 2027, when this check will be deprecated. Instances already encrypted with CSEK still report PASS, but a FAIL is not remediable; Google points to CMEK (Cloud KMS) as the replacement, which this check does not evaluate."
 }

--- a/prowler/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled.py
@@ -8,12 +8,14 @@ class compute_instance_encryption_with_csek_enabled(Check):
         for instance in compute_client.instances:
             report = Check_Report_GCP(metadata=self.metadata(), resource=instance)
             report.status = "FAIL"
-            report.status_extended = f"The VM Instance {instance.name} has the following unencrypted disks: '{', '.join([i[0] for i in instance.disks_encryption if not i[1]])}'."
+            report.status_extended = (
+                f"The VM Instance {instance.name} has the following disks not encrypted with CSEK: '{', '.join([i[0] for i in instance.disks_encryption if not i[1]])}'. "
+                "CSEK can no longer be applied to Compute Engine resources since July 20, 2026, so this finding is not remediable; Google recommends CMEK instead. "
+                "This check will be deprecated on July 20, 2027, when CSEK is removed from Compute Engine."
+            )
             if all([i[1] for i in instance.disks_encryption]):
                 report.status = "PASS"
-                report.status_extended = (
-                    f"The VM Instance {instance.name} has every disk encrypted."
-                )
+                report.status_extended = f"The VM Instance {instance.name} has every disk encrypted with CSEK."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled.py
@@ -3,6 +3,19 @@ from prowler.providers.gcp.services.compute.compute_client import compute_client
 
 
 class compute_instance_encryption_with_csek_enabled(Check):
+    """Ensure Compute Engine VM instance disks are encrypted with CSEK.
+
+    Google is retiring CSEK: it can no longer be applied to Compute Engine
+    resources since July 20, 2026, and it is removed entirely on July 20, 2027,
+    when this check is deprecated. Instances encrypted before the cutoff still
+    report PASS, but a FAIL cannot be remediated. Google points to CMEK
+    (Cloud KMS) as the replacement, which this check does not evaluate.
+    Reference: https://docs.cloud.google.com/compute/docs/deprecations/csek-deprecation-in-compute-engine
+
+    - PASS: Every disk attached to the VM instance is encrypted with CSEK.
+    - FAIL: At least one attached disk is not encrypted with CSEK.
+    """
+
     def execute(self) -> Check_Report_GCP:
         findings = []
         for instance in compute_client.instances:

--- a/tests/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled_test.py
@@ -72,7 +72,7 @@ class Test_compute_instance_encryption_with_csek_enabled:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert search(
-                f"The VM Instance {instance.name} has every disk encrypted.",
+                f"The VM Instance {instance.name} has every disk encrypted with CSEK.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
@@ -121,8 +121,16 @@ class Test_compute_instance_encryption_with_csek_enabled:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert search(
-                f"The VM Instance {instance.name} has the following unencrypted disks: '{', '.join([i[0] for i in instance.disks_encryption if not i[1]])}'",
+                f"The VM Instance {instance.name} has the following disks not encrypted with CSEK: '{', '.join([i[0] for i in instance.disks_encryption if not i[1]])}'",
                 result[0].status_extended,
+            )
+            assert (
+                "CSEK can no longer be applied to Compute Engine resources since July 20, 2026"
+                in result[0].status_extended
+            )
+            assert (
+                "This check will be deprecated on July 20, 2027"
+                in result[0].status_extended
             )
             assert result[0].resource_id == instance.id
             assert result[0].location == "us-central1"
@@ -170,8 +178,16 @@ class Test_compute_instance_encryption_with_csek_enabled:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert search(
-                f"The VM Instance {instance.name} has the following unencrypted disks: '{', '.join([i[0] for i in instance.disks_encryption if not i[1]])}'",
+                f"The VM Instance {instance.name} has the following disks not encrypted with CSEK: '{', '.join([i[0] for i in instance.disks_encryption if not i[1]])}'",
                 result[0].status_extended,
+            )
+            assert (
+                "CSEK can no longer be applied to Compute Engine resources since July 20, 2026"
+                in result[0].status_extended
+            )
+            assert (
+                "This check will be deprecated on July 20, 2027"
+                in result[0].status_extended
             )
             assert result[0].resource_id == instance.id
             assert result[0].location == "us-central1"

--- a/tests/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled_test.py
@@ -125,11 +125,12 @@ class Test_compute_instance_encryption_with_csek_enabled:
                 result[0].status_extended,
             )
             assert (
-                "CSEK can no longer be applied to Compute Engine resources since July 20, 2026"
+                "CSEK can no longer be applied to Compute Engine resources since July 20, 2026, "
+                "so this finding is not remediable; Google recommends CMEK instead."
                 in result[0].status_extended
             )
             assert (
-                "This check will be deprecated on July 20, 2027"
+                "This check will be deprecated on July 20, 2027, when CSEK is removed from Compute Engine."
                 in result[0].status_extended
             )
             assert result[0].resource_id == instance.id
@@ -182,11 +183,12 @@ class Test_compute_instance_encryption_with_csek_enabled:
                 result[0].status_extended,
             )
             assert (
-                "CSEK can no longer be applied to Compute Engine resources since July 20, 2026"
+                "CSEK can no longer be applied to Compute Engine resources since July 20, 2026, "
+                "so this finding is not remediable; Google recommends CMEK instead."
                 in result[0].status_extended
             )
             assert (
-                "This check will be deprecated on July 20, 2027"
+                "This check will be deprecated on July 20, 2027, when CSEK is removed from Compute Engine."
                 in result[0].status_extended
             )
             assert result[0].resource_id == instance.id


### PR DESCRIPTION
### Context

Fix #12305

Google turned CSEK off for Compute Engine on July 20, 2026, so `compute_instance_encryption_with_csek_enabled` can no longer be made to pass on a new resource. The FAIL text made that harder to read, because it called the disks "unencrypted" even when the disk carries a Cloud KMS key, which sounds like a data-at-rest problem rather than a missing CSEK.

Following @danibarranqueroo's proposal on the issue, the check stays as it is (instances encrypted before the cutoff still report PASS) and the status extended now says why the finding cannot be cleared and when the check goes away.

### Description

SDK only, no change to the PASS/FAIL condition.

- FAIL message names CSEK instead of calling the disks unencrypted, so a CMEK-encrypted disk is no longer described as unencrypted
- FAIL message adds that the finding is not remediable as of July 20, 2026, points to CMEK, and gives the July 20, 2027 deprecation date
- PASS message says "encrypted with CSEK" for the same reason: every Compute Engine disk is encrypted at rest, CSEK is what this check measures
- `Notes` records the retirement timeline, `AdditionalURLs` gains Google's deprecation page
- Both FAIL tests assert the new wording and the two dates

### Steps to review

Dates come from [Google's CSEK deprecation page](https://docs.cloud.google.com/compute/docs/deprecations/csek-deprecation-in-compute-engine).

Before, on the instance from the issue:

> The VM Instance runner has the following unencrypted disks: 'runner'.

After:

> The VM Instance runner has the following disks not encrypted with CSEK: 'runner'. CSEK can no longer be applied to Compute Engine resources since July 20, 2026, so this finding is not remediable; Google recommends CMEK instead. This check will be deprecated on July 20, 2027, when CSEK is removed from Compute Engine.

```bash
uv run pytest tests/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/
uv run make lint
```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. Not needed, this is a message-only change.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md). No count changes, no check added or removed.
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No, so no provider permission changes are needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Clarified CSEK encryption check results, including affected disks and why findings cannot be remediated.
  * Noted that CSEK is no longer applicable to Compute Engine resources as of July 20, 2026, and that the check is scheduled for deprecation on July 20, 2027.
  * Added documentation links and identified CMEK as the replacement encryption option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->