### PR TITLE
fix(aws): guard checks reading iam roles when unlisted

### DIFF
--- a/prowler/changelog.d/aws-checks-roles-unlisted.fixed.md
+++ b/prowler/changelog.d/aws-checks-roles-unlisted.fixed.md
@@ -1,0 +1,1 @@
+`rolesanywhere_profile_restricts_session_permissions`, `iam_role_service_trust_restricts_source_to_account` and `codebuild_project_uses_allowed_github_organizations` crashing with `TypeError` when `iam:ListRoles` is denied

--- a/prowler/providers/aws/services/codebuild/codebuild_project_uses_allowed_github_organizations/codebuild_project_uses_allowed_github_organizations.py
+++ b/prowler/providers/aws/services/codebuild/codebuild_project_uses_allowed_github_organizations/codebuild_project_uses_allowed_github_organizations.py
@@ -23,7 +23,7 @@ class codebuild_project_uses_allowed_github_organizations(Check):
                 project_role = next(
                     (
                         role
-                        for role in iam_client.roles
+                        for role in iam_client.roles or []
                         if role.arn == project.service_role_arn
                     ),
                     None,

--- a/prowler/providers/aws/services/iam/iam_role_service_trust_restricts_source_to_account/iam_role_service_trust_restricts_source_to_account.py
+++ b/prowler/providers/aws/services/iam/iam_role_service_trust_restricts_source_to_account/iam_role_service_trust_restricts_source_to_account.py
@@ -377,7 +377,7 @@ class iam_role_service_trust_restricts_source_to_account(Check):
         status. The sibling token-wildcard check carries the same note, for the same reason.
         """
         findings = []
-        for role in iam_client.roles:
+        for role in iam_client.roles or []:
             # Service-linked roles are excluded: their trust relationship is managed by
             # the service and cannot be edited, so a finding would not be actionable.
             if "aws-service-role" in role.arn:

--- a/prowler/providers/aws/services/rolesanywhere/rolesanywhere_profile_restricts_session_permissions/rolesanywhere_profile_restricts_session_permissions.py
+++ b/prowler/providers/aws/services/rolesanywhere/rolesanywhere_profile_restricts_session_permissions/rolesanywhere_profile_restricts_session_permissions.py
@@ -205,7 +205,9 @@ class rolesanywhere_profile_restricts_session_permissions(Check):
             not administrative, and disabled profiles.
         """
         findings = []
-        roles_by_arn = {role.arn: role for role in iam_client.roles}
+        # iam:ListRoles denied leaves roles as None: every referenced role is
+        # then unknown and the profile falls through to MANUAL.
+        roles_by_arn = {role.arn: role for role in (iam_client.roles or [])}
         for profile in rolesanywhere_client.profiles.values():
             report = Check_Report_AWS(metadata=self.metadata(), resource=profile)
             role_statuses = {

--- a/tests/providers/aws/services/codebuild/codebuild_project_uses_allowed_github_organizations/codebuild_project_uses_allowed_github_organizations_test.py
+++ b/tests/providers/aws/services/codebuild/codebuild_project_uses_allowed_github_organizations/codebuild_project_uses_allowed_github_organizations_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from boto3 import client
 from moto import mock_aws
@@ -181,6 +181,59 @@ class Test_codebuild_project_uses_allowed_github_organizations:
                 "which is not in the allowed organizations" in result[0].status_extended
             )
             assert result[0].region == AWS_REGION_EU_WEST_1
+
+    @mock_aws
+    def test_project_github_with_unlisted_roles(self):
+        # iam:ListRoles denied leaves iam_client.roles as None.
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        codebuild_client = client("codebuild", region_name=AWS_REGION_EU_WEST_1)
+        codebuild_client.create_project(
+            name="test-project-github-unlisted-roles",
+            source={
+                "type": "GITHUB",
+                "location": "https://github.com/allowed-org/repo",
+            },
+            artifacts={"type": "NO_ARTIFACTS"},
+            environment={
+                "type": "LINUX_CONTAINER",
+                "image": "aws/codebuild/standard:4.0",
+                "computeType": "BUILD_GENERAL1_SMALL",
+                "environmentVariables": [],
+            },
+            serviceRole=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:role/codebuild-test-role",
+        )
+
+        from prowler.providers.aws.services.codebuild.codebuild_service import Codebuild
+
+        iam_client = MagicMock()
+        iam_client.roles = None
+
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            patch(
+                "prowler.providers.aws.services.codebuild.codebuild_project_uses_allowed_github_organizations.codebuild_project_uses_allowed_github_organizations.codebuild_client",
+                new=Codebuild(aws_provider),
+            ),
+            patch(
+                "prowler.providers.aws.services.codebuild.codebuild_project_uses_allowed_github_organizations.codebuild_project_uses_allowed_github_organizations.iam_client",
+                new=iam_client,
+            ),
+            patch(
+                "prowler.providers.aws.services.codebuild.codebuild_project_uses_allowed_github_organizations.codebuild_project_uses_allowed_github_organizations.codebuild_client.audit_config",
+                {"codebuild_github_allowed_organizations": ["allowed-org"]},
+            ),
+        ):
+            from prowler.providers.aws.services.codebuild.codebuild_project_uses_allowed_github_organizations.codebuild_project_uses_allowed_github_organizations import (
+                codebuild_project_uses_allowed_github_organizations,
+            )
+
+            assert (
+                len(codebuild_project_uses_allowed_github_organizations().execute())
+                == 0
+            )
 
     @mock_aws
     def test_project_github_no_codebuild_trusted_principal(self):

--- a/tests/providers/aws/services/iam/iam_role_service_trust_restricts_source_to_account/iam_role_service_trust_restricts_source_to_account_test.py
+++ b/tests/providers/aws/services/iam/iam_role_service_trust_restricts_source_to_account/iam_role_service_trust_restricts_source_to_account_test.py
@@ -93,6 +93,10 @@ class Test_iam_role_service_trust_restricts_source_to_account:
         """An account with no roles produces no reports at all."""
         assert len(_run([])) == 0
 
+    def test_unlisted_roles_produce_no_reports(self):
+        # iam:ListRoles denied leaves iam_client.roles as None.
+        assert len(_run(None)) == 0
+
     def test_service_linked_role_skipped(self):
         """A service-linked role is excluded even when its trust policy would FAIL.
 

--- a/tests/providers/aws/services/rolesanywhere/rolesanywhere_profile_restricts_session_permissions/rolesanywhere_profile_restricts_session_permissions_test.py
+++ b/tests/providers/aws/services/rolesanywhere/rolesanywhere_profile_restricts_session_permissions/rolesanywhere_profile_restricts_session_permissions_test.py
@@ -472,6 +472,19 @@ class Test_rolesanywhere_profile_restricts_session_permissions:
             assert result[0].status == "MANUAL"
             assert "could not be evaluated" in result[0].status_extended
 
+    def test_unscoped_profile_with_unlisted_roles_is_manual(self):
+        # iam:ListRoles denied leaves iam_client.roles as None.
+        patches = _patched(
+            _build_client({PROFILE_ARN: _profile(role_arns=[ADMIN_ROLE_ARN])})
+        )
+        patches[-1].new.roles = None
+        with _enter(patches):
+            result = _run()
+            assert len(result) == 1
+            assert result[0].status == "MANUAL"
+            assert ADMIN_ROLE_ARN in result[0].status_extended
+            assert "could not be evaluated" in result[0].status_extended
+
     def test_unscoped_profile_without_roles_passes(self):
         with _enter(_patched(_build_client({PROFILE_ARN: _profile(role_arns=[])}))):
             result = _run()


### PR DESCRIPTION
### Context

`iam_service._get_roles()` returns `None` when `iam:ListRoles` answers `AccessDenied`, on purpose, so checks can tell "denied" from "no roles". Three checks iterate `iam_client.roles` without handling that case: the whole check crashes with `TypeError: 'NoneType' object is not iterable` on every scan of an account whose scanning role lacks that permission, and emits nothing for it. The other checks reading `iam_client.roles` already guard it.

### Description

Iterate `iam_client.roles or []` in the three unguarded checks:

- `rolesanywhere_profile_restricts_session_permissions`: with no role inventory every referenced role is unknown, so an enabled unscoped profile falls through to the existing MANUAL branch. Scoped and disabled profiles keep reporting PASS.
- `iam_role_service_trust_restricts_source_to_account`: no roles, no reports.
- `codebuild_project_uses_allowed_github_organizations`: the service role cannot be resolved, so the project is skipped as it already is when the role is missing from the inventory.

No FAIL is asserted on data that was not retrieved. A regression test per check sets `iam_client.roles = None`; each one reproduces the `TypeError` without the guard.

### Steps to review

```
uv run pytest -p no:randomly \
  tests/providers/aws/services/rolesanywhere/rolesanywhere_profile_restricts_session_permissions/ \
  tests/providers/aws/services/iam/iam_role_service_trust_restricts_source_to_account/ \
  tests/providers/aws/services/codebuild/codebuild_project_uses_allowed_github_organizations/
```

Revert the three one-line guards and run the `unlisted` tests again to see the original traceback.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented three AWS security checks from crashing when IAM role data is unavailable due to denied `iam:ListRoles` permissions.
  - Checks now return appropriate empty or manual findings when role information cannot be retrieved.

- **Tests**
  - Added coverage for denied IAM role-listing scenarios across CodeBuild, IAM, and Roles Anywhere checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
