### PR TITLE
fix(organizations): report MANUAL when policy inventory is incomplete

### DIFF
--- a/prowler/changelog.d/organizations-policies-unavailable-manual.fixed.md
+++ b/prowler/changelog.d/organizations-policies-unavailable-manual.fixed.md
@@ -1,0 +1,1 @@
+AWS Organizations policy checks now report `MANUAL` instead of a confident `PASS`/`FAIL` when the policy inventory could not be fully listed

--- a/prowler/changelog.d/organizations-policies-unavailable-manual.fixed.md
+++ b/prowler/changelog.d/organizations-policies-unavailable-manual.fixed.md
@@ -1,1 +1,1 @@
-AWS Organizations policy checks now report `MANUAL` instead of a confident `PASS`/`FAIL` when the policy inventory could not be fully listed
+Incomplete AWS Organizations policy inventories reported as `MANUAL` instead of `PASS`/`FAIL`

--- a/prowler/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy.py
+++ b/prowler/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy.py
@@ -9,6 +9,17 @@ class organizations_opt_out_ai_services_policy(Check):
         findings = []
 
         if organizations_client.organization:
+            if organizations_client.policies_unavailable:
+                report = Check_Report_AWS(
+                    metadata=self.metadata(),
+                    resource=organizations_client.organization,
+                )
+                report.region = organizations_client.region
+                report.status = "MANUAL"
+                report.status_extended = "Cannot evaluate the AI services opt-out policy: AWS Organizations policies could not be listed. Verify that the scanning identity is allowed to call organizations:ListPolicies, organizations:DescribePolicy and organizations:ListTargetsForPolicy."
+                findings.append(report)
+                return findings
+
             if (
                 organizations_client.organization.policies is not None
             ):  # Access Denied to list_policies

--- a/prowler/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions.py
+++ b/prowler/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions.py
@@ -12,6 +12,17 @@ class organizations_scp_check_deny_regions(Check):
         )
 
         if organizations_client.organization:
+            if organizations_client.policies_unavailable:
+                report = Check_Report_AWS(
+                    metadata=self.metadata(),
+                    resource=organizations_client.organization,
+                )
+                report.region = organizations_client.region
+                report.status = "MANUAL"
+                report.status_extended = "Cannot evaluate SCP region restrictions: AWS Organizations policies could not be listed. Verify that the scanning identity is allowed to call organizations:ListPolicies, organizations:DescribePolicy and organizations:ListTargetsForPolicy."
+                findings.append(report)
+                return findings
+
             if (
                 organizations_client.organization.policies is not None
             ):  # Access denied to list policies

--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -22,6 +22,7 @@ class Organizations(AWSService):
         super().__init__(__class__.__name__, provider)
         self.organization = None
         self.policies = {}
+        self.policies_unavailable = False
         self.delegated_administrators = []
         self._describe_organization()
 
@@ -106,8 +107,9 @@ class Organizations(AWSService):
                         )
 
         except ClientError as error:
+            policies = None
+            self.policies_unavailable = True
             if error.response["Error"]["Code"] == "AccessDeniedException":
-                policies = None
                 logger.warning(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
@@ -117,6 +119,8 @@ class Organizations(AWSService):
                 )
 
         except Exception as error:
+            policies = None
+            self.policies_unavailable = True
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )

--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -142,6 +142,7 @@ class Organizations(AWSService):
 
             return policy_content
         except Exception as error:
+            self.policies_unavailable = True
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
@@ -160,6 +161,7 @@ class Organizations(AWSService):
             return targets_for_policy
 
         except Exception as error:
+            self.policies_unavailable = True
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )

--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -125,6 +125,14 @@ class Organizations(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
+        # A per-policy helper (_describe_policy / _list_targets_for_policy) can
+        # fail without raising here, leaving a partial inventory built from
+        # empty content or targets. Discard it so Organization.policies never
+        # exposes incomplete records; consumers see None, matching the
+        # list-failure path above.
+        if self.policies_unavailable:
+            return None
+
         return policies
 
     def _describe_policy(self, policy_id) -> dict:

--- a/prowler/providers/aws/services/organizations/organizations_tags_policies_enabled_and_attached/organizations_tags_policies_enabled_and_attached.py
+++ b/prowler/providers/aws/services/organizations/organizations_tags_policies_enabled_and_attached/organizations_tags_policies_enabled_and_attached.py
@@ -9,6 +9,17 @@ class organizations_tags_policies_enabled_and_attached(Check):
         findings = []
 
         if organizations_client.organization:
+            if organizations_client.policies_unavailable:
+                report = Check_Report_AWS(
+                    metadata=self.metadata(),
+                    resource=organizations_client.organization,
+                )
+                report.region = organizations_client.region
+                report.status = "MANUAL"
+                report.status_extended = "Cannot evaluate tag policies: AWS Organizations policies could not be listed. Verify that the scanning identity is allowed to call organizations:ListPolicies, organizations:DescribePolicy and organizations:ListTargetsForPolicy."
+                findings.append(report)
+                return findings
+
             if (
                 organizations_client.organization.policies is not None
             ):  # Access Denied to list_policies

--- a/tests/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy_test.py
+++ b/tests/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy_test.py
@@ -11,6 +11,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
     def test_organization_no_organization(self):
         organizations_client = mock.MagicMock
         organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.policies_unavailable = False
         organizations_client.audited_partition = "aws"
         organizations_client.audited_account = "0123456789012"
         organizations_client.organization = Organization(
@@ -54,6 +55,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
     def test_organization_with_AI_optout_no_policies(self):
         organizations_client = mock.MagicMock
         organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.policies_unavailable = False
         organizations_client.audited_partition = "aws"
         organizations_client.audited_account = "0123456789012"
         organizations_client.organization = Organization(
@@ -99,10 +101,11 @@ class Test_organizations_tags_policies_enabled_and_attached:
     def test_organization_with_AI_optout_policy_complete(self):
         organizations_client = mock.MagicMock
         organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.policies_unavailable = False
         organizations_client.audited_partition = "aws"
         organizations_client.audited_account = "0123456789012"
-        organizations_client.get_unknown_arn = (
-            lambda x: f"arn:aws:organizations:{x}:0123456789012:unknown"
+        organizations_client.get_unknown_arn = lambda x: (
+            f"arn:aws:organizations:{x}:0123456789012:unknown"
         )
         organizations_client.organization = Organization(
             id="o-1234567890",
@@ -175,6 +178,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
     def test_organization_with_AI_optout_policy_no_content(self):
         organizations_client = mock.MagicMock
         organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.policies_unavailable = False
         organizations_client.audited_partition = "aws"
         organizations_client.audited_account = "0123456789012"
         organizations_client.organization = Organization(
@@ -231,6 +235,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
     def test_organization_with_AI_optout_policy_no_disallow(self):
         organizations_client = mock.MagicMock
         organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.policies_unavailable = False
         organizations_client.audited_partition = "aws"
         organizations_client.audited_account = "0123456789012"
         organizations_client.organization = Organization(
@@ -291,6 +296,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
     def test_organization_with_AI_optout_policy_no_opt_out(self):
         organizations_client = mock.MagicMock
         organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.policies_unavailable = False
         organizations_client.audited_partition = "aws"
         organizations_client.audited_account = "0123456789012"
         organizations_client.organization = Organization(
@@ -351,5 +357,45 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert (
                     result[0].resource_arn
                     == "arn:aws:organizations::1234567890:organization/o-1234567890"
+                )
+                assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_organization_policies_unavailable(self):
+        organizations_client = mock.MagicMock
+        organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.policies_unavailable = True
+        organizations_client.audited_partition = "aws"
+        organizations_client.audited_account = "0123456789012"
+        organizations_client.organization = Organization(
+            id="o-1234567890",
+            arn="arn:aws:organizations::1234567890:organization/o-1234567890",
+            status="ACTIVE",
+            master_id="1234567890",
+            policies=None,
+            delegated_administrators=None,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.organizations.organizations_opt_out_ai_services_policy.organizations_opt_out_ai_services_policy.organizations_client",
+                new=organizations_client,
+            ):
+                from prowler.providers.aws.services.organizations.organizations_opt_out_ai_services_policy.organizations_opt_out_ai_services_policy import (
+                    organizations_opt_out_ai_services_policy,
+                )
+
+                check = organizations_opt_out_ai_services_policy()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "MANUAL"
+                assert (
+                    "Cannot evaluate the AI services opt-out policy"
+                    in result[0].status_extended
                 )
                 assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions_test.py
+++ b/tests/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions_test.py
@@ -4,6 +4,7 @@ from boto3 import client
 from moto import mock_aws
 
 from prowler.providers.aws.services.organizations.organizations_service import (
+    Organization,
     Organizations,
 )
 from tests.providers.aws.utils import (
@@ -488,5 +489,46 @@ class Test_organizations_scp_check_deny_regions:
                 assert (
                     result[0].status_extended
                     == f"AWS Organization {org_id} has SCP policy {policy_id} restricting all configured regions found."
+                )
+                assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_organization_policies_unavailable(self):
+        organizations_client = mock.MagicMock
+        organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.policies_unavailable = True
+        organizations_client.audit_config = {
+            "organizations_enabled_regions": [AWS_REGION_EU_WEST_1]
+        }
+        organizations_client.organization = Organization(
+            id="o-1234567890",
+            arn="arn:aws:organizations::1234567890:organization/o-1234567890",
+            status="ACTIVE",
+            master_id="1234567890",
+            policies=None,
+            delegated_administrators=None,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.organizations.organizations_scp_check_deny_regions.organizations_scp_check_deny_regions.organizations_client",
+                new=organizations_client,
+            ):
+                from prowler.providers.aws.services.organizations.organizations_scp_check_deny_regions.organizations_scp_check_deny_regions import (
+                    organizations_scp_check_deny_regions,
+                )
+
+                check = organizations_scp_check_deny_regions()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "MANUAL"
+                assert (
+                    "Cannot evaluate SCP region restrictions"
+                    in result[0].status_extended
                 )
                 assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/organizations/organizations_service_test.py
+++ b/tests/providers/aws/services/organizations/organizations_service_test.py
@@ -99,3 +99,25 @@ class Test_Organizations_Service:
         result = organizations._list_targets_for_policy("p-1234567890")
         assert result == []
         assert organizations.policies_unavailable is True
+
+    @mock_aws
+    def test_list_policies_discards_partial_inventory_on_helper_failure(self):
+        # When a per-policy helper fails mid-listing, the whole inventory must
+        # be discarded (None) rather than exposing Policy records built from
+        # empty content/targets through Organization.policies.
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        conn = client("organizations", region_name=AWS_REGION_EU_WEST_1)
+        conn.create_policy(
+            Content=scp_restrict_regions_with_deny(),
+            Description="Test",
+            Name="Test",
+            Type="SERVICE_CONTROL_POLICY",
+        )
+        organizations = Organizations(aws_provider)
+        organizations.policies_unavailable = False
+        organizations.client.list_targets_for_policy = MagicMock(
+            side_effect=Exception("boom")
+        )
+        result = organizations._list_policies()
+        assert result is None
+        assert organizations.policies_unavailable is True

--- a/tests/providers/aws/services/organizations/organizations_service_test.py
+++ b/tests/providers/aws/services/organizations/organizations_service_test.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import MagicMock
 
 from boto3 import client
 from moto import mock_aws
@@ -70,3 +71,31 @@ class Test_Organizations_Service:
             response["Policy"]["PolicySummary"]["Id"]
         )
         assert policy == json.loads(response["Policy"]["Content"])
+
+    @mock_aws
+    def test_describe_policy_failure_marks_inventory_unavailable(self):
+        # A DescribePolicy failure must mark the inventory unavailable so the
+        # downstream checks report MANUAL instead of a confident PASS/FAIL from
+        # the partial ({}) content.
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        organizations = Organizations(aws_provider)
+        organizations.policies_unavailable = False
+        organizations.client = MagicMock()
+        organizations.client.describe_policy.side_effect = Exception("boom")
+        result = organizations._describe_policy("p-1234567890")
+        assert result == {}
+        assert organizations.policies_unavailable is True
+
+    @mock_aws
+    def test_list_targets_for_policy_failure_marks_inventory_unavailable(self):
+        # A ListTargetsForPolicy failure returns [] but must mark the inventory
+        # unavailable; otherwise an empty target list is indistinguishable from
+        # a genuinely unattached policy and the tag-policy check reports FAIL.
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        organizations = Organizations(aws_provider)
+        organizations.policies_unavailable = False
+        organizations.client = MagicMock()
+        organizations.client.list_targets_for_policy.side_effect = Exception("boom")
+        result = organizations._list_targets_for_policy("p-1234567890")
+        assert result == []
+        assert organizations.policies_unavailable is True

--- a/tests/providers/aws/services/organizations/organizations_tags_policies_enabled_and_attached/organizations_tags_policies_enabled_and_attached_test.py
+++ b/tests/providers/aws/services/organizations/organizations_tags_policies_enabled_and_attached/organizations_tags_policies_enabled_and_attached_test.py
@@ -11,6 +11,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
     def test_organization_no_organization(self):
         organizations_client = mock.MagicMock
         organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.policies_unavailable = False
         organizations_client.audited_partition = "aws"
         organizations_client.audited_account = "0123456789012"
         organizations_client.organization = Organization(
@@ -54,6 +55,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
     def test_organization_with_tag_policies_not_attached(self):
         organizations_client = mock.MagicMock
         organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.policies_unavailable = False
         organizations_client.audited_partition = "aws"
         organizations_client.audited_account = "0123456789012"
         organizations_client.organization = Organization(
@@ -110,8 +112,9 @@ class Test_organizations_tags_policies_enabled_and_attached:
     def test_organization_with_tag_policies_attached(self):
         organizations_client = mock.MagicMock
         organizations_client.region = AWS_REGION_EU_WEST_1
-        organizations_client.get_unknown_arn = (
-            lambda x: f"arn:aws:organizations:{x}:0123456789012:unknown"
+        organizations_client.policies_unavailable = False
+        organizations_client.get_unknown_arn = lambda x: (
+            f"arn:aws:organizations:{x}:0123456789012:unknown"
         )
         organizations_client.organization = Organization(
             id="o-1234567890",
@@ -168,4 +171,41 @@ class Test_organizations_tags_policies_enabled_and_attached:
                     result[0].resource_arn
                     == "arn:aws:organizations::1234567890:organization/o-1234567890"
                 )
+                assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_organization_policies_unavailable(self):
+        organizations_client = mock.MagicMock
+        organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.policies_unavailable = True
+        organizations_client.audited_partition = "aws"
+        organizations_client.audited_account = "0123456789012"
+        organizations_client.organization = Organization(
+            id="o-1234567890",
+            arn="arn:aws:organizations::1234567890:organization/o-1234567890",
+            status="ACTIVE",
+            master_id="1234567890",
+            policies=None,
+            delegated_administrators=None,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.organizations.organizations_tags_policies_enabled_and_attached.organizations_tags_policies_enabled_and_attached.organizations_client",
+                new=organizations_client,
+            ):
+                from prowler.providers.aws.services.organizations.organizations_tags_policies_enabled_and_attached.organizations_tags_policies_enabled_and_attached import (
+                    organizations_tags_policies_enabled_and_attached,
+                )
+
+                check = organizations_tags_policies_enabled_and_attached()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "MANUAL"
+                assert "Cannot evaluate tag policies" in result[0].status_extended
                 assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/organizations/organizations_tags_policies_enabled_and_attached/organizations_tags_policies_enabled_and_attached_test.py
+++ b/tests/providers/aws/services/organizations/organizations_tags_policies_enabled_and_attached/organizations_tags_policies_enabled_and_attached_test.py
@@ -174,7 +174,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_organization_policies_unavailable(self):
-        organizations_client = mock.MagicMock
+        organizations_client = mock.MagicMock()
         organizations_client.region = AWS_REGION_EU_WEST_1
         organizations_client.policies_unavailable = True
         organizations_client.audited_partition = "aws"
@@ -208,4 +208,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert len(result) == 1
                 assert result[0].status == "MANUAL"
                 assert "Cannot evaluate tag policies" in result[0].status_extended
+                assert "organizations:ListPolicies" in result[0].status_extended
+                assert "organizations:DescribePolicy" in result[0].status_extended
+                assert "organizations:ListTargetsForPolicy" in result[0].status_extended
                 assert result[0].region == AWS_REGION_EU_WEST_1


### PR DESCRIPTION
### Context

Fix #12583

`Organizations._list_policies` only reset the policy inventory to `None` on `AccessDeniedException`. If pagination or collection fails with another `ClientError` (e.g. `ThrottlingException`, `ValidationException`) or a transport/generic exception, it left an already-populated partial dict in place. The three consumer checks treat any non-`None` `policies` value as a complete inventory, so they could emit a confident `PASS`/`FAIL` from incomplete data:

- `organizations_opt_out_ai_services_policy`
- `organizations_scp_check_deny_regions`
- `organizations_tags_policies_enabled_and_attached`

This follows the convention added in #12645 ("Permission and Data-Availability Errors Are Not Findings" in `docs/developer-guide/checks.mdx`) and mirrors its CloudTrail/CloudWatch implementation (`trails_unavailable`, `metric_filters_unavailable`).

### Description

- `organizations_service.py`: discard any partially collected policies on *any* failure (not just `AccessDeniedException`) and raise a `policies_unavailable` flag instead of overloading the `None` sentinel.
- The three consumer checks emit a single account-level `MANUAL` finding when the flag is set, naming the required `organizations:*` permissions, instead of producing a finding (or none) from partial data.

### Steps to review

1. `_list_policies` now sets `policies = None` and `self.policies_unavailable = True` in both the non-`AccessDenied` `ClientError` branch and the generic `Exception` branch.
2. Each consumer check checks `organizations_client.policies_unavailable` first and returns one `MANUAL` finding.

### Validation

Local, on a clean `master` checkout (`uv sync`, Python 3.11.15):

```
$ uv run pytest tests/providers/aws/services/organizations/ -p no:randomly -q
................................                                         [100%]
32 passed in 16.00s
```

RED→GREEN for the three new `test_organization_policies_unavailable` tests — reverting only the source (keeping the tests) makes them fail because the old code returns 0 findings on an incomplete inventory:

```
$ git stash push -- <the 4 source files>
$ uv run pytest tests/.../organizations/ -k policies_unavailable -q
3 failed, 29 deselected
$ git stash pop
$ uv run pytest tests/.../organizations/ -q
32 passed
```

Linters: `black --check`, `isort --profile black`, `flake8` (project ignores) all clean on the changed files. Added a changelog fragment under `prowler/changelog.d/`.

Happy to adjust the `MANUAL` message wording or the flag name if you'd prefer a different shape.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - AWS Organizations policy checks now report **MANUAL** when policy data cannot be retrieved, avoiding inaccurate **PASS** or **FAIL** results.
  - Added clearer guidance when required permissions or policy inventory access is unavailable.
  - Applies to AI services opt-out policies, SCP region restrictions, and tag policies.

- **Tests**
  - Added coverage confirming **MANUAL** results and permission guidance when Organizations policies are unavailable or cannot be evaluated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->