### PR TITLE
chore(ci): bump agilepathway/label-checker to v1.6.66

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Check labels
         id: label_check
-        uses: agilepathway/label-checker@c3d16ad512e7cea5961df85ff2486bb774caf3c5 # v1.6.65
+        uses: agilepathway/label-checker@c324842522fbd012e4f590afe3b4e591301322ed # v1.6.66
         with:
           allow_failure: true
           prefix_mode: true


### PR DESCRIPTION
### Context

The `backport` job has been failing on every merged PR since Debian 11 (bullseye) reached LTS EOL on 2026-08-31. Example failure: run 34211456730, job 102014288517, on PR #12758.

The job fails during the Docker build of the `agilepathway/label-checker` action, before the action itself even runs, so the failure is unrelated to any individual PR's contents.

### Description

`agilepathway/label-checker` v1.6.65's Dockerfile builds on a `golang:*-bullseye` base image and runs `apt-get update && apt-get -y install --no-install-recommends upx-ucl=3.96-2`. With bullseye past LTS EOL, the `debian-security` `InRelease` file has expired, and `apt-get update` now exits 100:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired
```

Upstream released v1.6.66 on 2026-09-08 ("Fix expired bullseye problem", agilepathway/label-checker#493), which moves the build to bookworm and drops the apt-get/upx step entirely.

This PR bumps the pin in `.github/workflows/backport.yml` from `c3d16ad5...` (v1.6.65) to `c324842522fbd012e4f590afe3b4e591301322ed` (v1.6.66).

### Steps to review

- Confirm the SHA `c324842522fbd012e4f590afe3b4e591301322ed` corresponds to the `v1.6.66` tag on `agilepathway/label-checker`.
- Merge and confirm the next `backport` job run on a labeled PR completes the label-check step instead of failing at the Docker build.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the README.md
- [x] Ensure a changelog fragment is added under prowler/changelog.d/, if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated label-checking workflow to the latest maintenance release.
  * No user-facing behavior or workflow configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->