### PR TITLE
fix(tests): isolate secretsmanager policy test

### DIFF
--- a/tests/providers/aws/services/secretsmanager/secretsmanager_has_restrictive_resource_policy/secretsmanager_has_restrictive_resource_policy_test.py
+++ b/tests/providers/aws/services/secretsmanager/secretsmanager_has_restrictive_resource_policy/secretsmanager_has_restrictive_resource_policy_test.py
@@ -103,12 +103,6 @@ class TestSecretsManagerHasRestrictiveResourcePolicy:
         with mock_aws():
             aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
 
-            from prowler.providers.aws.services.secretsmanager.secretsmanager_has_restrictive_resource_policy.secretsmanager_has_restrictive_resource_policy import (
-                secretsmanager_client,
-            )
-
-            secretsmanager_client.secrets.clear()
-
             with (
                 mock.patch(
                     "prowler.providers.common.provider.Provider.get_global_provider",


### PR DESCRIPTION
### Context

`sdk-tests` failed twice on #12764 (different `pytest-randomly` seeds) on a test the PR did not touch: `secretsmanager_has_restrictive_resource_policy_test::test_no_secrets` raised `AttributeError: Mock object has no attribute 'secrets'` on a `<MagicMock spec='AwsProvider'>`. The same order reproduces the failure on `master`, so this is a test-isolation bug, not a regression.

### Description

`secretsmanager_automatic_rotation_enabled_test` patches the class `secretsmanager_service.SecretsManager` with `mock.MagicMock` and, inside that window, imports `secretsmanager_client.py` for the first time on the worker. The module's `from ... import SecretsManager` stays bound to `MagicMock` after the patch exits, so its module-level client becomes `MagicMock(<AwsProvider>)`: the positional argument is a `spec`. Once `tests/conftest.py` drops the `secrets` attribute the sibling test had set on the mock class, any attribute access on that client fails.

`test_no_secrets` imported that module-level client and called `.secrets.clear()` on it before patching it with a fresh `SecretsManager(aws_provider)`. The read is removed: the check runs against the fresh instance either way, and the test no longer depends on which test imported the client module first.

### Steps to review

Reproduce the failure on `master` with a fixed order (a test that sets the global provider, then the class-patching test, then the victim):

```
uv run pytest -p no:randomly \
  tests/providers/aws/services/account/account_service_test.py \
  tests/providers/aws/services/secretsmanager/secretsmanager_automatic_rotation_enabled \
  tests/providers/aws/services/secretsmanager/secretsmanager_has_restrictive_resource_policy
```

`master`: 1 failed, 87 passed. This branch: 88 passed. `uv run pytest tests/providers/aws/services/secretsmanager` with random order: 99 passed.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified Secrets Manager test setup by relying on a fresh, empty service instance for test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
