### PR TITLE
fix(m365): skip defender preset policies without rules

### DIFF
--- a/prowler/changelog.d/m365-defender-preset-policy-rules.fixed.md
+++ b/prowler/changelog.d/m365-defender-preset-policy-rules.fixed.md
@@ -1,0 +1,1 @@
+M365 Defender policy checks skip preset security policies without matching filter rules instead of crashing

--- a/prowler/providers/m365/services/defender/defender_antiphishing_policy_configured/defender_antiphishing_policy_configured.py
+++ b/prowler/providers/m365/services/defender/defender_antiphishing_policy_configured/defender_antiphishing_policy_configured.py
@@ -74,20 +74,26 @@ class defender_antiphishing_policy_configured(Check):
                             default_policy_well_configured = True
                             findings.append(report)
                     else:
+                        antiphishing_rule = defender_client.antiphishing_rules.get(
+                            policy.name
+                        )
+                        if not antiphishing_rule:
+                            continue
+
                         if not self._is_policy_properly_configured(policy):
                             included_resources = []
 
-                            if defender_client.antiphishing_rules[policy.name].users:
+                            if antiphishing_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.antiphishing_rules[policy.name].users)}"
+                                    f"users: {', '.join(antiphishing_rule.users)}"
                                 )
-                            if defender_client.antiphishing_rules[policy.name].groups:
+                            if antiphishing_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.antiphishing_rules[policy.name].groups)}"
+                                    f"groups: {', '.join(antiphishing_rule.groups)}"
                                 )
-                            if defender_client.antiphishing_rules[policy.name].domains:
+                            if antiphishing_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.antiphishing_rules[policy.name].domains)}"
+                                    f"domains: {', '.join(antiphishing_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
@@ -97,7 +103,7 @@ class defender_antiphishing_policy_configured(Check):
                                 report.status = "FAIL"
                                 report.status_extended = (
                                     f"Custom Anti-phishing policy {policy_name} is not properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.antiphishing_rules[policy.name].priority} (0 is the highest). "
+                                    f"with priority {antiphishing_rule.priority} (0 is the highest). "
                                     "However, the default policy is properly configured, so entities not included by this custom policy could be correctly protected."
                                 )
                                 findings.append(report)
@@ -106,24 +112,24 @@ class defender_antiphishing_policy_configured(Check):
                                 report.status = "FAIL"
                                 report.status_extended = (
                                     f"Custom Anti-phishing policy {policy_name} is not properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.antiphishing_rules[policy.name].priority} (0 is the highest). "
+                                    f"with priority {antiphishing_rule.priority} (0 is the highest). "
                                     "Also, the default policy is not properly configured, so entities not included by this custom policy could not be correctly protected."
                                 )
                                 findings.append(report)
                         else:
                             included_resources = []
 
-                            if defender_client.antiphishing_rules[policy.name].users:
+                            if antiphishing_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.antiphishing_rules[policy.name].users)}"
+                                    f"users: {', '.join(antiphishing_rule.users)}"
                                 )
-                            if defender_client.antiphishing_rules[policy.name].groups:
+                            if antiphishing_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.antiphishing_rules[policy.name].groups)}"
+                                    f"groups: {', '.join(antiphishing_rule.groups)}"
                                 )
-                            if defender_client.antiphishing_rules[policy.name].domains:
+                            if antiphishing_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.antiphishing_rules[policy.name].domains)}"
+                                    f"domains: {', '.join(antiphishing_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
@@ -133,7 +139,7 @@ class defender_antiphishing_policy_configured(Check):
                                 report.status = "PASS"
                                 report.status_extended = (
                                     f"Custom Anti-phishing policy {policy_name} is properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.antiphishing_rules[policy.name].priority} (0 is the highest). "
+                                    f"with priority {antiphishing_rule.priority} (0 is the highest). "
                                     "Also, the default policy is properly configured, so entities not included by this custom policy could still be correctly protected."
                                 )
                                 findings.append(report)
@@ -143,7 +149,7 @@ class defender_antiphishing_policy_configured(Check):
                                 report.status = "PASS"
                                 report.status_extended = (
                                     f"Custom Anti-phishing policy {policy_name} is properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.antiphishing_rules[policy.name].priority} (0 is the highest). "
+                                    f"with priority {antiphishing_rule.priority} (0 is the highest). "
                                     "However, the default policy is not properly configured, so entities not included by this custom policy could not be correctly protected."
                                 )
                                 findings.append(report)
@@ -160,13 +166,13 @@ class defender_antiphishing_policy_configured(Check):
         Returns:
             bool: True if the policy is properly configured, False otherwise.
         """
+        if not policy.default:
+            antiphishing_rule = defender_client.antiphishing_rules.get(policy.name)
+            if not antiphishing_rule or antiphishing_rule.state.lower() != "enabled":
+                return False
+
         return (
-            (
-                policy.default
-                or defender_client.antiphishing_rules[policy.name].state.lower()
-                == "enabled"
-            )
-            and policy.spoof_intelligence
+            policy.spoof_intelligence
             and policy.spoof_intelligence_action.lower() == "quarantine"
             and policy.dmarc_reject_action.lower() == "quarantine"
             and policy.dmarc_quarantine_action.lower() == "quarantine"

--- a/prowler/providers/m365/services/defender/defender_antispam_outbound_policy_configured/defender_antispam_outbound_policy_configured.py
+++ b/prowler/providers/m365/services/defender/defender_antispam_outbound_policy_configured/defender_antispam_outbound_policy_configured.py
@@ -74,20 +74,26 @@ class defender_antispam_outbound_policy_configured(Check):
                             default_policy_well_configured = True
                             findings.append(report)
                     else:
+                        outbound_spam_rule = defender_client.outbound_spam_rules.get(
+                            policy.name
+                        )
+                        if not outbound_spam_rule:
+                            continue
+
                         if not self._is_policy_properly_configured(policy):
                             included_resources = []
 
-                            if defender_client.outbound_spam_rules[policy.name].users:
+                            if outbound_spam_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.outbound_spam_rules[policy.name].users)}"
+                                    f"users: {', '.join(outbound_spam_rule.users)}"
                                 )
-                            if defender_client.outbound_spam_rules[policy.name].groups:
+                            if outbound_spam_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.outbound_spam_rules[policy.name].groups)}"
+                                    f"groups: {', '.join(outbound_spam_rule.groups)}"
                                 )
-                            if defender_client.outbound_spam_rules[policy.name].domains:
+                            if outbound_spam_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.outbound_spam_rules[policy.name].domains)}"
+                                    f"domains: {', '.join(outbound_spam_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
@@ -97,7 +103,7 @@ class defender_antispam_outbound_policy_configured(Check):
                                 report.status = "FAIL"
                                 report.status_extended = (
                                     f"Custom Outbound Spam policy {policy_name} is not properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.outbound_spam_rules[policy.name].priority} (0 is the highest). "
+                                    f"with priority {outbound_spam_rule.priority} (0 is the highest). "
                                     "However, the default policy is properly configured, so entities not included by this custom policy could be correctly protected."
                                 )
                                 findings.append(report)
@@ -106,24 +112,24 @@ class defender_antispam_outbound_policy_configured(Check):
                                 report.status = "FAIL"
                                 report.status_extended = (
                                     f"Custom Outbound Spam policy {policy_name} is not properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.outbound_spam_rules[policy.name].priority} (0 is the highest). "
+                                    f"with priority {outbound_spam_rule.priority} (0 is the highest). "
                                     "Also, the default policy is not properly configured, so entities not included by this custom policy could not be correctly protected."
                                 )
                                 findings.append(report)
                         else:
                             included_resources = []
 
-                            if defender_client.outbound_spam_rules[policy.name].users:
+                            if outbound_spam_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.outbound_spam_rules[policy.name].users)}"
+                                    f"users: {', '.join(outbound_spam_rule.users)}"
                                 )
-                            if defender_client.outbound_spam_rules[policy.name].groups:
+                            if outbound_spam_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.outbound_spam_rules[policy.name].groups)}"
+                                    f"groups: {', '.join(outbound_spam_rule.groups)}"
                                 )
-                            if defender_client.outbound_spam_rules[policy.name].domains:
+                            if outbound_spam_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.outbound_spam_rules[policy.name].domains)}"
+                                    f"domains: {', '.join(outbound_spam_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
@@ -133,7 +139,7 @@ class defender_antispam_outbound_policy_configured(Check):
                                 report.status = "PASS"
                                 report.status_extended = (
                                     f"Custom Outbound Spam policy {policy_name} is properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.outbound_spam_rules[policy.name].priority} (0 is the highest). "
+                                    f"with priority {outbound_spam_rule.priority} (0 is the highest). "
                                     "Also, the default policy is properly configured, so entities not included by this custom policy could still be correctly protected."
                                 )
                                 findings.append(report)
@@ -142,7 +148,7 @@ class defender_antispam_outbound_policy_configured(Check):
                                 report.status = "PASS"
                                 report.status_extended = (
                                     f"Custom Outbound Spam policy {policy_name} is properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.outbound_spam_rules[policy.name].priority} (0 is the highest). "
+                                    f"with priority {outbound_spam_rule.priority} (0 is the highest). "
                                     "However, the default policy is not properly configured, so entities not included by this custom policy could not be correctly protected."
                                 )
                                 findings.append(report)
@@ -159,13 +165,13 @@ class defender_antispam_outbound_policy_configured(Check):
         Returns:
             bool: True if the policy is properly configured, False otherwise.
         """
+        if not policy.default:
+            outbound_spam_rule = defender_client.outbound_spam_rules.get(policy.name)
+            if not outbound_spam_rule or outbound_spam_rule.state.lower() != "enabled":
+                return False
+
         return (
-            (
-                policy.default
-                or defender_client.outbound_spam_rules[policy.name].state.lower()
-                == "enabled"
-            )
-            and policy.notify_limit_exceeded
+            policy.notify_limit_exceeded
             and policy.notify_sender_blocked
             and policy.notify_limit_exceeded_addresses
             and policy.notify_sender_blocked_addresses

--- a/prowler/providers/m365/services/defender/defender_antispam_outbound_policy_forwarding_disabled/defender_antispam_outbound_policy_forwarding_disabled.py
+++ b/prowler/providers/m365/services/defender/defender_antispam_outbound_policy_forwarding_disabled/defender_antispam_outbound_policy_forwarding_disabled.py
@@ -77,20 +77,26 @@ class defender_antispam_outbound_policy_forwarding_disabled(Check):
                             default_policy_well_configured = True
                             findings.append(report)
                     else:
+                        outbound_spam_rule = defender_client.outbound_spam_rules.get(
+                            policy.name
+                        )
+                        if not outbound_spam_rule:
+                            continue
+
                         if not self._is_forwarding_disabled(policy):
                             included_resources = []
 
-                            if defender_client.outbound_spam_rules[policy.name].users:
+                            if outbound_spam_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.outbound_spam_rules[policy.name].users)}"
+                                    f"users: {', '.join(outbound_spam_rule.users)}"
                                 )
-                            if defender_client.outbound_spam_rules[policy.name].groups:
+                            if outbound_spam_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.outbound_spam_rules[policy.name].groups)}"
+                                    f"groups: {', '.join(outbound_spam_rule.groups)}"
                                 )
-                            if defender_client.outbound_spam_rules[policy.name].domains:
+                            if outbound_spam_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.outbound_spam_rules[policy.name].domains)}"
+                                    f"domains: {', '.join(outbound_spam_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
@@ -100,7 +106,7 @@ class defender_antispam_outbound_policy_forwarding_disabled(Check):
                                 report.status = "FAIL"
                                 report.status_extended = (
                                     f"Custom Outbound Spam policy {policy_name} allows mail forwarding and includes {included_resources_str}, "
-                                    f"with priority {defender_client.outbound_spam_rules[policy.name].priority} (0 is the highest). "
+                                    f"with priority {outbound_spam_rule.priority} (0 is the highest). "
                                     "However, the default policy disables mail forwarding, so entities not included by this custom policy could be correctly protected."
                                 )
                                 findings.append(report)
@@ -109,24 +115,24 @@ class defender_antispam_outbound_policy_forwarding_disabled(Check):
                                 report.status = "FAIL"
                                 report.status_extended = (
                                     f"Custom Outbound Spam policy {policy_name} allows mail forwarding and includes {included_resources_str}, "
-                                    f"with priority {defender_client.outbound_spam_rules[policy.name].priority} (0 is the highest). "
+                                    f"with priority {outbound_spam_rule.priority} (0 is the highest). "
                                     "Also, the default policy allows mail forwarding, so entities not included by this custom policy could not be correctly protected."
                                 )
                                 findings.append(report)
                         else:
                             included_resources = []
 
-                            if defender_client.outbound_spam_rules[policy.name].users:
+                            if outbound_spam_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.outbound_spam_rules[policy.name].users)}"
+                                    f"users: {', '.join(outbound_spam_rule.users)}"
                                 )
-                            if defender_client.outbound_spam_rules[policy.name].groups:
+                            if outbound_spam_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.outbound_spam_rules[policy.name].groups)}"
+                                    f"groups: {', '.join(outbound_spam_rule.groups)}"
                                 )
-                            if defender_client.outbound_spam_rules[policy.name].domains:
+                            if outbound_spam_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.outbound_spam_rules[policy.name].domains)}"
+                                    f"domains: {', '.join(outbound_spam_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
@@ -136,7 +142,7 @@ class defender_antispam_outbound_policy_forwarding_disabled(Check):
                                 report.status = "PASS"
                                 report.status_extended = (
                                     f"Custom Outbound Spam policy {policy_name} disables mail forwarding and includes {included_resources_str}, "
-                                    f"with priority {defender_client.outbound_spam_rules[policy.name].priority} (0 is the highest). "
+                                    f"with priority {outbound_spam_rule.priority} (0 is the highest). "
                                     "Also, the default policy disables mail forwarding, so entities not included by this custom policy could still be correctly protected."
                                 )
                                 findings.append(report)
@@ -145,7 +151,7 @@ class defender_antispam_outbound_policy_forwarding_disabled(Check):
                                 report.status = "PASS"
                                 report.status_extended = (
                                     f"Custom Outbound Spam policy {policy_name} disables mail forwarding and includes {included_resources_str}, "
-                                    f"with priority {defender_client.outbound_spam_rules[policy.name].priority} (0 is the highest). "
+                                    f"with priority {outbound_spam_rule.priority} (0 is the highest). "
                                     "However, the default policy allows mail forwarding, so entities not included by this custom policy could not be correctly protected."
                                 )
                                 findings.append(report)
@@ -162,8 +168,9 @@ class defender_antispam_outbound_policy_forwarding_disabled(Check):
         Returns:
             bool: True if mail forwarding is disabled, False otherwise.
         """
-        return (
-            policy.default
-            or defender_client.outbound_spam_rules[policy.name].state.lower()
-            == "enabled"
-        ) and policy.auto_forwarding_mode == "Off"
+        if not policy.default:
+            outbound_spam_rule = defender_client.outbound_spam_rules.get(policy.name)
+            if not outbound_spam_rule or outbound_spam_rule.state.lower() != "enabled":
+                return False
+
+        return policy.auto_forwarding_mode == "Off"

--- a/prowler/providers/m365/services/defender/defender_antispam_policy_inbound_no_allowed_domains/defender_antispam_policy_inbound_no_allowed_domains.py
+++ b/prowler/providers/m365/services/defender/defender_antispam_policy_inbound_no_allowed_domains/defender_antispam_policy_inbound_no_allowed_domains.py
@@ -77,32 +77,30 @@ class defender_antispam_policy_inbound_no_allowed_domains(Check):
                             default_policy_well_configured = True
                             findings.append(report)
                     else:
+                        inbound_spam_rule = defender_client.inbound_spam_rules.get(
+                            policy.identity
+                        )
+                        if not inbound_spam_rule:
+                            continue
+
                         if not self._has_no_allowed_domains(policy):
                             included_resources = []
 
-                            if defender_client.inbound_spam_rules[
-                                policy.identity
-                            ].users:
+                            if inbound_spam_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.inbound_spam_rules[policy.identity].users)}"
+                                    f"users: {', '.join(inbound_spam_rule.users)}"
                                 )
-                            if defender_client.inbound_spam_rules[
-                                policy.identity
-                            ].groups:
+                            if inbound_spam_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.inbound_spam_rules[policy.identity].groups)}"
+                                    f"groups: {', '.join(inbound_spam_rule.groups)}"
                                 )
-                            if defender_client.inbound_spam_rules[
-                                policy.identity
-                            ].domains:
+                            if inbound_spam_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.inbound_spam_rules[policy.identity].domains)}"
+                                    f"domains: {', '.join(inbound_spam_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
-                            priority = defender_client.inbound_spam_rules[
-                                policy.identity
-                            ].priority
+                            priority = inbound_spam_rule.priority
 
                             if default_policy_well_configured:
                                 # Case 3: Default policy has no allowed domains but custom one does
@@ -124,29 +122,21 @@ class defender_antispam_policy_inbound_no_allowed_domains(Check):
                         else:
                             included_resources = []
 
-                            if defender_client.inbound_spam_rules[
-                                policy.identity
-                            ].users:
+                            if inbound_spam_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.inbound_spam_rules[policy.identity].users)}"
+                                    f"users: {', '.join(inbound_spam_rule.users)}"
                                 )
-                            if defender_client.inbound_spam_rules[
-                                policy.identity
-                            ].groups:
+                            if inbound_spam_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.inbound_spam_rules[policy.identity].groups)}"
+                                    f"groups: {', '.join(inbound_spam_rule.groups)}"
                                 )
-                            if defender_client.inbound_spam_rules[
-                                policy.identity
-                            ].domains:
+                            if inbound_spam_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.inbound_spam_rules[policy.identity].domains)}"
+                                    f"domains: {', '.join(inbound_spam_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
-                            priority = defender_client.inbound_spam_rules[
-                                policy.identity
-                            ].priority
+                            priority = inbound_spam_rule.priority
 
                             if default_policy_well_configured:
                                 # Case 2: Both default and custom policies do not contain allowed domains
@@ -178,8 +168,9 @@ class defender_antispam_policy_inbound_no_allowed_domains(Check):
         Returns:
             bool: True if the policy has no allowed domains, False otherwise.
         """
-        return (
-            policy.default
-            or defender_client.inbound_spam_rules[policy.identity].state.lower()
-            == "enabled"
-        ) and not policy.allowed_sender_domains
+        if not policy.default:
+            inbound_spam_rule = defender_client.inbound_spam_rules.get(policy.identity)
+            if not inbound_spam_rule or inbound_spam_rule.state.lower() != "enabled":
+                return False
+
+        return not policy.allowed_sender_domains

--- a/prowler/providers/m365/services/defender/defender_malware_policy_common_attachments_filter_enabled/defender_malware_policy_common_attachments_filter_enabled.py
+++ b/prowler/providers/m365/services/defender/defender_malware_policy_common_attachments_filter_enabled/defender_malware_policy_common_attachments_filter_enabled.py
@@ -77,20 +77,26 @@ class defender_malware_policy_common_attachments_filter_enabled(Check):
                             default_policy_well_configured = True
                             findings.append(report)
                     else:
+                        malware_rule = defender_client.malware_rules.get(
+                            policy.identity
+                        )
+                        if not malware_rule:
+                            continue
+
                         if not policy.enable_file_filter:
                             included_resources = []
 
-                            if defender_client.malware_rules[policy.identity].users:
+                            if malware_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.malware_rules[policy.identity].users)}"
+                                    f"users: {', '.join(malware_rule.users)}"
                                 )
-                            if defender_client.malware_rules[policy.identity].groups:
+                            if malware_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.malware_rules[policy.identity].groups)}"
+                                    f"groups: {', '.join(malware_rule.groups)}"
                                 )
-                            if defender_client.malware_rules[policy.identity].domains:
+                            if malware_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.malware_rules[policy.identity].domains)}"
+                                    f"domains: {', '.join(malware_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
@@ -100,7 +106,7 @@ class defender_malware_policy_common_attachments_filter_enabled(Check):
                                 report.status = "FAIL"
                                 report.status_extended = (
                                     f"Custom Malware policy {policy.identity} does not enable Common Attachment Types Filter and includes {included_resources_str}, "
-                                    f"with priority {defender_client.malware_rules[policy.identity].priority} (0 is the highest). "
+                                    f"with priority {malware_rule.priority} (0 is the highest). "
                                     "However, the default policy enables the filter, so entities not included by this custom policy could be correctly protected."
                                 )
                                 findings.append(report)
@@ -109,24 +115,24 @@ class defender_malware_policy_common_attachments_filter_enabled(Check):
                                 report.status = "FAIL"
                                 report.status_extended = (
                                     f"Custom Malware policy {policy.identity} does not enable Common Attachment Types Filter and includes {included_resources_str}, "
-                                    f"with priority {defender_client.malware_rules[policy.identity].priority} (0 is the highest). "
+                                    f"with priority {malware_rule.priority} (0 is the highest). "
                                     "Also, the default policy does not enable the filter, so entities not included by this custom policy could not be correctly protected."
                                 )
                                 findings.append(report)
                         else:
                             included_resources = []
 
-                            if defender_client.malware_rules[policy.identity].users:
+                            if malware_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.malware_rules[policy.identity].users)}"
+                                    f"users: {', '.join(malware_rule.users)}"
                                 )
-                            if defender_client.malware_rules[policy.identity].groups:
+                            if malware_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.malware_rules[policy.identity].groups)}"
+                                    f"groups: {', '.join(malware_rule.groups)}"
                                 )
-                            if defender_client.malware_rules[policy.identity].domains:
+                            if malware_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.malware_rules[policy.identity].domains)}"
+                                    f"domains: {', '.join(malware_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
@@ -136,7 +142,7 @@ class defender_malware_policy_common_attachments_filter_enabled(Check):
                                 report.status = "PASS"
                                 report.status_extended = (
                                     f"Custom Malware policy {policy.identity} enables Common Attachment Types Filter and includes {included_resources_str}, "
-                                    f"with priority {defender_client.malware_rules[policy.identity].priority} (0 is the highest). "
+                                    f"with priority {malware_rule.priority} (0 is the highest). "
                                     "Also, the default policy enables the filter, so entities not included by this custom policy could still be correctly protected."
                                 )
                                 findings.append(report)
@@ -145,7 +151,7 @@ class defender_malware_policy_common_attachments_filter_enabled(Check):
                                 report.status = "PASS"
                                 report.status_extended = (
                                     f"Custom Malware policy {policy.identity} enables Common Attachment Types Filter and includes {included_resources_str}, "
-                                    f"with priority {defender_client.malware_rules[policy.identity].priority} (0 is the highest). "
+                                    f"with priority {malware_rule.priority} (0 is the highest). "
                                     "However, the default policy does not enable the filter, so entities not included by this custom policy could not be correctly protected."
                                 )
                                 findings.append(report)

--- a/prowler/providers/m365/services/defender/defender_malware_policy_comprehensive_attachments_filter_applied/defender_malware_policy_comprehensive_attachments_filter_applied.py
+++ b/prowler/providers/m365/services/defender/defender_malware_policy_comprehensive_attachments_filter_applied/defender_malware_policy_comprehensive_attachments_filter_applied.py
@@ -145,22 +145,28 @@ class defender_malware_policy_comprehensive_attachments_filter_applied(Check):
                             default_policy_well_configured = True
                             findings.append(report)
                     else:
+                        malware_rule = defender_client.malware_rules.get(
+                            policy.identity
+                        )
+                        if not malware_rule:
+                            continue
+
                         if not self._is_filter_properly_configured(
                             policy, recommended_extensions
                         ):
                             included_resources = []
 
-                            if defender_client.malware_rules[policy.identity].users:
+                            if malware_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.malware_rules[policy.identity].users)}"
+                                    f"users: {', '.join(malware_rule.users)}"
                                 )
-                            if defender_client.malware_rules[policy.identity].groups:
+                            if malware_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.malware_rules[policy.identity].groups)}"
+                                    f"groups: {', '.join(malware_rule.groups)}"
                                 )
-                            if defender_client.malware_rules[policy.identity].domains:
+                            if malware_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.malware_rules[policy.identity].domains)}"
+                                    f"domains: {', '.join(malware_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
@@ -173,7 +179,7 @@ class defender_malware_policy_comprehensive_attachments_filter_applied(Check):
                                 report.status = "FAIL"
                                 report.status_extended = (
                                     f"Custom Malware policy {policy.identity} is not properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.malware_rules[policy.identity].priority} (0 is the highest). "
+                                    f"with priority {malware_rule.priority} (0 is the highest). "
                                     f"Missing recommended file types: {', '.join(missing)}. "
                                     "However, the default policy is properly configured, so entities not included by this custom policy could be correctly protected."
                                 )
@@ -183,7 +189,7 @@ class defender_malware_policy_comprehensive_attachments_filter_applied(Check):
                                 report.status = "FAIL"
                                 report.status_extended = (
                                     f"Custom Malware policy {policy.identity} is not properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.malware_rules[policy.identity].priority} (0 is the highest). "
+                                    f"with priority {malware_rule.priority} (0 is the highest). "
                                     f"Missing recommended file types: {', '.join(missing)}. "
                                     "Also, the default policy is not properly configured, so entities not included by this custom policy could not be correctly protected."
                                 )
@@ -191,17 +197,17 @@ class defender_malware_policy_comprehensive_attachments_filter_applied(Check):
                         else:
                             included_resources = []
 
-                            if defender_client.malware_rules[policy.identity].users:
+                            if malware_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.malware_rules[policy.identity].users)}"
+                                    f"users: {', '.join(malware_rule.users)}"
                                 )
-                            if defender_client.malware_rules[policy.identity].groups:
+                            if malware_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.malware_rules[policy.identity].groups)}"
+                                    f"groups: {', '.join(malware_rule.groups)}"
                                 )
-                            if defender_client.malware_rules[policy.identity].domains:
+                            if malware_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.malware_rules[policy.identity].domains)}"
+                                    f"domains: {', '.join(malware_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
@@ -211,7 +217,7 @@ class defender_malware_policy_comprehensive_attachments_filter_applied(Check):
                                 report.status = "PASS"
                                 report.status_extended = (
                                     f"Custom Malware policy {policy.identity} is properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.malware_rules[policy.identity].priority} (0 is the highest). "
+                                    f"with priority {malware_rule.priority} (0 is the highest). "
                                     "Also, the default policy is properly configured, so entities not included by this custom policy could still be correctly protected."
                                 )
                                 findings.append(report)
@@ -220,7 +226,7 @@ class defender_malware_policy_comprehensive_attachments_filter_applied(Check):
                                 report.status = "PASS"
                                 report.status_extended = (
                                     f"Custom Malware policy {policy.identity} is properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.malware_rules[policy.identity].priority} (0 is the highest). "
+                                    f"with priority {malware_rule.priority} (0 is the highest). "
                                     "However, the default policy is not properly configured, so entities not included by this custom policy could not be correctly protected."
                                 )
                                 findings.append(report)
@@ -231,13 +237,10 @@ class defender_malware_policy_comprehensive_attachments_filter_applied(Check):
         if not policy.enable_file_filter:
             return False
 
-        if (
-            not policy.is_default
-            and policy.identity in defender_client.malware_rules
-            and defender_client.malware_rules[policy.identity].state.lower()
-            != "enabled"
-        ):
-            return False
+        if not policy.is_default:
+            malware_rule = defender_client.malware_rules.get(policy.identity)
+            if not malware_rule or malware_rule.state.lower() != "enabled":
+                return False
 
         blocked_extensions = [ext.lower() for ext in policy.file_types]
         return all(ext.lower() in blocked_extensions for ext in recommended_extensions)

--- a/prowler/providers/m365/services/defender/defender_malware_policy_notifications_internal_users_malware_enabled/defender_malware_policy_notifications_internal_users_malware_enabled.py
+++ b/prowler/providers/m365/services/defender/defender_malware_policy_notifications_internal_users_malware_enabled/defender_malware_policy_notifications_internal_users_malware_enabled.py
@@ -77,20 +77,26 @@ class defender_malware_policy_notifications_internal_users_malware_enabled(Check
                             default_policy_well_configured = True
                             findings.append(report)
                     else:
+                        malware_rule = defender_client.malware_rules.get(
+                            policy.identity
+                        )
+                        if not malware_rule:
+                            continue
+
                         if not self._are_notifications_enabled(policy):
                             included_resources = []
 
-                            if defender_client.malware_rules[policy.identity].users:
+                            if malware_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.malware_rules[policy.identity].users)}"
+                                    f"users: {', '.join(malware_rule.users)}"
                                 )
-                            if defender_client.malware_rules[policy.identity].groups:
+                            if malware_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.malware_rules[policy.identity].groups)}"
+                                    f"groups: {', '.join(malware_rule.groups)}"
                                 )
-                            if defender_client.malware_rules[policy.identity].domains:
+                            if malware_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.malware_rules[policy.identity].domains)}"
+                                    f"domains: {', '.join(malware_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
@@ -100,7 +106,7 @@ class defender_malware_policy_notifications_internal_users_malware_enabled(Check
                                 report.status = "FAIL"
                                 report.status_extended = (
                                     f"Custom Malware policy {policy.identity} is not properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.malware_rules[policy.identity].priority} (0 is the highest). "
+                                    f"with priority {malware_rule.priority} (0 is the highest). "
                                     "However, the default policy is properly configured, so entities not included by this custom policy could be correctly protected."
                                 )
                                 findings.append(report)
@@ -109,24 +115,24 @@ class defender_malware_policy_notifications_internal_users_malware_enabled(Check
                                 report.status = "FAIL"
                                 report.status_extended = (
                                     f"Custom Malware policy {policy.identity} is not properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.malware_rules[policy.identity].priority} (0 is the highest). "
+                                    f"with priority {malware_rule.priority} (0 is the highest). "
                                     "Also, the default policy is not properly configured, so entities not included by this custom policy could not be correctly protected."
                                 )
                                 findings.append(report)
                         else:
                             included_resources = []
 
-                            if defender_client.malware_rules[policy.identity].users:
+                            if malware_rule.users:
                                 included_resources.append(
-                                    f"users: {', '.join(defender_client.malware_rules[policy.identity].users)}"
+                                    f"users: {', '.join(malware_rule.users)}"
                                 )
-                            if defender_client.malware_rules[policy.identity].groups:
+                            if malware_rule.groups:
                                 included_resources.append(
-                                    f"groups: {', '.join(defender_client.malware_rules[policy.identity].groups)}"
+                                    f"groups: {', '.join(malware_rule.groups)}"
                                 )
-                            if defender_client.malware_rules[policy.identity].domains:
+                            if malware_rule.domains:
                                 included_resources.append(
-                                    f"domains: {', '.join(defender_client.malware_rules[policy.identity].domains)}"
+                                    f"domains: {', '.join(malware_rule.domains)}"
                                 )
 
                             included_resources_str = "; ".join(included_resources)
@@ -136,7 +142,7 @@ class defender_malware_policy_notifications_internal_users_malware_enabled(Check
                                 report.status = "PASS"
                                 report.status_extended = (
                                     f"Custom Malware policy {policy.identity} is properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.malware_rules[policy.identity].priority} (0 is the highest). "
+                                    f"with priority {malware_rule.priority} (0 is the highest). "
                                     "Also, the default policy is properly configured, so entities not included by this custom policy could still be correctly protected."
                                 )
                                 findings.append(report)
@@ -145,7 +151,7 @@ class defender_malware_policy_notifications_internal_users_malware_enabled(Check
                                 report.status = "PASS"
                                 report.status_extended = (
                                     f"Custom Malware policy {policy.identity} is properly configured and includes {included_resources_str}, "
-                                    f"with priority {defender_client.malware_rules[policy.identity].priority} (0 is the highest). "
+                                    f"with priority {malware_rule.priority} (0 is the highest). "
                                     "However, the default policy is not properly configured, so entities not included by this custom policy could not be correctly protected."
                                 )
                                 findings.append(report)
@@ -153,13 +159,10 @@ class defender_malware_policy_notifications_internal_users_malware_enabled(Check
         return findings
 
     def _are_notifications_enabled(self, policy) -> bool:
-        if (
-            not policy.is_default
-            and policy.identity in defender_client.malware_rules
-            and defender_client.malware_rules[policy.identity].state.lower()
-            != "enabled"
-        ):
-            return False
+        if not policy.is_default:
+            malware_rule = defender_client.malware_rules.get(policy.identity)
+            if not malware_rule or malware_rule.state.lower() != "enabled":
+                return False
 
         return (
             policy.enable_internal_sender_admin_notifications

--- a/tests/providers/m365/services/defender/defender_preset_policy_rules_test.py
+++ b/tests/providers/m365/services/defender/defender_preset_policy_rules_test.py
@@ -1,0 +1,192 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
+
+
+def _defender_client():
+    defender_client = mock.MagicMock()
+    defender_client.audited_tenant = "audited_tenant"
+    defender_client.audited_domain = DOMAIN
+    defender_client.audit_config = {}
+    return defender_client
+
+
+def _run_check(module_path, class_name, defender_client):
+    fake_client_module = SimpleNamespace(defender_client=defender_client)
+    with (
+        mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_m365_provider(),
+        ),
+        mock.patch(
+            "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+        ),
+        mock.patch.dict(
+            "sys.modules",
+            {
+                "prowler.providers.m365.services.defender.defender_client": fake_client_module
+            },
+        ),
+    ):
+        module = __import__(module_path, fromlist=[class_name])
+        return getattr(module, class_name)().execute()
+
+
+def _malware_policy(identity, is_default):
+    from prowler.providers.m365.services.defender.defender_service import MalwarePolicy
+
+    return MalwarePolicy(
+        identity=identity,
+        enable_file_filter=True,
+        enable_internal_sender_admin_notifications=True,
+        internal_sender_admin_address="admin@example.com",
+        file_types=["exe"],
+        is_default=is_default,
+    )
+
+
+def _antiphishing_policy(name, default):
+    from prowler.providers.m365.services.defender.defender_service import (
+        AntiphishingPolicy,
+    )
+
+    return AntiphishingPolicy(
+        name=name,
+        spoof_intelligence=True,
+        spoof_intelligence_action="Quarantine",
+        dmarc_reject_action="Quarantine",
+        dmarc_quarantine_action="Quarantine",
+        safety_tips=True,
+        unauthenticated_sender_action=True,
+        show_tag=True,
+        honor_dmarc_policy=True,
+        default=default,
+    )
+
+
+def _outbound_spam_policy(name, default):
+    from prowler.providers.m365.services.defender.defender_service import (
+        OutboundSpamPolicy,
+    )
+
+    return OutboundSpamPolicy(
+        name=name,
+        notify_sender_blocked=True,
+        notify_limit_exceeded=True,
+        notify_limit_exceeded_addresses=["admin@example.com"],
+        notify_sender_blocked_addresses=["admin@example.com"],
+        auto_forwarding_mode="Off",
+        default=default,
+    )
+
+
+@pytest.mark.parametrize(
+    ("module_path", "class_name"),
+    [
+        (
+            "prowler.providers.m365.services.defender.defender_malware_policy_notifications_internal_users_malware_enabled.defender_malware_policy_notifications_internal_users_malware_enabled",
+            "defender_malware_policy_notifications_internal_users_malware_enabled",
+        ),
+        (
+            "prowler.providers.m365.services.defender.defender_malware_policy_common_attachments_filter_enabled.defender_malware_policy_common_attachments_filter_enabled",
+            "defender_malware_policy_common_attachments_filter_enabled",
+        ),
+        (
+            "prowler.providers.m365.services.defender.defender_malware_policy_comprehensive_attachments_filter_applied.defender_malware_policy_comprehensive_attachments_filter_applied",
+            "defender_malware_policy_comprehensive_attachments_filter_applied",
+        ),
+    ],
+)
+def test_malware_checks_skip_preset_policy_without_filter_rule(module_path, class_name):
+    defender_client = _defender_client()
+    defender_client.audit_config = {"recommended_blocked_file_types": ["exe"]}
+    defender_client.malware_policies = [
+        _malware_policy("Default", True),
+        _malware_policy("Standard Preset Security Policy", False),
+    ]
+    defender_client.malware_rules = {"Other Policy": mock.MagicMock()}
+
+    result = _run_check(module_path, class_name, defender_client)
+
+    assert len(result) == 1
+    assert result[0].resource_name == "Default"
+
+
+def test_antiphishing_check_skips_preset_policy_without_rule():
+    module_path = "prowler.providers.m365.services.defender.defender_antiphishing_policy_configured.defender_antiphishing_policy_configured"
+    defender_client = _defender_client()
+    defender_client.antiphishing_policies = {
+        "Default": _antiphishing_policy("Default", True),
+        "Standard Preset Security Policy": _antiphishing_policy(
+            "Standard Preset Security Policy", False
+        ),
+    }
+    defender_client.antiphishing_rules = {"Other Policy": mock.MagicMock()}
+
+    result = _run_check(
+        module_path, "defender_antiphishing_policy_configured", defender_client
+    )
+
+    assert len(result) == 1
+    assert result[0].resource_name == "Default"
+
+
+@pytest.mark.parametrize(
+    ("module_path", "class_name"),
+    [
+        (
+            "prowler.providers.m365.services.defender.defender_antispam_outbound_policy_configured.defender_antispam_outbound_policy_configured",
+            "defender_antispam_outbound_policy_configured",
+        ),
+        (
+            "prowler.providers.m365.services.defender.defender_antispam_outbound_policy_forwarding_disabled.defender_antispam_outbound_policy_forwarding_disabled",
+            "defender_antispam_outbound_policy_forwarding_disabled",
+        ),
+    ],
+)
+def test_outbound_spam_checks_skip_preset_policy_without_rule(module_path, class_name):
+    defender_client = _defender_client()
+    defender_client.outbound_spam_policies = {
+        "Default": _outbound_spam_policy("Default", True),
+        "Standard Preset Security Policy": _outbound_spam_policy(
+            "Standard Preset Security Policy", False
+        ),
+    }
+    defender_client.outbound_spam_rules = {"Other Policy": mock.MagicMock()}
+
+    result = _run_check(module_path, class_name, defender_client)
+
+    assert len(result) == 1
+    assert result[0].resource_name == "Default"
+
+
+def test_inbound_spam_check_skips_preset_policy_without_rule():
+    from prowler.providers.m365.services.defender.defender_service import (
+        DefenderInboundSpamPolicy,
+    )
+
+    module_path = "prowler.providers.m365.services.defender.defender_antispam_policy_inbound_no_allowed_domains.defender_antispam_policy_inbound_no_allowed_domains"
+    defender_client = _defender_client()
+    defender_client.inbound_spam_policies = [
+        DefenderInboundSpamPolicy(
+            identity="Default", allowed_sender_domains=[], default=True
+        ),
+        DefenderInboundSpamPolicy(
+            identity="Standard Preset Security Policy",
+            allowed_sender_domains=[],
+            default=False,
+        ),
+    ]
+    defender_client.inbound_spam_rules = {"Other Policy": mock.MagicMock()}
+
+    result = _run_check(
+        module_path,
+        "defender_antispam_policy_inbound_no_allowed_domains",
+        defender_client,
+    )
+
+    assert len(result) == 1
+    assert result[0].resource_name == "Default"


### PR DESCRIPTION
### Context

Fixes #12751.

M365 tenants with Microsoft preset security policies can return Defender policy objects that do not have matching standard filter rules. Several Defender checks indexed the rule dictionaries directly for every non-default policy, so those checks crashed with `KeyError` instead of evaluating the remaining policies.

### Description

This PR skips non-default Defender policies when their matching standard rule is absent, which avoids treating Microsoft-managed preset policy objects as custom policies. It applies the same guard to the affected malware, anti-phishing, outbound spam, and inbound spam checks, and hardens the helper predicates against missing rule entries.

It also adds regression coverage for preset policies without matching rules and a SDK changelog fragment.

### Steps to review

```bash
uv run pytest tests/providers/m365/services/defender/defender_preset_policy_rules_test.py -q
uv run --with ruff ruff check --ignore UP006,UP035 prowler/providers/m365/services/defender/defender_malware_policy_notifications_internal_users_malware_enabled/defender_malware_policy_notifications_internal_users_malware_enabled.py prowler/providers/m365/services/defender/defender_malware_policy_common_attachments_filter_enabled/defender_malware_policy_common_attachments_filter_enabled.py prowler/providers/m365/services/defender/defender_malware_policy_comprehensive_attachments_filter_applied/defender_malware_policy_comprehensive_attachments_filter_applied.py prowler/providers/m365/services/defender/defender_antiphishing_policy_configured/defender_antiphishing_policy_configured.py prowler/providers/m365/services/defender/defender_antispam_outbound_policy_configured/defender_antispam_outbound_policy_configured.py prowler/providers/m365/services/defender/defender_antispam_outbound_policy_forwarding_disabled/defender_antispam_outbound_policy_forwarding_disabled.py prowler/providers/m365/services/defender/defender_antispam_policy_inbound_no_allowed_domains/defender_antispam_policy_inbound_no_allowed_domains.py tests/providers/m365/services/defender/defender_preset_policy_rules_test.py
uv run --with ruff ruff format --check prowler/providers/m365/services/defender/defender_malware_policy_notifications_internal_users_malware_enabled/defender_malware_policy_notifications_internal_users_malware_enabled.py prowler/providers/m365/services/defender/defender_malware_policy_common_attachments_filter_enabled/defender_malware_policy_common_attachments_filter_enabled.py prowler/providers/m365/services/defender/defender_malware_policy_comprehensive_attachments_filter_applied/defender_malware_policy_comprehensive_attachments_filter_applied.py prowler/providers/m365/services/defender/defender_antiphishing_policy_configured/defender_antiphishing_policy_configured.py prowler/providers/m365/services/defender/defender_antispam_outbound_policy_configured/defender_antispam_outbound_policy_configured.py prowler/providers/m365/services/defender/defender_antispam_outbound_policy_forwarding_disabled/defender_antispam_outbound_policy_forwarding_disabled.py prowler/providers/m365/services/defender/defender_antispam_policy_inbound_no_allowed_domains/defender_antispam_policy_inbound_no_allowed_domains.py tests/providers/m365/services/defender/defender_preset_policy_rules_test.py
```

Note: the broader existing M365 Defender check test files could not be run in this environment because they import the real Defender client before mocking and require `pwsh`, which is not installed here.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure a changelog fragment is added under <component>/changelog.d/, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - M365 Defender policy checks no longer crash when preset security policies lack matching filter rules.
  - Policies without corresponding rules are safely skipped, while default policies continue to be evaluated.
  - Checks now correctly treat missing or disabled rules as not properly configured.

- **Tests**
  - Added coverage for malware, anti-phishing, inbound spam, and outbound spam policy scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->