### PR TITLE
fix(ci): suppress grpc xDS DoS CVE from the Trivy binary

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -27,6 +27,17 @@ ignore:
     package:
       name: google.golang.org/grpc
       version: v1.82.1
+  # CVE-2026-84445 is the same temporary exception documented in .trivyignore.yaml:
+  # Trivy 0.74.0 still embeds grpc 1.82.1, while the 1.82.2 / 1.83.2 fix is not in any
+  # release. The panic needs a gRPC server built with `xds.NewGRPCServer()`; Prowler only
+  # runs `trivy image` / `trivy fs`, so the image serves no gRPC at all. Pinned to the
+  # embedded version so the rule stops matching on its own once Trivy bumps grpc. Remove
+  # with the Trivy exception by 2026-10-15.
+  # https://github.com/advisories/GHSA-2v4p-qf9q-27wj
+  - vulnerability: CVE-2026-84445
+    package:
+      name: google.golang.org/grpc
+      version: v1.82.1
   # CVE-2026-56855 / CVE-2026-78662 are the same temporary exception documented in
   # .trivyignore.yaml: Trivy 0.74.0 still embeds golang.org/x/crypto v0.55.0, while the
   # 0.56.0 fix (published 2026-09-02) hasn't reached any Trivy release, or even Trivy

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -176,6 +176,25 @@ vulnerabilities:
       - "pkg:golang/google.golang.org/grpc"
     expired_at: 2026-10-15
 
+  # CVE-2026-84445 is a DoS in grpc-go servers built with `xds.NewGRPCServer()`: a request
+  # carrying neither `:authority` nor `Host` reaches the xDS routing interceptor, which
+  # indexes an empty slice of authorities and panics. The per-RPC goroutine does not
+  # recover, so the whole server process dies. Fixed in 1.82.2 and 1.83.2 (published
+  # 2026-09-08). Trivy 0.74.0, the latest published release and the version the images
+  # ship, pins 1.82.1 as an indirect dependency:
+  # https://github.com/aquasecurity/trivy/blob/v0.74.0/go.mod
+  # Trivy main already carries 1.83.2, but no published release includes it yet.
+  # The reachability argument is the one made for CVE-2026-84304 above, only narrower:
+  # this panic needs an xDS-managed gRPC server. Prowler invokes Trivy exclusively as
+  # `trivy image` and `trivy fs` on a local path, never `trivy server`, so the image runs
+  # no gRPC server at all, xDS or otherwise. Remove this temporary suppression as soon as
+  # a Trivy release pins grpc >= 1.83.2.
+  # https://github.com/advisories/GHSA-2v4p-qf9q-27wj
+  - id: CVE-2026-84445
+    purls:
+      - "pkg:golang/google.golang.org/grpc@v1.82.1"
+    expired_at: 2026-10-15
+
   # CVE-2026-56855 and CVE-2026-78662 are DoS deadlocks in x/crypto/ssh: a malicious peer
   # can flood or misuse channel messages (RFC 4254) to block the whole connection.
   # Fixed in golang.org/x/crypto v0.56.0 (published 2026-09-02). Trivy 0.74.0, the latest


### PR DESCRIPTION
### Context

The container gate started failing on the SDK image with one HIGH: `CVE-2026-84445` in `google.golang.org/grpc v1.82.1`, target `usr/local/bin/trivy`. The advisory was published 2026-09-08 21:21 UTC, hours before the scan ran, which is why the last master run of `SDK: Container Checks` on 2026-09-04 was green. It blocks every PR and master, not one branch.

### Description

The finding is in the Trivy binary the images ship, pinned at 0.74.0 in the Dockerfile and verified by checksum. It is a panic in gRPC servers built with `xds.NewGRPCServer()`: a request carrying neither `:authority` nor `Host` reaches the xDS routing interceptor, which indexes an empty slice of authorities and panics, and the per-RPC goroutine does not recover, so the process dies. Fixed in grpc-go 1.82.2 and 1.83.2.

Trivy 0.74.0 is the latest published release and still pins 1.82.1; Trivy main already carries 1.83.2, but no release includes it, so there is no version to bump to. Prowler invokes Trivy only as `trivy image` and `trivy fs` on a local path, never `trivy server`, so the image runs no gRPC server at all and the affected path is not reachable.

Same reasoning and the same pattern as the existing CVE-2026-84304, go-git and x/crypto entries: pinned to the embedded version so the rule stops matching on its own once Trivy bumps grpc, expiring 2026-10-15 alongside them.

### Steps to review

Verified by re-filtering the exact Trivy report CI produced for the failing run (artifact `trivy-scan-report-prowler-6ff8abe...` from run 34322742224) through each ignore file:

```
trivy convert --format json --severity CRITICAL,HIGH --ignorefile <file> trivy-report.json
```

- master's `.trivyignore.yaml`: 1 blocking, `["CVE-2026-84445"]`
- this branch's `.trivyignore.yaml`: 0 blocking

The `.grype.yaml` entry is preventive. Grype last scanned before the advisory was published, so it reported nothing blocking, but that file's own rule is that a new CVE against an already-listed package still blocks, so it would start failing on the next DB refresh.

Confirm the container-scan checks go green on this branch.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated vulnerability scanning configuration with a temporary exception for a non-applicable gRPC vulnerability in the bundled scanning tool.
  - Added an expiration date and contextual scope to ensure the exception can be revisited when an updated tool version is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->