### PR TITLE
docs(aws): document scanning the ISO partitions

### DIFF
--- a/docs/user-guide/providers/aws/regions-and-partitions.mdx
+++ b/docs/user-guide/providers/aws/regions-and-partitions.mdx
@@ -21,7 +21,7 @@ When scanning the China (`aws-cn`), European Sovereign Cloud (`aws-eusc`) or Gov
 
 - Specify the regions to audit within that partition using the `-f/--region` flag.
 
-- Declare the partition with the `PROWLER_AWS_PARTITION` environment variable, set to `aws`, `aws-cn`, `aws-eusc` or `aws-us-gov`.
+- Declare the partition with the `PROWLER_AWS_PARTITION` environment variable, set to `aws`, `aws-cn`, `aws-eusc`, `aws-us-gov`, `aws-iso`, `aws-iso-b`, `aws-iso-e` or `aws-iso-f`.
 
 <Note>
 Refer to: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials for more information about the AWS credential configuration.
@@ -163,36 +163,45 @@ With this configuration, all partition regions will be scanned without needing t
 </Note>
 ### AWS ISO (US \& Europe)
 
-The AWS ISO partitions—commonly referred to as "secret partitions"—are air-gapped from the Internet, and Prowler does not have a built-in way to scan them. To audit an AWS ISO partition, manually update [aws\_regions\_by\_service.json](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/aws_regions_by_service.json) to include the partition, region, and services. For example:
+The AWS ISO partitions, commonly referred to as "secret partitions", are air-gapped from the Internet. Their regions, and the services available in each of them, ship with the AWS SDK, so Prowler resolves them like any other partition and no manual edit of [aws\_regions\_by\_service.json](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/aws_regions_by_service.json) is required.
 
-```json
-"iam": {
-    "regions": {
-    "aws": [
-        "eu-west-1",
-        "us-east-1",
-    ],
-    "aws-cn": [
-        "cn-north-1",
-        "cn-northwest-1"
-    ],
-    "aws-eusc": [
-        "eusc-de-east-1"
-    ],
-    "aws-us-gov": [
-        "us-gov-east-1",
-        "us-gov-west-1"
-    ],
-    "aws-iso": [
-        "aws-iso-global",
-        "us-iso-east-1",
-        "us-iso-west-1"
-    ],
-    "aws-iso-b": [
-        "aws-iso-b-global",
-        "us-isob-east-1"
-    ],
-    "aws-iso-e": [],
-    }
-},
-```
+<Warning>
+Support for the ISO partitions has not been exercised against a live ISO account. The regions and per-service availability come from the endpoint metadata bundled with the AWS SDK, and the behaviour is covered by tests, but scanning inside these partitions is still pending validation in a real environment. Report anything that does not work as described here.
+
+</Warning>
+
+To scan an account in an AWS ISO partition (`aws-iso`, `aws-iso-b`, `aws-iso-e` or `aws-iso-f`):
+
+- By using the `-f/--region` flag:
+
+    ```
+    prowler aws --region us-isob-east-1
+    ```
+
+- By using the region configured in your AWS profile at `~/.aws/credentials` or `~/.aws/config`:
+
+    ```
+    [default]
+    aws_access_key_id = XXXXXXXXXXXXXXXXXXX
+    aws_secret_access_key = XXXXXXXXXXXXXXXXXXX
+    region = us-isob-east-1
+    ```
+
+<Note>
+With this configuration, all partition regions will be scanned without needing the `-f/--region` flag
+
+</Note>
+
+The regions of each ISO partition are:
+
+| Partition | Regions |
+| --- | --- |
+| `aws-iso` | `us-iso-east-1`, `us-iso-west-1` |
+| `aws-iso-b` | `us-isob-east-1`, `us-isob-west-1` |
+| `aws-iso-e` | `eu-isoe-west-1` |
+| `aws-iso-f` | `us-isof-east-1`, `us-isof-south-1` |
+
+<Note>
+These partitions offer far fewer services than the commercial one. A service that is not available in the audited partition is skipped rather than reported as failing.
+
+</Note>


### PR DESCRIPTION
### Context

#12759 added the ISO partitions to the AWS service region matrix, and the documentation was left contradicting it. The ISO section of `docs/user-guide/providers/aws/regions-and-partitions.mdx` still says:

- that Prowler has no built-in way to scan the ISO partitions;
- that the way to audit one is to hand-edit `aws_regions_by_service.json`. That workaround never survived a week even before #12759, because `prowler-bot` regenerates the file every Monday and wipes the edit;
- and its example lists `aws-iso-global` and `aws-iso-b-global` as regions. Those are botocore pseudo endpoints rather than regions, and the provider no longer returns them.

Separately, #12764 documented `PROWLER_AWS_PARTITION` but lists only `aws`, `aws-cn`, `aws-eusc` and `aws-us-gov` as accepted values. The code accepts every partition botocore knows, and since #12759 the ISO ones have region data behind them.

### Description

The ISO section is rewritten to follow the same shape as the China, GovCloud and European Sovereign Cloud sections: selecting a region with `-f/--region` or through the profile, plus a table with the regions of the four ISO partitions.

It carries a `<Warning>` stating that support has not been exercised against a live ISO account and that scanning inside these partitions is pending validation in a real environment. The regions and per-service availability come from the endpoint metadata bundled with the AWS SDK and the behaviour is covered by tests, but that is not the same as having run a scan there, and the page should not suggest otherwise.

The accepted values listed for `PROWLER_AWS_PARTITION` are completed with the four ISO partitions.

Documentation only: one file, no code.

### Steps to review

The Mintlify preview is the fastest way in. The rewritten section is the last one on the page, "AWS ISO (US & Europe)".

Worth checking specifically:

1. The regions in the table match the partitions the AWS SDK declares: `us-iso-east-1`/`us-iso-west-1`, `us-isob-east-1`/`us-isob-west-1`, `eu-isoe-west-1`, `us-isof-east-1`/`us-isof-south-1`.
2. No reference to `aws-iso-global` or `aws-iso-b-global` survives anywhere on the page.
3. The page no longer tells anyone to edit `aws_regions_by_service.json` by hand.
4. The warning is placed before the usage instructions rather than after them.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. Not applicable: documentation only, and `docs` is not one of the monitored folders.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated AWS partition guidance to include ISO partitions: `aws-iso`, `aws-iso-b`, `aws-iso-e`, and `aws-iso-f`.
  - Added supported ISO regions, scanning examples, account validation details, and guidance for unavailable services.
  - Clarified that region and service information is resolved automatically through the SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->