### PR TITLE
test(mcp): cover the attack-paths, compliance, muting, providers, roles and scans models

### DIFF
--- a/mcp_server/changelog.d/mcp-server-coverage-phase2.added.md
+++ b/mcp_server/changelog.d/mcp-server-coverage-phase2.added.md
@@ -1,0 +1,1 @@
+Unit test coverage for the attack-paths, compliance, muting, providers, roles and scans models

--- a/mcp_server/tests/prowler_app/models/test_attack_paths.py
+++ b/mcp_server/tests/prowler_app/models/test_attack_paths.py
@@ -44,6 +44,8 @@ PROWLER_FINDING_NODE_DATA = {
 
 
 def test_attack_path_scan_reads_core_fields():
+    """id/state/progress come from attributes; provider_id is lifted out of the
+    `provider` relationship linkage."""
     scan = AttackPathScan.from_api_response(
         jsonapi_resource(
             "attack-path-scans",
@@ -70,11 +72,14 @@ def test_attack_path_scan_missing_provider_relationship_raises_validation_error(
 
 
 def test_attack_path_scans_list_response_raises_on_missing_pagination():
+    """This list response requires `meta.pagination` and raises a ValueError when
+    it is absent, unlike the sibling list models that default silently."""
     with pytest.raises(ValueError, match="Missing pagination metadata"):
         AttackPathScansListResponse.from_api_response({"data": []})
 
 
 def test_attack_path_scans_list_response_parses_pagination():
+    """page/pages/count are read straight from `meta.pagination`."""
     response = jsonapi_collection(
         [
             jsonapi_resource(
@@ -98,6 +103,8 @@ def test_attack_path_scans_list_response_parses_pagination():
 
 
 def test_attack_path_cartography_schema_reads_required_fields():
+    """provider/version/URLs come from a wrapped `{data: {...}}` document;
+    `schema_content` is left None for a separate fetch step to fill."""
     schema = AttackPathCartographySchema.from_api_response(
         jsonapi_document(
             jsonapi_resource(
@@ -129,6 +136,7 @@ def test_attack_path_cartography_schema_missing_data_key_raises():
 
 
 def test_attack_path_query_parameter_reads_fields():
+    """A query parameter is parsed from a flat dict (no JSON:API wrapper)."""
     param = AttackPathQueryParameter.from_api_response(
         {
             "name": "region",
@@ -147,6 +155,7 @@ def test_attack_path_query_parameter_reads_fields():
 
 
 def test_attack_path_query_parameter_defaults_data_type():
+    """`data_type` falls back to "string" when the API omits it."""
     param = AttackPathQueryParameter.from_api_response(
         {"name": "region", "label": "Region"}
     )
@@ -155,6 +164,8 @@ def test_attack_path_query_parameter_defaults_data_type():
 
 
 def test_attack_path_query_parses_nested_parameters():
+    """Each entry in the `parameters` attribute is recursively parsed into an
+    AttackPathQueryParameter."""
     query = AttackPathQuery.from_api_response(
         jsonapi_resource(
             "attack-paths-query",
@@ -178,6 +189,7 @@ def test_attack_path_query_parses_nested_parameters():
 
 
 def test_attack_path_query_tolerates_missing_parameters():
+    """A query with no `parameters` attribute yields an empty list, not an error."""
     query = AttackPathQuery.from_api_response(
         jsonapi_resource(
             "attack-paths-query",
@@ -229,6 +241,7 @@ def test_attack_path_graph_node_without_prowler_finding_label_drops_severity():
 
 
 def test_attack_path_graph_relationship_requires_all_fields():
+    """A graph edge is parsed from a flat dict of id/label/source/target."""
     rel = AttackPathsGraphRelationship.from_api_response(
         {
             "id": "rel1",
@@ -285,6 +298,7 @@ def test_attack_path_query_result_with_missing_data_key_is_normalized():
 
 
 def test_attack_path_query_result_with_populated_graph():
+    """nodes and relationships arrays are each parsed into their typed models."""
     response = jsonapi_document(
         jsonapi_resource(
             "attack-paths-result",

--- a/mcp_server/tests/prowler_app/models/test_attack_paths.py
+++ b/mcp_server/tests/prowler_app/models/test_attack_paths.py
@@ -1,0 +1,311 @@
+"""Tests for the attack paths models.
+
+Key edge cases: `AttackPathsGraphNode` branches on presence of "ProwlerFinding" in
+labels when extracting severity/status fields from properties. `AttackPathScan` and
+`SimplifiedScan` have a latent bug where provider_id field is non-Optional str but
+`from_api_response` can pass None (would raise ValidationError). These tests pin
+current behavior rather than fixing — appropriate for a coverage-only PR.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from prowler_mcp_server.prowler_app.models.attack_paths import (
+    AttackPathCartographySchema,
+    AttackPathQuery,
+    AttackPathQueryParameter,
+    AttackPathQueryResult,
+    AttackPathScan,
+    AttackPathScansListResponse,
+    AttackPathsGraphNode,
+    AttackPathsGraphRelationship,
+)
+from tests.helpers.jsonapi import (
+    jsonapi_collection,
+    jsonapi_document,
+    jsonapi_relationship_one,
+    jsonapi_resource,
+)
+
+SCAN_ATTRIBUTES = {
+    "state": "completed",
+    "progress": 100,
+}
+
+PROWLER_FINDING_NODE_DATA = {
+    "labels": ["ProwlerFinding"],
+    "properties": {
+        "id": "f1",
+        "severity": "high",
+        "status": "FAIL",
+        "status_extended": "Resource is non-compliant",
+    },
+}
+
+
+def test_attack_path_scan_reads_core_fields():
+    scan = AttackPathScan.from_api_response(
+        jsonapi_resource(
+            "attack-path-scans",
+            "scan1",
+            attributes=SCAN_ATTRIBUTES,
+            relationships={"provider": jsonapi_relationship_one("providers", "p1")},
+        )
+    )
+
+    assert scan.id == "scan1"
+    assert scan.state == "completed"
+    assert scan.progress == 100
+    assert scan.provider_id == "p1"
+
+
+def test_attack_path_scan_missing_provider_relationship_raises_validation_error():
+    """provider_id field is str (non-Optional) but from_api_response can produce
+    None when the provider relationship is absent — this raises ValidationError.
+    This pins current behavior (a likely latent bug) rather than fixing it."""
+    with pytest.raises(ValidationError):
+        AttackPathScan.from_api_response(
+            jsonapi_resource("attack-path-scans", "scan1", attributes=SCAN_ATTRIBUTES)
+        )
+
+
+def test_attack_path_scans_list_response_raises_on_missing_pagination():
+    with pytest.raises(ValueError, match="Missing pagination metadata"):
+        AttackPathScansListResponse.from_api_response({"data": []})
+
+
+def test_attack_path_scans_list_response_parses_pagination():
+    response = jsonapi_collection(
+        [
+            jsonapi_resource(
+                "attack-path-scans",
+                "scan1",
+                attributes=SCAN_ATTRIBUTES,
+                relationships={"provider": jsonapi_relationship_one("providers", "p1")},
+            )
+        ],
+        page=2,
+        pages=3,
+        count=42,
+    )
+
+    result = AttackPathScansListResponse.from_api_response(response)
+
+    assert result.current_page == 2
+    assert result.total_num_pages == 3
+    assert result.total_num_scans == 42
+    assert len(result.scans) == 1
+
+
+def test_attack_path_cartography_schema_reads_required_fields():
+    schema = AttackPathCartographySchema.from_api_response(
+        jsonapi_document(
+            jsonapi_resource(
+                "cartography-schema",
+                "schema1",
+                {
+                    "provider": "aws",
+                    "cartography_version": "1.0.0",
+                    "schema_url": "https://example.com/schema.json",
+                    "raw_schema_url": "https://raw.example.com/schema.json",
+                },
+            )
+        )
+    )
+
+    assert schema.id == "schema1"
+    assert schema.provider == "aws"
+    assert schema.cartography_version == "1.0.0"
+    assert schema.schema_url == "https://example.com/schema.json"
+    assert schema.raw_schema_url == "https://raw.example.com/schema.json"
+    assert schema.schema_content is None  # Never set by from_api_response
+
+
+def test_attack_path_cartography_schema_missing_data_key_raises():
+    """If data key is missing, response.get("data", {}) yields {}, then
+    data["id"] raises KeyError (inconsistent with attributes.get() pattern)."""
+    with pytest.raises(KeyError):
+        AttackPathCartographySchema.from_api_response({})
+
+
+def test_attack_path_query_parameter_reads_fields():
+    param = AttackPathQueryParameter.from_api_response(
+        {
+            "name": "region",
+            "label": "Cloud Region",
+            "data_type": "string",
+            "description": "The region to query",
+            "placeholder": "us-east-1",
+        }
+    )
+
+    assert param.name == "region"
+    assert param.label == "Cloud Region"
+    assert param.data_type == "string"
+    assert param.description == "The region to query"
+    assert param.placeholder == "us-east-1"
+
+
+def test_attack_path_query_parameter_defaults_data_type():
+    param = AttackPathQueryParameter.from_api_response(
+        {"name": "region", "label": "Region"}
+    )
+
+    assert param.data_type == "string"
+
+
+def test_attack_path_query_parses_nested_parameters():
+    query = AttackPathQuery.from_api_response(
+        jsonapi_resource(
+            "attack-paths-query",
+            "q1",
+            {
+                "name": "Find exposed resources",
+                "description": "Query for exposed resources",
+                "provider": "aws",
+                "parameters": [
+                    {"name": "region", "label": "Region"},
+                    {"name": "service", "label": "Service"},
+                ],
+            },
+        )
+    )
+
+    assert query.id == "q1"
+    assert query.name == "Find exposed resources"
+    assert len(query.parameters) == 2
+    assert query.parameters[0].name == "region"
+
+
+def test_attack_path_query_tolerates_missing_parameters():
+    query = AttackPathQuery.from_api_response(
+        jsonapi_resource(
+            "attack-paths-query",
+            "q1",
+            {
+                "name": "Find exposed resources",
+                "description": "Query for exposed resources",
+                "provider": "aws",
+            },
+        )
+    )
+
+    assert query.parameters == []
+
+
+def test_attack_path_graph_node_with_prowler_finding_label_extracts_severity():
+    """Severity/status/status_extended are ONLY extracted from properties when
+    'ProwlerFinding' is in labels. This tests the truthy branch. The node shape
+    is a flat dict with "labels"/"properties" keys -- not a JSON:API resource."""
+    node = AttackPathsGraphNode.from_api_response(PROWLER_FINDING_NODE_DATA)
+
+    assert node.resource_id == "f1"
+    assert "ProwlerFinding" in node.labels
+    assert node.severity == "high"
+    assert node.status == "FAIL"
+    assert node.status_extended == "Resource is non-compliant"
+
+
+def test_attack_path_graph_node_without_prowler_finding_label_drops_severity():
+    """Node without 'ProwlerFinding' in labels must NOT expose severity/status
+    fields even if the properties dict contains them. This tests the falsy branch."""
+    node = AttackPathsGraphNode.from_api_response(
+        {
+            "labels": ["AwsS3Bucket"],
+            "properties": {
+                "id": "res1",
+                "severity": "high",  # Present in properties
+                "status": "FAIL",  # Present in properties
+                "name": "my-bucket",
+            },
+        }
+    )
+
+    assert node.resource_id == "res1"
+    assert "ProwlerFinding" not in node.labels
+    assert node.severity is None  # NOT extracted, even though in properties
+    assert node.status is None  # NOT extracted
+    assert node.status_extended is None
+
+
+def test_attack_path_graph_relationship_requires_all_fields():
+    rel = AttackPathsGraphRelationship.from_api_response(
+        {
+            "id": "rel1",
+            "label": "depends_on",
+            "source": "n1",
+            "target": "n2",
+        }
+    )
+
+    assert rel.id == "rel1"
+    assert rel.label == "depends_on"
+    assert rel.source == "n1"
+    assert rel.target == "n2"
+
+
+def test_attack_path_query_result_with_empty_graph_is_normalized():
+    """Both empty nodes/relationships arrays and null attributes normalize to
+    the same empty result structure."""
+    result = AttackPathQueryResult.from_api_response(
+        jsonapi_document(
+            jsonapi_resource(
+                "attack-paths-result",
+                "r1",
+                {"nodes": [], "relationships": []},
+            )
+        )
+    )
+
+    assert result.nodes == []
+    assert result.relationships == []
+    assert result.message is None  # Never set by from_api_response
+
+
+def test_attack_path_query_result_with_null_attributes_is_normalized():
+    """Null attributes is normalized to empty attributes dict, then to empty
+    nodes/relationships. `jsonapi_resource`'s `attributes or {}` can't express a
+    literal `null`, so the document is built by hand here."""
+    result = AttackPathQueryResult.from_api_response(
+        {"data": {"type": "attack-paths-result", "id": "r1", "attributes": None}}
+    )
+
+    assert result.nodes == []
+    assert result.relationships == []
+    assert result.message is None
+
+
+def test_attack_path_query_result_with_missing_data_key_is_normalized():
+    """`response.get("data")` with no "data" key at all is also normalized to an
+    empty result rather than raising."""
+    result = AttackPathQueryResult.from_api_response({})
+
+    assert result.nodes == []
+    assert result.relationships == []
+
+
+def test_attack_path_query_result_with_populated_graph():
+    response = jsonapi_document(
+        jsonapi_resource(
+            "attack-paths-result",
+            "r1",
+            {
+                "nodes": [
+                    {
+                        "labels": ["AwsS3Bucket"],
+                        "properties": {"id": "n1", "name": "bucket1"},
+                    }
+                ],
+                "relationships": [
+                    {"id": "rel1", "label": "contains", "source": "n1", "target": "n2"}
+                ],
+            },
+        )
+    )
+
+    result = AttackPathQueryResult.from_api_response(response)
+
+    assert len(result.nodes) == 1
+    assert result.nodes[0].resource_id == "n1"
+    assert len(result.relationships) == 1
+    assert result.relationships[0].label == "contains"

--- a/mcp_server/tests/prowler_app/models/test_compliance.py
+++ b/mcp_server/tests/prowler_app/models/test_compliance.py
@@ -1,0 +1,225 @@
+"""Tests for the compliance models.
+
+`ComplianceFrameworkSummary` overrides `MinimalSerializerMixin`'s `_serialize`
+(same method name wins via MRO) to unconditionally inject computed
+`pass_percentage`/`fail_percentage` into every dump -- these must appear even
+at zero requirements, where the division-by-zero guard kicks in.
+"""
+
+from prowler_mcp_server.prowler_app.models.compliance import (
+    ComplianceFrameworksListResponse,
+    ComplianceFrameworkSummary,
+    ComplianceRequirement,
+    ComplianceRequirementAttribute,
+    ComplianceRequirementAttributesListResponse,
+    ComplianceRequirementsListResponse,
+)
+from tests.helpers.jsonapi import jsonapi_document, jsonapi_resource
+
+FRAMEWORK_ATTRIBUTES = {
+    "id": "cis_1.5_aws",
+    "framework": "CIS",
+    "version": "1.5",
+    "total_requirements": 100,
+    "requirements_passed": 60,
+    "requirements_failed": 30,
+    "requirements_manual": 10,
+}
+
+
+def test_requirement_attribute_reads_the_double_nested_check_ids():
+    """`check_ids` lives two levels deep: `data.attributes.attributes.check_ids`."""
+    attribute = ComplianceRequirementAttribute.from_api_response(
+        jsonapi_resource(
+            "compliance-requirement-attributes",
+            "req1",
+            {
+                "id": "1.1",
+                "name": "Ensure MFA is enabled",
+                "description": "Checks MFA is enabled for all users",
+                "attributes": {"check_ids": ["iam_mfa_enabled"]},
+            },
+        )
+    )
+
+    assert attribute.name == "Ensure MFA is enabled"
+    assert attribute.check_ids == ["iam_mfa_enabled"]
+
+
+def test_requirement_attribute_id_prefers_the_nested_attributes_id():
+    attribute = ComplianceRequirementAttribute.from_api_response(
+        jsonapi_resource("compliance-requirement-attributes", "req1", {"id": "1.1"})
+    )
+
+    assert attribute.id == "1.1"
+
+
+def test_requirement_attribute_id_falls_back_to_the_resource_id():
+    """When attributes.id is absent, falls back to the top-level JSON:API id."""
+    attribute = ComplianceRequirementAttribute.from_api_response(
+        jsonapi_resource("compliance-requirement-attributes", "req1", {})
+    )
+
+    assert attribute.id == "req1"
+
+
+def test_requirement_attribute_tolerates_missing_check_ids():
+    attribute = ComplianceRequirementAttribute.from_api_response(
+        jsonapi_resource("compliance-requirement-attributes", "req1", {"id": "1.1"})
+    )
+
+    assert attribute.check_ids == []
+
+
+def test_requirement_attributes_list_response_counts_from_the_parsed_list():
+    response = jsonapi_document(
+        data=[
+            jsonapi_resource("compliance-requirement-attributes", "r1", {"id": "1.1"}),
+            jsonapi_resource("compliance-requirement-attributes", "r2", {"id": "1.2"}),
+        ]
+    )
+
+    result = ComplianceRequirementAttributesListResponse.from_api_response(response)
+
+    assert result.total_count == 2
+    assert len(result.requirements) == 2
+
+
+def test_framework_summary_reads_the_counters():
+    summary = ComplianceFrameworkSummary.from_api_response(
+        jsonapi_resource("compliance-overviews", "fw1", FRAMEWORK_ATTRIBUTES)
+    )
+
+    assert summary.compliance_id == "cis_1.5_aws"
+    assert summary.framework == "CIS"
+    assert summary.total_requirements == 100
+    assert summary.requirements_passed == 60
+
+
+def test_framework_summary_id_falls_back_to_the_resource_id():
+    """compliance_id prefers attributes.id, falling back to the JSON:API id --
+    distinct from the resource's own `id` field."""
+    summary = ComplianceFrameworkSummary.from_api_response(
+        jsonapi_resource(
+            "compliance-overviews",
+            "fw1",
+            {"framework": "CIS", "version": "1.5"},
+        )
+    )
+
+    assert summary.id == "fw1"
+    assert summary.compliance_id == "fw1"
+
+
+def test_framework_summary_computes_pass_and_fail_percentages():
+    summary = ComplianceFrameworkSummary.from_api_response(
+        jsonapi_resource("compliance-overviews", "fw1", FRAMEWORK_ATTRIBUTES)
+    )
+
+    assert summary.pass_percentage == 60.0
+    assert summary.fail_percentage == 30.0
+
+
+def test_framework_summary_rounds_percentages_to_one_decimal():
+    summary = ComplianceFrameworkSummary.from_api_response(
+        jsonapi_resource(
+            "compliance-overviews",
+            "fw1",
+            {
+                "framework": "CIS",
+                "version": "1.5",
+                "total_requirements": 3,
+                "requirements_passed": 1,
+                "requirements_failed": 1,
+            },
+        )
+    )
+
+    assert summary.pass_percentage == 33.3
+    assert summary.fail_percentage == 33.3
+
+
+def test_framework_summary_percentages_are_zero_when_there_are_no_requirements():
+    summary = ComplianceFrameworkSummary.from_api_response(
+        jsonapi_resource(
+            "compliance-overviews", "fw1", {"framework": "CIS", "version": "1.5"}
+        )
+    )
+
+    assert summary.pass_percentage == 0.0
+    assert summary.fail_percentage == 0.0
+
+
+def test_framework_summary_serialization_always_includes_the_computed_percentages():
+    """The custom `_serialize` override injects both percentages into every dump,
+    even when total_requirements is 0 -- unlike the mixin's normal exclusion of
+    falsy/empty values, this bypasses it for these two computed keys."""
+    summary = ComplianceFrameworkSummary.from_api_response(
+        jsonapi_resource(
+            "compliance-overviews", "fw1", {"framework": "CIS", "version": "1.5"}
+        )
+    )
+
+    dumped = summary.model_dump()
+
+    assert dumped["pass_percentage"] == 0.0
+    assert dumped["fail_percentage"] == 0.0
+    assert dumped["total_requirements"] == 0
+
+
+def test_requirement_defaults_status_to_manual_when_missing():
+    requirement = ComplianceRequirement.from_api_response(
+        jsonapi_resource(
+            "compliance-requirements", "r1", {"description": "Ensure MFA is enabled"}
+        )
+    )
+
+    assert requirement.status == "MANUAL"
+
+
+def test_requirement_reads_an_explicit_status():
+    requirement = ComplianceRequirement.from_api_response(
+        jsonapi_resource(
+            "compliance-requirements",
+            "r1",
+            {"description": "Ensure MFA is enabled", "status": "FAIL"},
+        )
+    )
+
+    assert requirement.status == "FAIL"
+
+
+def test_frameworks_list_response_counts_from_the_parsed_list():
+    response = jsonapi_document(
+        data=[jsonapi_resource("compliance-overviews", "fw1", FRAMEWORK_ATTRIBUTES)]
+    )
+
+    result = ComplianceFrameworksListResponse.from_api_response(response)
+
+    assert result.total_count == 1
+    assert result.frameworks[0].framework == "CIS"
+
+
+def test_requirements_list_response_counts_match_the_status_breakdown():
+    """The invariant: passed + failed + manual always equals total_count, since
+    all four are derived from the same parsed list."""
+    response = jsonapi_document(
+        data=[
+            jsonapi_resource("compliance-requirements", "r1", {"status": "PASS"}),
+            jsonapi_resource("compliance-requirements", "r2", {"status": "FAIL"}),
+            jsonapi_resource(
+                "compliance-requirements", "r3", {}
+            ),  # No status -> MANUAL
+        ]
+    )
+
+    result = ComplianceRequirementsListResponse.from_api_response(response)
+
+    assert result.total_count == 3
+    assert result.passed_count == 1
+    assert result.failed_count == 1
+    assert result.manual_count == 1
+    assert (
+        result.passed_count + result.failed_count + result.manual_count
+        == result.total_count
+    )

--- a/mcp_server/tests/prowler_app/models/test_compliance.py
+++ b/mcp_server/tests/prowler_app/models/test_compliance.py
@@ -47,6 +47,7 @@ def test_requirement_attribute_reads_the_double_nested_check_ids():
 
 
 def test_requirement_attribute_id_prefers_the_nested_attributes_id():
+    """`id` is taken from `attributes.id` when present, ahead of the JSON:API id."""
     attribute = ComplianceRequirementAttribute.from_api_response(
         jsonapi_resource("compliance-requirement-attributes", "req1", {"id": "1.1"})
     )
@@ -64,6 +65,7 @@ def test_requirement_attribute_id_falls_back_to_the_resource_id():
 
 
 def test_requirement_attribute_tolerates_missing_check_ids():
+    """No nested `attributes.attributes.check_ids` yields an empty list."""
     attribute = ComplianceRequirementAttribute.from_api_response(
         jsonapi_resource("compliance-requirement-attributes", "req1", {"id": "1.1"})
     )
@@ -72,6 +74,7 @@ def test_requirement_attribute_tolerates_missing_check_ids():
 
 
 def test_requirement_attributes_list_response_counts_from_the_parsed_list():
+    """total_count is len() of the parsed list, not read from API pagination meta."""
     response = jsonapi_document(
         data=[
             jsonapi_resource("compliance-requirement-attributes", "r1", {"id": "1.1"}),
@@ -86,6 +89,7 @@ def test_requirement_attributes_list_response_counts_from_the_parsed_list():
 
 
 def test_framework_summary_reads_the_counters():
+    """framework/version and the requirement counters come straight from attributes."""
     summary = ComplianceFrameworkSummary.from_api_response(
         jsonapi_resource("compliance-overviews", "fw1", FRAMEWORK_ATTRIBUTES)
     )
@@ -112,6 +116,7 @@ def test_framework_summary_id_falls_back_to_the_resource_id():
 
 
 def test_framework_summary_computes_pass_and_fail_percentages():
+    """pass/fail percentages are computed properties over the counters."""
     summary = ComplianceFrameworkSummary.from_api_response(
         jsonapi_resource("compliance-overviews", "fw1", FRAMEWORK_ATTRIBUTES)
     )
@@ -121,6 +126,7 @@ def test_framework_summary_computes_pass_and_fail_percentages():
 
 
 def test_framework_summary_rounds_percentages_to_one_decimal():
+    """1/3 of the requirements renders as 33.3, not 33.33333."""
     summary = ComplianceFrameworkSummary.from_api_response(
         jsonapi_resource(
             "compliance-overviews",
@@ -140,6 +146,7 @@ def test_framework_summary_rounds_percentages_to_one_decimal():
 
 
 def test_framework_summary_percentages_are_zero_when_there_are_no_requirements():
+    """The division-by-zero guard returns 0.0 rather than raising."""
     summary = ComplianceFrameworkSummary.from_api_response(
         jsonapi_resource(
             "compliance-overviews", "fw1", {"framework": "CIS", "version": "1.5"}
@@ -168,6 +175,7 @@ def test_framework_summary_serialization_always_includes_the_computed_percentage
 
 
 def test_requirement_defaults_status_to_manual_when_missing():
+    """A requirement with no `status` attribute is treated as MANUAL."""
     requirement = ComplianceRequirement.from_api_response(
         jsonapi_resource(
             "compliance-requirements", "r1", {"description": "Ensure MFA is enabled"}
@@ -178,6 +186,7 @@ def test_requirement_defaults_status_to_manual_when_missing():
 
 
 def test_requirement_reads_an_explicit_status():
+    """An explicit `status` attribute is passed through unchanged."""
     requirement = ComplianceRequirement.from_api_response(
         jsonapi_resource(
             "compliance-requirements",
@@ -190,6 +199,7 @@ def test_requirement_reads_an_explicit_status():
 
 
 def test_frameworks_list_response_counts_from_the_parsed_list():
+    """total_count is len() of the parsed frameworks list."""
     response = jsonapi_document(
         data=[jsonapi_resource("compliance-overviews", "fw1", FRAMEWORK_ATTRIBUTES)]
     )

--- a/mcp_server/tests/prowler_app/models/test_muting.py
+++ b/mcp_server/tests/prowler_app/models/test_muting.py
@@ -22,6 +22,7 @@ MUTE_RULE_ATTRIBUTES = {
 
 
 def test_mutelist_response_reads_configuration():
+    """The raw mutelist `configuration` object is carried through verbatim."""
     mutelist = MutelistResponse.from_api_response(
         jsonapi_resource(
             "mutelists",
@@ -35,6 +36,7 @@ def test_mutelist_response_reads_configuration():
 
 
 def test_mutelist_response_defaults_configuration_to_an_empty_dict():
+    """A mutelist with no `configuration` attribute yields an empty dict."""
     mutelist = MutelistResponse.from_api_response(
         jsonapi_resource("mutelists", "m1", {})
     )
@@ -43,6 +45,7 @@ def test_mutelist_response_defaults_configuration_to_an_empty_dict():
 
 
 def test_simplified_mute_rule_derives_finding_count_from_finding_uids():
+    """finding_count is len(finding_uids), never read from the API directly."""
     rule = SimplifiedMuteRule.from_api_response(
         jsonapi_resource("mute-rules", "r1", MUTE_RULE_ATTRIBUTES)
     )
@@ -51,6 +54,7 @@ def test_simplified_mute_rule_derives_finding_count_from_finding_uids():
 
 
 def test_simplified_mute_rule_finding_count_is_zero_when_no_findings_are_muted():
+    """No `finding_uids` attribute derives a count of 0, not an error."""
     rule = SimplifiedMuteRule.from_api_response(
         jsonapi_resource(
             "mute-rules",
@@ -63,6 +67,8 @@ def test_simplified_mute_rule_finding_count_is_zero_when_no_findings_are_muted()
 
 
 def test_detailed_mute_rule_reads_the_finding_uids_and_creator():
+    """The full finding_uids list is kept, and user_creator_id is lifted from the
+    `created_by` relationship linkage."""
     resource = jsonapi_resource(
         "mute-rules",
         "r1",
@@ -79,6 +85,7 @@ def test_detailed_mute_rule_reads_the_finding_uids_and_creator():
 
 
 def test_detailed_mute_rule_creator_is_none_when_relationship_is_absent():
+    """No `created_by` relationship at all leaves user_creator_id as None."""
     rule = DetailedMuteRule.from_api_response(
         jsonapi_resource("mute-rules", "r1", MUTE_RULE_ATTRIBUTES)
     )
@@ -103,6 +110,7 @@ def test_detailed_mute_rule_creator_is_none_when_relationship_data_is_null():
 
 
 def test_mute_rules_list_response_carries_pagination_metadata():
+    """page/pages/count are read from `meta.pagination` when present."""
     response = jsonapi_document(
         data=[jsonapi_resource("mute-rules", "r1", MUTE_RULE_ATTRIBUTES)],
         meta={"pagination": {"page": 2, "pages": 5, "count": 42}},

--- a/mcp_server/tests/prowler_app/models/test_muting.py
+++ b/mcp_server/tests/prowler_app/models/test_muting.py
@@ -1,0 +1,126 @@
+"""Tests for the muting (mutelist and mute rule) models.
+
+`SimplifiedMuteRule.finding_count` is derived as `len(finding_uids)`, never read
+directly from the API. `DetailedMuteRule.user_creator_id` distinguishes an absent
+`created_by` relationship from one present with `data: null`.
+"""
+
+from prowler_mcp_server.prowler_app.models.muting import (
+    DetailedMuteRule,
+    MutelistResponse,
+    MuteRulesListResponse,
+    SimplifiedMuteRule,
+)
+from tests.helpers.jsonapi import jsonapi_document, jsonapi_resource
+
+MUTE_RULE_ATTRIBUTES = {
+    "name": "Ignore dev environment",
+    "reason": "Accepted risk for the dev account",
+    "enabled": True,
+    "finding_uids": ["f1", "f2", "f3"],
+}
+
+
+def test_mutelist_response_reads_configuration():
+    mutelist = MutelistResponse.from_api_response(
+        jsonapi_resource(
+            "mutelists",
+            "m1",
+            {"configuration": {"Accounts": {"*": {"Checks": {"*": {}}}}}},
+        )
+    )
+
+    assert mutelist.id == "m1"
+    assert mutelist.configuration == {"Accounts": {"*": {"Checks": {"*": {}}}}}
+
+
+def test_mutelist_response_defaults_configuration_to_an_empty_dict():
+    mutelist = MutelistResponse.from_api_response(
+        jsonapi_resource("mutelists", "m1", {})
+    )
+
+    assert mutelist.configuration == {}
+
+
+def test_simplified_mute_rule_derives_finding_count_from_finding_uids():
+    rule = SimplifiedMuteRule.from_api_response(
+        jsonapi_resource("mute-rules", "r1", MUTE_RULE_ATTRIBUTES)
+    )
+
+    assert rule.finding_count == 3
+
+
+def test_simplified_mute_rule_finding_count_is_zero_when_no_findings_are_muted():
+    rule = SimplifiedMuteRule.from_api_response(
+        jsonapi_resource(
+            "mute-rules",
+            "r1",
+            {"name": "Empty rule", "reason": "none yet", "enabled": False},
+        )
+    )
+
+    assert rule.finding_count == 0
+
+
+def test_detailed_mute_rule_reads_the_finding_uids_and_creator():
+    resource = jsonapi_resource(
+        "mute-rules",
+        "r1",
+        attributes=MUTE_RULE_ATTRIBUTES,
+        relationships={
+            "created_by": {"data": {"type": "users", "id": "u1"}},
+        },
+    )
+
+    rule = DetailedMuteRule.from_api_response(resource)
+
+    assert rule.finding_uids == ["f1", "f2", "f3"]
+    assert rule.user_creator_id == "u1"
+
+
+def test_detailed_mute_rule_creator_is_none_when_relationship_is_absent():
+    rule = DetailedMuteRule.from_api_response(
+        jsonapi_resource("mute-rules", "r1", MUTE_RULE_ATTRIBUTES)
+    )
+
+    assert rule.user_creator_id is None
+
+
+def test_detailed_mute_rule_creator_is_none_when_relationship_data_is_null():
+    """`created_by` is present but its `data` is explicitly null -- distinct from
+    the relationship being absent entirely, but the outcome (None) is the same
+    since the code checks `if creator_data:` (truthy), not presence."""
+    resource = jsonapi_resource(
+        "mute-rules",
+        "r1",
+        attributes=MUTE_RULE_ATTRIBUTES,
+        relationships={"created_by": {"data": None}},
+    )
+
+    rule = DetailedMuteRule.from_api_response(resource)
+
+    assert rule.user_creator_id is None
+
+
+def test_mute_rules_list_response_carries_pagination_metadata():
+    response = jsonapi_document(
+        data=[jsonapi_resource("mute-rules", "r1", MUTE_RULE_ATTRIBUTES)],
+        meta={"pagination": {"page": 2, "pages": 5, "count": 42}},
+    )
+
+    result = MuteRulesListResponse.from_api_response(response)
+
+    assert result.current_page == 2
+    assert result.total_num_pages == 5
+    assert result.total_num_mute_rules == 42
+    assert result.mute_rules[0].name == "Ignore dev environment"
+
+
+def test_mute_rules_list_response_defaults_pages_to_one_when_meta_is_missing():
+    """Unlike roles/scans list responses (which default `pages` to 0), this one
+    defaults to 1 -- a real inconsistency across the codebase, pinned here."""
+    result = MuteRulesListResponse.from_api_response({"data": []})
+
+    assert result.total_num_mute_rules == 0
+    assert result.total_num_pages == 1
+    assert result.current_page == 1

--- a/mcp_server/tests/prowler_app/models/test_providers.py
+++ b/mcp_server/tests/prowler_app/models/test_providers.py
@@ -1,0 +1,212 @@
+"""Tests for the provider models.
+
+`SimplifiedProvider` overrides `_should_exclude` to always keep `connected` and
+`secret_type` in the serialized output, even as `None` -- unlike every other
+`None` field, which the mixin drops. `ProvidersListResponse` uses bracket access
+throughout, so it raises `KeyError` on malformed input rather than defaulting,
+unlike its siblings in roles.py/scans.py.
+"""
+
+import pytest
+
+from prowler_mcp_server.prowler_app.models.providers import (
+    DetailedProvider,
+    ProviderConnectionStatus,
+    ProviderDeletionResult,
+    ProvidersListResponse,
+    SimplifiedProvider,
+)
+from tests.helpers.jsonapi import (
+    jsonapi_document,
+    jsonapi_relationship_many,
+    jsonapi_resource,
+)
+
+PROVIDER_ATTRIBUTES = {
+    "uid": "123456789012",
+    "alias": "production",
+    "provider": "aws",
+    "connection": {"connected": True},
+}
+
+
+def test_simplified_provider_reads_core_fields():
+    provider = SimplifiedProvider.from_api_response(
+        jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES)
+    )
+
+    assert provider.id == "p1"
+    assert provider.uid == "123456789012"
+    assert provider.alias == "production"
+    assert provider.provider == "aws"
+    assert provider.connected is True
+
+
+def test_simplified_provider_always_sets_secret_type_to_none():
+    """`secret_type` is hardcoded to None in from_api_response -- populated
+    separately via a secret endpoint, never derived here."""
+    provider = SimplifiedProvider.from_api_response(
+        jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES)
+    )
+
+    assert provider.secret_type is None
+
+
+def test_simplified_provider_connected_is_none_without_a_connection_block():
+    provider = SimplifiedProvider.from_api_response(
+        jsonapi_resource("providers", "p1", {"uid": "123", "provider": "aws"})
+    )
+
+    assert provider.connected is None
+
+
+def test_simplified_provider_serialization_always_includes_connected_and_secret_type():
+    """The custom _should_exclude override keeps connected/secret_type even when
+    None, contrasting with a sibling field like `alias` which gets dropped."""
+    provider = SimplifiedProvider.from_api_response(
+        jsonapi_resource("providers", "p1", {"uid": "123", "provider": "aws"})
+    )
+
+    dumped = provider.model_dump()
+
+    assert "connected" in dumped
+    assert dumped["connected"] is None
+    assert "secret_type" in dumped
+    assert dumped["secret_type"] is None
+    # alias is None too, but is NOT force-included -- normal mixin behavior applies.
+    assert "alias" not in dumped
+
+
+def test_detailed_provider_adds_temporal_fields():
+    resource = jsonapi_resource(
+        "providers",
+        "p1",
+        {
+            **PROVIDER_ATTRIBUTES,
+            "inserted_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-15T00:00:00Z",
+            "connection": {
+                "connected": True,
+                "last_checked_at": "2025-01-15T00:00:00Z",
+            },
+        },
+    )
+
+    provider = DetailedProvider.from_api_response(resource)
+
+    assert provider.inserted_at == "2025-01-01T00:00:00Z"
+    assert provider.updated_at == "2025-01-15T00:00:00Z"
+    assert provider.last_checked_at == "2025-01-15T00:00:00Z"
+
+
+def test_detailed_provider_parses_provider_group_ids():
+    resource = jsonapi_resource(
+        "providers",
+        "p1",
+        attributes=PROVIDER_ATTRIBUTES,
+        relationships={
+            "provider_groups": jsonapi_relationship_many("provider-groups", "g1", "g2")
+        },
+    )
+
+    provider = DetailedProvider.from_api_response(resource)
+
+    assert provider.provider_group_ids == ["g1", "g2"]
+
+
+def test_detailed_provider_group_ids_is_none_when_relationship_is_absent():
+    provider = DetailedProvider.from_api_response(
+        jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES)
+    )
+
+    assert provider.provider_group_ids is None
+
+
+def test_detailed_provider_group_ids_is_none_when_relationship_is_present_but_empty():
+    """Unlike roles.py's `extract_relationship_ids` util (which distinguishes
+    absent from present-but-empty), this hand-rolled extraction collapses both
+    cases to None via a falsy-list check -- a documented divergence, not a bug
+    to fix here."""
+    resource = jsonapi_resource(
+        "providers",
+        "p1",
+        attributes=PROVIDER_ATTRIBUTES,
+        relationships={"provider_groups": jsonapi_relationship_many("provider-groups")},
+    )
+
+    provider = DetailedProvider.from_api_response(resource)
+
+    assert provider.provider_group_ids is None
+
+
+def test_providers_list_response_reads_pagination():
+    response = jsonapi_document(
+        data=[jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES)],
+        meta={"pagination": {"page": 1, "pages": 1, "count": 1}},
+    )
+
+    result = ProvidersListResponse.from_api_response(response)
+
+    assert result.total_num_providers == 1
+    assert result.providers[0].uid == "123456789012"
+
+
+def test_providers_list_response_raises_on_missing_meta():
+    """Unlike roles/scans list responses (which use .get() with defaults), this
+    one uses bracket access throughout and raises KeyError on malformed input."""
+    with pytest.raises(KeyError):
+        ProvidersListResponse.from_api_response({"data": []})
+
+
+def test_providers_list_response_raises_on_missing_pagination():
+    with pytest.raises(KeyError):
+        ProvidersListResponse.from_api_response({"data": [], "meta": {}})
+
+
+def test_provider_deletion_result_is_constructed_directly():
+    """No from_api_response -- built directly by the tool layer."""
+    result = ProviderDeletionResult(
+        status="deleted", message="Provider deleted successfully"
+    )
+
+    assert result.status == "deleted"
+    assert result.task_id is None
+    assert "task_id" not in result.model_dump()
+
+
+def test_provider_connection_status_maps_true_to_connected():
+    status = ProviderConnectionStatus.create(
+        provider_data=jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES),
+        connection_status={"connected": True},
+    )
+
+    assert status.connected == "connected"
+    assert status.error is None
+
+
+def test_provider_connection_status_maps_false_to_failed():
+    status = ProviderConnectionStatus.create(
+        provider_data=jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES),
+        connection_status={"connected": False, "error": "Access denied"},
+    )
+
+    assert status.connected == "failed"
+    assert status.error == "Access denied"
+
+
+def test_provider_connection_status_maps_missing_connected_to_not_tested():
+    status = ProviderConnectionStatus.create(
+        provider_data=jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES),
+        connection_status={},
+    )
+
+    assert status.connected == "not_tested"
+
+
+def test_provider_connection_status_maps_explicit_none_to_not_tested():
+    status = ProviderConnectionStatus.create(
+        provider_data=jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES),
+        connection_status={"connected": None},
+    )
+
+    assert status.connected == "not_tested"

--- a/mcp_server/tests/prowler_app/models/test_providers.py
+++ b/mcp_server/tests/prowler_app/models/test_providers.py
@@ -31,6 +31,8 @@ PROVIDER_ATTRIBUTES = {
 
 
 def test_simplified_provider_reads_core_fields():
+    """uid/alias/provider come from attributes; `connected` is lifted out of the
+    nested `connection` block."""
     provider = SimplifiedProvider.from_api_response(
         jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES)
     )
@@ -53,6 +55,7 @@ def test_simplified_provider_always_sets_secret_type_to_none():
 
 
 def test_simplified_provider_connected_is_none_without_a_connection_block():
+    """No `connection` attribute leaves `connected` as None (unknown)."""
     provider = SimplifiedProvider.from_api_response(
         jsonapi_resource("providers", "p1", {"uid": "123", "provider": "aws"})
     )
@@ -78,6 +81,8 @@ def test_simplified_provider_serialization_always_includes_connected_and_secret_
 
 
 def test_detailed_provider_adds_temporal_fields():
+    """inserted_at/updated_at come from attributes; last_checked_at is lifted out
+    of the nested `connection` block."""
     resource = jsonapi_resource(
         "providers",
         "p1",
@@ -100,6 +105,7 @@ def test_detailed_provider_adds_temporal_fields():
 
 
 def test_detailed_provider_parses_provider_group_ids():
+    """The `provider_groups` relationship linkage is flattened to a list of ids."""
     resource = jsonapi_resource(
         "providers",
         "p1",
@@ -115,6 +121,7 @@ def test_detailed_provider_parses_provider_group_ids():
 
 
 def test_detailed_provider_group_ids_is_none_when_relationship_is_absent():
+    """No `provider_groups` relationship leaves provider_group_ids as None."""
     provider = DetailedProvider.from_api_response(
         jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES)
     )
@@ -140,6 +147,7 @@ def test_detailed_provider_group_ids_is_none_when_relationship_is_present_but_em
 
 
 def test_providers_list_response_reads_pagination():
+    """page/pages/count are read from `meta.pagination`."""
     response = jsonapi_document(
         data=[jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES)],
         meta={"pagination": {"page": 1, "pages": 1, "count": 1}},
@@ -159,6 +167,7 @@ def test_providers_list_response_raises_on_missing_meta():
 
 
 def test_providers_list_response_raises_on_missing_pagination():
+    """`meta` present but without `pagination` still raises KeyError (bracket access)."""
     with pytest.raises(KeyError):
         ProvidersListResponse.from_api_response({"data": [], "meta": {}})
 
@@ -175,6 +184,7 @@ def test_provider_deletion_result_is_constructed_directly():
 
 
 def test_provider_connection_status_maps_true_to_connected():
+    """A truthy `connected` flag maps to the "connected" state string."""
     status = ProviderConnectionStatus.create(
         provider_data=jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES),
         connection_status={"connected": True},
@@ -185,6 +195,7 @@ def test_provider_connection_status_maps_true_to_connected():
 
 
 def test_provider_connection_status_maps_false_to_failed():
+    """`connected: False` (not None) maps to "failed" and keeps the error text."""
     status = ProviderConnectionStatus.create(
         provider_data=jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES),
         connection_status={"connected": False, "error": "Access denied"},
@@ -195,6 +206,7 @@ def test_provider_connection_status_maps_false_to_failed():
 
 
 def test_provider_connection_status_maps_missing_connected_to_not_tested():
+    """An absent `connected` key maps to "not_tested"."""
     status = ProviderConnectionStatus.create(
         provider_data=jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES),
         connection_status={},
@@ -204,6 +216,7 @@ def test_provider_connection_status_maps_missing_connected_to_not_tested():
 
 
 def test_provider_connection_status_maps_explicit_none_to_not_tested():
+    """An explicit `connected: None` also maps to "not_tested", same as absent."""
     status = ProviderConnectionStatus.create(
         provider_data=jsonapi_resource("providers", "p1", PROVIDER_ATTRIBUTES),
         connection_status={"connected": None},

--- a/mcp_server/tests/prowler_app/models/test_roles.py
+++ b/mcp_server/tests/prowler_app/models/test_roles.py
@@ -1,0 +1,194 @@
+"""Tests for the RBAC role models.
+
+`DetailedRole` overrides `_should_exclude` to keep `unlimited_visibility=False`
+and empty `permissions`/`user_ids`/`provider_group_ids` lists -- only `None`
+excludes them, unlike the mixin's default which also drops empty lists.
+`permissions` itself is derived by scanning ALL attributes for any `manage_*`
+prefixed truthy key, schema-agnostically.
+"""
+
+from prowler_mcp_server.prowler_app.models.roles import (
+    DetailedRole,
+    RolesListResponse,
+    SimplifiedRole,
+    UserRolesResult,
+)
+from tests.helpers.jsonapi import (
+    jsonapi_document,
+    jsonapi_relationship_many,
+    jsonapi_resource,
+)
+
+ROLE_ATTRIBUTES = {
+    "name": "Security Admin",
+    "permission_state": "limited",
+    "manage_users": True,
+    "manage_scans": True,
+    "manage_providers": False,
+    "unlimited_visibility": False,
+}
+
+
+def test_simplified_role_reads_core_fields():
+    role = SimplifiedRole.from_api_response(
+        jsonapi_resource("roles", "r1", ROLE_ATTRIBUTES)
+    )
+
+    assert role.id == "r1"
+    assert role.name == "Security Admin"
+    assert role.permission_state == "limited"
+
+
+def test_detailed_role_derives_permissions_from_manage_prefixed_attributes():
+    """Only manage_* keys that are truthy are included; manage_providers=False
+    is correctly excluded, and non-manage_ keys are ignored entirely."""
+    role = DetailedRole.from_api_response(
+        jsonapi_resource("roles", "r1", ROLE_ATTRIBUTES)
+    )
+
+    assert set(role.permissions) == {"manage_users", "manage_scans"}
+    assert "manage_providers" not in role.permissions
+
+
+def test_detailed_role_permissions_is_an_empty_list_when_no_manage_keys_exist():
+    """The list comprehension always returns a list, never None, even with zero
+    matches -- distinct from provider_group_ids/user_ids, which can be None."""
+    role = DetailedRole.from_api_response(
+        jsonapi_resource("roles", "r1", {"name": "Read Only"})
+    )
+
+    assert role.permissions == []
+
+
+def test_detailed_role_includes_a_non_bool_truthy_manage_value():
+    """The check is `and enabled`, not `and enabled is True` -- any truthy value
+    is treated as granted."""
+    role = DetailedRole.from_api_response(
+        jsonapi_resource("roles", "r1", {"name": "Odd Role", "manage_scans": "yes"})
+    )
+
+    assert "manage_scans" in role.permissions
+
+
+def test_detailed_role_reads_unlimited_visibility_and_relationships():
+    resource = jsonapi_resource(
+        "roles",
+        "r1",
+        attributes=ROLE_ATTRIBUTES,
+        relationships={
+            "provider_groups": jsonapi_relationship_many("provider-groups", "g1"),
+            "users": jsonapi_relationship_many("users", "u1", "u2"),
+        },
+    )
+
+    role = DetailedRole.from_api_response(resource)
+
+    assert role.unlimited_visibility is False
+    assert role.provider_group_ids == ["g1"]
+    assert role.user_ids == ["u1", "u2"]
+
+
+def test_detailed_role_relationship_ids_are_none_when_absent():
+    """extract_relationship_ids: an absent relationship key yields None,
+    distinct from a present-but-empty one (which yields [])."""
+    role = DetailedRole.from_api_response(
+        jsonapi_resource("roles", "r1", ROLE_ATTRIBUTES)
+    )
+
+    assert role.provider_group_ids is None
+    assert role.user_ids is None
+
+
+def test_detailed_role_relationship_ids_are_empty_list_when_present_but_empty():
+    resource = jsonapi_resource(
+        "roles",
+        "r1",
+        attributes=ROLE_ATTRIBUTES,
+        relationships={"provider_groups": jsonapi_relationship_many("provider-groups")},
+    )
+
+    role = DetailedRole.from_api_response(resource)
+
+    assert role.provider_group_ids == []
+
+
+def test_detailed_role_serialization_keeps_false_unlimited_visibility():
+    """unlimited_visibility=False must survive serialization -- only None
+    triggers the custom exclusion override."""
+    role = DetailedRole.from_api_response(
+        jsonapi_resource("roles", "r1", ROLE_ATTRIBUTES)
+    )
+
+    dumped = role.model_dump()
+
+    assert dumped["unlimited_visibility"] is False
+
+
+def test_detailed_role_serialization_keeps_empty_permissions_list():
+    role = DetailedRole.from_api_response(
+        jsonapi_resource("roles", "r1", {"name": "Read Only"})
+    )
+
+    dumped = role.model_dump()
+
+    assert dumped["permissions"] == []
+
+
+def test_detailed_role_serialization_drops_none_relationship_ids():
+    """A field the override lists (provider_group_ids) is still dropped when
+    None -- the override only widens the exception for empty/False, not None."""
+    role = DetailedRole.from_api_response(
+        jsonapi_resource("roles", "r1", ROLE_ATTRIBUTES)
+    )
+
+    dumped = role.model_dump()
+
+    assert "provider_group_ids" not in dumped
+    assert "user_ids" not in dumped
+    # A field not in the override list still follows normal mixin exclusion.
+    assert "inserted_at" not in dumped
+
+
+def test_roles_list_response_carries_pagination_metadata():
+    response = jsonapi_document(
+        data=[jsonapi_resource("roles", "r1", ROLE_ATTRIBUTES)],
+        meta={"pagination": {"page": 1, "pages": 3, "count": 25}},
+    )
+
+    result = RolesListResponse.from_api_response(response)
+
+    assert result.total_num_roles == 25
+    assert result.total_num_pages == 3
+    assert result.roles[0].name == "Security Admin"
+
+
+def test_roles_list_response_defaults_pages_to_zero_when_meta_is_missing():
+    """Unlike muting.py's list response (which defaults pages to 1), this one
+    defaults to 0 -- a documented inconsistency across the codebase."""
+    result = RolesListResponse.from_api_response({"data": []})
+
+    assert result.total_num_roles == 0
+    assert result.total_num_pages == 0
+    assert result.current_page == 1
+
+
+def test_user_roles_result_build_derives_the_count():
+    role = DetailedRole.from_api_response(
+        jsonapi_resource("roles", "r1", ROLE_ATTRIBUTES)
+    )
+
+    result = UserRolesResult.build(user_id="u1", roles=[role])
+
+    assert result.total_num_roles == 1
+    assert result.roles[0].id == "r1"
+
+
+def test_user_roles_result_serialization_keeps_empty_roles_list():
+    """roles is always included, even when empty -- an explicit 'no roles'
+    signal rather than an omitted field."""
+    result = UserRolesResult.build(user_id="u1", roles=[])
+
+    dumped = result.model_dump()
+
+    assert dumped["roles"] == []
+    assert dumped["total_num_roles"] == 0

--- a/mcp_server/tests/prowler_app/models/test_roles.py
+++ b/mcp_server/tests/prowler_app/models/test_roles.py
@@ -30,6 +30,7 @@ ROLE_ATTRIBUTES = {
 
 
 def test_simplified_role_reads_core_fields():
+    """id/name and the `permission_state` summary come straight from attributes."""
     role = SimplifiedRole.from_api_response(
         jsonapi_resource("roles", "r1", ROLE_ATTRIBUTES)
     )
@@ -71,6 +72,8 @@ def test_detailed_role_includes_a_non_bool_truthy_manage_value():
 
 
 def test_detailed_role_reads_unlimited_visibility_and_relationships():
+    """unlimited_visibility comes from attributes; provider_group_ids/user_ids are
+    flattened from their relationship linkages."""
     resource = jsonapi_resource(
         "roles",
         "r1",
@@ -100,6 +103,8 @@ def test_detailed_role_relationship_ids_are_none_when_absent():
 
 
 def test_detailed_role_relationship_ids_are_empty_list_when_present_but_empty():
+    """A present-but-empty `provider_groups` relationship yields [], not None --
+    the distinction `extract_relationship_ids` preserves."""
     resource = jsonapi_resource(
         "roles",
         "r1",
@@ -125,6 +130,8 @@ def test_detailed_role_serialization_keeps_false_unlimited_visibility():
 
 
 def test_detailed_role_serialization_keeps_empty_permissions_list():
+    """An empty `permissions` list survives serialization ("grants nothing" is a
+    fact), unlike the mixin's default which would drop an empty list."""
     role = DetailedRole.from_api_response(
         jsonapi_resource("roles", "r1", {"name": "Read Only"})
     )
@@ -150,6 +157,7 @@ def test_detailed_role_serialization_drops_none_relationship_ids():
 
 
 def test_roles_list_response_carries_pagination_metadata():
+    """page/pages/count are read from `meta.pagination` when present."""
     response = jsonapi_document(
         data=[jsonapi_resource("roles", "r1", ROLE_ATTRIBUTES)],
         meta={"pagination": {"page": 1, "pages": 3, "count": 25}},
@@ -173,6 +181,8 @@ def test_roles_list_response_defaults_pages_to_zero_when_meta_is_missing():
 
 
 def test_user_roles_result_build_derives_the_count():
+    """The `build` factory sets total_num_roles from len(roles) so it cannot
+    drift from the list it describes."""
     role = DetailedRole.from_api_response(
         jsonapi_resource("roles", "r1", ROLE_ATTRIBUTES)
     )

--- a/mcp_server/tests/prowler_app/models/test_scans.py
+++ b/mcp_server/tests/prowler_app/models/test_scans.py
@@ -35,6 +35,8 @@ SCAN_ATTRIBUTES = {
 
 
 def test_simplified_scan_reads_core_fields():
+    """trigger/state come from attributes; provider_id is lifted out of the
+    `provider` relationship linkage."""
     scan = SimplifiedScan.from_api_response(
         jsonapi_resource(
             "scans",
@@ -60,6 +62,7 @@ def test_simplified_scan_missing_provider_relationship_raises_validation_error()
 
 
 def test_detailed_scan_reads_operational_fields():
+    """progress/duration/unique_resource_count are read from attributes."""
     resource = jsonapi_resource(
         "scans",
         "s1",
@@ -117,6 +120,7 @@ def test_detailed_scan_silently_drops_computed_task_and_processor_ids():
 
 
 def test_scans_list_response_carries_pagination_metadata():
+    """page/pages/count are read from `meta.pagination` when present."""
     response = jsonapi_collection(
         [
             jsonapi_resource(
@@ -139,6 +143,8 @@ def test_scans_list_response_carries_pagination_metadata():
 
 
 def test_scans_list_response_defaults_pagination_when_meta_is_missing():
+    """No `meta` at all defaults count/pages to 0 and page to 1 (unlike muting's
+    list response, which defaults pages to 1)."""
     result = ScansListResponse.from_api_response({"data": []})
 
     assert result.total_num_scans == 0
@@ -147,6 +153,7 @@ def test_scans_list_response_defaults_pagination_when_meta_is_missing():
 
 
 def test_scan_creation_result_is_constructed_directly_with_no_status_flag():
+    """Built directly by the tool layer; carries no success/status flag by design."""
     scan = DetailedScan.from_api_response(
         jsonapi_resource(
             "scans",
@@ -163,6 +170,7 @@ def test_scan_creation_result_is_constructed_directly_with_no_status_flag():
 
 
 def test_schedule_creation_result_first_run_state_can_be_omitted():
+    """first_run_state is optional; when None it is dropped from the dump."""
     result = ScheduleCreationResult(message="Schedule created successfully")
 
     assert result.first_run_state is None

--- a/mcp_server/tests/prowler_app/models/test_scans.py
+++ b/mcp_server/tests/prowler_app/models/test_scans.py
@@ -1,0 +1,169 @@
+"""Tests for the scan models.
+
+Two bug-shaped edge cases are pinned here rather than fixed (out of scope for a
+test-coverage PR):
+1. `SimplifiedScan.provider_id` is a non-Optional `str`, but `from_api_response`
+   can pass `None` when the provider relationship is absent, raising a
+   `ValidationError` at construction.
+2. `DetailedScan.from_api_response` computes `task_id`/`processor_id` from
+   relationships and passes them into the constructor, but neither is a
+   declared field -- Pydantic's default `extra="ignore"` silently drops them.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from prowler_mcp_server.prowler_app.models.scans import (
+    DetailedScan,
+    ScanCreationResult,
+    ScansListResponse,
+    ScheduleCreationResult,
+    SimplifiedScan,
+)
+from tests.helpers.jsonapi import (
+    jsonapi_collection,
+    jsonapi_relationship_one,
+    jsonapi_resource,
+)
+
+SCAN_ATTRIBUTES = {
+    "trigger": "manual",
+    "state": "completed",
+    "started_at": "2025-01-01T00:00:00Z",
+    "completed_at": "2025-01-01T00:10:00Z",
+}
+
+
+def test_simplified_scan_reads_core_fields():
+    scan = SimplifiedScan.from_api_response(
+        jsonapi_resource(
+            "scans",
+            "s1",
+            attributes=SCAN_ATTRIBUTES,
+            relationships={"provider": jsonapi_relationship_one("providers", "p1")},
+        )
+    )
+
+    assert scan.id == "s1"
+    assert scan.trigger == "manual"
+    assert scan.state == "completed"
+    assert scan.provider_id == "p1"
+
+
+def test_simplified_scan_missing_provider_relationship_raises_validation_error():
+    """provider_id is non-Optional str but from_api_response defaults to None
+    when the relationship is absent -- pins a likely latent bug."""
+    with pytest.raises(ValidationError):
+        SimplifiedScan.from_api_response(
+            jsonapi_resource("scans", "s1", attributes=SCAN_ATTRIBUTES)
+        )
+
+
+def test_detailed_scan_reads_operational_fields():
+    resource = jsonapi_resource(
+        "scans",
+        "s1",
+        attributes={
+            **SCAN_ATTRIBUTES,
+            "progress": 100,
+            "duration": 120,
+            "unique_resource_count": 42,
+        },
+        relationships={"provider": jsonapi_relationship_one("providers", "p1")},
+    )
+
+    scan = DetailedScan.from_api_response(resource)
+
+    assert scan.progress == 100
+    assert scan.duration == 120
+    assert scan.unique_resource_count == 42
+
+
+def test_detailed_scan_provider_id_defaults_to_empty_string_not_none():
+    """Unlike SimplifiedScan.from_api_response (defaults to None, which fails
+    validation), DetailedScan's own implementation defaults provider_id to ""
+    when the relationship is absent -- a valid str, so no error here. This
+    inconsistency between parent and child from_api_response is documented,
+    not fixed."""
+    scan = DetailedScan.from_api_response(
+        jsonapi_resource("scans", "s1", attributes=SCAN_ATTRIBUTES)
+    )
+
+    assert scan.provider_id == ""
+
+
+def test_detailed_scan_silently_drops_computed_task_and_processor_ids():
+    """task_id/processor_id are computed from relationships but never declared
+    as model fields -- Pydantic's default extra="ignore" drops them silently.
+    This test proves they never surface, rather than relying on that silently."""
+    resource = jsonapi_resource(
+        "scans",
+        "s1",
+        attributes=SCAN_ATTRIBUTES,
+        relationships={
+            "provider": jsonapi_relationship_one("providers", "p1"),
+            "task": jsonapi_relationship_one("tasks", "t1"),
+            "processor": jsonapi_relationship_one("processors", "proc1"),
+        },
+    )
+
+    scan = DetailedScan.from_api_response(resource)
+
+    assert not hasattr(scan, "task_id")
+    assert not hasattr(scan, "processor_id")
+    dumped = scan.model_dump()
+    assert "task_id" not in dumped
+    assert "processor_id" not in dumped
+
+
+def test_scans_list_response_carries_pagination_metadata():
+    response = jsonapi_collection(
+        [
+            jsonapi_resource(
+                "scans",
+                "s1",
+                attributes=SCAN_ATTRIBUTES,
+                relationships={"provider": jsonapi_relationship_one("providers", "p1")},
+            )
+        ],
+        page=1,
+        pages=2,
+        count=15,
+    )
+
+    result = ScansListResponse.from_api_response(response)
+
+    assert result.total_num_scans == 15
+    assert result.total_num_pages == 2
+    assert result.scans[0].id == "s1"
+
+
+def test_scans_list_response_defaults_pagination_when_meta_is_missing():
+    result = ScansListResponse.from_api_response({"data": []})
+
+    assert result.total_num_scans == 0
+    assert result.total_num_pages == 0
+    assert result.current_page == 1
+
+
+def test_scan_creation_result_is_constructed_directly_with_no_status_flag():
+    scan = DetailedScan.from_api_response(
+        jsonapi_resource(
+            "scans",
+            "s1",
+            attributes=SCAN_ATTRIBUTES,
+            relationships={"provider": jsonapi_relationship_one("providers", "p1")},
+        )
+    )
+
+    result = ScanCreationResult(scan=scan, message="Scan started successfully")
+
+    assert result.scan.id == "s1"
+    assert "status" not in result.model_dump()
+
+
+def test_schedule_creation_result_first_run_state_can_be_omitted():
+    result = ScheduleCreationResult(message="Schedule created successfully")
+
+    assert result.first_run_state is None
+    assert "first_run_state" not in result.model_dump()


### PR DESCRIPTION
## Summary
- Adds unit test coverage for 6 previously-untested MCP server model files (~1,460 lines, 0% covered before this PR): `models/attack_paths.py`, `models/compliance.py`, `models/muting.py`, `models/providers.py`, `models/roles.py`, `models/scans.py`.
- Their sibling tool files (`tools/attack_paths.py`, `tools/providers.py`, `tools/roles.py`, `tools/scans.py`, `tools/muting.py`) already have tests, but those are tool-level/integration tests driven through the MCP protocol that only indirectly touch a narrow slice of model logic. The models' own `from_api_response()`/`create()`/`build()` parsing, custom `_should_exclude` overrides, and computed properties (e.g. `ComplianceFrameworkSummary.pass_percentage`) were not directly unit-tested anywhere.
- This is **Phase 2**, following Phase 1 (#12757 — `tools/base.py`, `models/base.py`, and the users/resources/finding_groups tools+models pairs). Independent sibling PRs based on `master`, touching entirely disjoint files — safe to review/merge in either order.

## Notable findings (documented as pinning tests, not fixed — out of scope for a test-coverage PR)
Three bug-shaped edge cases surfaced during research and are captured with explanatory test comments rather than silently relied on:
1. `AttackPathScan.provider_id` / `SimplifiedScan.provider_id` are non-Optional `str` fields, but `from_api_response` can pass `None` when the provider relationship is absent — raises a `pydantic.ValidationError` at construction. Pinned with a test asserting the `ValidationError`.
2. `DetailedScan.from_api_response` computes `task_id`/`processor_id` from relationships and passes them to the constructor, but neither is a declared model field — Pydantic's default `extra="ignore"` silently drops them. Pinned with a test proving they never surface.
3. `DetailedProvider.provider_group_ids` collapses both "relationship absent" and "relationship present but empty" to `None` (a falsy-list check), unlike `roles.py`'s `extract_relationship_ids` util, which explicitly distinguishes the two. Documented as a divergence, not fixed.

## Test plan
- [x] `cd mcp_server && uv run pytest --cov=./prowler_mcp_server --cov-report=term-missing tests` — 330 passed (80 new), zero regressions
- [x] All 6 target model files: `models/attack_paths.py`, `models/compliance.py`, `models/muting.py`, `models/providers.py`, `models/roles.py`, `models/scans.py` at 100% coverage
- [x] `uv run prek run --files <changed files>` — all checks pass (TruffleHog binary unavailable in this sandbox, expected to run in CI)
- [x] Followed existing test conventions exactly: plain sync pytest functions, JSON:API documents built via `tests/helpers/jsonapi.py`, `Model.from_api_response(...)` + `.model_dump()` assertions (per `test_findings.py` and Phase 1's `test_finding_groups.py`/`test_resources.py`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for attack paths, compliance, muting, providers, roles, and scans models.
  * Covered API response parsing, serialization, pagination metadata, computed fields, relationship handling, defaults, and validation behavior.
* **Documentation**
  * Added a changelog entry documenting the expanded model test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->