### PR TITLE
fix(ci): don't fail setup-python-uv on empty grep match

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -46,7 +46,14 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        if ! grep -q "prowler-cloud/prowler" uv.lock; then
+        if grep -q "prowler-cloud/prowler" uv.lock; then
+          :
+        else
+          status=$?
+          if [ "$status" -ne 1 ]; then
+            echo "::error::grep failed reading uv.lock (exit code $status)."
+            exit "$status"
+          fi
           echo "No prowler-cloud/prowler entry in uv.lock, nothing to update."
           exit 0
         fi
@@ -70,7 +77,14 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        if ! grep -q "prowler-cloud/prowler" uv.lock; then
+        if grep -q "prowler-cloud/prowler" uv.lock; then
+          :
+        else
+          status=$?
+          if [ "$status" -ne 1 ]; then
+            echo "::error::grep failed reading uv.lock (exit code $status)."
+            exit "$status"
+          fi
           echo "No prowler-cloud/prowler entry in uv.lock, nothing to update."
           exit 0
         fi

--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -46,6 +46,10 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
+        if ! grep -q "prowler-cloud/prowler" uv.lock; then
+          echo "No prowler-cloud/prowler entry in uv.lock, nothing to update."
+          exit 0
+        fi
         LATEST_COMMIT=$(curl -sf --retry 3 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
           -H "Authorization: Bearer ${GITHUB_TOKEN}" \
           -H "Accept: application/vnd.github+json" \
@@ -66,6 +70,10 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
+        if ! grep -q "prowler-cloud/prowler" uv.lock; then
+          echo "No prowler-cloud/prowler entry in uv.lock, nothing to update."
+          exit 0
+        fi
         LATEST_COMMIT=$(curl -sf --retry 3 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
           -H "Authorization: Bearer ${GITHUB_TOKEN}" \
           -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
### Context

Every push to master fails `sdk-tests`, `sdk-code-quality` and `install-from-wheel`. It's not flaky and it's not a rate limit on the GitHub API call, even though that's what the error message says.

### Description

The last line of the "Update uv.lock" steps in `setup-python-uv/action.yml` is:

```
grep "prowler-cloud/prowler" uv.lock
```

The shell runs with `set -e`, and `grep` with no match returns exit 1, so it kills the step. `uv.lock` at the repo root (and in `mcp_server/`) never has that line, only `api/uv.lock` does, so this fails deterministically on every push to master for those jobs.

Added a `grep -q ... || exit 0` guard before doing the curl/sed, so it skips cleanly when there's nothing to update. `api/` keeps working exactly as before.

### Steps to review

Diff is one file, `.github/actions/setup-python-uv/action.yml`. Checked both branches locally (uv.lock with and without the `prowler-cloud/prowler` entry) and both exit 0.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automated lockfile update checks from failing when the lockfile does not contain a Prowler repository entry.
  * Preserved error reporting for unexpected lockfile check failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->