### PR TITLE
fix(mcp): patch the six high libuuid CVEs in the container image

### DIFF
--- a/mcp_server/Dockerfile
+++ b/mcp_server/Dockerfile
@@ -32,6 +32,8 @@ LABEL maintainer="https://github.com/prowler-cloud"
 # High CVEs fixed in Alpine 3.23 but not yet in the pinned base image:
 #   sqlite-libs 3.53.4-r0  CVE-2026-11822, CVE-2026-11824  (image ships 3.51.2-r0)
 #   libcrypto3/libssl3 3.5.8-r0  CVE-2026-14456            (image ships 3.5.7-r0)
+#   libuuid 2.41.6-r1  CVE-2026-53612, -53613, -53614, -76642, -78408, -78410
+#     (image ships 2.41.4-r0; -78408 is the one that needs -r1 rather than -r0)
 # The base image pins python 3.13.14, which has not been rebuilt since those
 # packages were published, so the upgrade is taken here rather than by moving
 # the pin -- the newest published python:3.13-alpine3.23 carries the same
@@ -43,7 +45,8 @@ LABEL maintainer="https://github.com/prowler-cloud"
 RUN apk add --no-cache --upgrade \
     "sqlite-libs>=3.53.4-r0" \
     "libcrypto3>=3.5.8-r0" \
-    "libssl3>=3.5.8-r0"
+    "libssl3>=3.5.8-r0" \
+    "libuuid>=2.41.6-r1"
 
 # Create non-root user for security
 # Using specific UID/GID for consistency across environments

--- a/mcp_server/changelog.d/mcp-image-libuuid-cves.security.md
+++ b/mcp_server/changelog.d/mcp-image-libuuid-cves.security.md
@@ -1,0 +1,1 @@
+`libuuid` upgraded to 2.41.6-r1 in the container image, patching CVE-2026-53612, CVE-2026-53613, CVE-2026-53614, CVE-2026-76642, CVE-2026-78408 and CVE-2026-78410


### PR DESCRIPTION
### Context

The MCP container image ships `libuuid 2.41.4-r0` on its Alpine 3.23.5 base, carrying six HIGH CVEs: `CVE-2026-53612`, `CVE-2026-53613`, `CVE-2026-53614`, `CVE-2026-76642`, `CVE-2026-78408` and `CVE-2026-78410`.

They surfaced on 2026-09-09 when PR #12777 touched the shared scanner ignore files, which is what makes `mcp-container-build-and-scan` actually run. The MCP image had not been really scanned since 2026-09-02. Tracked as PROWLER-2497.

### Description

All six have published fixes, so this is a package upgrade rather than a suppression. Alpine 3.23 currently ships `libuuid 2.41.6-r1`, which covers all six; note `CVE-2026-78408` is fixed in `-r1` specifically, not `-r0`, so the pin is `>=2.41.6-r1`.

The change adds one line to the `apk add --no-cache --upgrade` block the Dockerfile already carries for exactly this situation, and extends the comment above it naming the CVEs. That block, its `>=` pin convention and the reasoning for upgrading in the image rather than moving the base digest are all pre-existing; this follows them unchanged. Same shape as #12537 (sqlite) and #12547 (openssl).

### Steps to review

Verified locally by building the image from this branch and scanning it:

```
docker build --platform linux/amd64 -t prowler-mcp:libuuid-fix mcp_server/
docker run --rm --entrypoint sh prowler-mcp:libuuid-fix -c "apk list --installed | grep libuuid"
trivy image --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore.yaml prowler-mcp:libuuid-fix
```

- The built image ships `libuuid-2.41.6-r1`
- Trivy reports 0 findings at critical or high, where CI reported 6 high on master

Reviewer should confirm `mcp-container-build-and-scan` goes green on this branch.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### MCP Server
- [x] All issue/task requirements work as expected on the MCP Server
- [x] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the container image’s `libuuid` package to address six reported security vulnerabilities.
* **Documentation**
  * Added a changelog entry documenting the security update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->