### PR TITLE
fix(github): preserve unkown secret scanning state

### DIFF
--- a/prowler/providers/github/services/repository/repository_service.py
+++ b/prowler/providers/github/services/repository/repository_service.py
@@ -761,7 +761,7 @@ class Repository(GithubService):
                 ):
                     approval_count_source = "ruleset_not_active"
 
-            secret_scanning_enabled = False
+            secret_scanning_enabled = None
             dependabot_alerts_enabled = False
             try:
                 if (

--- a/tests/providers/github/services/repository/repository_service_test.py
+++ b/tests/providers/github/services/repository/repository_service_test.py
@@ -158,9 +158,37 @@ class Test_Repository_GraphQL:
                 assert len(repos) == 1
                 assert 1 in repos
                 assert repos[1].name == "repo1"
+                assert repos[1].secret_scanning_enabled is None
 
                 mock_graphql_call.assert_called_once()
                 mock_client.get_repo.assert_called_once_with("owner1/repo1")
+
+    @pytest.mark.parametrize(
+        ("status", "expected"), [("enabled", True), ("disabled", False)]
+    )
+    def test_secret_scanning_status(self, status, expected):
+        provider = set_mocked_github_provider()
+        provider.repositories = []
+        provider.organizations = []
+        self.mock_repo1.security_and_analysis = MagicMock()
+        self.mock_repo1.security_and_analysis.secret_scanning.status = status
+
+        with patch.object(Repository, "__init__", lambda *_: None):
+            repository_service = Repository(provider)
+            mock_client = MagicMock()
+            repository_service.clients = [mock_client]
+            repository_service.provider = provider
+
+            with patch.object(
+                repository_service,
+                "_get_accessible_repos_graphql",
+                return_value=["owner1/repo1"],
+            ):
+                mock_client.get_repo.return_value = self.mock_repo1
+
+                repos = repository_service._list_repositories()
+
+                assert repos[1].secret_scanning_enabled is expected
 
     def test_graphql_call_api_error(self):
         """Test that an error during the GraphQL call is handled gracefully"""


### PR DESCRIPTION
### Context

GitHub may omit `security_and_analysis` when the caller does not have sufficient repository permissions. In that case, the repository service currently initializes `secret_scanning_enabled` to `False`, which causes an unknown state to be treated as explicitly disabled.

This results in false FAIL findings for `repository_secret_scanning_enabled` when GitHub has not actually returned the security configuration.

Fix #12729

### Description

Preserve the unknown state for repository secret scanning when `security_and_analysis` is not returned by GitHub.

The repository service now initializes `secret_scanning_enabled` to `None` instead of `False`, while still mapping explicit GitHub statuses to:

- `enabled` -> `True`
- `disabled` -> `False`
- omitted `security_and_analysis` -> `None`

Added service-level regression coverage for the omitted-field case and explicit enabled/disabled status conversion.

No new dependencies are required.

### Steps to review

1. Review the change in `repository_service.py` and confirm that `secret_scanning_enabled` defaults to `None`.
2. Review the repository service tests covering:
   - explicit `enabled` status -> `True`
   - explicit `disabled` status -> `False`
   - omitted `security_and_analysis` -> `None`
3. Run:

   ```bash
   uv run pytest \
     tests/providers/github/services/repository/repository_service_test.py \
     tests/providers/github/services/repository/repository_secret_scanning_enabled/repository_secret_scanning_enabled_test.py -v
   ```

   Result: `68 passed`.

4. Run the relevant pre-commit hooks:

   ```bash
   prek run --files \
     prowler/providers/github/services/repository/repository_service.py \
     tests/providers/github/services/repository/repository_service_test.py
   ```

   All applicable SDK hooks pass.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Repository secret-scanning status is now reported as unknown when it cannot be determined, rather than incorrectly reported as disabled.
  - Enabled and disabled secret-scanning states continue to be represented accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->