### PR TITLE
feat(googleworkspace): keyless authentication via ADC and Service Account impersonation

### DIFF
--- a/docs/user-guide/providers/googleworkspace/authentication.mdx
+++ b/docs/user-guide/providers/googleworkspace/authentication.mdx
@@ -8,6 +8,8 @@ import { VersionBadge } from "/snippets/version-badge.mdx"
 
 Prowler for Google Workspace uses a **Service Account with Domain-Wide Delegation** to authenticate to the Google Workspace Admin SDK and the Cloud Identity Policy API. This allows Prowler to read directory data and domain-level application policies on behalf of a super administrator without requiring an interactive login.
 
+The Service Account can authenticate with a downloaded **JSON key**, or **keyless** by [impersonating the Service Account](#keyless-authentication-with-service-account-impersonation) through Application Default Credentials. The Domain-Wide Delegation setup is the same in both cases.
+
 ## Required Open Authorization (OAuth) Scopes
 
 Prowler requests the following read-only OAuth 2.0 scopes:
@@ -77,13 +79,17 @@ The Service Account does not need any GCP IAM roles. Its access to Google Worksp
 This JSON key grants access to your Google Workspace organization. Never commit it to version control, share it in plain text, or store it in an insecure location.
 </Warning>
 
+<Note>
+Skip this step to authenticate without a key — see [Keyless Authentication with Service Account Impersonation](#keyless-authentication-with-service-account-impersonation).
+</Note>
+
 ### Step 5: Configure Domain-Wide Delegation in Google Workspace
 
 1. Navigate to the [Google Workspace Admin Console](https://admin.google.com)
 2. Navigate to **Security → Access and data control → API controls**
 3. Click **Manage Domain Wide Delegation**
 4. Click **Add new**
-5. Enter the **Client ID** of the Service Account (found in the JSON key as `client_id`, or on the Service Account details page)
+5. Enter the **Client ID** of the Service Account (found in the JSON key as `client_id`, on the Service Account details page as **Unique ID**, or with `gcloud iam service-accounts describe <service-account-email> --format='value(uniqueId)'`)
 6. In the **OAuth scopes** field, enter the following scopes as a comma-separated list:
 
 ```
@@ -115,17 +121,65 @@ export GOOGLEWORKSPACE_DELEGATED_USER="admin@yourdomain.com"
 prowler googleworkspace
 ```
 
+## Keyless Authentication with Service Account Impersonation
+
+If Service Account keys are not allowed in your organization (for example under the `iam.disableServiceAccountKeyCreation` organization policy), Prowler can impersonate the Service Account through **Application Default Credentials (ADC)** instead of loading a JSON key. The Service Account still needs Domain-Wide Delegation exactly as described in Steps 1–3 and 5 above; only Step 4 is skipped.
+
+How it works: the ADC identity asks the IAM Service Account Credentials API to sign the Domain-Wide Delegation assertion on behalf of the Service Account (`iam.serviceAccounts.signJwt`), and Prowler exchanges that assertion for an access token of the delegated user. No private key is created, downloaded, or stored.
+
+### Prerequisites
+
+- **Application Default Credentials** where Prowler runs: `gcloud auth application-default login` on a workstation, Workload Identity Federation (for example `google-github-actions/auth`) in CI, or the metadata server on Google Cloud compute.
+- The identity behind ADC holds **`roles/iam.serviceAccountTokenCreator`** (`iam.serviceAccounts.signJwt`) on the Service Account. When ADC already *is* the Service Account (Workload Identity Federation impersonating it, or a workload running as it), the Service Account signs its own assertion, so grant the role to the Service Account on itself. Verify the grant before the first scan with `gcloud iam service-accounts get-iam-policy <service-account-email>`.
+- The **IAM Service Account Credentials API** (`iamcredentials.googleapis.com`) is enabled in the project that hosts the Service Account, in addition to the APIs from Step 2.
+
+### Run Prowler
+
+```console
+export GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT="prowler-googleworkspace-reader@your-project.iam.gserviceaccount.com"
+export GOOGLEWORKSPACE_DELEGATED_USER="admin@yourdomain.com"
+prowler googleworkspace
+```
+
+The `--impersonate-service-account` flag is equivalent to the environment variable:
+
+```console
+export GOOGLEWORKSPACE_DELEGATED_USER="admin@yourdomain.com"
+prowler googleworkspace --impersonate-service-account prowler-googleworkspace-reader@your-project.iam.gserviceaccount.com
+```
+
+<Note>
+If `GOOGLEWORKSPACE_CREDENTIALS_FILE` or `GOOGLEWORKSPACE_CREDENTIALS_CONTENT` is also set, the key is used and impersonation is ignored.
+</Note>
+
+### Example: GitHub Actions with Workload Identity Federation
+
+```yaml
+permissions:
+  id-token: write
+steps:
+  - uses: google-github-actions/auth@v3
+    with:
+      workload_identity_provider: projects/123456789012/locations/global/workloadIdentityPools/github/providers/github
+      service_account: prowler-googleworkspace-reader@your-project.iam.gserviceaccount.com
+  - run: prowler googleworkspace --impersonate-service-account prowler-googleworkspace-reader@your-project.iam.gserviceaccount.com
+    env:
+      GOOGLEWORKSPACE_DELEGATED_USER: admin@yourdomain.com
+```
+
 ## How Prowler Resolves Credentials
 
 Prowler resolves credentials in the following order:
 
 1. `GOOGLEWORKSPACE_CREDENTIALS_FILE` environment variable
 2. `GOOGLEWORKSPACE_CREDENTIALS_CONTENT` environment variable
+3. `GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT` environment variable or the `--impersonate-service-account` flag (keyless, through Application Default Credentials)
 
 The delegated user must be provided via the `GOOGLEWORKSPACE_DELEGATED_USER` environment variable.
 
 ## Best Practices
 
+- **Prefer keyless impersonation** — Where Application Default Credentials are available, [Service Account impersonation](#keyless-authentication-with-service-account-impersonation) avoids a long-lived key entirely
 - **Use environment variables** — Never hardcode credentials in scripts or commands
 - **Use a dedicated Service Account** — Create one specifically for Prowler, separate from other integrations
 - **Use read-only scopes** — Prowler only requires the read-only scopes listed above
@@ -150,7 +204,11 @@ export GOOGLEWORKSPACE_DELEGATED_USER="admin@yourdomain.com"
 
 ### `GoogleWorkspaceNoCredentialsError`
 
-No credentials were found. Ensure either `GOOGLEWORKSPACE_CREDENTIALS_FILE` or `GOOGLEWORKSPACE_CREDENTIALS_CONTENT` is set.
+No credentials were found. Ensure either `GOOGLEWORKSPACE_CREDENTIALS_FILE` or `GOOGLEWORKSPACE_CREDENTIALS_CONTENT` is set, or `GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT` (or `--impersonate-service-account`) for keyless authentication.
+
+### `GoogleWorkspaceADCError`
+
+`GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT` is set but no Application Default Credentials were found. Run `gcloud auth application-default login`, point `GOOGLE_APPLICATION_CREDENTIALS` at a credential configuration file, or run Prowler where ADC is provided (Workload Identity Federation in CI, or a Google Cloud compute identity).
 
 ### `GoogleWorkspaceInvalidCredentialsError`
 
@@ -167,6 +225,7 @@ The Service Account cannot impersonate the delegated user. This usually means Do
 - The Service Account Client ID is correctly entered in the Admin Console
 - All required OAuth scopes are included
 - The delegated user is a super administrator
+- When impersonating the Service Account through Application Default Credentials: the ADC identity holds `roles/iam.serviceAccountTokenCreator` on it (a `403` mentioning `iam.serviceAccounts.signJwt` means it does not), and the IAM Service Account Credentials API is enabled in the project that hosts the Service Account
 
 ### Permission Denied on Admin SDK Calls
 

--- a/docs/user-guide/providers/googleworkspace/authentication.mdx
+++ b/docs/user-guide/providers/googleworkspace/authentication.mdx
@@ -123,6 +123,8 @@ prowler googleworkspace
 
 ## Keyless Authentication with Service Account Impersonation
 
+<VersionBadge version="5.42.0" />
+
 If Service Account keys are not allowed in your organization (for example under the `iam.disableServiceAccountKeyCreation` organization policy), Prowler can impersonate the Service Account through **Application Default Credentials (ADC)** instead of loading a JSON key. The Service Account still needs Domain-Wide Delegation exactly as described in Steps 1–3 and 5 above; only Step 4 is skipped.
 
 How it works: the ADC identity asks the IAM Service Account Credentials API to sign the Domain-Wide Delegation assertion on behalf of the Service Account (`iam.serviceAccounts.signJwt`), and Prowler exchanges that assertion for an access token of the delegated user. No private key is created, downloaded, or stored.
@@ -152,6 +154,10 @@ prowler googleworkspace --impersonate-service-account prowler-googleworkspace-re
 If `GOOGLEWORKSPACE_CREDENTIALS_FILE` or `GOOGLEWORKSPACE_CREDENTIALS_CONTENT` is also set, the key is used and impersonation is ignored.
 </Note>
 
+<Note>
+google-auth may log `No project ID could be determined` while loading the Application Default Credentials. Prowler loads them without scopes and this provider needs no Google Cloud project, so the warning is harmless.
+</Note>
+
 ### Example: GitHub Actions with Workload Identity Federation
 
 ```yaml
@@ -173,7 +179,10 @@ Prowler resolves credentials in the following order:
 
 1. `GOOGLEWORKSPACE_CREDENTIALS_FILE` environment variable
 2. `GOOGLEWORKSPACE_CREDENTIALS_CONTENT` environment variable
-3. `GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT` environment variable or the `--impersonate-service-account` flag (keyless, through Application Default Credentials)
+3. `--impersonate-service-account` flag (keyless, through Application Default Credentials)
+4. `GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT` environment variable
+
+Service Account key material always takes precedence over keyless impersonation, whichever way each is provided.
 
 The delegated user must be provided via the `GOOGLEWORKSPACE_DELEGATED_USER` environment variable.
 
@@ -218,6 +227,14 @@ The JSON key file is malformed or cannot be parsed. Verify the file was download
 python3 -c "import json; json.load(open('/path/to/key.json'))" && echo "Valid JSON"
 ```
 
+### `GoogleWorkspaceInsufficientScopesError`
+
+Google refused the delegated request with a `403` or `PERMISSION_DENIED`. Verify:
+
+- The Service Account Client ID is authorized in the Admin Console with all required OAuth scopes (Step 5)
+- The delegated user is an active super administrator
+- When impersonating the Service Account through Application Default Credentials: the ADC identity holds `roles/iam.serviceAccountTokenCreator` on it, and the IAM Service Account Credentials API is enabled in the project that hosts the Service Account. A `PERMISSION_DENIED` mentioning `iam.serviceAccounts.signJwt` means the role is missing; one mentioning `iam.serviceAccounts.getAccessToken` means the Workload Identity Federation principal lacks `roles/iam.workloadIdentityUser` on the Service Account
+
 ### `GoogleWorkspaceImpersonationError`
 
 The Service Account cannot impersonate the delegated user. This usually means Domain-Wide Delegation has not been configured, or the OAuth scopes are incorrect. Verify:
@@ -225,7 +242,6 @@ The Service Account cannot impersonate the delegated user. This usually means Do
 - The Service Account Client ID is correctly entered in the Admin Console
 - All required OAuth scopes are included
 - The delegated user is a super administrator
-- When impersonating the Service Account through Application Default Credentials: the ADC identity holds `roles/iam.serviceAccountTokenCreator` on it (a `403` mentioning `iam.serviceAccounts.signJwt` means it does not), and the IAM Service Account Credentials API is enabled in the project that hosts the Service Account
 
 ### Permission Denied on Admin SDK Calls
 

--- a/docs/user-guide/providers/googleworkspace/getting-started-googleworkspace.mdx
+++ b/docs/user-guide/providers/googleworkspace/getting-started-googleworkspace.mdx
@@ -110,6 +110,13 @@ export GOOGLEWORKSPACE_CREDENTIALS_CONTENT='{"type": "service_account", ...}'
 export GOOGLEWORKSPACE_DELEGATED_USER="admin@yourdomain.com"
 ```
 
+Or skip the key entirely and impersonate the Service Account through Application Default Credentials (see [Keyless Authentication](/user-guide/providers/googleworkspace/authentication#keyless-authentication-with-service-account-impersonation)):
+
+```console
+export GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT="prowler-googleworkspace-reader@your-project.iam.gserviceaccount.com"
+export GOOGLEWORKSPACE_DELEGATED_USER="admin@yourdomain.com"
+```
+
 ### Step 2: Run the First Scan
 
 Run a baseline scan after credentials are configured:

--- a/prowler/changelog.d/googleworkspace-keyless-impersonation.added.md
+++ b/prowler/changelog.d/googleworkspace-keyless-impersonation.added.md
@@ -1,0 +1,1 @@
+`--impersonate-service-account` flag and `GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT` environment variable for the Google Workspace provider, authenticating through Application Default Credentials and Service Account impersonation so Domain-Wide Delegation works without downloading a Service Account key

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -512,6 +512,7 @@ class Provider(ABC):
                     )
                 elif arguments.provider == "googleworkspace":
                     provider_class(
+                        impersonate_service_account=arguments.impersonate_service_account,
                         config_path=arguments.config_file,
                         mutelist_path=arguments.mutelist_file,
                         fixer_config=fixer_config,

--- a/prowler/providers/googleworkspace/exceptions/exceptions.py
+++ b/prowler/providers/googleworkspace/exceptions/exceptions.py
@@ -12,7 +12,7 @@ class GoogleWorkspaceBaseException(ProwlerException):
         },
         (12001, "GoogleWorkspaceNoCredentialsError"): {
             "message": "Google Workspace credentials are required to authenticate",
-            "remediation": "Set the GOOGLEWORKSPACE_CREDENTIALS_FILE or GOOGLEWORKSPACE_CREDENTIALS_CONTENT environment variable with a valid Service Account JSON.",
+            "remediation": "Set the GOOGLEWORKSPACE_CREDENTIALS_FILE or GOOGLEWORKSPACE_CREDENTIALS_CONTENT environment variable with a valid Service Account JSON, or set GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT (or --impersonate-service-account) to authenticate keyless through Application Default Credentials.",
         },
         (12002, "GoogleWorkspaceInvalidCredentialsError"): {
             "message": "Google Workspace credentials provided are not valid",
@@ -41,6 +41,10 @@ class GoogleWorkspaceBaseException(ProwlerException):
         (12008, "GoogleWorkspaceInvalidProviderIdError"): {
             "message": "The provided provider_id does not match the credentials customer ID",
             "remediation": "Check the provider_id (Customer ID) and ensure it matches the Google Workspace organization for the given credentials.",
+        },
+        (12009, "GoogleWorkspaceADCError"): {
+            "message": "Application Default Credentials could not be loaded for Service Account impersonation",
+            "remediation": "Authenticate with `gcloud auth application-default login`, run where Application Default Credentials are provided (for example Workload Identity Federation in CI), or set GOOGLE_APPLICATION_CREDENTIALS. The calling identity needs roles/iam.serviceAccountTokenCreator on the impersonated Service Account.",
         },
     }
 
@@ -127,4 +131,11 @@ class GoogleWorkspaceInvalidProviderIdError(GoogleWorkspaceBaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             12008, file=file, original_exception=original_exception, message=message
+        )
+
+
+class GoogleWorkspaceADCError(GoogleWorkspaceCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            12009, file=file, original_exception=original_exception, message=message
         )

--- a/prowler/providers/googleworkspace/googleworkspace_provider.py
+++ b/prowler/providers/googleworkspace/googleworkspace_provider.py
@@ -196,10 +196,10 @@ class GoogleworkspaceProvider(Provider):
         Sets up the Google Workspace session with Service Account and Domain-Wide Delegation.
 
         Credentials are resolved in this order: credentials_file, credentials_content,
-        impersonate_service_account, then the GOOGLEWORKSPACE_CREDENTIALS_FILE,
-        GOOGLEWORKSPACE_CREDENTIALS_CONTENT and GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT
-        environment variables in the same order. Service Account key material always wins
-        over impersonation when both are present.
+        the GOOGLEWORKSPACE_CREDENTIALS_FILE and GOOGLEWORKSPACE_CREDENTIALS_CONTENT
+        environment variables, impersonate_service_account, then the
+        GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT environment variable. Service Account
+        key material always wins over impersonation, whichever way each is provided.
 
         Args:
             credentials_file (str): Path to Service Account JSON credentials file.
@@ -237,7 +237,9 @@ class GoogleworkspaceProvider(Provider):
                 message=f"Invalid delegated user email format: {delegated_user}. Must be a valid email address.",
             )
 
-        # Determine credentials source
+        # Determine credentials source. Service Account key material (argument,
+        # then environment variable) always wins over keyless impersonation
+        # (argument, then environment variable).
         impersonated_service_account = None
         if credentials_file:
             logger.info(
@@ -281,12 +283,6 @@ class GoogleworkspaceProvider(Provider):
                     original_exception=error,
                     message="Invalid service account credentials in content",
                 )
-        elif impersonate_service_account:
-            credentials = GoogleworkspaceProvider.setup_impersonated_credentials(
-                impersonate_service_account,
-                delegated_user,
-            )
-            impersonated_service_account = impersonate_service_account
         else:
             # Try environment variables
             logger.info(
@@ -294,9 +290,6 @@ class GoogleworkspaceProvider(Provider):
             )
             env_file = environ.get("GOOGLEWORKSPACE_CREDENTIALS_FILE", "")
             env_content = environ.get("GOOGLEWORKSPACE_CREDENTIALS_CONTENT", "")
-            env_impersonate_service_account = environ.get(
-                "GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT", ""
-            )
 
             if env_file:
                 logger.info(
@@ -342,17 +335,25 @@ class GoogleworkspaceProvider(Provider):
                         original_exception=error,
                         message="Invalid service account credentials in GOOGLEWORKSPACE_CREDENTIALS_CONTENT",
                     )
-            elif env_impersonate_service_account:
-                credentials = GoogleworkspaceProvider.setup_impersonated_credentials(
-                    env_impersonate_service_account,
-                    delegated_user,
-                )
-                impersonated_service_account = env_impersonate_service_account
             else:
-                raise GoogleWorkspaceNoCredentialsError(
-                    file=os.path.basename(__file__),
-                    message="No credentials provided. Set the GOOGLEWORKSPACE_CREDENTIALS_FILE or GOOGLEWORKSPACE_CREDENTIALS_CONTENT environment variable, or GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT to authenticate keyless through Application Default Credentials.",
+                # The flag wins over its environment variable
+                impersonated_service_account = (
+                    impersonate_service_account
+                    or environ.get("GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT")
+                    or None
                 )
+                if impersonated_service_account:
+                    credentials = (
+                        GoogleworkspaceProvider.setup_impersonated_credentials(
+                            impersonated_service_account,
+                            delegated_user,
+                        )
+                    )
+                else:
+                    raise GoogleWorkspaceNoCredentialsError(
+                        file=os.path.basename(__file__),
+                        message="No credentials provided. Set the GOOGLEWORKSPACE_CREDENTIALS_FILE or GOOGLEWORKSPACE_CREDENTIALS_CONTENT environment variable, or GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT to authenticate keyless through Application Default Credentials.",
+                    )
 
         # Perform Domain-Wide Delegation impersonation
         logger.info(f"Impersonating user: {delegated_user}")
@@ -383,10 +384,11 @@ class GoogleworkspaceProvider(Provider):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
             )
             error_message = str(error).lower()
-            # Admin SDK errors carry "403"/"forbidden"; an IAM Credentials signJwt
-            # refusal on the impersonation path surfaces as a TransportError whose
-            # body says "PERMISSION_DENIED"; an unauthorized Domain-Wide Delegation
-            # client surfaces as a RefreshError with "unauthorized_client".
+            # Admin SDK errors carry "403"/"forbidden"; an IAM Credentials refusal on
+            # the impersonation path (signJwt, or getAccessToken behind Workload
+            # Identity Federation) surfaces as a RefreshError whose body says
+            # "PERMISSION_DENIED"; an unauthorized Domain-Wide Delegation client
+            # surfaces as a RefreshError with "unauthorized_client".
             if (
                 "403" in str(error)
                 or "forbidden" in error_message
@@ -397,7 +399,7 @@ class GoogleworkspaceProvider(Provider):
             ):
                 remediation = "Ensure the Service Account Client ID is authorized in Google Workspace Admin Console with the required OAuth scopes."
                 if impersonated_service_account:
-                    remediation += f" When impersonating {impersonated_service_account} through Application Default Credentials, also ensure the calling identity holds roles/iam.serviceAccountTokenCreator (iam.serviceAccounts.signJwt) on that Service Account."
+                    remediation += f" When impersonating {impersonated_service_account} through Application Default Credentials, also ensure the calling identity holds roles/iam.serviceAccountTokenCreator on that Service Account (iam.serviceAccounts.signJwt) and, behind Workload Identity Federation, roles/iam.workloadIdentityUser (iam.serviceAccounts.getAccessToken)."
                 raise GoogleWorkspaceInsufficientScopesError(
                     file=os.path.basename(__file__),
                     original_exception=error,

--- a/prowler/providers/googleworkspace/googleworkspace_provider.py
+++ b/prowler/providers/googleworkspace/googleworkspace_provider.py
@@ -5,6 +5,8 @@ import re
 from os import environ
 
 from colorama import Fore, Style
+from google.auth import default, impersonated_credentials
+from google.auth.exceptions import DefaultCredentialsError
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
@@ -18,6 +20,7 @@ from prowler.lib.utils.utils import print_boxes
 from prowler.providers.common.models import Audit_Metadata, Connection
 from prowler.providers.common.provider import Provider
 from prowler.providers.googleworkspace.exceptions.exceptions import (
+    GoogleWorkspaceADCError,
     GoogleWorkspaceImpersonationError,
     GoogleWorkspaceInsufficientScopesError,
     GoogleWorkspaceInvalidCredentialsError,
@@ -79,6 +82,7 @@ class GoogleworkspaceProvider(Provider):
         credentials_file: str = None,
         credentials_content: str = None,
         delegated_user: str = None,
+        impersonate_service_account: str = None,
         # Provider configuration
         config_path: str = None,
         config_content: dict = None,
@@ -93,6 +97,8 @@ class GoogleworkspaceProvider(Provider):
             credentials_file (str): Path to Service Account JSON credentials file.
             credentials_content (str): Service Account JSON credentials as a string.
             delegated_user (str): Email of the user to impersonate via Domain-Wide Delegation.
+            impersonate_service_account (str): Email of a Service Account to impersonate through
+                Application Default Credentials for keyless Domain-Wide Delegation (no JSON key).
             config_path (str): Path to the audit configuration file.
             config_content (dict): Audit configuration content.
             fixer_config (dict): Fixer configuration content.
@@ -106,9 +112,10 @@ class GoogleworkspaceProvider(Provider):
         logging.getLogger("googleapiclient.discovery_cache").setLevel(logging.ERROR)
 
         self._session, resolved_delegated_user = GoogleworkspaceProvider.setup_session(
-            credentials_file,
-            credentials_content,
-            delegated_user,
+            credentials_file=credentials_file,
+            credentials_content=credentials_content,
+            delegated_user=delegated_user,
+            impersonate_service_account=impersonate_service_account,
         )
 
         self._identity = GoogleworkspaceProvider.setup_identity(
@@ -183,14 +190,23 @@ class GoogleworkspaceProvider(Provider):
         credentials_file: str = None,
         credentials_content: str = None,
         delegated_user: str = None,
+        impersonate_service_account: str = None,
     ) -> tuple[GoogleWorkspaceSession, str]:
         """
         Sets up the Google Workspace session with Service Account and Domain-Wide Delegation.
+
+        Credentials are resolved in this order: credentials_file, credentials_content,
+        impersonate_service_account, then the GOOGLEWORKSPACE_CREDENTIALS_FILE,
+        GOOGLEWORKSPACE_CREDENTIALS_CONTENT and GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT
+        environment variables in the same order. Service Account key material always wins
+        over impersonation when both are present.
 
         Args:
             credentials_file (str): Path to Service Account JSON credentials file.
             credentials_content (str): Service Account JSON credentials as a string.
             delegated_user (str): Email of the user to impersonate via Domain-Wide Delegation.
+            impersonate_service_account (str): Email of a Service Account to impersonate through
+                Application Default Credentials for keyless Domain-Wide Delegation (no JSON key).
 
         Returns:
             tuple[GoogleWorkspaceSession, str]: Tuple containing the authenticated session and resolved delegated user email.
@@ -199,6 +215,7 @@ class GoogleworkspaceProvider(Provider):
             GoogleWorkspaceNoCredentialsError: If no credentials are provided.
             GoogleWorkspaceMissingDelegatedUserError: If delegated_user is not provided.
             GoogleWorkspaceInvalidCredentialsError: If credentials are invalid.
+            GoogleWorkspaceADCError: If Application Default Credentials cannot be loaded for impersonation.
             GoogleWorkspaceImpersonationError: If impersonation fails.
             GoogleWorkspaceSetUpSessionError: If session setup fails.
         """
@@ -221,6 +238,7 @@ class GoogleworkspaceProvider(Provider):
             )
 
         # Determine credentials source
+        impersonated_service_account = None
         if credentials_file:
             logger.info(
                 f"Using Service Account credentials from file: {credentials_file}"
@@ -263,13 +281,22 @@ class GoogleworkspaceProvider(Provider):
                     original_exception=error,
                     message="Invalid service account credentials in content",
                 )
+        elif impersonate_service_account:
+            credentials = GoogleworkspaceProvider.setup_impersonated_credentials(
+                impersonate_service_account,
+                delegated_user,
+            )
+            impersonated_service_account = impersonate_service_account
         else:
             # Try environment variables
             logger.info(
-                "Looking for GOOGLEWORKSPACE_CREDENTIALS_FILE or GOOGLEWORKSPACE_CREDENTIALS_CONTENT environment variables..."
+                "Looking for GOOGLEWORKSPACE_CREDENTIALS_FILE, GOOGLEWORKSPACE_CREDENTIALS_CONTENT or GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT environment variables..."
             )
             env_file = environ.get("GOOGLEWORKSPACE_CREDENTIALS_FILE", "")
             env_content = environ.get("GOOGLEWORKSPACE_CREDENTIALS_CONTENT", "")
+            env_impersonate_service_account = environ.get(
+                "GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT", ""
+            )
 
             if env_file:
                 logger.info(
@@ -315,17 +342,29 @@ class GoogleworkspaceProvider(Provider):
                         original_exception=error,
                         message="Invalid service account credentials in GOOGLEWORKSPACE_CREDENTIALS_CONTENT",
                     )
+            elif env_impersonate_service_account:
+                credentials = GoogleworkspaceProvider.setup_impersonated_credentials(
+                    env_impersonate_service_account,
+                    delegated_user,
+                )
+                impersonated_service_account = env_impersonate_service_account
             else:
                 raise GoogleWorkspaceNoCredentialsError(
                     file=os.path.basename(__file__),
-                    message="No credentials provided. Set the GOOGLEWORKSPACE_CREDENTIALS_FILE or GOOGLEWORKSPACE_CREDENTIALS_CONTENT environment variable.",
+                    message="No credentials provided. Set the GOOGLEWORKSPACE_CREDENTIALS_FILE or GOOGLEWORKSPACE_CREDENTIALS_CONTENT environment variable, or GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT to authenticate keyless through Application Default Credentials.",
                 )
 
         # Perform Domain-Wide Delegation impersonation
         logger.info(f"Impersonating user: {delegated_user}")
-        # Note: with_subject() never fails - it just creates an object
-        # We need to verify the delegation actually works by making an API call
-        delegated_credentials = credentials.with_subject(delegated_user)
+        if impersonated_service_account:
+            # Impersonated credentials already carry the delegated user as the JWT
+            # subject: google-auth asks the IAM Credentials API to sign the delegation
+            # assertion on every refresh, so there is no with_subject() step here.
+            delegated_credentials = credentials
+        else:
+            # Note: with_subject() never fails - it just creates an object
+            # We need to verify the delegation actually works by making an API call
+            delegated_credentials = credentials.with_subject(delegated_user)
 
         # Test the delegation by making an actual API call to verify it works
         try:
@@ -344,16 +383,25 @@ class GoogleworkspaceProvider(Provider):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
             )
             error_message = str(error).lower()
+            # Admin SDK errors carry "403"/"forbidden"; an IAM Credentials signJwt
+            # refusal on the impersonation path surfaces as a TransportError whose
+            # body says "PERMISSION_DENIED"; an unauthorized Domain-Wide Delegation
+            # client surfaces as a RefreshError with "unauthorized_client".
             if (
                 "403" in str(error)
                 or "forbidden" in error_message
                 or "insufficient" in error_message
                 or "unauthorized" in error_message
+                or "permission_denied" in error_message
+                or "permission denied" in error_message
             ):
+                remediation = "Ensure the Service Account Client ID is authorized in Google Workspace Admin Console with the required OAuth scopes."
+                if impersonated_service_account:
+                    remediation += f" When impersonating {impersonated_service_account} through Application Default Credentials, also ensure the calling identity holds roles/iam.serviceAccountTokenCreator (iam.serviceAccounts.signJwt) on that Service Account."
                 raise GoogleWorkspaceInsufficientScopesError(
                     file=os.path.basename(__file__),
                     original_exception=error,
-                    message=f"Domain-Wide Delegation is not configured or user {delegated_user} lacks required permissions. Ensure the Service Account Client ID is authorized in Google Workspace Admin Console with the required OAuth scopes.",
+                    message=f"Domain-Wide Delegation is not configured or user {delegated_user} lacks required permissions. {remediation}",
                 )
             else:
                 raise GoogleWorkspaceImpersonationError(
@@ -362,8 +410,69 @@ class GoogleworkspaceProvider(Provider):
                     message=f"Failed to verify delegation for user {delegated_user}: {error}",
                 )
 
-        session = GoogleWorkspaceSession(credentials=delegated_credentials)
+        session = GoogleWorkspaceSession(
+            credentials=delegated_credentials,
+            impersonated_service_account=impersonated_service_account,
+        )
         return session, delegated_user
+
+    @staticmethod
+    def setup_impersonated_credentials(
+        service_account_email: str,
+        delegated_user: str,
+    ) -> impersonated_credentials.Credentials:
+        """
+        Builds keyless Domain-Wide Delegation credentials by impersonating a Service Account
+        through Application Default Credentials (ADC).
+
+        The ADC identity (a user signed in with `gcloud auth application-default login`, a
+        Workload Identity Federation credential in CI, a GCE/GKE metadata identity, or the
+        Service Account itself) asks the IAM Credentials API to sign the delegation JWT on
+        behalf of `service_account_email`, so no Service Account private key is ever
+        downloaded. The calling identity needs `roles/iam.serviceAccountTokenCreator`
+        (`iam.serviceAccounts.signJwt`) on the Service Account, and the Service Account
+        Client ID must be authorized for Domain-Wide Delegation exactly as with a JSON key.
+
+        Args:
+            service_account_email (str): Email of the Service Account to impersonate.
+            delegated_user (str): Email of the user to impersonate via Domain-Wide Delegation.
+
+        Returns:
+            impersonated_credentials.Credentials: Credentials that authenticate as the delegated user.
+
+        Raises:
+            GoogleWorkspaceInvalidCredentialsError: If the Service Account email is malformed.
+            GoogleWorkspaceADCError: If Application Default Credentials cannot be loaded.
+        """
+        email_pattern = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
+        if not email_pattern.match(service_account_email):
+            raise GoogleWorkspaceInvalidCredentialsError(
+                file=os.path.basename(__file__),
+                message=f"Invalid Service Account email format: {service_account_email}. Must be a valid Service Account email address.",
+            )
+
+        logger.info(
+            f"Using Application Default Credentials to impersonate Service Account: {service_account_email}"
+        )
+        try:
+            # The ADC project is not needed: the delegated access token is issued to
+            # the Service Account's own OAuth client, so Admin SDK and Cloud Identity
+            # calls are attributed to the project that hosts the Service Account and
+            # no quota project has to be set on the source credentials.
+            source_credentials, _ = default()
+        except DefaultCredentialsError as error:
+            raise GoogleWorkspaceADCError(
+                file=os.path.basename(__file__),
+                original_exception=error,
+                message=f"Application Default Credentials could not be loaded to impersonate {service_account_email}: {error}",
+            )
+
+        return impersonated_credentials.Credentials(
+            source_credentials=source_credentials,
+            target_principal=service_account_email,
+            target_scopes=GoogleworkspaceProvider.SCOPES,
+            subject=delegated_user,
+        )
 
     @staticmethod
     def setup_identity(
@@ -506,11 +615,15 @@ class GoogleworkspaceProvider(Provider):
         Usage:
             >>> self.print_credentials()
         """
+        if self.session.impersonated_service_account:
+            authentication_method = f"Application Default Credentials impersonating {self.session.impersonated_service_account} with Domain-Wide Delegation"
+        else:
+            authentication_method = "Service Account with Domain-Wide Delegation"
         report_lines = [
             f"Google Workspace Domain: {Fore.YELLOW}{self.identity.domain}{Style.RESET_ALL}",
             f"Customer ID: {Fore.YELLOW}{self.identity.customer_id}{Style.RESET_ALL}",
             f"Delegated User: {Fore.YELLOW}{self.identity.delegated_user}{Style.RESET_ALL}",
-            f"Authentication Method: {Fore.YELLOW}Service Account with Domain-Wide Delegation{Style.RESET_ALL}",
+            f"Authentication Method: {Fore.YELLOW}{authentication_method}{Style.RESET_ALL}",
         ]
         report_title = f"{Style.BRIGHT}Using the Google Workspace credentials below:{Style.RESET_ALL}"
         print_boxes(report_lines, report_title)
@@ -522,6 +635,7 @@ class GoogleworkspaceProvider(Provider):
         delegated_user: str = None,
         raise_on_exception: bool = True,
         provider_id: str = None,
+        impersonate_service_account: str = None,
     ) -> Connection:
         """Test connection to Google Workspace.
 
@@ -533,6 +647,8 @@ class GoogleworkspaceProvider(Provider):
             delegated_user (str): Email of the user to impersonate via Domain-Wide Delegation.
             raise_on_exception (bool): Flag indicating whether to raise an exception if the connection fails.
             provider_id (str): The provider ID (Customer ID). Optional, not used in connection test.
+            impersonate_service_account (str): Email of a Service Account to impersonate through
+                Application Default Credentials for keyless Domain-Wide Delegation (no JSON key).
 
         Returns:
             Connection: Connection object with success status or error information.
@@ -556,6 +672,7 @@ class GoogleworkspaceProvider(Provider):
                 credentials_file=credentials_file,
                 credentials_content=credentials_content,
                 delegated_user=delegated_user,
+                impersonate_service_account=impersonate_service_account,
             )
 
             # Set up the identity to test the connection

--- a/prowler/providers/googleworkspace/lib/arguments/arguments.py
+++ b/prowler/providers/googleworkspace/lib/arguments/arguments.py
@@ -11,7 +11,6 @@ def init_parser(self):
     )
     googleworkspace_auth_subparser.add_argument(
         "--impersonate-service-account",
-        nargs="?",
         metavar="SERVICE_ACCOUNT",
         help="Impersonate a Google Service Account through Application Default Credentials and use it for Domain-Wide Delegation without a Service Account key (same as the GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT environment variable)",
     )

--- a/prowler/providers/googleworkspace/lib/arguments/arguments.py
+++ b/prowler/providers/googleworkspace/lib/arguments/arguments.py
@@ -1,7 +1,17 @@
 def init_parser(self):
     """Init the Google Workspace Provider CLI parser"""
-    self.subparsers.add_parser(
+    googleworkspace_parser = self.subparsers.add_parser(
         "googleworkspace",
         parents=[self.common_providers_parser],
         help="Google Workspace Provider",
+    )
+    # Authentication Modes
+    googleworkspace_auth_subparser = googleworkspace_parser.add_argument_group(
+        "Authentication Modes"
+    )
+    googleworkspace_auth_subparser.add_argument(
+        "--impersonate-service-account",
+        nargs="?",
+        metavar="SERVICE_ACCOUNT",
+        help="Impersonate a Google Service Account through Application Default Credentials and use it for Domain-Wide Delegation without a Service Account key (same as the GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT environment variable)",
     )

--- a/prowler/providers/googleworkspace/models.py
+++ b/prowler/providers/googleworkspace/models.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from google.oauth2.service_account import Credentials
+from google.auth.credentials import Credentials
 from pydantic.v1 import BaseModel
 
 from prowler.config.config import output_file_timestamp
@@ -10,7 +10,12 @@ from prowler.providers.common.models import ProviderOutputOptions
 class GoogleWorkspaceSession(BaseModel):
     """Google Workspace session containing credentials"""
 
+    # The google-auth base type, so both key-based Service Account credentials and
+    # keyless impersonated credentials (ADC + Domain-Wide Delegation) fit here.
     credentials: Credentials
+    # Service Account impersonated through Application Default Credentials when
+    # authenticating keyless; None when a Service Account key was used.
+    impersonated_service_account: Optional[str] = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -1354,6 +1354,20 @@ class Test_Parser:
         assert parsed.provider == "gcp"
         assert parsed.impersonate_service_account == service_account
 
+    def test_parser_googleworkspace_impersonate_service_account(self):
+        argument = "--impersonate-service-account"
+        service_account = "prowler-reader@test-project.iam.gserviceaccount.com"
+        command = [prowler_command, "googleworkspace", argument, service_account]
+        parsed = self.parser.parse(command)
+        assert parsed.provider == "googleworkspace"
+        assert parsed.impersonate_service_account == service_account
+
+    def test_parser_googleworkspace_impersonate_service_account_default(self):
+        command = [prowler_command, "googleworkspace"]
+        parsed = self.parser.parse(command)
+        assert parsed.provider == "googleworkspace"
+        assert parsed.impersonate_service_account is None
+
     def test_parser_gcp_retries_max_attempts(self):
         argument = "--gcp-retries-max-attempts"
         max_retries = "10"

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -1368,6 +1368,13 @@ class Test_Parser:
         assert parsed.provider == "googleworkspace"
         assert parsed.impersonate_service_account is None
 
+    def test_parser_googleworkspace_impersonate_service_account_requires_value(self):
+        command = [prowler_command, "googleworkspace", "--impersonate-service-account"]
+        with pytest.raises(SystemExit) as wrapped_exit:
+            _ = self.parser.parse(command)
+        assert wrapped_exit.type == SystemExit
+        assert wrapped_exit.value.code == 2
+
     def test_parser_gcp_retries_max_attempts(self):
         argument = "--gcp-retries-max-attempts"
         max_retries = "10"

--- a/tests/providers/googleworkspace/googleworkspace_fixtures.py
+++ b/tests/providers/googleworkspace/googleworkspace_fixtures.py
@@ -12,6 +12,9 @@ from prowler.providers.googleworkspace.models import (
 DOMAIN = "test-company.com"
 CUSTOMER_ID = "C1234567"
 DELEGATED_USER = "prowler-reader@test-company.com"
+IMPERSONATED_SERVICE_ACCOUNT = (
+    "prowler-reader@test-project-12345.iam.gserviceaccount.com"
+)
 ROOT_ORG_UNIT_ID = "03ph8a2z1234"
 
 # Service Account credentials (mock)

--- a/tests/providers/googleworkspace/googleworkspace_provider_test.py
+++ b/tests/providers/googleworkspace/googleworkspace_provider_test.py
@@ -1,10 +1,14 @@
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.auth.exceptions import DefaultCredentialsError, RefreshError
+from google.auth.impersonated_credentials import Credentials as ImpersonatedCredentials
 from google.oauth2.service_account import Credentials
 from googleapiclient.errors import HttpError
 
 from prowler.providers.googleworkspace.exceptions.exceptions import (
+    GoogleWorkspaceADCError,
     GoogleWorkspaceImpersonationError,
     GoogleWorkspaceInsufficientScopesError,
     GoogleWorkspaceInvalidCredentialsError,
@@ -24,6 +28,7 @@ from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
     DELEGATED_USER,
     DOMAIN,
+    IMPERSONATED_SERVICE_ACCOUNT,
     ROOT_ORG_UNIT_ID,
     SERVICE_ACCOUNT_CREDENTIALS,
 )
@@ -421,3 +426,290 @@ class TestGoogleWorkspaceProvider:
                     delegated_user=delegated_user,
                     raise_on_exception=True,
                 )
+
+    def test_setup_session_impersonate_service_account(self):
+        """Test keyless authentication through ADC + Service Account impersonation"""
+        mock_source_credentials = MagicMock()
+        mock_impersonated_credentials = MagicMock(spec=ImpersonatedCredentials)
+
+        with (
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.default",
+                return_value=(mock_source_credentials, None),
+            ) as mock_default,
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.impersonated_credentials.Credentials",
+                return_value=mock_impersonated_credentials,
+            ) as mock_impersonated_class,
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.build"
+            ) as mock_build,
+        ):
+            mock_service = MagicMock()
+            mock_build.return_value = mock_service
+            mock_service.users().get().execute.return_value = {
+                "primaryEmail": DELEGATED_USER
+            }
+
+            session, resolved_delegated_user = GoogleworkspaceProvider.setup_session(
+                impersonate_service_account=IMPERSONATED_SERVICE_ACCOUNT,
+                delegated_user=DELEGATED_USER,
+            )
+
+            mock_default.assert_called_once()
+            # The delegated user travels as the JWT subject of the impersonated
+            # credentials, which google-auth signs through the IAM Credentials API.
+            mock_impersonated_class.assert_called_once_with(
+                source_credentials=mock_source_credentials,
+                target_principal=IMPERSONATED_SERVICE_ACCOUNT,
+                target_scopes=GoogleworkspaceProvider.SCOPES,
+                subject=DELEGATED_USER,
+            )
+            assert session.credentials is mock_impersonated_credentials
+            assert session.impersonated_service_account == IMPERSONATED_SERVICE_ACCOUNT
+            assert resolved_delegated_user == DELEGATED_USER
+            mock_build.assert_called_once_with(
+                "admin",
+                "directory_v1",
+                credentials=mock_impersonated_credentials,
+                cache_discovery=False,
+            )
+
+    def test_setup_session_impersonate_service_account_from_env(self):
+        """Test GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT is used when no key is given"""
+        mock_impersonated_credentials = MagicMock(spec=ImpersonatedCredentials)
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "GOOGLEWORKSPACE_CREDENTIALS_FILE": "",
+                    "GOOGLEWORKSPACE_CREDENTIALS_CONTENT": "",
+                    "GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT": IMPERSONATED_SERVICE_ACCOUNT,
+                    "GOOGLEWORKSPACE_DELEGATED_USER": DELEGATED_USER,
+                },
+            ),
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.default",
+                return_value=(MagicMock(), None),
+            ),
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.impersonated_credentials.Credentials",
+                return_value=mock_impersonated_credentials,
+            ) as mock_impersonated_class,
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.build"
+            ) as mock_build,
+        ):
+            mock_build.return_value.users().get().execute.return_value = {}
+
+            session, resolved_delegated_user = GoogleworkspaceProvider.setup_session()
+
+            assert mock_impersonated_class.call_args.kwargs["target_principal"] == (
+                IMPERSONATED_SERVICE_ACCOUNT
+            )
+            assert mock_impersonated_class.call_args.kwargs["subject"] == DELEGATED_USER
+            assert session.impersonated_service_account == IMPERSONATED_SERVICE_ACCOUNT
+            assert resolved_delegated_user == DELEGATED_USER
+
+    def test_setup_session_key_takes_precedence_over_impersonation(self):
+        """Test Service Account key material wins when both a key and impersonation are given"""
+        mock_credentials = MagicMock(spec=Credentials)
+        mock_credentials.with_subject.return_value = MagicMock(spec=Credentials)
+
+        with (
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.service_account.Credentials.from_service_account_file",
+                return_value=mock_credentials,
+            ),
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.default"
+            ) as mock_default,
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.build"
+            ) as mock_build,
+        ):
+            mock_build.return_value.users().get().execute.return_value = {}
+
+            session, _ = GoogleworkspaceProvider.setup_session(
+                credentials_file="/path/to/creds.json",
+                impersonate_service_account=IMPERSONATED_SERVICE_ACCOUNT,
+                delegated_user=DELEGATED_USER,
+            )
+
+            mock_default.assert_not_called()
+            mock_credentials.with_subject.assert_called_once_with(DELEGATED_USER)
+            assert session.impersonated_service_account is None
+
+    def test_setup_session_impersonation_without_adc(self):
+        """Test GoogleWorkspaceADCError when Application Default Credentials are missing"""
+        with patch(
+            "prowler.providers.googleworkspace.googleworkspace_provider.default",
+            side_effect=DefaultCredentialsError(
+                "Could not automatically determine credentials"
+            ),
+        ):
+            with pytest.raises(GoogleWorkspaceADCError) as exc_info:
+                GoogleworkspaceProvider.setup_session(
+                    impersonate_service_account=IMPERSONATED_SERVICE_ACCOUNT,
+                    delegated_user=DELEGATED_USER,
+                )
+            assert "Application Default Credentials could not be loaded" in str(
+                exc_info.value
+            )
+
+    def test_setup_session_impersonation_invalid_service_account_email(self):
+        """Test a malformed Service Account email is rejected before touching ADC"""
+        with patch(
+            "prowler.providers.googleworkspace.googleworkspace_provider.default"
+        ) as mock_default:
+            with pytest.raises(GoogleWorkspaceInvalidCredentialsError) as exc_info:
+                GoogleworkspaceProvider.setup_session(
+                    impersonate_service_account="not-a-service-account",
+                    delegated_user=DELEGATED_USER,
+                )
+            assert "Invalid Service Account email format" in str(exc_info.value)
+            mock_default.assert_not_called()
+
+    def test_setup_session_impersonation_sign_jwt_denied(self):
+        """Test the 403 hint mentions serviceAccountTokenCreator when impersonating"""
+        mock_impersonated_credentials = MagicMock(spec=ImpersonatedCredentials)
+        http_error = HttpError(
+            resp=MagicMock(status=403), content=b"Forbidden", uri="test"
+        )
+
+        with (
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.default",
+                return_value=(MagicMock(), None),
+            ),
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.impersonated_credentials.Credentials",
+                return_value=mock_impersonated_credentials,
+            ),
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.build"
+            ) as mock_build,
+        ):
+            mock_build.return_value.users().get().execute.side_effect = http_error
+
+            with pytest.raises(GoogleWorkspaceInsufficientScopesError) as exc_info:
+                GoogleworkspaceProvider.setup_session(
+                    impersonate_service_account=IMPERSONATED_SERVICE_ACCOUNT,
+                    delegated_user=DELEGATED_USER,
+                )
+            assert "roles/iam.serviceAccountTokenCreator" in str(exc_info.value)
+            assert IMPERSONATED_SERVICE_ACCOUNT in str(exc_info.value)
+
+    def test_googleworkspace_provider_print_credentials_impersonation(self):
+        """Test print_credentials reports the keyless authentication method"""
+        mock_credentials = MagicMock(spec=ImpersonatedCredentials)
+
+        with (
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.GoogleworkspaceProvider.setup_session",
+                return_value=(
+                    GoogleWorkspaceSession(
+                        credentials=mock_credentials,
+                        impersonated_service_account=IMPERSONATED_SERVICE_ACCOUNT,
+                    ),
+                    DELEGATED_USER,
+                ),
+            ),
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.GoogleworkspaceProvider.setup_identity",
+                return_value=GoogleWorkspaceIdentityInfo(
+                    domain=DOMAIN,
+                    customer_id=CUSTOMER_ID,
+                    delegated_user=DELEGATED_USER,
+                    profile="default",
+                ),
+            ),
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.print_boxes"
+            ) as mock_print_boxes,
+        ):
+            provider = GoogleworkspaceProvider(
+                impersonate_service_account=IMPERSONATED_SERVICE_ACCOUNT,
+                delegated_user=DELEGATED_USER,
+            )
+
+            provider.print_credentials()
+
+            report_lines = mock_print_boxes.call_args[0][0]
+            assert any(
+                "Application Default Credentials" in line
+                and IMPERSONATED_SERVICE_ACCOUNT in line
+                for line in report_lines
+            )
+
+    def test_test_connection_impersonate_service_account(self):
+        """Test test_connection forwards impersonate_service_account to setup_session"""
+        mock_credentials = MagicMock(spec=ImpersonatedCredentials)
+
+        with (
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.GoogleworkspaceProvider.setup_session",
+                return_value=(
+                    GoogleWorkspaceSession(
+                        credentials=mock_credentials,
+                        impersonated_service_account=IMPERSONATED_SERVICE_ACCOUNT,
+                    ),
+                    DELEGATED_USER,
+                ),
+            ) as mock_setup_session,
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.GoogleworkspaceProvider.setup_identity",
+                return_value=GoogleWorkspaceIdentityInfo(
+                    domain=DOMAIN,
+                    customer_id=CUSTOMER_ID,
+                    delegated_user=DELEGATED_USER,
+                    profile="default",
+                ),
+            ),
+        ):
+            connection = GoogleworkspaceProvider.test_connection(
+                delegated_user=DELEGATED_USER,
+                impersonate_service_account=IMPERSONATED_SERVICE_ACCOUNT,
+            )
+
+            assert connection.is_connected is True
+            mock_setup_session.assert_called_once_with(
+                credentials_file=None,
+                credentials_content=None,
+                delegated_user=DELEGATED_USER,
+                impersonate_service_account=IMPERSONATED_SERVICE_ACCOUNT,
+            )
+
+    def test_setup_session_impersonation_sign_jwt_permission_denied(self):
+        """Test an IAM Credentials signJwt refusal (RefreshError) maps to the scopes error with the hint"""
+        mock_impersonated_credentials = MagicMock(spec=ImpersonatedCredentials)
+        # Shape raised by google.auth.impersonated_credentials._sign_jwt_request on a
+        # non-200 response: RefreshError(_REFRESH_ERROR, <raw IAM Credentials API body>).
+        sign_jwt_error = RefreshError(
+            "Unable to acquire impersonated credentials",
+            '{"error": {"code": 403, "message": "Permission \'iam.serviceAccounts.signJwt\' '
+            'denied on resource (or it may not exist).", "status": "PERMISSION_DENIED"}}',
+        )
+
+        with (
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.default",
+                return_value=(MagicMock(), None),
+            ),
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.impersonated_credentials.Credentials",
+                return_value=mock_impersonated_credentials,
+            ),
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.build"
+            ) as mock_build,
+        ):
+            mock_build.return_value.users().get().execute.side_effect = sign_jwt_error
+
+            with pytest.raises(GoogleWorkspaceInsufficientScopesError) as exc_info:
+                GoogleworkspaceProvider.setup_session(
+                    impersonate_service_account=IMPERSONATED_SERVICE_ACCOUNT,
+                    delegated_user=DELEGATED_USER,
+                )
+            assert "roles/iam.serviceAccountTokenCreator" in str(exc_info.value)

--- a/tests/providers/googleworkspace/googleworkspace_provider_test.py
+++ b/tests/providers/googleworkspace/googleworkspace_provider_test.py
@@ -541,6 +541,80 @@ class TestGoogleWorkspaceProvider:
             mock_credentials.with_subject.assert_called_once_with(DELEGATED_USER)
             assert session.impersonated_service_account is None
 
+    def test_setup_session_env_key_takes_precedence_over_impersonation_flag(self):
+        """Test GOOGLEWORKSPACE_CREDENTIALS_FILE wins over the --impersonate-service-account flag"""
+        mock_credentials = MagicMock(spec=Credentials)
+        mock_credentials.with_subject.return_value = MagicMock(spec=Credentials)
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "GOOGLEWORKSPACE_CREDENTIALS_FILE": "/path/to/creds.json",
+                    "GOOGLEWORKSPACE_CREDENTIALS_CONTENT": "",
+                    "GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT": "",
+                },
+            ),
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.service_account.Credentials.from_service_account_file",
+                return_value=mock_credentials,
+            ) as mock_from_file,
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.default"
+            ) as mock_default,
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.build"
+            ) as mock_build,
+        ):
+            mock_build.return_value.users().get().execute.return_value = {}
+
+            session, _ = GoogleworkspaceProvider.setup_session(
+                impersonate_service_account=IMPERSONATED_SERVICE_ACCOUNT,
+                delegated_user=DELEGATED_USER,
+            )
+
+            assert mock_from_file.call_args.args[0] == "/path/to/creds.json"
+            mock_default.assert_not_called()
+            mock_credentials.with_subject.assert_called_once_with(DELEGATED_USER)
+            assert session.impersonated_service_account is None
+
+    def test_setup_session_impersonation_flag_takes_precedence_over_env(self):
+        """Test --impersonate-service-account wins over GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT"""
+        mock_impersonated_credentials = MagicMock(spec=ImpersonatedCredentials)
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "GOOGLEWORKSPACE_CREDENTIALS_FILE": "",
+                    "GOOGLEWORKSPACE_CREDENTIALS_CONTENT": "",
+                    "GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT": "other-reader@test-project-12345.iam.gserviceaccount.com",
+                },
+            ),
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.default",
+                return_value=(MagicMock(), None),
+            ),
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.impersonated_credentials.Credentials",
+                return_value=mock_impersonated_credentials,
+            ) as mock_impersonated_class,
+            patch(
+                "prowler.providers.googleworkspace.googleworkspace_provider.build"
+            ) as mock_build,
+        ):
+            mock_build.return_value.users().get().execute.return_value = {}
+
+            session, _ = GoogleworkspaceProvider.setup_session(
+                impersonate_service_account=IMPERSONATED_SERVICE_ACCOUNT,
+                delegated_user=DELEGATED_USER,
+            )
+
+            assert mock_impersonated_class.call_args.kwargs["target_principal"] == (
+                IMPERSONATED_SERVICE_ACCOUNT
+            )
+            assert session.impersonated_service_account == IMPERSONATED_SERVICE_ACCOUNT
+
     def test_setup_session_impersonation_without_adc(self):
         """Test GoogleWorkspaceADCError when Application Default Credentials are missing"""
         with patch(


### PR DESCRIPTION
### Context

The Google Workspace provider can only authenticate with a downloaded Service Account JSON key. Organizations that enforce `iam.disableServiceAccountKeyCreation` (Google's default for new organizations) cannot create that key, and CI systems that already run keyless through Workload Identity Federation end up storing a long-lived, super-admin-scoped secret just for this provider. `google-auth` 2.52.0 (already pinned) supports Domain-Wide Delegation over impersonated credentials — `impersonated_credentials.Credentials(..., subject=<user>)` has the IAM Service Account Credentials API sign the delegation assertion. That is the path google-auth's maintainers pointed to when keyless delegation was requested in googleapis/google-auth-library-python#1785 (closed July 2025 as already supported; that repository has since been archived and the library now lives in `googleapis/google-cloud-python/packages/google-auth`, where the `subject` support is unchanged) — so no key is technically required, exactly like `prowler gcp --impersonate-service-account`.

Fix #12775

### Description

- **New credential source**, tried after the key file/content (argument or environment variable): `--impersonate-service-account <sa-email>` on the CLI (parity with the GCP provider), `GOOGLEWORKSPACE_IMPERSONATE_SERVICE_ACCOUNT` as the environment variable, and `impersonate_service_account=` on `GoogleworkspaceProvider` / `test_connection`. The provider takes `google.auth.default()` as the source and builds `impersonated_credentials.Credentials(source, target_principal=<sa>, target_scopes=SCOPES, subject=<delegated user>)`; the delegated user travels as the JWT subject, so `with_subject()` is not applied on this path. Key material keeps precedence over impersonation whichever way each is provided; the flag wins over its environment variable.
- **Errors:** new `GoogleWorkspaceADCError` (12009) when Application Default Credentials cannot be loaded; a malformed Service Account email is rejected before touching ADC; the 403 path also matches the IAM Credentials `PERMISSION_DENIED` body (the `RefreshError` raised by google-auth when `signJwt` is refused) and adds a `roles/iam.serviceAccountTokenCreator` (`iam.serviceAccounts.signJwt`) hint when impersonating, plus `roles/iam.workloadIdentityUser` (`iam.serviceAccounts.getAccessToken`) for Workload Identity Federation setups. The `GoogleWorkspaceNoCredentialsError` remediation mentions the new option.
- **Models:** `GoogleWorkspaceSession.credentials` is now typed as the google-auth base `Credentials` so both credential classes validate, and the session records `impersonated_service_account`; `print_credentials` reports "Application Default Credentials impersonating <sa> with Domain-Wide Delegation" instead of the key-based label.
- **Docs:** `authentication.mdx` gains a "Keyless Authentication with Service Account Impersonation" section (how it works, prerequisites — ADC, `roles/iam.serviceAccountTokenCreator` on the SA, the IAM Service Account Credentials API —, env var / flag usage, a GitHub Actions example with `google-github-actions/auth`), the credential resolution order, a best-practice bullet and troubleshooting entries (`GoogleWorkspaceADCError`, `GoogleWorkspaceInsufficientScopesError`); the getting-started page shows the keyless variant.
- **Changelog fragment:** `prowler/changelog.d/googleworkspace-keyless-impersonation.added.md`.
- **Unchanged:** the key-based flow, Prowler Cloud / API onboarding (the new kwarg defaults to `None`), all checks and outputs.

### Steps to review

1. Unit tests — `pytest tests/providers/googleworkspace tests/lib/cli/parser_test.py`. Eleven new provider tests cover: the ADC path builds impersonated credentials with the subject and no `with_subject()`; the environment-variable path; key precedence over impersonation (both as arguments, and the environment key over the flag) and the flag over its environment variable; missing ADC → `GoogleWorkspaceADCError`; malformed SA email rejected before ADC; the Admin SDK 403 and the IAM Credentials `signJwt` refusal both produce the `serviceAccountTokenCreator` hint; the credentials banner; `test_connection` forwarding; plus three parser tests for the new flag (value given, default, and a bare option rejected by argparse).
2. Manual, keyless — in a project with the Admin SDK, Cloud Identity and IAM Service Account Credentials APIs enabled, a Service Account whose client id is authorized for Domain-Wide Delegation with the six scopes, and `roles/iam.serviceAccountTokenCreator` granted to your user on that Service Account:
   ```console
   gcloud auth application-default login
   export GOOGLEWORKSPACE_DELEGATED_USER="<super-admin>@<domain>"
   prowler googleworkspace --impersonate-service-account <sa-email>
   ```
   The banner reports the impersonation method and the scan runs exactly as with a key.
3. Manual, regression — `GOOGLEWORKSPACE_CREDENTIALS_FILE=<key.json> prowler googleworkspace` behaves as before; setting both the key and `--impersonate-service-account` uses the key.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [x] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added keyless Google Workspace authentication through Application Default Credentials and Service Account impersonation.
  - Added the `--impersonate-service-account` option and corresponding environment variable.
  - Added clearer authentication status and troubleshooting messages, including ADC and permission errors.

- **Documentation**
  - Expanded setup, authentication, credential resolution, best practices, troubleshooting, and GitHub Actions guidance for keyless authentication.

- **Tests**
  - Added coverage for impersonation configuration, credential precedence, validation, failures, and connection reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->