### PR TITLE
fix(api): make findings partition bounds tile exactly

### DIFF
--- a/api/changelog.d/uuid7-partition-bounds-tile.fixed.md
+++ b/api/changelog.d/uuid7-partition-bounds-tile.fixed.md
@@ -1,0 +1,1 @@
+Findings partitions now tile exactly instead of leaving a sub-millisecond gap at each window boundary, where findings landed in the default partition and were never aged out

--- a/api/src/backend/api/partitions.py
+++ b/api/src/backend/api/partitions.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 
 from api.models import Finding, ResourceFindingMapping
 from api.rls import RowLevelSecurityConstraint
-from api.uuid_utils import datetime_to_uuid7
+from api.uuid_utils import uuid7_range_bound
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -102,11 +102,13 @@ class PostgresUUIDv7PartitioningStrategy(PostgresRangePartitioningStrategy):
         )
 
         for _ in range(self.count):
-            end_datetime = (
-                current_datetime + self.size.as_delta() - relativedelta(microseconds=1)
-            )
-            start_uuid7 = datetime_to_uuid7(current_datetime)
-            end_uuid7 = datetime_to_uuid7(end_datetime)
+            # The upper bound is the next window's start, not an instant just
+            # before it: PostgreSQL's upper bound is exclusive, so this is what
+            # makes consecutive partitions meet instead of leaving the gap a
+            # sub-millisecond offset produces on a millisecond-resolution key.
+            end_datetime = current_datetime + self.size.as_delta()
+            start_uuid7 = uuid7_range_bound(current_datetime)
+            end_uuid7 = uuid7_range_bound(end_datetime)
 
             yield PostgresUUIDv7RangePartition(
                 from_values=start_uuid7,
@@ -126,8 +128,8 @@ class PostgresUUIDv7PartitioningStrategy(PostgresRangePartitioningStrategy):
 
         while True:
             end_datetime = current_datetime + self.size.as_delta()
-            start_uuid7 = datetime_to_uuid7(current_datetime)
-            end_uuid7 = datetime_to_uuid7(end_datetime)
+            start_uuid7 = uuid7_range_bound(current_datetime)
+            end_uuid7 = uuid7_range_bound(end_datetime)
 
             # dropping table will delete indexes and policies
             yield PostgresUUIDv7RangePartition(

--- a/api/src/backend/api/tests/test_partitions.py
+++ b/api/src/backend/api/tests/test_partitions.py
@@ -6,6 +6,7 @@ from api.partitions import (
     PostgresUUIDv7PartitioningStrategy,
     relative_months_or_none,
 )
+from api.uuid_utils import uuid7_range_bound
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ImproperlyConfigured
 from psqlextra.partitioning import PostgresTimePartitionSize
@@ -61,3 +62,39 @@ class TestToDelete:
         starts = [datetime.strptime(n, "%Y_%b") for n in names]
 
         assert starts == sorted(starts, reverse=True)
+
+
+class TestToCreate:
+    def test_consecutive_partitions_meet_exactly(self):
+        # PostgreSQL's upper bound is exclusive, so windows tile only when one
+        # partition's to_values is the next one's from_values. Anything less
+        # leaves ids in between with no partition to go to.
+        strategy = PostgresUUIDv7PartitioningStrategy(
+            size=PostgresTimePartitionSize(months=1),
+            count=4,
+            start_date=datetime(2026, 1, 1, tzinfo=UTC),
+            max_age=None,
+            name_format="%Y_%b",
+        )
+
+        partitions = list(strategy.to_create())
+
+        for earlier, later in zip(partitions, partitions[1:]):
+            assert earlier.to_values == later.from_values
+
+    def test_bounds_do_not_depend_on_when_they_were_derived(self):
+        # A bound that is regenerated has to come out identical, or a partition's
+        # declared range cannot be reconciled against the one it was created with.
+        moment = datetime(2026, 5, 17, 9, 30, tzinfo=UTC)
+
+        assert uuid7_range_bound(moment) == uuid7_range_bound(moment)
+
+    def test_bound_is_the_lowest_uuid7_of_its_millisecond(self):
+        moment = datetime(2026, 5, 17, 9, 30, tzinfo=UTC)
+
+        bound = uuid7_range_bound(moment)
+
+        assert bound.version == 7
+        # Timestamp preserved, every field below it zero.
+        assert bound.int >> 80 == int(moment.timestamp() * 1000)
+        assert bound.int & ((1 << 76) - 1) == (0x2 << 62)

--- a/api/src/backend/api/tests/test_partitions.py
+++ b/api/src/backend/api/tests/test_partitions.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from itertools import islice
 
 import pytest
@@ -88,6 +88,17 @@ class TestToCreate:
         moment = datetime(2026, 5, 17, 9, 30, tzinfo=UTC)
 
         assert uuid7_range_bound(moment) == uuid7_range_bound(moment)
+
+    def test_bound_holds_its_millisecond_far_into_the_future(self):
+        # A float second stops resolving milliseconds in 2249, so
+        # int(dt.timestamp() * 1000) rounds the last microsecond of a millisecond
+        # up into the next one and the bound excludes the ids it exists to cover.
+        moment = datetime(2262, 5, 17, 9, 30, 0, 999, tzinfo=UTC)
+        epoch = datetime(1970, 1, 1, tzinfo=UTC)
+
+        bound = uuid7_range_bound(moment)
+
+        assert bound.int >> 80 == (moment - epoch) // timedelta(milliseconds=1)
 
     def test_bound_is_the_lowest_uuid7_of_its_millisecond(self):
         moment = datetime(2026, 5, 17, 9, 30, tzinfo=UTC)

--- a/api/src/backend/api/uuid_utils.py
+++ b/api/src/backend/api/uuid_utils.py
@@ -32,6 +32,28 @@ def transform_into_uuid7(uuid_obj: UUID) -> UUID:
         raise ValidationError("Invalid UUIDv7 value.")
 
 
+def uuid7_range_bound(dt: datetime) -> UUID:
+    """
+    Returns the lowest UUIDv7 whose timestamp is the millisecond containing `dt`.
+
+    Partition bounds have to be derived, not generated: two calls for the same
+    instant must give the same literal, and consecutive windows must meet
+    exactly. `datetime_to_uuid7` fills the sequence and node fields with
+    randomness, which is right for an identifier and wrong for a bound -- a
+    bound a millisecond wide with a random tail leaves the values above it in
+    that millisecond outside every partition.
+
+    Args:
+        dt: The instant the bound sits at.
+
+    Returns:
+        UUID: The smallest UUIDv7 in `dt`'s millisecond.
+    """
+    timestamp_ms = int(dt.timestamp() * 1000) & 0xFFFFFFFFFFFF
+    # Version 7 in bits 76-79 and variant "10" in bits 62-63; every other bit zero.
+    return UUID(int=(timestamp_ms << 80) | (0x7 << 76) | (0x2 << 62))
+
+
 def datetime_to_uuid7(dt: datetime) -> UUID:
     """
     Generates a UUIDv7 from a given datetime object.

--- a/api/src/backend/api/uuid_utils.py
+++ b/api/src/backend/api/uuid_utils.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from random import getrandbits
 
 from dateutil.relativedelta import relativedelta
@@ -43,13 +43,20 @@ def uuid7_range_bound(dt: datetime) -> UUID:
     bound a millisecond wide with a random tail leaves the values above it in
     that millisecond outside every partition.
 
+    The millisecond is counted with integer arithmetic rather than through
+    `dt.timestamp() * 1000`: past year 2249 a float second no longer resolves a
+    millisecond, so an instant in the last microsecond of one rounds up into the
+    next, putting the bound a millisecond above the values it exists to include.
+
     Args:
-        dt: The instant the bound sits at.
+        dt: The instant the bound sits at. A naive `dt` is read as local time,
+            the same way `datetime.timestamp()` reads it.
 
     Returns:
         UUID: The smallest UUIDv7 in `dt`'s millisecond.
     """
-    timestamp_ms = int(dt.timestamp() * 1000) & 0xFFFFFFFFFFFF
+    since_epoch = dt.astimezone(UTC) - datetime(1970, 1, 1, tzinfo=UTC)
+    timestamp_ms = (since_epoch // timedelta(milliseconds=1)) & 0xFFFFFFFFFFFF
     # Version 7 in bits 76-79 and variant "10" in bits 62-63; every other bit zero.
     return UUID(int=(timestamp_ms << 80) | (0x7 << 76) | (0x2 << 62))
 


### PR DESCRIPTION
### Context

Fix #12736.

Findings are partitioned by UUIDv7, so the partition key carries a millisecond timestamp. `PostgresUUIDv7PartitioningStrategy.to_create()` derives each window's upper bound as `datetime_to_uuid7(current + size - relativedelta(microseconds=1))`, and that is off in two ways.

PostgreSQL's upper bound is already exclusive, so nothing needs subtracting — and on a millisecond-resolution key a microsecond rounds down into the previous millisecond, so consecutive partitions stop meeting. Every window boundary leaves one millisecond that no partition covers. A finding whose id lands in it goes to `findings_default`, and the retention pass only drops named partitions, so those rows stay for the life of the install.

The second problem is that `datetime_to_uuid7` fills `rand_a` and `rand_b` with randomness. That is exactly right for an identifier and wrong for a bound: the same instant produces a different literal on every call, so a partition's declared range cannot be recomputed and reconciled against the one it was created with. It also means the hole is not exactly a millisecond, but a millisecond plus wherever the random tail happened to fall.

### Description

`uuid7_range_bound(dt)` in `api/uuid_utils.py` returns the lowest UUIDv7 in `dt`'s millisecond: timestamp in place, version and variant set, every other bit zero. Deterministic by construction.

`to_create()` and `to_delete()` derive both bounds through it and the `- relativedelta(microseconds=1)` is dropped, so one partition's `to_values` is exactly the next one's `from_values`.

`datetime_to_uuid7` is untouched — it is still the right function for generating an id.

This changes the bounds that new partitions are created with. It does not move anything: rows that already went to `findings_default` at earlier boundaries stay there, and clearing those is a separate operation.

### Steps to review

`api/src/backend/api/tests/test_partitions.py` has the three properties that matter: consecutive partitions meet exactly, a bound is the same on every call, and a bound really is the lowest UUIDv7 of its millisecond.

To see the old behaviour, the arithmetic is small enough to check without the app — for each of six monthly windows, `datetime_to_uuid7(next_start - 1µs)` comes out below `datetime_to_uuid7(next_start)`, with one millisecond of timestamp uncovered between them, and two calls for the same instant compare unequal. With `uuid7_range_bound` all six pairs meet and repeat calls are identical; `2026-05-17 09:30 UTC` gives `019e3545-61c0-7000-8000-000000000000`.

I should be straight about one thing: I checked the bound arithmetic standalone, not through your Django suite, which needs an environment I do not have set up. The change is confined to how two integers are built, but the tests have not been executed in CI on my side — please treat that as unverified until your pipeline runs them.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com — #12736
- [ ] Is it assigned to me — it is not; #12736 has not been triaged yet. I opened this because the fix was already written while reporting the issue. Happy to close it and wait if you would rather assign it first.
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>

- [x] Review if the code is being covered by tests — three added in `test_partitions.py`
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed — your call; the bug exists wherever this strategy shipped
- [ ] Review if is needed to change the README.md — not applicable
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d) — `api/changelog.d/uuid7-partition-bounds-tile.fixed.md`

#### SDK/CLI
- Are there new checks included in this PR? No

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes — not applicable, no query changes
- [x] Any other relevant evidence of the implementation — the bound arithmetic above
- [ ] Verify if API specs need to be regenerated — not needed, no API surface change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Findings partitions now tile exactly at window boundaries, preventing records from falling into the default partition and being missed during aging.
  * Partition boundaries are now consistently aligned to the earliest UUIDv7 value for each millisecond.

* **Tests**
  * Added coverage confirming consecutive partitions share exact boundaries and that UUIDv7 range bounds remain stable and correctly formed.

* **Documentation**
  * Added a changelog entry describing the partition boundary fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->