### PR TITLE
chore(codeowners): consolidate retired teams under engineering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,23 +1,23 @@
 # SDK
-/* @prowler-cloud/detection-remediation
-/prowler/ @prowler-cloud/detection-remediation
-/tests/ @prowler-cloud/detection-remediation
-/dashboard/ @prowler-cloud/detection-remediation
-/docs/ @prowler-cloud/detection-remediation
-/examples/ @prowler-cloud/detection-remediation
-/util/ @prowler-cloud/detection-remediation
-/contrib/ @prowler-cloud/detection-remediation
-/permissions/ @prowler-cloud/detection-remediation
-/codecov.yml @prowler-cloud/detection-remediation @prowler-cloud/api
+/* @prowler-cloud/engineering
+/prowler/ @prowler-cloud/engineering
+/tests/ @prowler-cloud/engineering
+/dashboard/ @prowler-cloud/engineering
+/docs/ @prowler-cloud/engineering
+/examples/ @prowler-cloud/engineering
+/util/ @prowler-cloud/engineering
+/contrib/ @prowler-cloud/engineering
+/permissions/ @prowler-cloud/engineering
+/codecov.yml @prowler-cloud/engineering
 
 # API
-/api/ @prowler-cloud/api
+/api/ @prowler-cloud/engineering
 
 # UI
-/ui/ @prowler-cloud/ui
+/ui/ @prowler-cloud/engineering
 
 # AI
-/mcp_server/ @prowler-cloud/detection-remediation
+/mcp_server/ @prowler-cloud/engineering
 
 # Platform
 /.github/ @prowler-cloud/platform


### PR DESCRIPTION
### Context

The org's team structure is being flattened: `application`, `detection-remediation`, `api`, `ui`, `compliance`, and `product` are being retired, and `engineering` becomes the single team for everyone who writes code.

### Description

This file named `detection-remediation`, `api`, and `ui` as owners. All three are retired, so every line they owned now points to `@prowler-cloud/engineering` instead. `@prowler-cloud/platform` lines are untouched. `engineering` already holds `push` on all 31 active repos (platform#1142), which is what makes it a valid code owner — a team without write access is ignored by CODEOWNERS.

### Steps to review

Diff is `.github/CODEOWNERS` only: `detection-remediation` / `api` / `ui` replaced by `engineering`, everything else identical.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

N/A — this PR only touches `.github/CODEOWNERS`; no code, tests, or docs are affected.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership assignments for SDK, API, UI, and AI-related paths.
  * Consolidated code coverage ownership under the engineering team.
  * Platform ownership assignments remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->