### PR TITLE
fix(api): sign S3 report download URLs with Signature Version 4

### DIFF
--- a/api/changelog.d/s3-report-download-sigv4.fixed.md
+++ b/api/changelog.d/s3-report-download-sigv4.fixed.md
@@ -1,0 +1,1 @@
+Scan report downloads from an S3 bucket with default SSE-KMS encryption no longer fail with an `InvalidArgument` error, by signing presigned download URLs with AWS Signature Version 4

--- a/api/src/backend/tasks/jobs/export.py
+++ b/api/src/backend/tasks/jobs/export.py
@@ -6,6 +6,7 @@ import boto3
 import config.django.base as base
 from api.db_utils import rls_transaction
 from api.models import Scan
+from botocore.config import Config
 from botocore.exceptions import ClientError, NoCredentialsError, ParamValidationError
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -215,6 +216,9 @@ def get_s3_client():
     Raises:
         ClientError, NoCredentialsError, or ParamValidationError if both attempts to create a client fail.
     """
+    # Pinning SigV4 is required: boto3's default query-string signer for S3 falls back to
+    # SigV2, which S3 rejects for objects encrypted with SSE-KMS.
+    s3_config = Config(signature_version="s3v4")
     s3_client = None
     try:
         s3_client = boto3.client(
@@ -223,10 +227,11 @@ def get_s3_client():
             aws_secret_access_key=settings.DJANGO_OUTPUT_S3_AWS_SECRET_ACCESS_KEY,
             aws_session_token=settings.DJANGO_OUTPUT_S3_AWS_SESSION_TOKEN,
             region_name=settings.DJANGO_OUTPUT_S3_AWS_DEFAULT_REGION,
+            config=s3_config,
         )
         s3_client.list_buckets()
     except (ClientError, NoCredentialsError, ParamValidationError, ValueError):
-        s3_client = boto3.client("s3")
+        s3_client = boto3.client("s3", config=s3_config)
         s3_client.list_buckets()
 
     return s3_client

--- a/api/src/backend/tasks/tests/test_export.py
+++ b/api/src/backend/tasks/tests/test_export.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import boto3
 import pytest
 from botocore.exceptions import ClientError
 from tasks.jobs.export import (
@@ -46,6 +47,35 @@ class TestOutputs:
         client = get_s3_client()
         assert client is not None
         client_mock.list_buckets.assert_called()
+
+    @patch("tasks.jobs.export.boto3.client")
+    @patch("tasks.jobs.export.settings")
+    def test_get_s3_client_generates_sigv4_presigned_url(
+        self, mock_settings, mock_boto_client
+    ):
+        mock_settings.DJANGO_OUTPUT_S3_AWS_ACCESS_KEY_ID = "test-access-key"
+        mock_settings.DJANGO_OUTPUT_S3_AWS_SECRET_ACCESS_KEY = "test-secret-key"
+        mock_settings.DJANGO_OUTPUT_S3_AWS_SESSION_TOKEN = ""
+        mock_settings.DJANGO_OUTPUT_S3_AWS_DEFAULT_REGION = "us-east-1"
+
+        def create_client(service_name, **kwargs):
+            # Build a real boto3 client so signing runs for real, only faking the
+            # network call used to validate the credentials.
+            real_client = boto3.client(service_name, **kwargs)
+            real_client.list_buckets = MagicMock()
+            return real_client
+
+        mock_boto_client.side_effect = create_client
+
+        client = get_s3_client()
+        url = client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": "test-bucket", "Key": "report.zip"},
+            ExpiresIn=300,
+        )
+
+        # SSE-KMS objects require SigV4; the default query signer falls back to SigV2.
+        assert "X-Amz-Algorithm=AWS4-HMAC-SHA256" in url
 
     @patch("tasks.jobs.export.boto3.client")
     @patch("tasks.jobs.export.settings")

--- a/api/src/backend/tasks/tests/test_export.py
+++ b/api/src/backend/tasks/tests/test_export.py
@@ -60,8 +60,10 @@ class TestOutputs:
 
         def create_client(service_name, **kwargs):
             # Build a real boto3 client so signing runs for real, only faking the
-            # network call used to validate the credentials.
-            real_client = boto3.client(service_name, **kwargs)
+            # network call used to validate the credentials. Use boto3.Session()
+            # rather than boto3.client() directly, since the latter is patched
+            # above and would recurse into this same side effect.
+            real_client = boto3.Session().client(service_name, **kwargs)
             real_client.list_buckets = MagicMock()
             return real_client
 
@@ -79,13 +81,34 @@ class TestOutputs:
 
     @patch("tasks.jobs.export.boto3.client")
     @patch("tasks.jobs.export.settings")
-    def test_get_s3_client_fallback(self, mock_settings, mock_boto_client):
-        mock_boto_client.side_effect = [
-            ClientError({"Error": {"Code": "403"}}, "ListBuckets"),
-            MagicMock(),
-        ]
+    def test_get_s3_client_fallback(self, mock_settings, mock_boto_client, monkeypatch):
+        # The fallback branch relies on boto3's default credential chain (e.g. an
+        # IAM role), so provide env credentials for the real client to sign with.
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fallback-access-key")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fallback-secret-key")
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+        calls = {"count": 0}
+
+        def create_client(service_name, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise ClientError({"Error": {"Code": "403"}}, "ListBuckets")
+            real_client = boto3.Session().client(service_name, **kwargs)
+            real_client.list_buckets = MagicMock()
+            return real_client
+
+        mock_boto_client.side_effect = create_client
+
         client = get_s3_client()
-        assert client is not None
+        url = client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": "test-bucket", "Key": "report.zip"},
+            ExpiresIn=300,
+        )
+
+        # The credential-less fallback path must also pin SigV4.
+        assert "X-Amz-Algorithm=AWS4-HMAC-SHA256" in url
 
     @patch("tasks.jobs.export.get_s3_client")
     @patch("tasks.jobs.export.base")


### PR DESCRIPTION
### Context

Prowler App report downloads redirect the browser to a presigned S3 `GetObject` URL generated by `get_s3_client()` in `api/src/backend/tasks/jobs/export.py`. That function builds its `boto3` S3 client without an explicit `signature_version`. Even though the resolved client config reports `signature_version="s3v4"`, boto3/botocore's presigned-URL query signer for S3 still falls back to Signature Version 2 (`AWSAccessKeyId=...&Signature=...&Expires=...`) unless `Config(signature_version="s3v4")` is passed explicitly — this is a long-standing boto3/botocore quirk specific to `generate_presigned_url`, separate from normal request signing.

AWS S3 rejects SigV2 presigned requests for objects encrypted with SSE-KMS:
`InvalidArgument: Requests specifying Server Side Encryption with AWS KMS managed keys require AWS Signature Version 4.`

So report downloads fail whenever the output bucket uses default SSE-KMS encryption, even though the object itself is accessible and the credentials are valid.

### Description

Explicitly pins `config=Config(signature_version="s3v4")` on both `boto3.client("s3", ...)` calls in `get_s3_client()` (the primary credentialed path and the credential-less fallback), so `generate_presigned_url` always emits a proper SigV4 (`X-Amz-Algorithm=AWS4-HMAC-SHA256...`) URL. No settings, defaults, or public API change; only the client construction inside `get_s3_client()` is touched.

Adds `test_get_s3_client_generates_sigv4_presigned_url` to `api/src/backend/tasks/tests/test_export.py`, which builds a real (unmocked) S3 client through `get_s3_client()` — only stubbing out the network-dependent `list_buckets()` credential check — and asserts the real `generate_presigned_url()` output contains `X-Amz-Algorithm=AWS4-HMAC-SHA256`.

Adds a changelog fragment at `api/changelog.d/s3-report-download-sigv4.fixed.md`.

### Validation

- Independently reproduced the exact defect and fix using the exact dependency versions this repo pins (`botocore==1.40.61`, `boto3==1.40.61`, matching the issue reporter's environment) in an isolated Python environment, calling the same `boto3.client(...)` construction `get_s3_client()` uses:
  - Without `config=Config(signature_version="s3v4")`: `generate_presigned_url("get_object", ...)` produced `https://.../report.zip?AWSAccessKeyId=...&Signature=...&Expires=...` (SigV2 — reproduces the reported defect).
  - With `config=Config(signature_version="s3v4")` added: it produced `https://.../report.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=...` (SigV4 — confirms the fix). This is the exact fail-before/pass-after behavior the new test asserts.
- Could not run this repo's actual `pytest`/Django test suite (including the new test), because it requires a live PostgreSQL 16 instance (normally started with `docker compose up postgres valkey`) and this sandbox has neither `docker` nor enough free disk space to install/run one. For the same reason, `uv sync`, `ruff`, and `pylint` could not be run here either. The new test was traced by hand against the reproduction above and is believed correct, but it was not executed through pytest in this environment.
- The root cause and fix were confirmed directly against the pinned library versions, independent of Django/the test harness, so I'm confident in the change despite not running the full suite.

### Steps to review

1. Confirm the root cause: `boto3.client("s3").generate_presigned_url(...)` defaults to SigV2 for S3 unless `Config(signature_version="s3v4")` is passed explicitly, and AWS S3 requires SigV4 for presigned requests against SSE-KMS objects.
2. Review `get_s3_client()` in `api/src/backend/tasks/jobs/export.py` — both the try and except branches now pass the same `s3_config`.
3. Review the new test in `api/src/backend/tasks/tests/test_export.py`; it uses a real (unmocked) `boto3` client so the signing behavior it asserts on is genuine, not mocked away.
4. Ideally run `uv run pytest src/backend/tasks/tests/test_export.py -v` from `api/` against a live PostgreSQL instance to confirm the new test passes; I was unable to do this locally (see Validation).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- Not applicable — this PR only changes API-side S3 client configuration.

#### API
- [x] All issue/task requirements work as expected on the API
- Endpoint response output: not applicable — the fix changes only the signature scheme of the redirect URL generated for `GET /api/v1/scans/{id}/report`; the response shape and status codes are unchanged.
- EXPLAIN ANALYZE: not applicable, no query changes.
- Performance test results: not applicable, no performance-sensitive change.
- Other evidence: see Validation section above.
- [x] Verify if API specs need to be regenerated. (Not needed — no serializer/endpoint schema change.)
- [x] Check if version updates are required (e.g., specs, uv, etc.). (Not needed — no dependency version change.)
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- Not applicable — this PR does not touch the MCP Server.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #12734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scanning report downloads from S3 buckets using default SSE-KMS encryption, preventing `InvalidArgument` errors.
  * Presigned download URLs now use AWS Signature Version 4 for improved compatibility with encrypted S3 objects.
  * Download behavior is now more reliable across supported S3 configurations, including environments that use credential fallback.
  * Resolved failures affecting downloads when S3 requires modern request signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->