### PR TITLE
fix(ci): suppress unfixed x/crypto CVEs from Trivy binary

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -27,6 +27,19 @@ ignore:
     package:
       name: google.golang.org/grpc
       version: v1.82.1
+  # CVE-2026-56855 / CVE-2026-78662 are the same temporary exception documented in
+  # .trivyignore.yaml: Trivy 0.74.0 still embeds golang.org/x/crypto v0.55.0, while the
+  # 0.56.0 fix (published 2026-09-02) hasn't reached any Trivy release, or even Trivy
+  # main, yet. Pinned to the embedded version so the rule stops matching on its own once
+  # Trivy bumps it. Remove with the Trivy exception by 2026-10-15.
+  - vulnerability: CVE-2026-56855
+    package:
+      name: golang.org/x/crypto
+      version: v0.55.0
+  - vulnerability: CVE-2026-78662
+    package:
+      name: golang.org/x/crypto
+      version: v0.55.0
   - vulnerability: CVE-2026-56852
     package:
       name: golang.org/x/text

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -190,11 +190,11 @@ vulnerabilities:
   # suppression as soon as a fixed Trivy release is available.
   - id: CVE-2026-56855
     purls:
-      - "pkg:golang/golang.org/x/crypto"
+      - "pkg:golang/golang.org/x/crypto@v0.55.0"
     expired_at: 2026-10-15
   - id: CVE-2026-78662
     purls:
-      - "pkg:golang/golang.org/x/crypto"
+      - "pkg:golang/golang.org/x/crypto@v0.55.0"
     expired_at: 2026-10-15
 
   - id: CVE-2026-56852

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -176,6 +176,27 @@ vulnerabilities:
       - "pkg:golang/google.golang.org/grpc"
     expired_at: 2026-10-15
 
+  # CVE-2026-56855 and CVE-2026-78662 are DoS deadlocks in x/crypto/ssh: a malicious peer
+  # can flood or misuse channel messages (RFC 4254) to block the whole connection.
+  # Fixed in golang.org/x/crypto v0.56.0 (published 2026-09-02). Trivy 0.74.0, the latest
+  # published release and the version the images ship, still pins v0.55.0, and Trivy main
+  # has not bumped it either:
+  # https://github.com/aquasecurity/trivy/blob/v0.74.0/go.mod
+  # x/crypto/ssh is pulled in transitively through go-git's ssh transport, the same
+  # dependency chain as the CVE-2026-71556 entry above. Prowler invokes Trivy only with
+  # `fs` on an existing local path or with `image`; it never asks Trivy to clone over SSH
+  # or to run `trivy server`, so no SSH connection -- as client or server -- ever exists in
+  # the image and the affected code path is not reachable. Remove this temporary
+  # suppression as soon as a fixed Trivy release is available.
+  - id: CVE-2026-56855
+    purls:
+      - "pkg:golang/golang.org/x/crypto"
+    expired_at: 2026-10-15
+  - id: CVE-2026-78662
+    purls:
+      - "pkg:golang/golang.org/x/crypto"
+    expired_at: 2026-10-15
+
   - id: CVE-2026-56852
     purls:
       - "pkg:golang/golang.org/x/text"


### PR DESCRIPTION
### Context

The Grype/Trivy container gate started failing on `golang.org/x/crypto` (CVE-2026-56855, CVE-2026-78662).

### Description

These CVEs are in `x/crypto/ssh`, compiled into the Trivy binary our SDK/API images ship (Trivy 0.74.0 pins x/crypto v0.55.0). The fix landed upstream in x/crypto v0.56.0 a couple days ago, but no Trivy release has bumped to it yet, not even `main`.

We don't control that dependency, and the vulnerable path isn't reachable anyway: both CVEs need something acting as an SSH peer, and we only run `trivy fs` / `trivy image` on local paths, never `trivy server` or ssh cloning.

Added both CVEs to `.grype.yaml` and `.trivyignore.yaml` with the reasoning, same pattern as the existing go-git/grpc entries. Set to expire 2026-10-15 so it gets re-checked once Trivy picks up the new x/crypto version.

### Steps to review

- Check that `golang.org/x/crypto` is really only pulled in through Trivy's own go.mod (via go-git's ssh transport), not something we depend on directly.
- Confirm the container-scan checks go green on this branch.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated vulnerability scanning configuration to prevent known, unreachable transitive dependency findings from blocking scans.
  - Added expiration dates for temporary exceptions, supporting follow-up review before October 15, 2026.
  - Suppressed duplicate findings consistently across supported scanning tools.

- **Chores**
  - Aligned vulnerability suppressions across scanning tools for more consistent scan results.
  - Documented the scope and temporary nature of the exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->