### PR TITLE
fix(image): honour TRIVY_CACHE_DIR when it is set

### DIFF
--- a/docs/user-guide/providers/image/getting-started-image.mdx
+++ b/docs/user-guide/providers/image/getting-started-image.mdx
@@ -98,6 +98,8 @@ For additional installation methods, see the [Trivy installation guide](https://
 
 ### Vulnerability Database Cache
 
+<VersionBadge version="5.42.0" />
+
 Trivy keeps its vulnerability database in a cache directory. By default Prowler gives it a temporary one and removes it when the scan ends, so the database is downloaded again for every scan.
 
 Set `TRIVY_CACHE_DIR` to a directory that persists and the database is downloaded once and reused:
@@ -107,10 +109,12 @@ export TRIVY_CACHE_DIR="$HOME/.cache/trivy"
 prowler image --image <image>
 ```
 
-Prowler leaves a directory you supply exactly as it found it, and never deletes it.
+Prowler never deletes a directory you supply. Trivy still creates and updates its cache and database files inside it.
 
 <Note>
-This is required on hosts with no internet access. Trivy cannot fetch the database there, so it has to be supplied: populate the directory on a machine that does have access, copy it across, and point `TRIVY_CACHE_DIR` at it.
+A host with no internet access needs a pre-populated vulnerability database in a persistent directory, with `TRIVY_CACHE_DIR` pointing at it. Populate the directory on a machine that does have access and copy it across.
+
+Trivy tries to refresh the database when it considers it stale, and that download fails without network access. Set `TRIVY_SKIP_DB_UPDATE=true` (and `TRIVY_SKIP_JAVA_DB_UPDATE=true` if Java scanning is enabled) so it uses the supplied database as is.
 
 The database ages. A scan run against an old one reports only the vulnerabilities known when it was built, and nothing in the output says so, so keep track of when it was last refreshed.
 </Note>

--- a/docs/user-guide/providers/image/getting-started-image.mdx
+++ b/docs/user-guide/providers/image/getting-started-image.mdx
@@ -96,6 +96,25 @@ Install Trivy using one of the following methods:
 
 For additional installation methods, see the [Trivy installation guide](https://trivy.dev/latest/getting-started/installation/).
 
+### Vulnerability Database Cache
+
+Trivy keeps its vulnerability database in a cache directory. By default Prowler gives it a temporary one and removes it when the scan ends, so the database is downloaded again for every scan.
+
+Set `TRIVY_CACHE_DIR` to a directory that persists and the database is downloaded once and reused:
+
+```bash
+export TRIVY_CACHE_DIR="$HOME/.cache/trivy"
+prowler image --image <image>
+```
+
+Prowler leaves a directory you supply exactly as it found it, and never deletes it.
+
+<Note>
+This is required on hosts with no internet access. Trivy cannot fetch the database there, so it has to be supplied: populate the directory on a machine that does have access, copy it across, and point `TRIVY_CACHE_DIR` at it.
+
+The database ages. A scan run against an old one reports only the vulnerabilities known when it was built, and nothing in the output says so, so keep track of when it was last refreshed.
+</Note>
+
 
 ### Supported Scanners
 

--- a/prowler/changelog.d/trivy-cache-dir-configurable.fixed.md
+++ b/prowler/changelog.d/trivy-cache-dir-configurable.fixed.md
@@ -1,0 +1,1 @@
+The Image provider now uses the directory named by `TRIVY_CACHE_DIR` when one is set, instead of a fresh temporary directory it deletes afterwards, so a deployment can supply a vulnerability database it already holds and one with network access stops re-downloading the database for every image it scans

--- a/prowler/providers/image/image_provider.py
+++ b/prowler/providers/image/image_provider.py
@@ -115,9 +115,7 @@ class ImageProvider(Provider):
         self._session = None
         self._identity = "prowler"
         self._listing_only = False
-        # A deployment that cannot reach the vulnerability database on demand has
-        # to be able to point at one it already holds, and one that can reach it
-        # should not re-download it for every image scanned.
+        # A supplied cache dir is never deleted: it may hold a DB we cannot refetch
         configured_cache_dir = os.environ.get("TRIVY_CACHE_DIR", "").strip()
         if configured_cache_dir:
             self._trivy_cache_dir = configured_cache_dir

--- a/prowler/providers/image/image_provider.py
+++ b/prowler/providers/image/image_provider.py
@@ -115,10 +115,17 @@ class ImageProvider(Provider):
         self._session = None
         self._identity = "prowler"
         self._listing_only = False
-        self._trivy_cache_dir_obj = tempfile.TemporaryDirectory(
-            prefix="prowler-trivy-cache-"
-        )
-        self._trivy_cache_dir = self._trivy_cache_dir_obj.name
+        # A deployment that cannot reach the vulnerability database on demand has
+        # to be able to point at one it already holds, and one that can reach it
+        # should not re-download it for every image scanned.
+        configured_cache_dir = os.environ.get("TRIVY_CACHE_DIR", "").strip()
+        if configured_cache_dir:
+            self._trivy_cache_dir = configured_cache_dir
+        else:
+            self._trivy_cache_dir_obj = tempfile.TemporaryDirectory(
+                prefix="prowler-trivy-cache-"
+            )
+            self._trivy_cache_dir = self._trivy_cache_dir_obj.name
 
         # Registry authentication (follows IaC pattern: explicit params, env vars internal)
         self.registry_username = registry_username or os.environ.get(

--- a/tests/providers/image/image_provider_test.py
+++ b/tests/providers/image/image_provider_test.py
@@ -999,6 +999,34 @@ class TestCleanup:
         provider.cleanup()
         provider.cleanup()
 
+    def test_configured_cache_dir_is_used(self, monkeypatch, tmp_path):
+        """A deployment that supplies a cache directory gets that one."""
+        monkeypatch.setenv("TRIVY_CACHE_DIR", str(tmp_path))
+
+        provider = _make_provider()
+
+        assert provider._trivy_cache_dir == str(tmp_path)
+
+    def test_configured_cache_dir_survives_cleanup(self, monkeypatch, tmp_path):
+        """A supplied directory is not the provider's to delete: it holds a
+        database the deployment may have no way to fetch again."""
+        monkeypatch.setenv("TRIVY_CACHE_DIR", str(tmp_path))
+        provider = _make_provider()
+
+        provider.cleanup()
+
+        assert os.path.isdir(str(tmp_path))
+
+    def test_unset_cache_dir_keeps_the_temporary_one(self, monkeypatch):
+        """Without one configured, nothing changes for existing deployments."""
+        monkeypatch.delenv("TRIVY_CACHE_DIR", raising=False)
+
+        provider = _make_provider()
+
+        assert os.path.isdir(provider._trivy_cache_dir)
+        provider.cleanup()
+        assert not os.path.isdir(provider._trivy_cache_dir)
+
     def test_cleanup_removes_trivy_cache_dir(self):
         """Test that cleanup removes the temporary Trivy cache directory."""
         provider = _make_provider()

--- a/tests/providers/image/image_provider_test.py
+++ b/tests/providers/image/image_provider_test.py
@@ -50,6 +50,11 @@ def _make_provider(**kwargs):
     return ImageProvider(**defaults)
 
 
+@pytest.fixture(autouse=True)
+def _no_configured_cache_dir(monkeypatch):
+    monkeypatch.delenv("TRIVY_CACHE_DIR", raising=False)
+
+
 class TestImageProvider:
     def test_image_provider(self):
         """Test default initialization."""


### PR DESCRIPTION
### Context

The Image provider builds a fresh temporary cache directory for every provider instance and deletes it when the scan is done:

```python
self._trivy_cache_dir_obj = tempfile.TemporaryDirectory(prefix="prowler-trivy-cache-")
self._trivy_cache_dir = self._trivy_cache_dir_obj.name
...
trivy_command = ["trivy", "image", "--cache-dir", self._trivy_cache_dir, ...]
```

There is no way to point it anywhere else. `--cache-dir` on the command line wins over Trivy's own `TRIVY_CACHE_DIR`, so setting that variable has no effect today.

Two consequences follow.

The vulnerability database is downloaded again for every image scanned, on any deployment, because the cache never survives the scan that filled it. The code already treats this download as a source of trouble elsewhere, in the same file:

> Uses registry HTTP APIs directly instead of trivy to avoid false failures caused by trivy DB download issues.

And a deployment without egress cannot scan images at all. It has no way to supply a database it already holds, since the provider will not read from anywhere it is given. This is how the Image provider behaves on an air-gapped install: not degraded, unusable.

### Description

When `TRIVY_CACHE_DIR` names a directory, the provider uses it and leaves it alone. When it does not, nothing changes: the temporary directory is created and cleaned up exactly as before.

The supplied directory is deliberately not deleted on cleanup. It holds a database the deployment may have no way to fetch again, and it does not belong to the provider that borrowed it.

### Steps to review

The change is in `ImageProvider.__init__`, and `cleanup` needed nothing: it was already guarded on the attribute existing, so a run that never created a temporary directory has nothing to remove.

```
pytest tests/providers/image/image_provider_test.py -k cache_dir
```

Three cases added: a configured directory is used, a configured directory survives cleanup, and an unset variable keeps today's create-and-delete behaviour. The full `image_provider_test.py` suite passes (146 tests).

### Why it is worth having beyond air-gap

A connected deployment scanning a hundred images downloads the database a hundred times. Pointing the variable at a persistent path makes that once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image scanning now supports configuring Trivy’s cache location with `TRIVY_CACHE_DIR`.
  * Configured cache directories preserve vulnerability databases between scans, reducing repeated downloads.
  * Persistent caching supports offline scanning when a suitable database is available.

* **Bug Fixes**
  * Temporary cache behavior remains unchanged when no directory is configured.
  * Configured cache directories are preserved during cleanup, while temporary caches continue to be removed automatically.

* **Documentation**
  * Added guidance on cache configuration, offline usage, and database freshness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->